### PR TITLE
fix(studio): confirm before discarding dirty replication destination forms

### DIFF
--- a/.claude/skills/react-hook-form/SKILL.md
+++ b/.claude/skills/react-hook-form/SKILL.md
@@ -235,6 +235,12 @@ schema, `onChange`, rendering, and the submit mapping.
 
 - Gate Save on `isDirty`; show Cancel only when dirty. In the owner, destructure
   from `form.formState`; anywhere else, `useFormState({ control })`.
+- When the form lives in a Sheet or Dialog, also wire dirty dismissal:
+  `useConfirmOnClose` + `DiscardChangesConfirmationDialog`. Route Cancel,
+  Escape, and backdrop through the guard; call the raw `onClose` on successful
+  submit so you do not prompt after save. Details:
+  `apps/design-system/content/docs/ui-patterns/modality.mdx` (Dirty form
+  dismissal) and the studio-ui-patterns skill Sheets section.
 - To show _which_ fields changed (review/summary dialogs), read `dirtyFields`
   from the same subscription instead of hand-comparing
   `defaultValues.x !== watchedX`. RHF already does that comparison correctly;

--- a/.claude/skills/studio-ui-patterns/SKILL.md
+++ b/.claude/skills/studio-ui-patterns/SKILL.md
@@ -125,6 +125,10 @@ Forms in sheets:
 
 - `layout="horizontal"` for wider sheets
 - `layout="vertical"` for narrow sheets (`size="sm"` or below)
+- When the sheet contains a form, wire dirty dismissal with `useConfirmOnClose` +
+  `DiscardChangesConfirmationDialog` (Cancel, Escape, and backdrop). Source of
+  truth: `apps/design-system/content/docs/ui-patterns/modality.mdx` (Dirty form
+  dismissal). Also see the react-hook-form skill for `isDirty` destructuring.
 
 ## Copy
 

--- a/apps/design-system/content/docs/ui-patterns/forms.mdx
+++ b/apps/design-system/content/docs/ui-patterns/forms.mdx
@@ -55,7 +55,7 @@ Build a custom row when the cells are mixed controls, such as an input paired wi
 
 4. **Use Cards for grouping**: Wrap form sections in `Card` components with `CardContent` and `CardFooter` for actions.
 
-5. **Handle dirty state**: Show cancel buttons and disable save buttons based on `form.formState.isDirty`. Make sure you destructure `isDirty` from `form.formState` (see https://react-hook-form.com/docs/useform/formstate)
+5. **Handle dirty state**: Show cancel buttons and disable save buttons based on `form.formState.isDirty`. Make sure you destructure `isDirty` from `form.formState` (see https://react-hook-form.com/docs/useform/formstate). When the form is in a dialog or sheet, also follow [Dirty form dismissal](./modality#dirty-form-dismissal) so Cancel, Escape, and backdrop ask before discarding unsaved changes.
 
 6. **Error handling**: Match feedback to its scope. Use `FormMessage` or `FieldError` for field validation. Show submission failures inline near the form actions when the user needs to retry or change something. Reserve toasts for non-blocking feedback or completed operations whose originating surface is no longer visible.
 

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/NewPublicationPanel.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/NewPublicationPanel.tsx
@@ -44,9 +44,9 @@ export const NewPublicationPanel = ({ visible, onClose }: NewPublicationPanelPro
     name: z.string().min(1, 'Name is required'),
     tables: z.array(z.string()).min(1, 'At least one table is required'),
   })
-  const defaultValues = {
+  const defaultValues: z.infer<typeof FormSchema> = {
     name: '',
-    tables: [] as string[],
+    tables: [],
   }
   const form = useForm<z.infer<typeof FormSchema>>({
     mode: 'onBlur',

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/NewPublicationPanel.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/NewPublicationPanel.tsx
@@ -20,10 +20,12 @@ import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { MultiSelector } from 'ui-patterns/multi-select'
 import { z } from 'zod'
 
+import { DiscardChangesConfirmationDialog } from '@/components/ui-patterns/Dialogs/DiscardChangesConfirmationDialog'
 import { useCreatePublicationMutation } from '@/data/replication/publication-create-mutation'
 import { useReplicationSourceId } from '@/data/replication/sources-query'
 import { useReplicationTablesQuery } from '@/data/replication/tables-query'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { useConfirmOnClose } from '@/hooks/ui/useConfirmOnClose'
 
 interface NewPublicationPanelProps {
   visible: boolean
@@ -37,15 +39,6 @@ export const NewPublicationPanel = ({ visible, onClose }: NewPublicationPanelPro
 
   const { data: tables } = useReplicationTablesQuery({ projectRef, sourceId }, { enabled: visible })
 
-  const { mutate: createPublication, isPending: creatingPublication } =
-    useCreatePublicationMutation({
-      onSuccess: (_, vars) => {
-        toast.success('Successfully created publication')
-        form.reset(defaultValues)
-        onClose(vars.name)
-      },
-    })
-
   const formId = 'publication-editor'
   const FormSchema = z.object({
     name: z.string().min(1, 'Name is required'),
@@ -53,7 +46,7 @@ export const NewPublicationPanel = ({ visible, onClose }: NewPublicationPanelPro
   })
   const defaultValues = {
     name: '',
-    tables: [],
+    tables: [] as string[],
   }
   const form = useForm<z.infer<typeof FormSchema>>({
     mode: 'onBlur',
@@ -61,6 +54,28 @@ export const NewPublicationPanel = ({ visible, onClose }: NewPublicationPanelPro
     resolver: zodResolver(FormSchema),
     defaultValues,
   })
+
+  // Always destructure formState values otherwise they won't be updated
+  // See https://react-hook-form.com/docs/useform/formstate
+  const { isDirty } = form.formState
+
+  const closePanel = (newPublication?: string) => {
+    form.reset(defaultValues)
+    onClose(newPublication)
+  }
+
+  const { confirmOnClose, handleOpenChange, modalProps } = useConfirmOnClose({
+    checkIsDirty: () => isDirty,
+    onClose: () => closePanel(),
+  })
+
+  const { mutate: createPublication, isPending: creatingPublication } =
+    useCreatePublicationMutation({
+      onSuccess: (_, vars) => {
+        toast.success('Successfully created publication')
+        closePanel(vars.name)
+      },
+    })
 
   const onSubmit = async (data: z.infer<typeof FormSchema>) => {
     if (!projectRef) return console.error('Project ref is required')
@@ -82,80 +97,83 @@ export const NewPublicationPanel = ({ visible, onClose }: NewPublicationPanelPro
   }
 
   return (
-    <Sheet open={visible} onOpenChange={() => onClose()}>
-      <SheetContent size="default">
-        <div className="flex flex-col h-full">
-          <SheetHeader>
-            <SheetTitle>Create a new publication</SheetTitle>
-            <SheetDescription>Choose which tables to replicate to destinations.</SheetDescription>
-          </SheetHeader>
-          <SheetSection className="grow overflow-auto">
-            <Form {...form}>
-              <form
-                id={formId}
-                onSubmit={form.handleSubmit(onSubmit)}
-                className="flex flex-col gap-y-4"
-              >
-                <FormField
-                  control={form.control}
-                  name="name"
-                  render={({ field }) => (
-                    <FormItemLayout label="Name" layout="vertical">
-                      <FormControl>
-                        <Input {...field} placeholder="Name" />
-                      </FormControl>
-                    </FormItemLayout>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="tables"
-                  render={({ field }) => (
-                    <FormItemLayout
-                      label="Tables"
-                      description="Select at least one table to include in the publication."
-                    >
-                      <FormControl>
-                        <MultiSelector
-                          values={field.value}
-                          onValuesChange={field.onChange}
-                          disabled={creatingPublication}
-                        >
-                          <MultiSelector.Trigger
-                            badgeLimit="wrap"
-                            label="Select tables..."
-                            mode="inline-combobox"
-                          />
-                          <MultiSelector.Content>
-                            <MultiSelector.List>
-                              {tables?.map((table) => (
-                                <MultiSelector.Item
-                                  key={`${table.schema}.${table.name}`}
-                                  value={`${table.schema}.${table.name}`}
-                                >
-                                  {`${table.schema}.${table.name}`}
-                                </MultiSelector.Item>
-                              ))}
-                            </MultiSelector.List>
-                          </MultiSelector.Content>
-                        </MultiSelector>
-                      </FormControl>
-                    </FormItemLayout>
-                  )}
-                />
-              </form>
-            </Form>
-          </SheetSection>
-          <SheetFooter>
-            <Button variant="default" disabled={creatingPublication} onClick={() => onClose()}>
-              Cancel
-            </Button>
-            <Button variant="primary" loading={creatingPublication} form={formId} type="submit">
-              Create publication
-            </Button>
-          </SheetFooter>
-        </div>
-      </SheetContent>
-    </Sheet>
+    <>
+      <Sheet open={visible} onOpenChange={handleOpenChange}>
+        <SheetContent size="default">
+          <div className="flex flex-col h-full">
+            <SheetHeader>
+              <SheetTitle>Create a new publication</SheetTitle>
+              <SheetDescription>Choose which tables to replicate to destinations.</SheetDescription>
+            </SheetHeader>
+            <SheetSection className="grow overflow-auto">
+              <Form {...form}>
+                <form
+                  id={formId}
+                  onSubmit={form.handleSubmit(onSubmit)}
+                  className="flex flex-col gap-y-4"
+                >
+                  <FormField
+                    control={form.control}
+                    name="name"
+                    render={({ field }) => (
+                      <FormItemLayout label="Name" layout="vertical">
+                        <FormControl>
+                          <Input {...field} placeholder="Name" />
+                        </FormControl>
+                      </FormItemLayout>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="tables"
+                    render={({ field }) => (
+                      <FormItemLayout
+                        label="Tables"
+                        description="Select at least one table to include in the publication."
+                      >
+                        <FormControl>
+                          <MultiSelector
+                            values={field.value}
+                            onValuesChange={field.onChange}
+                            disabled={creatingPublication}
+                          >
+                            <MultiSelector.Trigger
+                              badgeLimit="wrap"
+                              label="Select tables..."
+                              mode="inline-combobox"
+                            />
+                            <MultiSelector.Content>
+                              <MultiSelector.List>
+                                {tables?.map((table) => (
+                                  <MultiSelector.Item
+                                    key={`${table.schema}.${table.name}`}
+                                    value={`${table.schema}.${table.name}`}
+                                  >
+                                    {`${table.schema}.${table.name}`}
+                                  </MultiSelector.Item>
+                                ))}
+                              </MultiSelector.List>
+                            </MultiSelector.Content>
+                          </MultiSelector>
+                        </FormControl>
+                      </FormItemLayout>
+                    )}
+                  />
+                </form>
+              </Form>
+            </SheetSection>
+            <SheetFooter>
+              <Button variant="default" disabled={creatingPublication} onClick={confirmOnClose}>
+                Cancel
+              </Button>
+              <Button variant="primary" loading={creatingPublication} form={formId} type="submit">
+                Create publication
+              </Button>
+            </SheetFooter>
+          </div>
+        </SheetContent>
+      </Sheet>
+      <DiscardChangesConfirmationDialog {...modalProps} />
+    </>
   )
 }

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/index.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/index.tsx
@@ -426,7 +426,9 @@ export const DestinationForm = ({
   }, [checkIsDirtyRef, isDirty])
 
   useEffect(() => {
-    if (visible && !isDirty) {
+    // Reset when closed (including after discard) so reopening does not restore
+    // discarded values, and when open but pristine so async defaults can apply.
+    if (!visible || !isDirty) {
       form.reset(defaultValues)
       resetValidation()
     }

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/index.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/index.tsx
@@ -3,7 +3,7 @@ import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useParams } from 'common'
 import { AnimatePresence, motion } from 'framer-motion'
 import { Loader2 } from 'lucide-react'
-import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { useEffect, useMemo, useRef, useState, type MutableRefObject, type ReactNode } from 'react'
 import { useForm, useWatch } from 'react-hook-form'
 import { AWS_REGIONS } from 'shared-data'
 import { toast } from 'sonner'
@@ -83,7 +83,9 @@ interface DestinationFormProps {
   visible: boolean
   existingDestination?: ExistingDestination
   typeSelection?: ReactNode
+  checkIsDirtyRef?: MutableRefObject<() => boolean>
   onClose: () => void
+  onCancel?: () => void
 }
 
 export const DestinationForm = ({
@@ -91,7 +93,9 @@ export const DestinationForm = ({
   visible,
   existingDestination,
   typeSelection,
+  checkIsDirtyRef,
   onClose,
+  onCancel = onClose,
 }: DestinationFormProps) => {
   const { ref: projectRef } = useParams()
 
@@ -261,6 +265,10 @@ export const DestinationForm = ({
     defaultValues,
   })
 
+  // Always destructure formState values otherwise they won't be updated
+  // See https://react-hook-form.com/docs/useform/formstate
+  const { isDirty } = form.formState
+
   const publicationName = useWatch({ control: form.control, name: 'publicationName' })
 
   const publicationNames = useMemo(() => publications?.map((pub) => pub.name) ?? [], [publications])
@@ -409,11 +417,20 @@ export const DestinationForm = ({
   }
 
   useEffect(() => {
-    if (visible && !form.formState.isDirty) {
+    if (!checkIsDirtyRef) return
+
+    checkIsDirtyRef.current = () => isDirty
+    return () => {
+      checkIsDirtyRef.current = () => false
+    }
+  }, [checkIsDirtyRef, isDirty])
+
+  useEffect(() => {
+    if (visible && !isDirty) {
       form.reset(defaultValues)
       resetValidation()
     }
-  }, [visible, defaultValues, form, resetValidation])
+  }, [visible, defaultValues, form, isDirty, resetValidation])
 
   useEffect(() => {
     if (visible && projectRef && sourceId) {
@@ -567,7 +584,7 @@ export const DestinationForm = ({
           )}
         </AnimatePresence>
         <div className="flex items-center gap-x-2">
-          <Button disabled={isSaving} variant="default" onClick={onClose}>
+          <Button disabled={isSaving} variant="default" onClick={onCancel}>
             Cancel
           </Button>
           <Button disabled={isSubmitDisabled} loading={isSaving} form={formId} type="submit">

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/index.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/index.tsx
@@ -3,7 +3,7 @@ import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useParams } from 'common'
 import { AnimatePresence, motion } from 'framer-motion'
 import { Loader2 } from 'lucide-react'
-import { useEffect, useMemo, useRef, useState, type MutableRefObject, type ReactNode } from 'react'
+import { RefObject, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { useForm, useWatch } from 'react-hook-form'
 import { AWS_REGIONS } from 'shared-data'
 import { toast } from 'sonner'
@@ -83,7 +83,7 @@ interface DestinationFormProps {
   visible: boolean
   existingDestination?: ExistingDestination
   typeSelection?: ReactNode
-  checkIsDirtyRef?: MutableRefObject<() => boolean>
+  checkIsDirtyRef?: RefObject<() => boolean>
   onClose: () => void
   onCancel?: () => void
 }

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanel.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanel.tsx
@@ -2,7 +2,7 @@ import { useParams } from 'common'
 import { ArrowUpRight } from 'lucide-react'
 import Link from 'next/link'
 import { parseAsInteger, parseAsStringEnum, useQueryState } from 'nuqs'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { toast } from 'sonner'
 import {
   Button,
@@ -25,9 +25,11 @@ import { DestinationForm } from './DestinationForm'
 import { DestinationType } from './DestinationPanel.types'
 import { DestinationTypeSelection } from './DestinationTypeSelection'
 import { ReadReplicaForm } from './ReadReplicaForm'
+import { DiscardChangesConfirmationDialog } from '@/components/ui-patterns/Dialogs/DiscardChangesConfirmationDialog'
 import { DocsButton } from '@/components/ui/DocsButton'
 import { useReplicationDestinationsQuery } from '@/data/replication/destinations-query'
 import { checkLocalETLNotSetUp } from '@/data/replication/utils'
+import { useConfirmOnClose } from '@/hooks/ui/useConfirmOnClose'
 import { DOCS_URL } from '@/lib/constants'
 
 interface DestinationPanelProps {
@@ -88,10 +90,18 @@ export const DestinationPanel = ({ onSuccessCreateReadReplica }: DestinationPane
       }
     : undefined
 
+  const checkIsDirtyRef = useRef<() => boolean>(() => false)
+
   const onClose = () => {
+    checkIsDirtyRef.current = () => false
     setDestinationType(null)
     setEdit(null)
   }
+
+  const { confirmOnClose, handleOpenChange, modalProps } = useConfirmOnClose({
+    checkIsDirty: () => checkIsDirtyRef.current(),
+    onClose,
+  })
 
   const docsUrl =
     destinationType === 'BigQuery'
@@ -129,12 +139,7 @@ export const DestinationPanel = ({ onSuccessCreateReadReplica }: DestinationPane
 
   return (
     <>
-      <Sheet
-        open={visible}
-        onOpenChange={(open) => {
-          if (!open) onClose()
-        }}
-      >
+      <Sheet open={visible} onOpenChange={handleOpenChange}>
         <SheetContent size="lg" showClose={false} className="max-w-3xl">
           <div className="flex flex-col h-full min-h-0" tabIndex={-1}>
             <SheetHeader className="flex items-center justify-between">
@@ -155,7 +160,9 @@ export const DestinationPanel = ({ onSuccessCreateReadReplica }: DestinationPane
             {destinationType === 'Read Replica' ? (
               <ReadReplicaForm
                 typeSelection={typeSelection}
+                checkIsDirtyRef={checkIsDirtyRef}
                 onClose={onClose}
+                onCancel={confirmOnClose}
                 onSuccess={() => onSuccessCreateReadReplica?.()}
               />
             ) : !enablePgReplicate ? (
@@ -203,12 +210,15 @@ export const DestinationPanel = ({ onSuccessCreateReadReplica }: DestinationPane
                 selectedType={destinationType ?? 'Read Replica'}
                 existingDestination={existingDestination}
                 typeSelection={pipelinesTypeSelection}
+                checkIsDirtyRef={checkIsDirtyRef}
                 onClose={onClose}
+                onCancel={confirmOnClose}
               />
             )}
           </div>
         </SheetContent>
       </Sheet>
+      <DiscardChangesConfirmationDialog {...modalProps} />
     </>
   )
 }

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicaForm/index.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicaForm/index.tsx
@@ -1,5 +1,5 @@
 import { useParams } from 'common'
-import { useState, type ReactNode } from 'react'
+import { useEffect, useState, type MutableRefObject, type ReactNode } from 'react'
 import { AWS_REGIONS, AWS_REGIONS_KEYS } from 'shared-data'
 import { toast } from 'sonner'
 import {
@@ -25,11 +25,19 @@ import { AWS_REGIONS_DEFAULT, BASE_PATH } from '@/lib/constants'
 
 interface ReadReplicaFormProps {
   typeSelection?: ReactNode
+  checkIsDirtyRef?: MutableRefObject<() => boolean>
   onSuccess: () => void
   onClose: () => void
+  onCancel?: () => void
 }
 
-export const ReadReplicaForm = ({ typeSelection, onSuccess, onClose }: ReadReplicaFormProps) => {
+export const ReadReplicaForm = ({
+  typeSelection,
+  checkIsDirtyRef,
+  onSuccess,
+  onClose,
+  onCancel = onClose,
+}: ReadReplicaFormProps) => {
   const { ref: projectRef } = useParams()
   const { data } = useReadReplicasQuery({ projectRef })
 
@@ -39,6 +47,16 @@ export const ReadReplicaForm = ({ typeSelection, onSuccess, onClose }: ReadRepli
   const { can: canDeployReplica } = useCheckEligibilityDeployReplica()
 
   const [selectedRegion, setSelectedRegion] = useState<string>(defaultRegion)
+  const isDirty = selectedRegion !== defaultRegion
+
+  useEffect(() => {
+    if (!checkIsDirtyRef) return
+
+    checkIsDirtyRef.current = () => isDirty
+    return () => {
+      checkIsDirtyRef.current = () => false
+    }
+  }, [checkIsDirtyRef, isDirty])
 
   const { mutate: setUpReplica, isPending: isSettingUp } = useReadReplicaSetUpMutation({
     onSuccess: () => {
@@ -118,7 +136,7 @@ export const ReadReplicaForm = ({ typeSelection, onSuccess, onClose }: ReadRepli
         </div>
 
         <div className="flex items-center gap-x-2">
-          <Button disabled={isSettingUp} variant="default" onClick={onClose}>
+          <Button disabled={isSettingUp} variant="default" onClick={onCancel}>
             Cancel
           </Button>
           <Button disabled={!canDeployReplica} loading={isSettingUp} onClick={onSubmit}>

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicaForm/index.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicaForm/index.tsx
@@ -1,5 +1,5 @@
 import { useParams } from 'common'
-import { useEffect, useState, type MutableRefObject, type ReactNode } from 'react'
+import { RefObject, useEffect, useState, type ReactNode } from 'react'
 import { AWS_REGIONS, AWS_REGIONS_KEYS } from 'shared-data'
 import { toast } from 'sonner'
 import {
@@ -25,7 +25,7 @@ import { AWS_REGIONS_DEFAULT, BASE_PATH } from '@/lib/constants'
 
 interface ReadReplicaFormProps {
   typeSelection?: ReactNode
-  checkIsDirtyRef?: MutableRefObject<() => boolean>
+  checkIsDirtyRef?: RefObject<() => boolean>
   onSuccess: () => void
   onClose: () => void
   onCancel?: () => void


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (dirty form dismissal for Replication destination sheets), plus small docs/skill updates so agents pick up the existing modality pattern.

## What is the current behavior?

Closing the Add/Edit destination sheet (Cancel, Escape, or backdrop) discards in-progress form state with no confirm. Same for the nested Create publication sheet.

## What is the new behavior?

Dirty closes go through `useConfirmOnClose` + `DiscardChangesConfirmationDialog`, matching other Studio sheets. Successful submit still closes without prompting.

Also: skills + `forms.mdx` now point at Modality “Dirty form dismissal”.

| After |
| --- |
| <img width="1024" height="759" alt="Replication  Database  Chisel  Toolshed  Supabase" src="https://github.com/user-attachments/assets/6f568a2a-c76b-442a-b592-d638bb36adc4" /> |

### How to test

1. Studio → Database → Replication → **Add destination** (any pipelines type with access).
2. Change a field so the form is dirty.
3. Try Cancel, Escape, and backdrop click → discard dialog appears; **Keep editing** stays open; **Discard changes** closes.
4. Submit successfully with a valid config → sheet closes with no discard dialog.
5. Repeat for **Edit destination** from a destination row menu.
6. Optional: Add destination → create a new publication from the publication picker → dirty that nested sheet and dismiss the same way.
7. Optional: Add destination → Read Replica → change region → dismiss → discard dialog; deploy still closes without prompting.

## Additional context

Sheet owns the close guard; forms report dirty via a ref because RHF lives in the child. Nested `NewPublicationPanel` wires the guard locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added unsaved-changes tracking to replication destination and publication forms.
  - Added confirmation prompts before closing forms with unsaved changes via Cancel, Escape, or backdrop dismissal.
  - Forms now reset appropriately after successful submission or confirmed dismissal.

- **Documentation**
  - Updated form and UI pattern guidance to document dirty-form dismissal behavior for sheets and dialogs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->