### PR TITLE
feat: tos v3 update banner + publish subprocessor list

### DIFF
--- a/apps/studio/components/interfaces/App/AppBannerWrapper.tsx
+++ b/apps/studio/components/interfaces/App/AppBannerWrapper.tsx
@@ -9,7 +9,7 @@ import { BannerTOSUpdate } from '@/components/ui/BannerStack/Banners/BannerTOSUp
 import { useBannerStack } from '@/components/ui/BannerStack/BannerStackProvider'
 import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
 
-const TOSUpdateExpiry = new Date('2026-07-04T00:00:00Z')
+const TOSUpdateExpiry = new Date('2026-08-29T00:00:00Z')
 
 export const AppBannerWrapper = ({ children }: PropsWithChildren<{}>) => {
   const showNoticeBanner = useFlag('showNoticeBanner')

--- a/apps/studio/components/ui/BannerStack/Banners/BannerTOSUpdate.tsx
+++ b/apps/studio/components/ui/BannerStack/Banners/BannerTOSUpdate.tsx
@@ -19,11 +19,6 @@ import { BannerCard } from '../BannerCard'
 import { useBannerStack } from '../BannerStackProvider'
 import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
 
-/**
- * [Joshen] TOS update takes place from 6th June onwards, can remove from 4th July onwards as
- * previously stated in the NoticeBanner
- */
-
 export const BannerTOSUpdate = () => {
   const { dismissBanner } = useBannerStack()
   const [, setTOSUpdateAcknowledged] = useLocalStorageQuery(
@@ -44,9 +39,9 @@ export const BannerTOSUpdate = () => {
         </Badge>
 
         <div className="flex flex-col gap-y-1 mb-2">
-          <p className="text-sm font-medium">We've updated our Terms of Service</p>
+          <p className="text-sm font-medium">We're updating our Terms of Service</p>
           <p className="text-xs text-foreground-lighter text-balance">
-            Updates define the responsibilities of both you and Supabase in the use of AI.
+            Our Data Processing Addendum is now built into the Terms, effective August 1, 2026.
           </p>
         </div>
         <UpdatedTermsOfServiceDialog />
@@ -72,37 +67,46 @@ const UpdatedTermsOfServiceDialog = () => {
         <DialogHeader>
           <DialogTitle>Terms of Service update</DialogTitle>
           <DialogDescription>
-            We've updated our Terms of Service to better define the responsibilities of both you and
-            Supabase in the use of AI.
+            We're updating our Terms of Service, effective August 1, 2026.
           </DialogDescription>
         </DialogHeader>
 
         <DialogSectionSeparator />
 
         <DialogSection className="text-sm flex flex-col gap-y-2">
-          <p>
-            We've clarified how we use AI in our customer support tooling, introduced guidelines for
-            the responsible use of AI by our users, and updated our indemnification terms to clarify
-            the allocation of responsibility for claims arising from AI-generated inputs and
-            outputs.
-          </p>
+          <p>What's changing:</p>
+
+          <ul className="list-disc pl-4 flex flex-col gap-y-2">
+            <li>
+              Our{' '}
+              <InlineLink href="https://supabase.com/legal/customer-resources/data-processing-addendum">
+                Data Processing Addendum
+              </InlineLink>{' '}
+              is now built into the Terms, so all customers get its protections automatically. No
+              separate signed DPA is needed.
+            </li>
+            <li>
+              Our subprocessor list now lives at{' '}
+              <InlineLink href="https://supabase.com/legal/customer-resources/subprocessor-list">
+                supabase.com/legal/customer-resources/subprocessor-list
+              </InlineLink>
+              , where you can subscribe to receive updates to the list.
+            </li>
+            <li>
+              We've added provisions to our fees section relevant to fraud prevention and the rights
+              of EU and UK consumers.
+            </li>
+          </ul>
 
           <p>
-            Additionally, we've made an explicit commitment that Supabase will never use the data
-            you submit to the Supabase services to train or improve any AI without your prior
-            written consent.
-          </p>
-
-          <p>
-            The updated Terms (Version 2) will take effect on June 6, 2026. By continuing to use the
+            The updated Terms (Version 3) take effect on August 1, 2026. By continuing to use the
             Services after that date, you agree to the updated Terms. You can review the changes{' '}
             <InlineLink href="https://supabase.com/terms">here</InlineLink>.
           </p>
 
           <p>
-            This notice applies to users on Supabase's standard Terms of Service only. If you are on
-            an Enterprise plan or with a separately negotiated agreement, your existing terms
-            continue to govern your use of the Services.
+            If you have a separate signed subscription agreement or DPA with us, that agreement
+            continues to govern your use of our Services.
           </p>
         </DialogSection>
 

--- a/apps/www/pages/legal/customer-resources/subprocessor-list.tsx
+++ b/apps/www/pages/legal/customer-resources/subprocessor-list.tsx
@@ -26,14 +26,10 @@ const meta = {
   description: 'The list of third-party sub-processors Supabase uses to provide its services.',
 }
 
-// NOTE: This page is intentionally HIDDEN for now — it is not linked from the Legal Hub
-// index (`pages/legal/index.tsx`) or any navigation. It is also marked noindex/nofollow
-// so search engines do not index it while it is in draft. Remove `noindex`/`nofollow` and
-// add a link from the Legal Hub index when Legal is ready to publish it.
 export default function SubprocessorListPage() {
   return (
     <DefaultLayout>
-      <NextSeo {...meta} noindex nofollow />
+      <NextSeo {...meta} />
       <PageHeader
         breadcrumb={
           <PageBreadcrumb

--- a/apps/www/pages/legal/index.tsx
+++ b/apps/www/pages/legal/index.tsx
@@ -21,6 +21,11 @@ const sections = [
         type: 'document' as const,
       },
       {
+        label: 'Subprocessor List',
+        href: '/legal/customer-resources/subprocessor-list',
+        type: 'document' as const,
+      },
+      {
         label: 'Support Policy',
         href: '/support-policy',
         type: 'document' as const,

--- a/e2e/studio/utils/test.ts
+++ b/e2e/studio/utils/test.ts
@@ -26,7 +26,7 @@ export const test = base.extend<TestOptions>({
         `table-editor-queue-operations-banner-dismissed-${ref}`,
         JSON.stringify(true)
       )
-      localStorage.setItem(`terms-of-service-update-2026-06-06`, JSON.stringify(true))
+      localStorage.setItem(`terms-of-service-update-2026-08-01`, JSON.stringify(true))
     }, ref)
     await use(page)
   },

--- a/packages/common/constants/local-storage.ts
+++ b/packages/common/constants/local-storage.ts
@@ -71,7 +71,7 @@ export const LOCAL_STORAGE_KEYS = {
   GITHUB_AUTHORIZATION_STATE: 'supabase-github-authorization-state',
   // Notice banner keys
   API_KEYS_FEEDBACK_DISMISSED: (ref: string) => `supabase-api-keys-feedback-dismissed-${ref}`,
-  TERMS_OF_SERVICE_UPDATE: 'terms-of-service-update-2026-06-06',
+  TERMS_OF_SERVICE_UPDATE: 'terms-of-service-update-2026-08-01',
   SUPAVISOR_MAINTENANCE: (ref: string) => `supavisor-maintenance-2026-06-09-${ref}`,
   REPORT_DATERANGE: 'supabase-report-daterange',
   PROJECT_PAUSING_STARTED_AT: (ref: string) => `supabase-project-pausing-started-at-${ref}`,


### PR DESCRIPTION
Terms of Service v3 (effective August 1, 2026, #48482) incorporates the Data Processing Addendum by reference, and Legal asked for an in-app notice announcing the change. The subprocessor list page that the new Terms, DPA, and notice all point at was merged as an intentionally hidden draft (#48100) and never un-hidden.

**Changed:**

- **Dashboard ToS-update banner**: re-enables `BannerTOSUpdate` with the v3 copy provided by Legal (DPA incorporation, subprocessor list location, fees provisions). New expiry (August 29) and a new localStorage key, since anyone who dismissed the May v2 banner would otherwise never see this one.
- **Subprocessor list page published**: removes `noindex,nofollow` and links the page from the Legal Hub index, so the page customers are told to subscribe on is actually discoverable.
- **Studio e2e fixture updated**: the global Playwright fixture suppressed the banner via the old localStorage key; with the gate live again it would have rendered the banner into every e2e run. It now sets the new key.

## To test

Verified on the Vercel previews :

- [x] Studio: banner renders on dashboard load with the Notice badge and new copy; Learn more dialog shows the three changes with correct hrefs (DPA page, subprocessor list, /terms); Understood dismisses and persists across reload via `terms-of-service-update-2026-08-01`
- [x] www: `/legal` lists Subprocessor List under Customer Legal Resources; `/legal/customer-resources/subprocessor-list` serves `robots` meta `index,follow` and renders the download button + subscribe form; zero console errors on all tested pages

## Linear

- fixes GROWTH-1067


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a publicly accessible Subprocessor List to the legal resources.
  * Updated the Terms of Service notice to reflect the August 1, 2026 update, including data processing, subprocessors, fraud prevention, and consumer provisions.

* **Documentation**
  * Made the Subprocessor List discoverable through standard search indexing and the legal resources page.
  * Extended the Terms of Service banner availability through August 29, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->