### PR TITLE
docs: point renamed Auth and OAuth reference links at their current pages

### DIFF
--- a/apps/docs/content/guides/auth/auth-mfa/totp.mdx
+++ b/apps/docs/content/guides/auth/auth-mfa/totp.mdx
@@ -38,7 +38,7 @@ In the **login flow**, the user signs in (upgrading the session to AAL1) and the
 
 <Admonition type="note">
 
-[TOTP MFA API](/docs/reference/javascript/auth-mfa-api) is free to use and is enabled on all Supabase projects by default.
+[TOTP MFA API](/docs/reference/javascript/auth-mfa) is free to use and is enabled on all Supabase projects by default.
 
 </Admonition>
 

--- a/apps/docs/content/guides/auth/oauth-server/getting-started.mdx
+++ b/apps/docs/content/guides/auth/oauth-server/getting-started.mdx
@@ -637,7 +637,7 @@ Response:
 
 <Admonition type="note">
 
-For complete API documentation, see the [OAuth Admin API reference](/docs/reference/javascript/auth-admin-oauth-admin).
+For complete API documentation, see the [OAuth Admin API reference](/docs/reference/javascript/oauth-admin).
 
 </Admonition>
 

--- a/apps/docs/content/guides/auth/oauth-server/oauth-flows.mdx
+++ b/apps/docs/content/guides/auth/oauth-server/oauth-flows.mdx
@@ -849,7 +849,7 @@ It's a good practice to provide a settings page where users can view all authori
 
 </Admonition>
 
-For complete API reference, see the [OAuth methods in supabase-js](/docs/reference/javascript/auth-admin-oauth-server).
+For complete API reference, see the [OAuth methods in supabase-js](/docs/reference/javascript/oauth-server).
 
 ## Next steps
 

--- a/apps/docs/content/guides/auth/passkeys.mdx
+++ b/apps/docs/content/guides/auth/passkeys.mdx
@@ -403,7 +403,7 @@ let response = try await supabase.auth.verifyPasskeyAuthentication(
 
 The `options` field returned from the start methods matches the [WebAuthn `PublicKeyCredentialCreationOptions`](https://www.w3.org/TR/webauthn-3/#dictdef-publickeycredentialcreationoptions) and [`PublicKeyCredentialRequestOptions`](https://www.w3.org/TR/webauthn-3/#dictdef-publickeycredentialrequestoptions) shapes (with `ArrayBuffer` fields encoded as base64url).
 
-See the `auth.passkey` reference ([JavaScript](/docs/reference/javascript/auth-passkey-api) · [Dart](/docs/reference/dart/auth-passkey-api) · [Swift](/docs/reference/swift/auth-passkey-api)) for the full API.
+See the `auth.passkey` reference ([JavaScript](/docs/reference/javascript/auth-passkey) · [Dart](/docs/reference/dart/auth-passkey) · [Swift](/docs/reference/swift/auth-passkey-api)) for the full API.
 
 ## Manage passkeys
 
@@ -474,7 +474,7 @@ try await supabase.auth.deletePasskey(id: passkeys.first!.id)
 
 `friendlyName` is limited to 120 characters. `lastUsedAt` is updated each time the passkey is used to sign in.
 
-See the `auth.passkey` reference ([JavaScript](/docs/reference/javascript/auth-passkey-api) · [Dart](/docs/reference/dart/auth-passkey-api) · [Swift](/docs/reference/swift/auth-passkey-api)) for the full API.
+See the `auth.passkey` reference ([JavaScript](/docs/reference/javascript/auth-passkey) · [Dart](/docs/reference/dart/auth-passkey) · [Swift](/docs/reference/swift/auth-passkey-api)) for the full API.
 
 ## Admin API
 
@@ -520,7 +520,7 @@ await supabase.auth.admin.passkey.deletePasskey(
 </TabPanel>
 </Tabs>
 
-See the `auth.admin.passkey` reference ([JavaScript](/docs/reference/javascript/auth-admin-passkey-api) · [Dart](/docs/reference/dart/auth-admin-passkey-api)) for the full API. The Swift SDK does not expose admin passkey methods.
+See the `auth.admin.passkey` reference ([JavaScript](/docs/reference/javascript/passkey-admin) · [Dart](/docs/reference/dart/passkey-admin)) for the full API. The Swift SDK does not expose admin passkey methods.
 
 ## Error codes
 

--- a/apps/docs/content/guides/auth/password-security.mdx
+++ b/apps/docs/content/guides/auth/password-security.mdx
@@ -36,7 +36,7 @@ Leaked password protection is available on the Pro Plan and above.
 
 Users will need to be recently logged in to change their password without requiring reauthentication. (A user is considered recently logged in if the session was created within the last 24 hours.) If disabled, a user can change their password at any time.
 
-When enabled, a `nonce` will be sent to the user and this nonce must be validated before the a password change can occur. This can be triggered with the [reauthenticate()](/docs/reference/javascript/auth-reauthentication) API call.
+When enabled, a `nonce` will be sent to the user and this nonce must be validated before the a password change can occur. This can be triggered with the [reauthenticate()](/docs/reference/javascript/auth-reauthenticate) API call.
 
 ```
 const { error } = await supabase.auth.reauthenticate()

--- a/apps/docs/content/troubleshooting/database-error-saving-new-user-RU_EwB.mdx
+++ b/apps/docs/content/troubleshooting/database-error-saving-new-user-RU_EwB.mdx
@@ -52,7 +52,7 @@ error finding user: sql: Scan error on column index 8, name "confirmation_token"
 
 **Cause:**
 
-The `auth` schema is managed by Supabase and expects specific column formats. This error typically happens when users are inserted directly via SQL or using an AI tool that uses a direct SQL `INSERT`, rather than through the [Auth API](/docs/reference/javascript/auth-api). A direct insert can leave required columns as `NULL` when the Auth service expects an empty string.
+The `auth` schema is managed by Supabase and expects specific column formats. This error typically happens when users are inserted directly via SQL or using an AI tool that uses a direct SQL `INSERT`, rather than through the [Auth API](/docs/reference/javascript/auth). A direct insert can leave required columns as `NULL` when the Auth service expects an empty string.
 
 **Fix:**
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs fix (broken links).

## What is the current behavior?

Eleven links across six Auth guides point at JS and Dart reference pages that no longer exist, so "see the reference" links in the passkeys, MFA and OAuth server guides land on a 404:

| link | status |
| --- | --- |
| `/docs/reference/javascript/auth-api` | 404 |
| `/docs/reference/javascript/auth-mfa-api` | 404 |
| `/docs/reference/javascript/auth-passkey-api` | 404 |
| `/docs/reference/javascript/auth-admin-passkey-api` | 404 |
| `/docs/reference/javascript/auth-admin-oauth-admin` | 404 |
| `/docs/reference/javascript/auth-admin-oauth-server` | 404 |
| `/docs/reference/javascript/auth-reauthentication` | 404 |
| `/docs/reference/dart/auth-passkey-api` | 404 |
| `/docs/reference/dart/auth-admin-passkey-api` | 404 |

None of those slugs are in the docs sitemap any more. This is the same class of link rot @czenko fixed in #48453, so I followed that PR's approach and repointed the links rather than adding redirects.

## What is the new behavior?

Each link now points at the current page for the API the surrounding sentence is describing:

- `auth-api` to `auth`
- `auth-mfa-api` to `auth-mfa`
- `auth-passkey-api` to `auth-passkey`
- `auth-admin-passkey-api` to `passkey-admin`
- `auth-admin-oauth-admin` to `oauth-admin`
- `auth-admin-oauth-server` to `oauth-server`
- `auth-reauthentication` to `auth-reauthenticate`

and the same passkey mapping for the two Dart links. Prose is untouched, these are link target changes only.

The mapping is not guesswork: the surrounding text names the API in each case. For example the passkeys guide says "See the `auth.passkey` reference" next to the JS and Dart links, and `auth-passkey` / `passkey-admin` are the live pages for `auth.passkey` and `auth.admin.passkey`. Where the old slug just carried a stale `-api` suffix, the base slug is the live page (`auth-mfa-api` to `auth-mfa`).

Important scoping detail: the Swift reference still uses `auth-passkey-api` and that page is alive today, so I left all four Swift links alone. In `passkeys.mdx` that means the JavaScript and Dart links in a line change while the Swift link in the same line stays as it is, which looks odd in the diff but is correct.

## Additional context

Files touched (11 replacements across 6 files):

- `guides/auth/passkeys.mdx` (6)
- `guides/auth/auth-mfa/totp.mdx` (1)
- `guides/auth/oauth-server/getting-started.mdx` (1)
- `guides/auth/oauth-server/oauth-flows.mdx` (1)
- `guides/auth/password-security.mdx` (1)
- `troubleshooting/database-error-saving-new-user-RU_EwB.mdx` (1)

How I verified:

1. Extracted every `auth-*` reference link in `apps/docs/content` and curled each one. Ten distinct links, nine dead across JS and Dart, one alive (Swift).
2. Confirmed each replacement target returns 200 and is present in the docs sitemap.
3. Re-ran the extraction after the change: zero dead JS or Dart slugs remain, and the four Swift links are untouched.

Gates run locally: `test:prettier` passed repo wide, `typecheck` passed 15/15, and the docs vitest suite passed (22 files, 167 tests, 1 file and 2 tests skipped). `lint --filter=docs` reports the same problem count as a clean master and none of it is in these files.

One related thing I left out on purpose: `/docs/reference/javascript/explain` is also dead, but two of its three usages pass `example=call-a-postgres-function-with-arguments`, which is an `rpc()` example rather than an explain one. That looks like it needs a decision about what those links were meant to point at, so I would rather ask than guess. Happy to follow up if you tell me where they should go.

I found these while checking docs links across the repo and verified every status code myself, with Claude Code's help along the way. Freshman contributor, so if any of these should point somewhere else I am glad to change them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated authentication and OAuth guides with current API reference links.
  * Corrected passkey, TOTP MFA, reauthentication, and OAuth documentation paths.
  * Updated troubleshooting guidance to reference the current Auth API documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->