### PR TITLE
fix(www): restore redirects for old CLI guide URLs shadowed by the cli catch-all

### DIFF
--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -2941,6 +2941,29 @@ module.exports = [
     source: '/docs/guides/cli/managing-environments',
     destination: '/docs/guides/deployment/managing-environments',
   },
+  // These have to stay above the `/docs/guides/cli/:path*` catch-all below.
+  // Next matches redirects in order, so the catch-all would otherwise send
+  // them to `/docs/guides/local-development/cli/...`, which does not exist.
+  {
+    permanent: true,
+    source: '/docs/guides/cli/github-actions/:path*',
+    destination: '/docs/guides/deployment/ci/:path*',
+  },
+  {
+    permanent: true,
+    source: '/docs/guides/cli/github-action/:path*',
+    destination: '/docs/guides/deployment/ci/:path*',
+  },
+  {
+    permanent: true,
+    source: '/docs/guides/cli/cicd-workflow',
+    destination: '/docs/guides/deployment/managing-environments',
+  },
+  {
+    permanent: true,
+    source: '/docs/guides/cli/seeding-your-database',
+    destination: '/docs/guides/local-development/seeding-your-database',
+  },
   {
     permanent: true,
     source: '/docs/guides/cli/:path*',
@@ -2983,11 +3006,6 @@ module.exports = [
     permanent: true,
     source: '/docs/guides/platform/shared-responsibility-model',
     destination: '/docs/guides/deployment/shared-responsibility-model',
-  },
-  {
-    permanent: true,
-    source: '/docs/guides/cli/github-actions/:path*',
-    destination: '/docs/guides/deployment/ci/:path*',
   },
   {
     permanent: true,

--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -2977,6 +2977,29 @@ module.exports = [
     source: '/docs/guides/local-development/cli/managing-environments',
     destination: '/docs/guides/deployment/managing-environments',
   },
+  // Same reasoning as the entry above, for the paths the catch-all used to
+  // send people to. The old `/docs/guides/cli/:path*` rule was permanent, so
+  // browsers that already followed it have these dead targets cached.
+  {
+    permanent: false,
+    source: '/docs/guides/local-development/cli/github-actions/:path*',
+    destination: '/docs/guides/deployment/ci/:path*',
+  },
+  {
+    permanent: false,
+    source: '/docs/guides/local-development/cli/github-action/:path*',
+    destination: '/docs/guides/deployment/ci/:path*',
+  },
+  {
+    permanent: false,
+    source: '/docs/guides/local-development/cli/cicd-workflow',
+    destination: '/docs/guides/deployment/managing-environments',
+  },
+  {
+    permanent: false,
+    source: '/docs/guides/local-development/cli/seeding-your-database',
+    destination: '/docs/guides/local-development/seeding-your-database',
+  },
   {
     permanent: true,
     source: '/docs/guides/platform/branching',


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix (docs redirects).

## What is the current behavior?

Four old `/docs/guides/cli/*` URLs currently 404 instead of landing on the pages they moved to. They are still linked from published Supabase blog posts, so readers hit dead ends today:

| URL | linked from | currently lands on |
| --- | --- | --- |
| `/docs/guides/cli/seeding-your-database` | `2023-08-08-supabase-local-dev.mdx`, `2023-12-13-supabase-branching.mdx`, `2023-08-10-supabase-integrations-marketplace.mdx` | `/docs/guides/local-development/cli/seeding-your-database` (404) |
| `/docs/guides/cli/github-action/generating-types` | `2023-08-08-supabase-local-dev.mdx` | `/docs/guides/local-development/cli/github-action/generating-types` (404) |
| `/docs/guides/cli/github-action/testing` | `2023-08-08-supabase-local-dev.mdx` | `/docs/guides/local-development/cli/github-action/testing` (404) |
| `/docs/guides/cli/cicd-workflow` | `2022-08-15-supabase-cli-v1-and-admin-api-beta.mdx` | `/docs/guides/local-development/cli/cicd-workflow` (404) |

Root cause is redirect ordering in `apps/www/lib/redirects.js`. Next matches redirects in array order, and the catch-all

```js
{ source: '/docs/guides/cli/:path*', destination: '/docs/guides/local-development/cli/:path*' }
```

sits earlier in the array than

```js
{ source: '/docs/guides/cli/github-actions/:path*', destination: '/docs/guides/deployment/ci/:path*' }
```

so that second rule never runs. Anything under `/docs/guides/cli/` that did not move into `local-development/cli/` gets rewritten to a path that does not exist. That also means the existing `github-actions` rule is currently dead: `/docs/guides/cli/github-actions/generating-types` 404s too, even though the rule intends to send it to `/docs/guides/deployment/ci/generating-types`.

No linked issue, I found this while checking the docs links referenced across the repo.

## What is the new behavior?

Moved the existing `github-actions` rule above the catch-all so it can match, and added three sibling rules next to it for the old singular paths. Destinations are the current live pages:

- `/docs/guides/cli/github-actions/:path*` and `/docs/guides/cli/github-action/:path*` go to `/docs/guides/deployment/ci/:path*` ("Generate types using GitHub Actions", "Automated testing using GitHub Actions")
- `/docs/guides/cli/cicd-workflow` goes to `/docs/guides/deployment/managing-environments`, matching where the existing plural `cicd-workflows` rule already ends up
- `/docs/guides/cli/seeding-your-database` goes to `/docs/guides/local-development/seeding-your-database`

I did not touch the catch-all itself, so anything that legitimately moved into `local-development/cli/` is unaffected.

## Additional context

Root cause: `apps/www/lib/redirects.js`, the `/docs/guides/cli/:path*` catch-all and the `github-actions` rule that followed it.

Verified by resolving each path through the real exported array with `path-to-regexp`, the same way Next matches (first match wins, following the chain):

```
/docs/guides/cli/cicd-workflow                    -> /docs/guides/deployment/managing-environments
/docs/guides/cli/github-action/generating-types   -> /docs/guides/deployment/ci/generating-types
/docs/guides/cli/github-action/testing            -> /docs/guides/deployment/ci/testing
/docs/guides/cli/seeding-your-database            -> /docs/guides/local-development/seeding-your-database
/docs/guides/cli/github-actions/generating-types  -> /docs/guides/deployment/ci/generating-types

unchanged (regression check):
/docs/guides/cli/getting-started -> /docs/guides/local-development/cli/getting-started
/docs/guides/cli/config          -> /docs/guides/local-development/cli/config
/docs/guides/cli/unknown-page    -> /docs/guides/local-development/cli/unknown-page
```

All five destinations return 200 on the live docs site today, and the three control paths keep their existing behavior. I also confirmed the file still loads and that this adds no duplicate `source` entries (the four duplicates in the file already exist on master and are untouched).

Gates run locally: `test:prettier` passed repo wide, `lint --filter=www` passed with 0 errors, `typecheck` passed 15/15, and the www vitest suite passed 73/73.

One honest gap on the pre-flight build: `pnpm build --filter=www` cannot complete in my environment because it first runs the docs `build:federated-content` step, which exits with `DOCS_GITHUB_APP_PRIVATE_KEY environment variable is required`. That is a credential I do not have, and it fails before Next compiles, so it is unrelated to this change. The redirect resolution check above is what I used instead.

Apologies if I have misjudged any of the destinations, particularly `cicd-workflow`, where I matched the behavior of the existing plural rule rather than guessing something new. I worked through this with Claude Code's help and verified every path and status code myself. Freshman still learning my way around this repo, so I am very happy to adjust if you would rather these pointed somewhere else.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added permanent redirects for relocated CLI documentation pages, including GitHub Actions, CI/CD workflows, and database seeding.
  * Added redirects for equivalent legacy documentation paths.
  * Removed a duplicate redirect to ensure these documentation links resolve correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->