### PR TITLE
fix(www): point client library reference redirects at /introduction instead of dead /start

### DIFF
--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -2046,32 +2046,32 @@ module.exports = [
   {
     permanent: true,
     source: '/docs/reference/javascript',
-    destination: '/docs/reference/javascript/start',
+    destination: '/docs/reference/javascript/introduction',
   },
   {
     permanent: true,
     source: '/docs/reference/dart',
-    destination: '/docs/reference/dart/start',
+    destination: '/docs/reference/dart/introduction',
   },
   {
     permanent: true,
     source: '/docs/reference/python',
-    destination: '/docs/reference/python/start',
+    destination: '/docs/reference/python/introduction',
   },
   {
     permanent: true,
     source: '/docs/reference/csharp',
-    destination: '/docs/reference/csharp/start',
+    destination: '/docs/reference/csharp/introduction',
   },
   {
     permanent: true,
     source: '/docs/reference/swift',
-    destination: '/docs/reference/swift/start',
+    destination: '/docs/reference/swift/introduction',
   },
   {
     permanent: true,
     source: '/docs/reference/kotlin',
-    destination: '/docs/reference/kotlin/start',
+    destination: '/docs/reference/kotlin/introduction',
   },
   {
     permanent: true,


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix (docs redirects).

## What is the current behavior?

The bare reference landing URL for every client library 404s:

| URL | redirects to | result |
| --- | --- | --- |
| `/docs/reference/javascript` | `/docs/reference/javascript/start` | 404 |
| `/docs/reference/dart` | `/docs/reference/dart/start` | 404 |
| `/docs/reference/python` | `/docs/reference/python/start` | 404 |
| `/docs/reference/csharp` | `/docs/reference/csharp/start` | 404 |
| `/docs/reference/swift` | `/docs/reference/swift/start` | 404 |
| `/docs/reference/kotlin` | `/docs/reference/kotlin/start` | 404 |

Each of those six redirects in `apps/www/lib/redirects.js` sends the bare path to a `/start` page that no longer exists, so the redirect itself lands on a 404. These are commonly linked entry points, so anyone following `supabase.com/docs/reference/javascript` from outside the docs hits a dead page.

This is the bug @czenko called out while fixing the docs-side links in #48453:

> `/docs/reference/javascript`, `/docs/reference/dart`, `/docs/reference/kotlin`, `/docs/reference/python`, `/docs/reference/csharp` -> their `/introduction` pages (the redirect's own destination, `/start`, turned out to be dead even on production -- a separate bug in `redirects.js` I didn't touch here)

That PR repointed the links inside `apps/docs` to `/introduction`. This one fixes the redirect entries themselves, which still send external traffic to `/start`.

## What is the new behavior?

Those six destinations now point at `/introduction`, matching where #48453 pointed the in-repo links:

```
/docs/reference/javascript -> /docs/reference/javascript/introduction
```

and the same for dart, python, csharp, swift and kotlin.

I deliberately left the other five `/start` destinations in that block alone. `cli`, `api`, `self-hosting-auth`, `self-hosting-storage` and `self-hosting-realtime` all resolve fine today (bare, `/start` and `/introduction` all return 200), which matches @czenko's note that bare `/docs/reference/api` and `/docs/reference/cli` already work.

## Additional context

Root cause: `apps/www/lib/redirects.js`, the six client library entries around line 2048.

Status codes I measured on the live site before and after picking the destination:

```
ref                    bare   /start   /introduction
javascript             404    404      200
dart                   404    404      200
python                 404    404      200
csharp                 404    404      200
swift                  404    404      200
kotlin                 404    404      200
cli                    200    200      200   (left alone)
api                    200    200      200   (left alone)
self-hosting-auth      200    200      200   (left alone)
self-hosting-storage   200    200      200   (left alone)
self-hosting-realtime  200    200      200   (left alone)
```

I also resolved the paths through the real exported array with `path-to-regexp`, the same first-match-wins way Next does, to confirm the six now end at `/introduction` and that `cli` and `api` still resolve to their existing working `/start` pages. Entry count is unchanged at 666, since this only edits destination strings.

Gates run locally: `test:prettier` passed repo wide, `lint --filter=www` passed with 0 errors, `typecheck` passed 15/15, and the www vitest suite passed 73/73.

One honest note on the pre-flight build: `pnpm build --filter=www` cannot complete in my environment because it first runs the docs `build:federated-content` step, which exits with `DOCS_GITHUB_APP_PRIVATE_KEY environment variable is required`. That is a credential I do not have and it fails before Next compiles, so it is unrelated to this change.

One thing worth your call: these are `permanent: true`, so browsers that already cached the old 308 will keep going to `/start` until that cache clears. There is precedent in this file for adding a temporary non-permanent rule to rescue those users, like the `local-development/cli/managing-environments` entry. I did not add `/start` to `/introduction` rules because it would grow the diff and I did not want to assume, but I am happy to add them for the six libraries if you would like.

I found this while checking docs links across the repo, and verified every status code above myself with Claude Code's help. Freshman contributor, so if `/introduction` is not where you want these to land, just say and I will repoint them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated language reference page redirects for JavaScript, Dart, Python, C#, Swift, and Kotlin to lead to the correct Introduction pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->