### PR TITLE
docs: add Deployment & Branching cross-link on Database overview

### DIFF
--- a/apps/docs/data/content-listings/database.data.ts
+++ b/apps/docs/data/content-listings/database.data.ts
@@ -86,5 +86,11 @@ export const databaseNextSteps: ContentListingGroup = {
       href: '/guides/database/postgres/roles',
       description: 'The Postgres roles Supabase ships with and how to add your own.',
     },
+    {
+      title: 'Deployment & Branching',
+      href: '/guides/deployment',
+      description:
+        'Preview environments, branching, migrations, and production readiness for your database changes.',
+    },
   ],
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Adds a cross-link from the Database overview's "Next steps" section to the Deployment & Branching guide, so readers who land on Database looking for Branching docs can find them without guessing at top-level nav.

Closes DOCS-1263.

## What is the current behavior?

- Linear item: [DOCS-1263](https://linear.app/supabase/issue/DOCS-1263/add-deployment-and-branching-cross-link-on-database-overview-next)
- User feedback: someone looking for Branching docs expected them under Products → Database. The canonical docs live under Build → Deployment & Branching (`/guides/deployment`, with Branching at `/guides/deployment/branching`). That placement stays correct (it's a preview/deploy workflow, not a Database product guide) — the miss is that Database overview's "Next steps" grid has no link out to it.

## What is the new behavior?

- Added a "Deployment & Branching" card to `databaseNextSteps` in `apps/docs/data/content-listings/database.data.ts`, linking to `/guides/deployment` (the Deployment & Branching hub, not a Branching-only link)
- No nav changes, no URL redirects, no Features sidebar work

## Additional context

- Worktree: `~/GitHub/supabase/supabase-worktrees/nrichers/docs-1263-add-deployment-branching-cross-link-on-database-overview`
- Change is a single data-file addition (`databaseNextSteps` array), rendered on `/guides/database/overview` via `<ContentListings id="database-next-steps" />`
- Verification: reviewed diff for correct schema shape (matches existing `ContentListingGroup` items, e.g. the existing cross-product `Backups` → `/guides/platform/backups` entry)

### Proof: Database overview "Next steps" now links out to Deployment & Branching

**Verified:** docs preview deploy (pass) · both URLs return `200` · new card renders next to "Roles and permissions" and links to `/guides/deployment`

### Before & After

| [Before (production)](https://supabase.com/docs/guides/database/overview)                                                                               | [After (PR preview)](https://docs-git-nikrichers-docs-1263-add-deployment-br-fd2915-supabase.vercel.app/docs/guides/database/overview)                |
| ------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
| ![Before](https://moijyfpvgnmgoxvwcikq.supabase.co/storage/v1/object/public/pr-proof/supabase/supabase/pr48509/database-next-steps-before-f719b4f6.png) | ![After](https://moijyfpvgnmgoxvwcikq.supabase.co/storage/v1/object/public/pr-proof/supabase/supabase/pr48509/database-next-steps-after-14b5ec5e.png) |

- **Before:** https://supabase.com/docs/guides/database/overview
- **After:** https://docs-git-nikrichers-docs-1263-add-deployment-br-fd2915-supabase.vercel.app/docs/guides/database/overview

### Test plan

- [x] Visit `/guides/database/overview` on the PR preview and confirm the "Next steps" grid shows a **Deployment & Branching** card
- [x] Confirm the card links to `/guides/deployment` (not `/guides/deployment/branching`)
- [x] Confirm no other Next steps cards, nav items, or redirects changed
