### PR TITLE
feat(account): require a user to name their TOTP authenticator

### DIFF
--- a/apps/studio/components/interfaces/Account/TOTPFactors/AddNewFactorModal.tsx
+++ b/apps/studio/components/interfaces/Account/TOTPFactors/AddNewFactorModal.tsx
@@ -1,7 +1,7 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useQueryClient } from '@tanstack/react-query'
 import { useEffect, useState } from 'react'
-import { useForm, type SubmitHandler } from 'react-hook-form'
+import { useForm, useWatch, type SubmitHandler } from 'react-hook-form'
 import { toast } from 'sonner'
 import { Form, FormControl, FormField, Input } from 'ui'
 import { Input as PasswordInput } from 'ui-patterns/DataInputs/Input'
@@ -59,25 +59,31 @@ interface FirstStepProps {
   onClose: () => void
 }
 
+const ENROLL_FORM_ID = 'add-totp-factor-form'
+
+const EnrollFormSchema = z.object({
+  name: z.string().trim().min(1, 'Name is required'),
+})
+type EnrollFormValues = z.infer<typeof EnrollFormSchema>
+
+const enrollFormDefaultValues: EnrollFormValues = { name: '' }
+
 const FirstStep = ({ visible, isEnrolling, enroll, onClose }: FirstStepProps) => {
-  const FormSchema = z.object({
-    name: z.string().min(1, 'Please provide a name to identify this app'),
-  })
-  const form = useForm<z.infer<typeof FormSchema>>({
-    resolver: zodResolver(FormSchema),
-    defaultValues: { name: '' },
+  const form = useForm<EnrollFormValues>({
+    resolver: zodResolver(EnrollFormSchema),
+    defaultValues: enrollFormDefaultValues,
     mode: 'onChange',
   })
 
-  const onSubmit: SubmitHandler<z.infer<typeof FormSchema>> = async (values) => {
+  const name = useWatch({ control: form.control, name: 'name' })
+  const isNameProvided = name.trim().length > 0
+
+  const onSubmit: SubmitHandler<EnrollFormValues> = async (values) => {
     enroll({ factorType: 'totp', friendlyName: values.name })
   }
 
   useEffect(() => {
-    if (!visible) {
-      // Generate a name with a number between 0 and 1000
-      form.reset({ name: `App ${Math.floor(Math.random() * 1000)}` })
-    }
+    if (visible) form.reset(enrollFormDefaultValues)
   }, [form, visible])
 
   return (
@@ -88,12 +94,13 @@ const FirstStep = ({ visible, isEnrolling, enroll, onClose }: FirstStepProps) =>
       confirmLabel="Generate QR"
       confirmLabelLoading="Generating QR"
       loading={isEnrolling}
+      disabled={!isNameProvided}
       onCancel={onClose}
       onConfirm={form.handleSubmit(onSubmit)}
     >
       <Form {...form}>
         <form
-          id="verify-otp-form"
+          id={ENROLL_FORM_ID}
           className="flex flex-col gap-4"
           onSubmit={form.handleSubmit(onSubmit)}
         >
@@ -104,11 +111,11 @@ const FirstStep = ({ visible, isEnrolling, enroll, onClose }: FirstStepProps) =>
             render={({ field }) => (
               <FormItemLayout
                 name="name"
-                label="Provide a name to identify this app"
-                description="A string will be randomly generated if a name is not provided"
+                label="Authenticator app name"
+                description="Shown at sign-in to identify which app to use"
               >
                 <FormControl>
-                  <Input id="name" {...field} />
+                  <Input id="name" placeholder="e.g.: Google Authenticator" autoFocus {...field} />
                 </FormControl>
               </FormItemLayout>
             )}

--- a/apps/studio/components/interfaces/Account/TOTPFactors/AddNewFactorModal.tsx
+++ b/apps/studio/components/interfaces/Account/TOTPFactors/AddNewFactorModal.tsx
@@ -1,7 +1,7 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useQueryClient } from '@tanstack/react-query'
 import { useEffect, useState } from 'react'
-import { useForm, useWatch, type SubmitHandler } from 'react-hook-form'
+import { useForm, type SubmitHandler } from 'react-hook-form'
 import { toast } from 'sonner'
 import { Form, FormControl, FormField, Input } from 'ui'
 import { Input as PasswordInput } from 'ui-patterns/DataInputs/Input'
@@ -75,9 +75,6 @@ const FirstStep = ({ visible, isEnrolling, enroll, onClose }: FirstStepProps) =>
     mode: 'onChange',
   })
 
-  const name = useWatch({ control: form.control, name: 'name' })
-  const isNameProvided = name.trim().length > 0
-
   const onSubmit: SubmitHandler<EnrollFormValues> = async (values) => {
     enroll({ factorType: 'totp', friendlyName: values.name })
   }
@@ -94,7 +91,6 @@ const FirstStep = ({ visible, isEnrolling, enroll, onClose }: FirstStepProps) =>
       confirmLabel="Generate QR"
       confirmLabelLoading="Generating QR"
       loading={isEnrolling}
-      disabled={!isNameProvided}
       onCancel={onClose}
       onConfirm={form.handleSubmit(onSubmit)}
     >

--- a/apps/studio/components/interfaces/Account/TOTPFactors/AddNewFactorModal.tsx
+++ b/apps/studio/components/interfaces/Account/TOTPFactors/AddNewFactorModal.tsx
@@ -115,7 +115,7 @@ const FirstStep = ({ visible, isEnrolling, enroll, onClose }: FirstStepProps) =>
                 description="Used to identify the app in your account settings and during sign-in."
               >
                 <FormControl>
-                  <Input id="name" placeholder="e.g.: Google Authenticator" autoFocus {...field} />
+                  <Input placeholder="e.g.: Google Authenticator" autoFocus {...field} />
                 </FormControl>
               </FormItemLayout>
             )}

--- a/apps/studio/components/interfaces/Account/TOTPFactors/AddNewFactorModal.tsx
+++ b/apps/studio/components/interfaces/Account/TOTPFactors/AddNewFactorModal.tsx
@@ -112,7 +112,7 @@ const FirstStep = ({ visible, isEnrolling, enroll, onClose }: FirstStepProps) =>
               <FormItemLayout
                 name="name"
                 label="Authenticator app name"
-                description="Shown at sign-in to identify which app to use"
+                description="Used to identify the app in your account settings and during sign-in."
               >
                 <FormControl>
                   <Input id="name" placeholder="e.g.: Google Authenticator" autoFocus {...field} />

--- a/apps/studio/components/interfaces/Account/TOTPFactors/index.tsx
+++ b/apps/studio/components/interfaces/Account/TOTPFactors/index.tsx
@@ -18,7 +18,7 @@ export const TOTPFactors = () => {
     <>
       <section className="space-y-3">
         <p className="text-sm text-foreground-light">
-          Use an authenticator app (like 1Password or Authy) to verify your identity at sign-in.
+          Use an authenticator app (like Google Authenticator or 1Password) to protect your account.
         </p>
         <div>
           {isLoading && <GenericSkeletonLoader />}


### PR DESCRIPTION
Currently it's an autogenerated name. We want users to explicitly enter a name for their authenticator so that:

- They can remember that they took the action of registering an authenticator
- They can see a meaningful name during sign-in if they have multiple TOTP authenticators

<img width="536" height="269" alt="Screenshot 2026-07-30 at 16 05 10" src="https://github.com/user-attachments/assets/e43de27f-b4ca-4d4f-969a-578267eeebe4" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TOTP enrollment: confirmation is no longer enabled unless an authenticator app name is provided (validated beyond whitespace).

* **UI Improvements**
  * Updated the authenticator app name label/description, added an example placeholder, and auto-focused the field when the confirmation step appears.
  * Refined the on-screen guidance for suggested authenticator apps (e.g., Google Authenticator or 1Password).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->