### PR TITLE
feat(www): rate limit submit-form endpoints

### DIFF
--- a/apps/www/app/api-v2/submit-form-apply-to-supasquad/route.test.ts
+++ b/apps/www/app/api-v2/submit-form-apply-to-supasquad/route.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { POST } from './route'
+
+vi.mock('server-only', () => ({}))
+vi.mock('~/lib/notion', () => ({ insertPageInDatabase: vi.fn() }))
+vi.mock('~/data/open-source/contributing/supasquad.utils', () => ({
+  supaSquadApplicationSchema: {
+    safeParse: () => ({ success: false, error: { flatten: () => ({}) } }),
+  },
+}))
+vi.mock('@sentry/nextjs', () => ({
+  getDefaultIntegrations: () => [],
+  NodeClient: class {},
+  makeNodeTransport: vi.fn(),
+  defaultStackParser: [],
+  Scope: class {
+    setClient() {}
+    captureException() {}
+  },
+}))
+
+const makeRequest = (ip: string) =>
+  new Request('http://localhost/api-v2/submit-form-apply-to-supasquad', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-forwarded-for': ip },
+    body: JSON.stringify({}),
+  })
+
+describe('submit-form-apply-to-supasquad rate limiting', () => {
+  it('returns 429 on the sixth request in a window from one ip', async () => {
+    for (let i = 0; i < 5; i++) {
+      const res = await POST(makeRequest('203.0.113.9'))
+      expect(res.status).not.toBe(429)
+    }
+    const res = await POST(makeRequest('203.0.113.9'))
+    expect(res.status).toBe(429)
+  })
+})

--- a/apps/www/app/api-v2/submit-form-apply-to-supasquad/route.test.ts
+++ b/apps/www/app/api-v2/submit-form-apply-to-supasquad/route.test.ts
@@ -2,6 +2,11 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { POST } from './route'
 
+vi.hoisted(() => {
+  process.env.NOTION_SUPASQUAD_API_KEY = 'test-key'
+  process.env.NOTION_SUPASQUAD_APPLICATIONS_DB_ID = 'test-db'
+})
+
 vi.mock('server-only', () => ({}))
 vi.mock('~/lib/notion', () => ({ insertPageInDatabase: vi.fn() }))
 vi.mock('~/data/open-source/contributing/supasquad.utils', () => ({
@@ -31,7 +36,7 @@ describe('submit-form-apply-to-supasquad rate limiting', () => {
   it('returns 429 on the sixth request in a window from one ip', async () => {
     for (let i = 0; i < 5; i++) {
       const res = await POST(makeRequest('203.0.113.9'))
-      expect(res.status).not.toBe(429)
+      expect(res.status).toBe(422)
     }
     const res = await POST(makeRequest('203.0.113.9'))
     expect(res.status).toBe(429)

--- a/apps/www/app/api-v2/submit-form-apply-to-supasquad/route.tsx
+++ b/apps/www/app/api-v2/submit-form-apply-to-supasquad/route.tsx
@@ -1,12 +1,11 @@
 import * as Sentry from '@sentry/nextjs'
-
-import { CustomerioAppClient, CustomerioTrackClient } from '~/lib/customerio'
-import { insertPageInDatabase } from '~/lib/notion'
-
 import {
   SupaSquadApplication,
   supaSquadApplicationSchema,
 } from '~/data/open-source/contributing/supasquad.utils'
+import { CustomerioAppClient, CustomerioTrackClient } from '~/lib/customerio'
+import { insertPageInDatabase } from '~/lib/notion'
+import { createRateLimiter } from '~/lib/rate-limit'
 
 // Using a separate Sentry client for community following this guide:
 // https://docs.sentry.io/platforms/javascript/best-practices/multiple-sentry-instances/
@@ -59,7 +58,16 @@ function normalizeTrack(t: { heading: string; description: string } | string) {
   return trackName
 }
 
+const isRateLimited = createRateLimiter({ max: 5, windowMs: 60 * 1000 })
+
 export async function POST(req: Request) {
+  if (isRateLimited(req)) {
+    return new Response(JSON.stringify({ message: 'Too many requests. Try again later.' }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      status: 429,
+    })
+  }
+
   if (!NOTION_API_KEY || !NOTION_DB_ID) {
     captureSentryCommunityException(new Error('Server misconfigured: missing Notion credentials'))
     return new Response(

--- a/apps/www/app/api-v2/submit-form-contact-sales/route.tsx
+++ b/apps/www/app/api-v2/submit-form-contact-sales/route.tsx
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/nextjs'
+import { createRateLimiter } from '~/lib/rate-limit'
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -33,7 +34,16 @@ const isCompanyEmail = (email: string): boolean => {
   return true
 }
 
+const isRateLimited = createRateLimiter({ max: 5, windowMs: 60 * 1000 })
+
 export async function POST(req: Request) {
+  if (isRateLimited(req)) {
+    return new Response(JSON.stringify({ message: 'Too many requests. Try again later.' }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      status: 429,
+    })
+  }
+
   const HUBSPOT_PORTAL_ID = process.env.HUBSPOT_PORTAL_ID
   const HUBSPOT_FORM_GUID = process.env.HUBSPOT_ENTERPRISE_FORM_GUID
 

--- a/apps/www/app/api-v2/submit-form-newsletter/route.tsx
+++ b/apps/www/app/api-v2/submit-form-newsletter/route.tsx
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/nextjs'
-
 import { CustomerioTrackClient } from '~/lib/customerio'
+import { createRateLimiter } from '~/lib/rate-limit'
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -13,9 +13,7 @@ const isValidEmail = (email: string): boolean => {
   return emailPattern.test(email)
 }
 
-const RATE_LIMIT_WINDOW = 60 * 1000 // 1 minute
-const RATE_LIMIT_MAX = 5
-const ipRequestMap = new Map<string, { count: number; resetAt: number }>()
+const isRateLimited = createRateLimiter({ max: 5, windowMs: 60 * 1000 })
 
 export async function OPTIONS() {
   return new Response(null, {
@@ -25,20 +23,11 @@ export async function OPTIONS() {
 }
 
 export async function POST(req: Request) {
-  const ip = req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'unknown'
-  const now = Date.now()
-  const entry = ipRequestMap.get(ip)
-
-  if (entry && now < entry.resetAt) {
-    if (entry.count >= RATE_LIMIT_MAX) {
-      return new Response(JSON.stringify({ message: 'Too many requests. Try again later.' }), {
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-        status: 429,
-      })
-    }
-    entry.count++
-  } else {
-    ipRequestMap.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW })
+  if (isRateLimited(req)) {
+    return new Response(JSON.stringify({ message: 'Too many requests. Try again later.' }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      status: 429,
+    })
   }
 
   let body: any

--- a/apps/www/app/api-v2/submit-form-security-newsletter/route.tsx
+++ b/apps/www/app/api-v2/submit-form-security-newsletter/route.tsx
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/nextjs'
-
 import { CustomerioTrackClient } from '~/lib/customerio'
+import { createRateLimiter } from '~/lib/rate-limit'
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -12,7 +12,16 @@ const isValidEmail = (email: string): boolean => {
   return emailPattern.test(email)
 }
 
+const isRateLimited = createRateLimiter({ max: 5, windowMs: 60 * 1000 })
+
 export async function POST(req: Request) {
+  if (isRateLimited(req)) {
+    return new Response(JSON.stringify({ message: 'Too many requests. Try again later.' }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      status: 429,
+    })
+  }
+
   const body = await req.json()
   const { firstName, lastName, email } = body
 

--- a/apps/www/app/api-v2/submit-form-sos2025-newsletter/route.tsx
+++ b/apps/www/app/api-v2/submit-form-sos2025-newsletter/route.tsx
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/nextjs'
+import { createRateLimiter } from '~/lib/rate-limit'
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -10,7 +11,16 @@ const isValidEmail = (email: string): boolean => {
   return emailPattern.test(email)
 }
 
+const isRateLimited = createRateLimiter({ max: 5, windowMs: 60 * 1000 })
+
 export async function POST(req: Request) {
+  if (isRateLimited(req)) {
+    return new Response(JSON.stringify({ message: 'Too many requests. Try again later.' }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      status: 429,
+    })
+  }
+
   const HUBSPOT_PORTAL_ID = process.env.HUBSPOT_PORTAL_ID
   const HUBSPOT_FORM_GUID = '721fc4aa-13eb-4c25-91be-4fe9b530bed1'
 

--- a/apps/www/app/api-v2/submit-form-subprocessor-updates/route.test.ts
+++ b/apps/www/app/api-v2/submit-form-subprocessor-updates/route.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { POST } from './route'
+
+vi.mock('server-only', () => ({}))
+vi.mock('@sentry/nextjs', () => ({ captureException: vi.fn() }))
+
+const makeRequest = (ip: string) =>
+  new Request('http://localhost/api-v2/submit-form-subprocessor-updates', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-forwarded-for': ip },
+    body: JSON.stringify({}),
+  })
+
+describe('submit-form-subprocessor-updates rate limiting', () => {
+  it('returns 429 on the sixth request in a window from one ip', async () => {
+    for (let i = 0; i < 5; i++) {
+      const res = await POST(makeRequest('203.0.113.7'))
+      expect(res.status).toBe(422)
+    }
+    const res = await POST(makeRequest('203.0.113.7'))
+    expect(res.status).toBe(429)
+  })
+
+  it('does not rate limit a different ip', async () => {
+    const res = await POST(makeRequest('203.0.113.8'))
+    expect(res.status).toBe(422)
+  })
+})

--- a/apps/www/app/api-v2/submit-form-subprocessor-updates/route.tsx
+++ b/apps/www/app/api-v2/submit-form-subprocessor-updates/route.tsx
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/nextjs'
-
 import { CustomerioTrackClient } from '~/lib/customerio'
+import { createRateLimiter } from '~/lib/rate-limit'
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -12,7 +12,16 @@ const isValidEmail = (email: string): boolean => {
   return emailPattern.test(email)
 }
 
+const isRateLimited = createRateLimiter({ max: 5, windowMs: 60 * 1000 })
+
 export async function POST(req: Request) {
+  if (isRateLimited(req)) {
+    return new Response(JSON.stringify({ message: 'Too many requests. Try again later.' }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      status: 429,
+    })
+  }
+
   const body = await req.json()
   const { firstName, lastName, email } = body
 

--- a/apps/www/app/api-v2/submit-form-talk-to-partnership/route.tsx
+++ b/apps/www/app/api-v2/submit-form-talk-to-partnership/route.tsx
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/nextjs'
+import { createRateLimiter } from '~/lib/rate-limit'
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -33,7 +34,16 @@ const isCompanyEmail = (email: string): boolean => {
   return true
 }
 
+const isRateLimited = createRateLimiter({ max: 5, windowMs: 60 * 1000 })
+
 export async function POST(req: Request) {
+  if (isRateLimited(req)) {
+    return new Response(JSON.stringify({ message: 'Too many requests. Try again later.' }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      status: 429,
+    })
+  }
+
   const HUBSPOT_PORTAL_ID = process.env.HUBSPOT_PORTAL_ID
   const HUBSPOT_FORM_GUID = process.env.HUBSPOT_PARTNERSHIP_FORM_GUID
 

--- a/apps/www/lib/rate-limit.test.ts
+++ b/apps/www/lib/rate-limit.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createRateLimiter } from './rate-limit'
+
+const makeRequest = (ip?: string) =>
+  new Request('http://localhost/test', {
+    method: 'POST',
+    headers: ip ? { 'x-forwarded-for': ip } : {},
+  })
+
+describe('createRateLimiter', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('allows up to max requests within the window', () => {
+    const isRateLimited = createRateLimiter({ max: 3, windowMs: 60_000 })
+    expect(isRateLimited(makeRequest('1.1.1.1'))).toBe(false)
+    expect(isRateLimited(makeRequest('1.1.1.1'))).toBe(false)
+    expect(isRateLimited(makeRequest('1.1.1.1'))).toBe(false)
+    expect(isRateLimited(makeRequest('1.1.1.1'))).toBe(true)
+  })
+
+  it('resets after the window elapses', () => {
+    const isRateLimited = createRateLimiter({ max: 1, windowMs: 60_000 })
+    expect(isRateLimited(makeRequest('1.1.1.1'))).toBe(false)
+    expect(isRateLimited(makeRequest('1.1.1.1'))).toBe(true)
+    vi.advanceTimersByTime(60_000)
+    expect(isRateLimited(makeRequest('1.1.1.1'))).toBe(false)
+  })
+
+  it('tracks ips independently', () => {
+    const isRateLimited = createRateLimiter({ max: 1, windowMs: 60_000 })
+    expect(isRateLimited(makeRequest('1.1.1.1'))).toBe(false)
+    expect(isRateLimited(makeRequest('2.2.2.2'))).toBe(false)
+  })
+
+  it('keys on the first hop of a multi-hop x-forwarded-for', () => {
+    const isRateLimited = createRateLimiter({ max: 1, windowMs: 60_000 })
+    expect(isRateLimited(makeRequest('1.1.1.1, 10.0.0.1'))).toBe(false)
+    expect(isRateLimited(makeRequest('1.1.1.1, 10.0.0.2'))).toBe(true)
+  })
+
+  it('buckets requests without x-forwarded-for together', () => {
+    const isRateLimited = createRateLimiter({ max: 1, windowMs: 60_000 })
+    expect(isRateLimited(makeRequest())).toBe(false)
+    expect(isRateLimited(makeRequest())).toBe(true)
+  })
+
+  it('keeps separate buckets per limiter instance', () => {
+    const a = createRateLimiter({ max: 1, windowMs: 60_000 })
+    const b = createRateLimiter({ max: 1, windowMs: 60_000 })
+    expect(a(makeRequest('1.1.1.1'))).toBe(false)
+    expect(b(makeRequest('1.1.1.1'))).toBe(false)
+  })
+})

--- a/apps/www/lib/rate-limit.test.ts
+++ b/apps/www/lib/rate-limit.test.ts
@@ -5,7 +5,7 @@ import { createRateLimiter } from './rate-limit'
 const makeRequest = (ip?: string) =>
   new Request('http://localhost/test', {
     method: 'POST',
-    headers: ip ? { 'x-forwarded-for': ip } : {},
+    headers: ip === undefined ? {} : { 'x-forwarded-for': ip },
   })
 
 describe('createRateLimiter', () => {
@@ -49,6 +49,22 @@ describe('createRateLimiter', () => {
     const isRateLimited = createRateLimiter({ max: 1, windowMs: 60_000 })
     expect(isRateLimited(makeRequest())).toBe(false)
     expect(isRateLimited(makeRequest())).toBe(true)
+  })
+
+  it('treats an empty x-forwarded-for like a missing one', () => {
+    const isRateLimited = createRateLimiter({ max: 1, windowMs: 60_000 })
+    expect(isRateLimited(makeRequest(''))).toBe(false)
+    expect(isRateLimited(makeRequest())).toBe(true)
+  })
+
+  it('sweeps expired entries once the map grows large', () => {
+    const isRateLimited = createRateLimiter({ max: 1, windowMs: 60_000 })
+    for (let i = 0; i <= 10_000; i++) {
+      isRateLimited(makeRequest(`10.0.${Math.floor(i / 256)}.${i % 256}`))
+    }
+    vi.advanceTimersByTime(60_000)
+    expect(isRateLimited(makeRequest('10.0.0.0'))).toBe(false)
+    expect(isRateLimited(makeRequest('10.0.0.0'))).toBe(true)
   })
 
   it('keeps separate buckets per limiter instance', () => {

--- a/apps/www/lib/rate-limit.ts
+++ b/apps/www/lib/rate-limit.ts
@@ -1,0 +1,17 @@
+export function createRateLimiter({ max, windowMs }: { max: number; windowMs: number }) {
+  const requests = new Map<string, { count: number; resetAt: number }>()
+
+  return function isRateLimited(req: Request): boolean {
+    const ip = req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'unknown'
+    const now = Date.now()
+    const entry = requests.get(ip)
+
+    if (!entry || now >= entry.resetAt) {
+      requests.set(ip, { count: 1, resetAt: now + windowMs })
+      return false
+    }
+
+    entry.count += 1
+    return entry.count > max
+  }
+}

--- a/apps/www/lib/rate-limit.ts
+++ b/apps/www/lib/rate-limit.ts
@@ -1,9 +1,20 @@
+const SWEEP_THRESHOLD = 10_000
+
 export function createRateLimiter({ max, windowMs }: { max: number; windowMs: number }) {
   const requests = new Map<string, { count: number; resetAt: number }>()
 
   return function isRateLimited(req: Request): boolean {
-    const ip = req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'unknown'
+    // Trusts the first x-forwarded-for hop: Vercel overwrites client-supplied
+    // values, so this stops being spoof-proof if another proxy fronts the app.
+    const ip = req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown'
     const now = Date.now()
+
+    if (requests.size > SWEEP_THRESHOLD) {
+      for (const [key, value] of requests) {
+        if (now >= value.resetAt) requests.delete(key)
+      }
+    }
+
     const entry = requests.get(ip)
 
     if (!entry || now >= entry.resetAt) {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Security hardening (rate limiting on public endpoints)

## What is the current behavior?

The unauthenticated POST routes under `apps/www/app/api-v2/submit-form-*` accept attacker-supplied input with shape validation only. The two subscribe routes (`submit-form-subprocessor-updates`, `submit-form-security-newsletter`) let anyone bulk-subscribe arbitrary third-party emails to Customer.io topics; the other form routes are equally unprotected writes (Notion page creation plus a transactional email on the supasquad route, CRM form submissions on the rest). Only `submit-form-newsletter` had a rate limiter, inlined in its handler. The www middleware matcher excludes `/api*`, so no middleware-level protection applies.

fixes GROWTH-1070

## What is the new behavior?

I extracted the newsletter route's per-IP in-memory limiter into a shared factory (`apps/www/lib/rate-limit.ts`) and wired it into all seven `submit-form-*` routes as the first statement of each POST handler: 5 requests per minute per IP (first `x-forwarded-for` hop), 429 with the existing response shape after that. Each route keeps its own bucket, so a flood on one form cannot lock users out of another. The newsletter route now uses the shared helper with identical behavior.

Known limitation, accepted deliberately: the limiter is in-memory per warm serverless instance, so enforcement is best-effort. A burst that fans out across N concurrent instances sees roughly N times the nominal 5/min before it bites, and distributed attacks are out of scope entirely. Escalation paths if abuse is observed: hCaptcha (plumbing already exists in `opt-out/[ref]`) or a shared-store limiter (new infra decision). Details in the Linear issue.

Tests: unit tests for the limiter (fake timers), plus route-level tests on the two structurally distinct handlers proving the guard runs before validation (6th request 429s while earlier ones fail validation and never reach any external service).

## Additional context

Local verification: `pnpm --filter www test` 80/80 passing, lint 0 errors with no new warnings on changed files, prettier clean. Local `tsc --noEmit` (TypeScript 7 preview) crashes with an internal compiler panic on unmodified master state in my environment, with zero type diagnostics emitted, so CI's typecheck is the authoritative gate for this PR.
