### PR TITLE
chore(self-hosted): remove em-dashes

### DIFF
--- a/docker/tests/test-s3-backend.sh
+++ b/docker/tests/test-s3-backend.sh
@@ -4,7 +4,7 @@
 #
 # Validates that the S3-compatible backend (MinIO, RustFS, etc.) handles
 # all S3 operations that Storage relies on. Uses the aws cli so the test
-# is backend-agnostic — no vendor-specific tools required.
+# is backend-agnostic - no vendor-specific tools required.
 #
 # Usage:
 #   sh test-s3-backend.sh                   # Uses localhost:9100

--- a/docker/tests/test-s3-backend.sh
+++ b/docker/tests/test-s3-backend.sh
@@ -82,7 +82,7 @@ s3() {
 }
 
 # Wrapper for jq that yields empty output instead of aborting the suite when
-# the payload is not JSON — an S3 error document, say — and jq exits non-zero.
+# the payload is not JSON (e.g. an S3 error document) and jq exits non-zero.
 jq_r() {
     jq -r "$@" 2>/dev/null || true
 }

--- a/docker/tests/test-s3.sh
+++ b/docker/tests/test-s3.sh
@@ -3,7 +3,7 @@
 # Test S3 protocol endpoint for self-hosted Supabase Storage.
 #
 # Verifies that the S3-compatible endpoint at /storage/v1/s3 works with
-# standard S3 clients — the same way end users interact with it via
+# standard S3 clients - the same way end users interact with it via
 # aws cli, rclone, or other S3-compatible tools.
 #
 # Usage:

--- a/docker/tests/test-s3.sh
+++ b/docker/tests/test-s3.sh
@@ -80,7 +80,7 @@ s3() {
 }
 
 # Wrapper for jq that yields empty output instead of aborting the suite when
-# the payload is not JSON — an S3 error document, say — and jq exits non-zero.
+# the payload is not JSON (e.g. an S3 error document) and jq exits non-zero.
 jq_r() {
     jq -r "$@" 2>/dev/null || true
 }

--- a/docker/tests/test-self-hosted.sh
+++ b/docker/tests/test-self-hosted.sh
@@ -167,7 +167,7 @@ else
     check "Create user (admin)" "true" "false"
 fi
 
-# Public signup (optional — depends on email autoconfirm setting)
+# Public signup (optional - depends on email autoconfirm setting)
 signup_email="smoke-signup-$$@example.com"
 signup_resp=$(http_body "$BASE_URL/auth/v1/signup" \
     -H "apikey: $ANON_KEY" \

--- a/docker/volumes/api/kong.yml
+++ b/docker/volumes/api/kong.yml
@@ -305,7 +305,7 @@ services:
             - anon
 
   ## Storage API endpoint (with Authorization header transformation).
-  ## No key-auth — S3 protocol requests don't carry an apikey header.
+  ## No key-auth - S3 protocol requests don't carry an apikey header.
   ##
   ## The request-transformer translates opaque API keys to asymmetric JWTs
   ## and passes through existing Authorization headers (user JWTs, AWS SigV4).


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Removes em-dashes from comments in self-hosted utility scripts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability of S3 test scripts by capturing AWS command output, reporting the last AWS error line, and avoiding premature aborts on failures.
  * Added a safer `jq -r` helper to prevent suite failures when payloads are non-JSON or unexpected.
  * Updated presigned URL validation to tolerate `curl` non-zero exit statuses so tests can proceed.
* **Style**
  * Standardized dash punctuation/wording in comments across S3, self-hosted, and API configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->