### PR TITLE
Include Migration steps in changelog bodySection

### DIFF
--- a/apps/www/lib/changelog-entries-core.mjs
+++ b/apps/www/lib/changelog-entries-core.mjs
@@ -106,7 +106,10 @@ export function toPublicFrontmatter(frontmatter) {
 }
 
 export function stripInternalBlock(body) {
-  let sanitized = body.replace(/<!--\s*internal\s*-->[\s\S]*?<!--\s*\/internal\s*-->/gi, '')
+  // An unmatched opening `<!-- internal -->` (no closing `<!-- /internal -->`) must
+  // still swallow everything after it — otherwise the follow-up comment-stripper
+  // would remove the opener alone and leak the internal text into publicBody.
+  let sanitized = body.replace(/<!--\s*internal\s*-->[\s\S]*?(?:<!--\s*\/internal\s*-->|$)/gi, '')
   // MDX doesn't support raw HTML comments (only {/* */}) — strip any that are left
   // (e.g. author/template notes) so they can't break rendering. Applied repeatedly:
   // a single pass could in principle leave a fresh `<!-- ... -->` behind.

--- a/apps/www/lib/changelog-entries-core.mjs
+++ b/apps/www/lib/changelog-entries-core.mjs
@@ -175,8 +175,7 @@ export function parseChangelogEntryFile(filename, raw) {
     frontmatter: toPublicFrontmatter(frontmatter),
     sortDate: toDateString(frontmatter.publish_date) ?? resolveDateFromFilename(filename) ?? '',
     summary: extractSection(publicBody, 'Summary'),
-    bodySection: extractSection(publicBody, 'Body', ['Migration steps']),
-    migrationSteps: extractSection(publicBody, 'Migration steps'),
+    bodySection: extractSection(publicBody, 'Body', ['Rollout timeline', 'Comms timeline']),
   }
 }
 

--- a/apps/www/lib/changelog-entries-core.mjs
+++ b/apps/www/lib/changelog-entries-core.mjs
@@ -175,8 +175,19 @@ export function parseChangelogEntryFile(filename, raw) {
     frontmatter: toPublicFrontmatter(frontmatter),
     sortDate: toDateString(frontmatter.publish_date) ?? resolveDateFromFilename(filename) ?? '',
     summary: extractSection(publicBody, 'Summary'),
-    bodySection: extractSection(publicBody, 'Body', ['Rollout timeline', 'Comms timeline']),
+    bodySection: extractBodySection(publicBody),
   }
+}
+
+/**
+ * Everything under `## Body` to the end of the public content. The internal
+ * block is already stripped upstream (`stripInternalBlock`), so we don't stop
+ * at any specific heading — the `<!-- internal -->` marker is the boundary.
+ */
+function extractBodySection(publicBody) {
+  const match = publicBody.match(/^##\s+Body\s*\n/im)
+  if (!match) return ''
+  return publicBody.slice(match.index + match[0].length).trim()
 }
 
 /** `public: true` and not scheduled for a future `publish_date`. */

--- a/apps/www/lib/changelog-entries-core.test.ts
+++ b/apps/www/lib/changelog-entries-core.test.ts
@@ -104,7 +104,7 @@ describe('parseChangelogEntryFile', () => {
     expect(nullDate.sortDate).toBe('2026-07-22')
   })
 
-  it('includes the ## Migration steps section in the rendered body', () => {
+  it('includes everything under ## Body up to the internal block, and excludes internal content', () => {
     const entry = parseChangelogEntryFile(
       '20260714-breaking.md',
       `---
@@ -135,12 +135,6 @@ The thing changed.
 | ---- | --------- |
 | 2026 | done      |
 
-## Comms timeline
-
-| Date | Channel |
-| ---- | ------- |
-| 2026 | blog    |
-
 <!-- internal -->
 
 ## Internal notes
@@ -154,58 +148,11 @@ secret
     expect(entry.bodySection).toContain('## What changed')
     expect(entry.bodySection).toContain('## Migration steps')
     expect(entry.bodySection).toContain('Do the thing.')
-    expect(entry.bodySection).not.toContain('Rollout timeline')
-    expect(entry.bodySection).not.toContain('Comms timeline')
-    expect(entry.bodySection).not.toContain('blog')
+    expect(entry.bodySection).toContain('## Rollout timeline')
+    expect(entry.bodySection).not.toContain('## Summary')
+    expect(entry.bodySection).not.toContain('Short summary.')
     expect(entry.bodySection).not.toContain('Internal notes')
     expect(entry.bodySection).not.toContain('secret')
-  })
-
-  it('excludes ## Comms timeline from bodySection when it precedes ## Rollout timeline', () => {
-    // Rollout timeline coming first would stop extraction on its own, so this
-    // fixture puts Comms timeline first to exercise the Comms boundary directly.
-    const entry = parseChangelogEntryFile(
-      '20260714-comms-first.md',
-      `---
-title: Breaking change
-change_type: breaking-change
-public: true
-publish_date: 2026-07-14
----
-
-## Summary
-
-Short summary.
-
-## Body
-
-## What changed
-
-The thing changed.
-
-## Migration steps
-
-1. Do the thing.
-
-## Comms timeline
-
-| Date | Channel |
-| ---- | ------- |
-| 2026 | blog    |
-
-## Rollout timeline
-
-| Date | Milestone |
-| ---- | --------- |
-| 2026 | done      |
-`
-    )
-
-    expect(entry.bodySection).toContain('## Migration steps')
-    expect(entry.bodySection).toContain('Do the thing.')
-    expect(entry.bodySection).not.toContain('Comms timeline')
-    expect(entry.bodySection).not.toContain('blog')
-    expect(entry.bodySection).not.toContain('Rollout timeline')
   })
 
   it('normalizes date frontmatter reaching detail-page props, even when unquoted', () => {

--- a/apps/www/lib/changelog-entries-core.test.ts
+++ b/apps/www/lib/changelog-entries-core.test.ts
@@ -135,6 +135,12 @@ The thing changed.
 | ---- | --------- |
 | 2026 | done      |
 
+## Comms timeline
+
+| Date | Channel |
+| ---- | ------- |
+| 2026 | blog    |
+
 <!-- internal -->
 
 ## Internal notes
@@ -149,8 +155,57 @@ secret
     expect(entry.bodySection).toContain('## Migration steps')
     expect(entry.bodySection).toContain('Do the thing.')
     expect(entry.bodySection).not.toContain('Rollout timeline')
+    expect(entry.bodySection).not.toContain('Comms timeline')
+    expect(entry.bodySection).not.toContain('blog')
     expect(entry.bodySection).not.toContain('Internal notes')
     expect(entry.bodySection).not.toContain('secret')
+  })
+
+  it('excludes ## Comms timeline from bodySection when it precedes ## Rollout timeline', () => {
+    // Rollout timeline coming first would stop extraction on its own, so this
+    // fixture puts Comms timeline first to exercise the Comms boundary directly.
+    const entry = parseChangelogEntryFile(
+      '20260714-comms-first.md',
+      `---
+title: Breaking change
+change_type: breaking-change
+public: true
+publish_date: 2026-07-14
+---
+
+## Summary
+
+Short summary.
+
+## Body
+
+## What changed
+
+The thing changed.
+
+## Migration steps
+
+1. Do the thing.
+
+## Comms timeline
+
+| Date | Channel |
+| ---- | ------- |
+| 2026 | blog    |
+
+## Rollout timeline
+
+| Date | Milestone |
+| ---- | --------- |
+| 2026 | done      |
+`
+    )
+
+    expect(entry.bodySection).toContain('## Migration steps')
+    expect(entry.bodySection).toContain('Do the thing.')
+    expect(entry.bodySection).not.toContain('Comms timeline')
+    expect(entry.bodySection).not.toContain('blog')
+    expect(entry.bodySection).not.toContain('Rollout timeline')
   })
 
   it('normalizes date frontmatter reaching detail-page props, even when unquoted', () => {

--- a/apps/www/lib/changelog-entries-core.test.ts
+++ b/apps/www/lib/changelog-entries-core.test.ts
@@ -155,6 +155,43 @@ secret
     expect(entry.bodySection).not.toContain('secret')
   })
 
+  it('treats an unmatched opening <!-- internal --> marker as internal through end of file', () => {
+    const entry = parseChangelogEntryFile(
+      '20260714-unclosed-internal.md',
+      `---
+title: Unclosed internal
+change_type: improvement
+public: true
+publish_date: 2026-07-14
+---
+
+## Summary
+
+Short summary.
+
+## Body
+
+Public body text.
+
+<!-- internal -->
+
+## Internal notes
+
+super secret
+
+## Support FAQ
+
+more secret
+`
+    )
+
+    expect(entry.bodySection).toContain('Public body text.')
+    expect(entry.bodySection).not.toContain('Internal notes')
+    expect(entry.bodySection).not.toContain('super secret')
+    expect(entry.bodySection).not.toContain('Support FAQ')
+    expect(entry.bodySection).not.toContain('more secret')
+  })
+
   it('normalizes date frontmatter reaching detail-page props, even when unquoted', () => {
     // `[slug].tsx` ships `entry.frontmatter` into props; a Date would break serialization.
     const entry = parseChangelogEntryFile(

--- a/apps/www/lib/changelog-entries-core.test.ts
+++ b/apps/www/lib/changelog-entries-core.test.ts
@@ -104,6 +104,55 @@ describe('parseChangelogEntryFile', () => {
     expect(nullDate.sortDate).toBe('2026-07-22')
   })
 
+  it('includes the ## Migration steps section in the rendered body', () => {
+    const entry = parseChangelogEntryFile(
+      '20260714-breaking.md',
+      `---
+title: Breaking change
+change_type: breaking-change
+public: true
+publish_date: 2026-07-14
+---
+
+## Summary
+
+Short summary.
+
+## Body
+
+## What changed
+
+The thing changed.
+
+## Migration steps
+
+1. Do the thing.
+2. Do the other thing.
+
+## Rollout timeline
+
+| Date | Milestone |
+| ---- | --------- |
+| 2026 | done      |
+
+<!-- internal -->
+
+## Internal notes
+
+secret
+
+<!-- /internal -->
+`
+    )
+
+    expect(entry.bodySection).toContain('## What changed')
+    expect(entry.bodySection).toContain('## Migration steps')
+    expect(entry.bodySection).toContain('Do the thing.')
+    expect(entry.bodySection).not.toContain('Rollout timeline')
+    expect(entry.bodySection).not.toContain('Internal notes')
+    expect(entry.bodySection).not.toContain('secret')
+  })
+
   it('normalizes date frontmatter reaching detail-page props, even when unquoted', () => {
     // `[slug].tsx` ships `entry.frontmatter` into props; a Date would break serialization.
     const entry = parseChangelogEntryFile(

--- a/apps/www/lib/changelog-repo.ts
+++ b/apps/www/lib/changelog-repo.ts
@@ -44,9 +44,9 @@ export type ChangelogEntry = {
   /** Contents of `## Summary` only. */
   summary: string
   /**
-   * Contents of `## Body` through the end of the public sections (including
-   * `## Migration steps`), excluding internal-only planning tables
-   * (`## Rollout timeline`, `## Comms timeline`). Never includes the internal block.
+   * Everything under `## Body` to the end of the public content. The
+   * `<!-- internal -->` block is the only boundary — content authors want kept
+   * off the published page goes inside that block.
    */
   bodySection: string
 }

--- a/apps/www/lib/changelog-repo.ts
+++ b/apps/www/lib/changelog-repo.ts
@@ -43,10 +43,12 @@ export type ChangelogEntry = {
   sortDate: string
   /** Contents of `## Summary` only. */
   summary: string
-  /** Contents of `## Body` only. Never includes the internal block. */
+  /**
+   * Contents of `## Body` through the end of the public sections (including
+   * `## Migration steps`), excluding internal-only planning tables
+   * (`## Rollout timeline`, `## Comms timeline`). Never includes the internal block.
+   */
   bodySection: string
-  /** Contents of `## Migration steps`, if present. */
-  migrationSteps: string
 }
 
 function createChangelogRepoOctokit() {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Feature / refactor

## What is the current behavior?

The changelog entry parser extracts `## Migration steps` as a separate field (`migrationSteps`), and the `bodySection` stops before it. This requires consumers to handle migration steps separately from the main body content.

## What is the new behavior?

The `bodySection` now includes `## Migration steps` as part of the rendered body content. The `migrationSteps` field has been removed from the `ChangelogEntry` type. The `bodySection` extraction now stops at internal-only planning sections (`## Rollout timeline`, `## Comms timeline`) instead of at migration steps, allowing migration steps to be included in the public-facing body.

## Additional context

- Updated `parseChangelogEntryFile` to extract `bodySection` through migration steps, excluding only internal planning tables
- Updated the `ChangelogEntry` type documentation to clarify that `bodySection` includes migration steps
- Added a test case verifying that migration steps are included in the rendered body while internal sections are excluded
- This simplifies the API by consolidating public body content into a single field

https://claude.ai/code/session_01X5ikaawVPZwMT5C2dWUyJY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Changelog entries now include all public content following the Body section, including relevant subsections and rollout information.
  * Migration guidance is included directly within the main changelog body for a clearer reading experience.
  * Internal notes, communications, and planning details remain excluded from displayed changelog content.
  * Unmatched internal markers now correctly hide all subsequent content from public changelogs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->