### PR TITLE
Replace disable pipelines cta with enable pipelines if pipelines not enabled yet

### DIFF
--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanel.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanel.tsx
@@ -28,7 +28,6 @@ import { ReadReplicaForm } from './ReadReplicaForm'
 import { DocsButton } from '@/components/ui/DocsButton'
 import { useReplicationDestinationsQuery } from '@/data/replication/destinations-query'
 import { checkLocalETLNotSetUp } from '@/data/replication/utils'
-import { useCheckEntitlements } from '@/hooks/misc/useCheckEntitlements'
 import { DOCS_URL } from '@/lib/constants'
 
 interface DestinationPanelProps {
@@ -38,7 +37,6 @@ interface DestinationPanelProps {
 export const DestinationPanel = ({ onSuccessCreateReadReplica }: DestinationPanelProps) => {
   const { ref: projectRef } = useParams()
   const enablePgReplicate = useIsETLPrivateAlpha()
-  const { hasAccess: hasETLReplicationAccess } = useCheckEntitlements('replication.etl')
   const { error: destinationsError } = useReplicationDestinationsQuery({ projectRef })
   const isLocalETLNotSetUp = checkLocalETLNotSetUp(destinationsError)
 
@@ -196,11 +194,7 @@ export const DestinationPanel = ({ onSuccessCreateReadReplica }: DestinationPane
               <div className="grow overflow-auto min-h-0">
                 {pipelinesTypeSelection}
                 <SheetSection>
-                  <EnablePipelinesCallout
-                    className="p-6!"
-                    type={destinationType}
-                    hasAccess={hasETLReplicationAccess}
-                  />
+                  <EnablePipelinesCallout className="p-6!" type={destinationType} />
                 </SheetSection>
               </div>
             ) : (

--- a/apps/studio/components/interfaces/Database/Replication/Destinations.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/Destinations.tsx
@@ -403,7 +403,7 @@ export const Destinations = () => {
 
       <EnablePipelinesModal
         open={showEnablePipelinesDialog}
-        setOpen={setShowEnablePipelinesDialog}
+        onOpenChange={setShowEnablePipelinesDialog}
       />
 
       <DisablePipelinesDialog

--- a/apps/studio/components/interfaces/Database/Replication/Destinations.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/Destinations.tsx
@@ -30,6 +30,7 @@ import { DestinationPanel } from './DestinationPanel/DestinationPanel'
 import { DestinationType } from './DestinationPanel/DestinationPanel.types'
 import { DestinationRow } from './DestinationRow'
 import { DisablePipelinesDialog } from './DisablePipelinesDialog'
+import { EnablePipelinesModal } from './EnablePipelinesCallout'
 import { ReadReplicaRow } from './ReadReplicas/ReadReplicaRow'
 import {
   useIsETLBigQueryPrivateAlpha,
@@ -86,6 +87,7 @@ export const Destinations = () => {
   const searchInputRef = useRef<HTMLInputElement>(null)
   const [filterString, setFilterString] = useState<string>('')
   const [statusRefetchInterval, setStatusRefetchInterval] = useState<number | false>(5000)
+  const [showEnablePipelinesDialog, setShowEnablePipelinesDialog] = useState(false)
   const [showDisablePipelinesDialog, setShowDisablePipelinesDialog] = useState(false)
 
   const [_, setDestinationType] = useQueryState(
@@ -157,6 +159,8 @@ export const Destinations = () => {
     () => sourcesData?.sources.find((source) => source.name === projectRef),
     [projectRef, sourcesData?.sources]
   )
+  const replicationNotEnabled = isSourcesSuccess && !externalReplicationSource
+
   const canDisablePipelines =
     isSourcesSuccess &&
     isDestinationsSuccess &&
@@ -270,18 +274,24 @@ export const Destinations = () => {
                 </Link>
               </DropdownMenuItem>
               <DropdownMenuSeparator />
-              <DropdownMenuItemTooltip
-                disabled={canDisablePipelines}
-                tooltip={{
-                  content: {
-                    side: 'left',
-                    text: 'Remove all existing destinations before disabling Pipelines',
-                  },
-                }}
-                onClick={() => setShowDisablePipelinesDialog(true)}
-              >
-                Disable Pipelines
-              </DropdownMenuItemTooltip>
+              {replicationNotEnabled ? (
+                <DropdownMenuItem onClick={() => setShowEnablePipelinesDialog(true)}>
+                  Enable Pipelines
+                </DropdownMenuItem>
+              ) : (
+                <DropdownMenuItemTooltip
+                  disabled={!canDisablePipelines}
+                  tooltip={{
+                    content: {
+                      side: 'left',
+                      text: 'Remove all existing destinations before disabling Pipelines',
+                    },
+                  }}
+                  onClick={() => setShowDisablePipelinesDialog(true)}
+                >
+                  Disable Pipelines
+                </DropdownMenuItemTooltip>
+              )}
             </DropdownMenuContent>
           </DropdownMenu>
 
@@ -390,6 +400,11 @@ export const Destinations = () => {
       </div>
 
       <DestinationPanel onSuccessCreateReadReplica={() => setStatusRefetchInterval(5000)} />
+
+      <EnablePipelinesModal
+        open={showEnablePipelinesDialog}
+        setOpen={setShowEnablePipelinesDialog}
+      />
 
       <DisablePipelinesDialog
         open={showDisablePipelinesDialog}

--- a/apps/studio/components/interfaces/Database/Replication/DisablePipelinesDialog.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DisablePipelinesDialog.tsx
@@ -40,8 +40,12 @@ export const DisablePipelinesDialog = ({ open, setOpen }: DisablePipelinesDialog
     try {
       if (!projectRef) throw new Error('Project ref is required')
       await deleteReplicationTenant({ projectRef })
-    } catch (error: any) {
-      setError(error.message ?? 'An unknown error occurred')
+    } catch (error) {
+      setError(
+        error instanceof Error
+          ? error.message
+          : 'An unknown error occurred while disabling Pipelines'
+      )
       throw error
     }
   }
@@ -51,13 +55,13 @@ export const DisablePipelinesDialog = ({ open, setOpen }: DisablePipelinesDialog
       <AlertDialogContent size="small">
         <AlertDialogHeader>
           <AlertDialogTitle>Disable Pipelines</AlertDialogTitle>
-          <AlertDialogDescription className="space-y-2 text-sm">
-            <p>
+          <AlertDialogDescription className="flex flex-col gap-y-2 text-sm">
+            <span>
               This will remove the <code className="text-code-inline">etl</code> schema and all
               Pipelines-managed resources from your database. Data already written to destination
               systems is not deleted.
-            </p>
-            <p>Read replicas are not affected.</p>
+            </span>
+            <span>Read replicas are not affected.</span>
           </AlertDialogDescription>
         </AlertDialogHeader>
         {error && (

--- a/apps/studio/components/interfaces/Database/Replication/EnablePipelinesCallout.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/EnablePipelinesCallout.tsx
@@ -23,19 +23,20 @@ import { useCreateTenantSourceMutation } from '@/data/replication/create-tenant-
 import { useCheckEntitlements } from '@/hooks/misc/useCheckEntitlements'
 import { DOCS_URL } from '@/lib/constants'
 
+type EnablePipelinesModalProps =
+  | { open: boolean; onOpenChange: (open: boolean) => void }
+  | { open?: never; onOpenChange?: never }
+
 export const EnablePipelinesModal = ({
   open: extOpen,
-  setOpen: setExtOpen,
-}: {
-  open?: boolean
-  setOpen?: (val: boolean) => void
-}) => {
+  onOpenChange,
+}: EnablePipelinesModalProps) => {
   const { ref: projectRef } = useParams()
   const [_open, _setOpen] = useState(false)
 
   const open = extOpen ?? _open
-  const setOpen = setExtOpen ?? _setOpen
-  const hideTrigger = extOpen !== undefined && setExtOpen !== undefined
+  const setOpen = onOpenChange ?? _setOpen
+  const hideTrigger = extOpen !== undefined && onOpenChange !== undefined
 
   const { hasAccess } = useCheckEntitlements('replication.etl')
 

--- a/apps/studio/components/interfaces/Database/Replication/EnablePipelinesCallout.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/EnablePipelinesCallout.tsx
@@ -20,11 +20,24 @@ import { DocsButton } from '@/components/ui/DocsButton'
 import { InlineLink } from '@/components/ui/InlineLink'
 import { UpgradePlanButton } from '@/components/ui/UpgradePlanButton'
 import { useCreateTenantSourceMutation } from '@/data/replication/create-tenant-source-mutation'
+import { useCheckEntitlements } from '@/hooks/misc/useCheckEntitlements'
 import { DOCS_URL } from '@/lib/constants'
 
-const EnablePipelinesModal = () => {
+export const EnablePipelinesModal = ({
+  open: extOpen,
+  setOpen: setExtOpen,
+}: {
+  open?: boolean
+  setOpen?: (val: boolean) => void
+}) => {
   const { ref: projectRef } = useParams()
-  const [open, setOpen] = useState(false)
+  const [_open, _setOpen] = useState(false)
+
+  const open = extOpen ?? _open
+  const setOpen = setExtOpen ?? _setOpen
+  const hideTrigger = extOpen !== undefined && setExtOpen !== undefined
+
+  const { hasAccess } = useCheckEntitlements('replication.etl')
 
   const { mutate: createTenantSource, isPending: creatingTenantSource } =
     useCreateTenantSourceMutation({
@@ -44,12 +57,14 @@ const EnablePipelinesModal = () => {
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>
-        <Button variant="primary" className="w-min">
-          Enable Pipelines
-        </Button>
-      </DialogTrigger>
-      <DialogContent>
+      {!hideTrigger && (
+        <DialogTrigger asChild>
+          <Button variant="primary" className="w-min">
+            Enable Pipelines
+          </Button>
+        </DialogTrigger>
+      )}
+      <DialogContent aria-describedby={undefined}>
         <DialogHeader>
           <DialogTitle>Enable Pipelines</DialogTitle>
         </DialogHeader>
@@ -60,27 +75,41 @@ const EnablePipelinesModal = () => {
             className="rounded-none border-0"
             title="Pipelines is currently in public alpha"
           >
-            <p className="text-sm leading-normal!">
-              Public alpha features may change as we refine the product and incorporate customer
-              feedback.
-            </p>
-            <p className="text-sm leading-normal!">
-              Pipelines is billed for configured pipeline hours and Postgres row data processed
-              during initial sync and ongoing replication. Review the{' '}
-              <InlineLink href={`${DOCS_URL}/guides/platform/manage-your-usage/pipelines`}>
-                Pipelines pricing
-              </InlineLink>{' '}
-              before enabling it.
-            </p>
+            {hasAccess ? (
+              <>
+                <p className="text-sm leading-normal!">
+                  Public alpha features may change as we refine the product and incorporate customer
+                  feedback.
+                </p>
+                <p className="text-sm leading-normal!">
+                  Pipelines is billed for configured pipeline hours and Postgres row data processed
+                  during initial sync and ongoing replication. Review the{' '}
+                  <InlineLink href={`${DOCS_URL}/guides/platform/manage-your-usage/pipelines`}>
+                    Pipelines pricing
+                  </InlineLink>{' '}
+                  before enabling it.
+                </p>
+              </>
+            ) : (
+              <p className="text-sm text-foreground-light">
+                Supabase Pipelines replicates database changes to supported destination systems.{' '}
+                {hasAccess ? 'Enable Pipelines for your project' : 'Upgrade to the Pro plan'} to
+                replicate database changes to data warehouses and analytics platforms.
+              </p>
+            )}
           </Admonition>
         </DialogSection>
         <DialogFooter>
           <Button variant="default" disabled={creatingTenantSource} onClick={() => setOpen(false)}>
             Cancel
           </Button>
-          <Button variant="primary" loading={creatingTenantSource} onClick={onEnablePipelines}>
-            Enable Pipelines
-          </Button>
+          {hasAccess ? (
+            <Button variant="primary" loading={creatingTenantSource} onClick={onEnablePipelines}>
+              Enable Pipelines
+            </Button>
+          ) : (
+            <UpgradePlanButton source="replication" featureProposition="use replication" />
+          )}
         </DialogFooter>
       </DialogContent>
     </Dialog>
@@ -90,12 +119,12 @@ const EnablePipelinesModal = () => {
 export const EnablePipelinesCallout = ({
   type,
   className,
-  hasAccess,
 }: {
   type?: DestinationType | null
   className?: string
-  hasAccess: boolean
 }) => {
+  const { hasAccess } = useCheckEntitlements('replication.etl')
+
   return (
     <div className={cn('border rounded-md p-4 md:p-12 flex flex-col gap-y-4', className)}>
       <div className="flex flex-col gap-y-1">


### PR DESCRIPTION
## Context

Addresses 2 issues found for the Replication UI

- "Disable Pipelines" CTA was still being shown despite Pipelines not being enabled yet
  - Opting to show the "Enable Pipelines" CTA instead in this case, which will open the `EnablePipelinesModal`
  <img width="269" height="162" alt="image" src="https://github.com/user-attachments/assets/41e5ec7d-11b1-4008-ae9d-64def00329eb" />
- Fixes "Disable Pipelines" being incorrectly disabled


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added options to enable or disable Pipelines directly from the replication destinations menu.
  * Added an enablement modal with messaging and upgrade actions based on available access.
  * Added support for opening the Pipelines modal through external controls.

* **Bug Fixes**
  * Corrected action disabled states and destination-removal guidance.
  * Improved error handling when disabling Pipelines, including a reliable fallback message.
  * Refined modal and dialog layout spacing for a more consistent presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->