### PR TITLE
fix sheets stealing focus

### DIFF
--- a/apps/studio/components/interfaces/Auth/CustomAuthProviders/CreateOrUpdateCustomProviderSheet.tsx
+++ b/apps/studio/components/interfaces/Auth/CustomAuthProviders/CreateOrUpdateCustomProviderSheet.tsx
@@ -250,12 +250,7 @@ export const CreateOrUpdateCustomProviderSheet = ({
 
   return (
     <Sheet open={visible} onOpenChange={handleOpenChange}>
-      <SheetContent
-        size="lg"
-        showClose={false}
-        className="flex flex-col gap-0"
-        tabIndex={undefined}
-      >
+      <SheetContent size="lg" showClose={false} className="flex flex-col gap-0">
         <SheetHeader>
           <div className="flex flex-row gap-3 items-center">
             <SheetClose

--- a/apps/studio/components/interfaces/Auth/OAuthApps/CreateOrUpdateOAuthAppSheet.tsx
+++ b/apps/studio/components/interfaces/Auth/OAuthApps/CreateOrUpdateOAuthAppSheet.tsx
@@ -258,7 +258,6 @@ export const CreateOrUpdateOAuthAppSheet = ({
           size="lg"
           showClose={false}
           className="flex flex-col gap-0"
-          tabIndex={undefined}
           aria-describedby={undefined}
         >
           <SheetHeader>

--- a/apps/studio/components/interfaces/ConnectSheet/ConnectSheet.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/ConnectSheet.tsx
@@ -162,7 +162,6 @@ export const ConnectSheet = () => {
       <SheetContent
         size="lg"
         className="flex w-full min-w-0 flex-col gap-0 space-y-0 p-0 max-w-4xl"
-        tabIndex={undefined}
       >
         <SheetHeader className={cn('text-left border-b shrink-0 py-6 px-8')}>
           <SheetTitle>Connect to your project</SheetTitle>

--- a/apps/studio/components/interfaces/Integrations/Queues/CreateQueueSheet/CreateQueueSheet.tsx
+++ b/apps/studio/components/interfaces/Integrations/Queues/CreateQueueSheet/CreateQueueSheet.tsx
@@ -109,7 +109,7 @@ export const CreateQueueSheet = ({ visible, onClose }: CreateQueueSheetProps) =>
 
   return (
     <Sheet open={visible} onOpenChange={handleOpenChange}>
-      <SheetContent size="default" className="w-[35%]" tabIndex={undefined}>
+      <SheetContent size="default" className="w-[35%]">
         <div className="flex flex-col h-full" tabIndex={-1}>
           <SheetHeader>
             <SheetTitle>Create a new queue</SheetTitle>

--- a/apps/studio/components/interfaces/Integrations/Wrappers/OverviewTab.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/OverviewTab.tsx
@@ -60,7 +60,7 @@ const WrapperOverviewContent = () => {
 
       {!!CreateWrapperSheetComponent && !!wrapperMeta && (
         <Sheet open={!!createWrapperShown} onOpenChange={handleOpenChange}>
-          <SheetContent size="lg" tabIndex={undefined}>
+          <SheetContent size="lg">
             <CreateWrapperSheetComponent
               wrapperMeta={wrapperMeta}
               onDirty={setIsDirty}

--- a/apps/studio/components/interfaces/Integrations/Wrappers/WrapperTable.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/WrapperTable.tsx
@@ -110,7 +110,7 @@ export const WrapperTable = ({ isLatest = false }: WrapperTableProps) => {
           if (!open) setIsClosingEditWrapper(true)
         }}
       >
-        <SheetContent size="lg" tabIndex={undefined}>
+        <SheetContent size="lg">
           {selectedWrapperToEdit && (
             <EditWrapperSheet
               wrapper={selectedWrapperToEdit}

--- a/apps/studio/components/interfaces/Integrations/Wrappers/WrappersTab.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/WrappersTab.tsx
@@ -84,7 +84,7 @@ export const WrappersTab = () => {
       )}
 
       <Sheet open={!!isCreating} onOpenChange={handleOpenChange}>
-        <SheetContent size="lg" tabIndex={undefined}>
+        <SheetContent size="lg">
           {wrapperMeta && (
             <CreateWrapperSheet
               wrapperMeta={wrapperMeta}

--- a/apps/studio/components/interfaces/Integrations/templates/StripeSyncEngine/OverviewTab.tsx
+++ b/apps/studio/components/interfaces/Integrations/templates/StripeSyncEngine/OverviewTab.tsx
@@ -248,7 +248,7 @@ const StripeSyncContent = ({ hideInstallCTA = false }: { hideInstallCTA?: boolea
       )}
 
       <Sheet open={!!shouldShowInstallSheet} onOpenChange={handleCloseInstallSheet}>
-        <SheetContent size="lg" tabIndex={undefined} className="flex flex-col gap-0">
+        <SheetContent size="lg" className="flex flex-col gap-0">
           <Form {...form}>
             <form
               id={formId}

--- a/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
+++ b/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
@@ -411,12 +411,7 @@ export function LogDrainDestinationSheetForm({
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent
-        tabIndex={undefined}
-        showClose={false}
-        size="lg"
-        className="overflow-y-auto flex flex-col"
-      >
+      <SheetContent showClose={false} size="lg" className="overflow-y-auto flex flex-col">
         <SheetHeader>
           <SheetTitle>Add destination</SheetTitle>
         </SheetHeader>

--- a/apps/studio/components/interfaces/Storage/VectorBuckets/VectorBucketDetails/VectorBucketTableExamplesSheet.tsx
+++ b/apps/studio/components/interfaces/Storage/VectorBuckets/VectorBucketDetails/VectorBucketTableExamplesSheet.tsx
@@ -62,7 +62,7 @@ export const VectorBucketTableExamplesSheet = ({ index }: VectorBucketTableExamp
           Insert vectors
         </Button>
       </SheetTrigger>
-      <SheetContent tabIndex={undefined}>
+      <SheetContent>
         <div className="flex flex-col h-full" tabIndex={-1}>
           <SheetHeader>
             <SheetTitle>

--- a/packages/ui/src/components/shadcn/ui/sheet.test.tsx
+++ b/packages/ui/src/components/shadcn/ui/sheet.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { Sheet, SheetContent, SheetDescription, SheetTitle } from './sheet'
+
+const TestSheet = ({ tabIndex }: { tabIndex?: number }) => {
+  const tabIndexProps = tabIndex === undefined ? {} : { tabIndex }
+
+  return (
+    <Sheet open>
+      <SheetContent {...tabIndexProps}>
+        <SheetTitle>Sheet title</SheetTitle>
+        <SheetDescription>Sheet description</SheetDescription>
+        <input aria-label="First field" />
+      </SheetContent>
+    </Sheet>
+  )
+}
+
+describe('SheetContent', () => {
+  it('focuses its first interactive child without making the sheet focusable', async () => {
+    render(<TestSheet />)
+
+    const sheet = screen.getByRole('dialog')
+    const input = screen.getByRole('textbox', { name: 'First field' })
+
+    await waitFor(() => expect(input).toHaveFocus())
+    expect(sheet).not.toHaveAttribute('tabindex')
+  })
+
+  it('allows the sheet to be made programmatically focusable explicitly', () => {
+    render(<TestSheet tabIndex={-1} />)
+
+    expect(screen.getByRole('dialog')).toHaveAttribute('tabindex', '-1')
+  })
+
+  it('does not move focus to the sheet when a focused child is removed', async () => {
+    const renderSheet = (showFirstButton: boolean) => (
+      <Sheet open>
+        <SheetContent>
+          <SheetTitle>Sheet title</SheetTitle>
+          <SheetDescription>Sheet description</SheetDescription>
+          {showFirstButton && <button>Remove me</button>}
+          <input aria-label="Remaining field" />
+        </SheetContent>
+      </Sheet>
+    )
+    const { rerender } = render(renderSheet(true))
+    const button = screen.getByRole('button', { name: 'Remove me' })
+
+    await waitFor(() => expect(button).toHaveFocus())
+    rerender(renderSheet(false))
+
+    await waitFor(() => expect(button).not.toBeInTheDocument())
+    await new Promise<void>((resolve) => queueMicrotask(resolve))
+    expect(screen.getByRole('dialog')).not.toHaveFocus()
+  })
+})

--- a/packages/ui/src/components/shadcn/ui/sheet.tsx
+++ b/packages/ui/src/components/shadcn/ui/sheet.tsx
@@ -174,6 +174,7 @@ const SheetContent = React.forwardRef<
     <SheetPrimitive.Content
       ref={ref}
       className={cn(sheetVariants({ side, size }), className)}
+      tabIndex={undefined}
       {...props}
     >
       {children}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix. Resolves DEPR-539.

## What is the current behavior?

When a focused child unmounts, Radix can move focus to the Sheet wrapper and break the expected tab order. Several callsites suppress the wrapper's tabindex individually.

## What is the new behavior?

Sheet still focuses its first interactive child when opened, but the wrapper itself is no longer focusable by default. Callers can opt in with an explicit `tabIndex` when needed.

## Additional context

### Testing

Compare this Studio experience on both this branch and `master`:

1. Open any project with an Edge Function.
2. Go to **Edge Functions**, open the function, then click **Test**.
3. Under **Headers**, click **Add Headers**. Click the first header key input, then Tab slowly through the header inputs and remove buttons.

On `master`, focus can jump to the whole Sheet. On this branch, focus stays on the controls in order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard focus behavior across sheets and panels.
  * Sheets now focus the first available interactive element when opened, without adding unnecessary focus targets.
  * Preserved support for programmatic focus and prevented focus from unexpectedly moving to the sheet when focused content is removed.
  * Updated authentication, integrations, connection, logging, storage, and other sheet interfaces consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->