### PR TITLE
Fix: RadioGroupCard focus state design

### DIFF
--- a/packages/ui/src/components/radio-group-card.tsx
+++ b/packages/ui/src/components/radio-group-card.tsx
@@ -38,10 +38,7 @@ const RadioGroupCardItem = React.forwardRef<
         // 'hover:bg-selection',
         'hover:border-foreground-muted',
         'hover:z-1 focus-visible:z-1',
-        'data-[state=checked]:z-1',
-        'data-[state=checked]:ring-2 data-[state=checked]:ring-border',
-        'data-[state=checked]:bg-surface-300 dark:data-[state=checked]:bg-surface-300',
-        'data-[state=checked]:border-foreground/50',
+        'outline-hidden',
         'transition-colors',
         'group',
         props.className


### PR DESCRIPTION
Fix the `<RadioGroupCard>` focus state design

Before:
<img width="676" height="117" alt="image" src="https://github.com/user-attachments/assets/39849fd3-e6de-43dc-b4d7-67edcce3812d" />

After:
<img width="741" height="167" alt="image" src="https://github.com/user-attachments/assets/13dad707-bc63-48da-8574-eb3d90b29625" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated radio group card selection styling for a cleaner, more consistent focus and checked-state appearance.
  * Added improved outline handling for radio group card items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->