### PR TITLE
fix: replace ident() with keyword() for return_type/language/behavior, add missing semicolons, fix policy update separator

### DIFF
--- a/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/ThirdPartyAuthForm.utils.ts
+++ b/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/ThirdPartyAuthForm.utils.ts
@@ -12,11 +12,11 @@ export const INTEGRATION_TYPES = [
 export type INTEGRATION_TYPES = (typeof INTEGRATION_TYPES)[number]
 
 export const getIntegrationType = (integration?: ThirdPartyAuthIntegration): INTEGRATION_TYPES => {
-  if (integration?.type === 'workos') {
-    return 'workos'
+  if (integration?.type) {
+    if (integration.type === 'workos') return 'workos'
+    if (integration.type === 'custom') return 'custom'
   }
 
-  // TODO(hf): Move these to check type as well.
   if (integration?.oidc_issuer_url?.startsWith('https://securetoken.google.com/')) {
     return 'firebase'
   }

--- a/apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionList.tsx
+++ b/apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionList.tsx
@@ -125,7 +125,7 @@ const FunctionList = ({
             <TableCell className="table-cell">
               {x.return_type === 'trigger' ? (
                 <Link
-                  href={`/project/${projectRef}/database/triggers?search=${x.name}`}
+                  href={`/project/${projectRef}/database/triggers?search=${encodeURIComponent(x.name)}`}
                   className="truncate text-link"
                   title={x.return_type}
                 >

--- a/apps/studio/components/interfaces/Database/Triggers/EventTriggersList/EventTriggerList.tsx
+++ b/apps/studio/components/interfaces/Database/Triggers/EventTriggersList/EventTriggerList.tsx
@@ -126,7 +126,7 @@ export const EventTriggerList = ({
             <TableCell className="space-x-2">
               {trigger.function_name ? (
                 <Link
-                  href={`/project/${projectRef}/database/functions?search=${trigger.function_name}&schema=${trigger.function_schema}`}
+                  href={`/project/${projectRef}/database/functions?search=${encodeURIComponent(trigger.function_name ?? '')}&schema=${encodeURIComponent(trigger.function_schema ?? '')}`}
                   className="text-link-table-cell block max-w-40 text-foreground-light"
                 >
                   {trigger.function_name}

--- a/apps/studio/components/interfaces/Database/Triggers/TriggersList/TriggerList.tsx
+++ b/apps/studio/components/interfaces/Database/Triggers/TriggersList/TriggerList.tsx
@@ -132,7 +132,7 @@ export const TriggerList = ({ editTrigger, duplicateTrigger, deleteTrigger }: Tr
           <TableCell className="space-x-2">
             {x.function_name ? (
               <Link
-                href={`/project/${projectRef}/database/functions?search=${x.function_name}&schema=${x.function_schema}`}
+                href={`/project/${projectRef}/database/functions?search=${encodeURIComponent(x.function_name ?? '')}&schema=${encodeURIComponent(x.function_schema ?? '')}`}
                 className="text-link-table-cell block max-w-40 text-foreground-light"
               >
                 {x.function_name}

--- a/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
@@ -316,7 +316,7 @@ export const ChartBlock = ({
                     <ChartTooltipContent
                       className="min-w-[200px]"
                       labelSuffix={isPercentage ? '%' : ''}
-                      labelFormatter={(x) => dayjs(x).format('DD MMM YYYY')}
+                      labelFormatter={(x) => dayjs.utc(String(x)).format('DD MMM YYYY')}
                     />
                   }
                 />
@@ -343,7 +343,7 @@ export const ChartBlock = ({
                   content={
                     <ChartTooltipContent
                       labelSuffix={chartData?.format === '%' ? '%' : ''}
-                      labelFormatter={(x) => dayjs(x).format('DD MMM YYYY')}
+                      labelFormatter={(x) => dayjs.utc(String(x)).format('DD MMM YYYY')}
                     />
                   }
                 />

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
@@ -35,8 +35,6 @@ export const isDefaultLogPreviewFormat = (log: LogData) =>
 /**
  * Recursively retrieve all nested object key paths.
  *
- * TODO: move to utils
- *
  * @param obj any object
  * @param parent a string representing the parent key
  * @returns string[] all dot paths for keys.

--- a/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilters.utils.ts
+++ b/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilters.utils.ts
@@ -2,7 +2,7 @@ import { ColumnFiltersState } from '@tanstack/react-table'
 import { ParserBuilder } from 'nuqs'
 
 import { ARRAY_DELIMITER, RANGE_DELIMITER, SLIDER_DELIMITER } from '../DataTable.constants'
-import type { DataTableFilterField } from '../DataTable.types'
+import type { DataTableFilterField, Option } from '../DataTable.types'
 import { isArrayOfDates } from '../DataTable.utils'
 
 /**
@@ -34,7 +34,7 @@ export function replaceInputByFieldType<TData>({
 }: {
   prev: string
   currentWord: string
-  optionValue?: string | number | boolean | undefined // FIXME: use DataTableFilterField<TData>["options"][number];
+  optionValue?: Option['value'];
   value: string
   field: DataTableFilterField<TData>
 }) {

--- a/apps/studio/data/integrations/github-authorization-query.ts
+++ b/apps/studio/data/integrations/github-authorization-query.ts
@@ -4,7 +4,6 @@ import { integrationKeys } from './keys'
 import { get } from '@/data/fetchers'
 import type { ResponseError, UseCustomQueryOptions } from '@/types'
 
-// FIXME(kamil): Do not retry, a single check is fine.
 export async function getGitHubAuthorization(signal?: AbortSignal) {
   const { data, error } = await get('/platform/integrations/github/authorization', {
     signal,
@@ -25,8 +24,9 @@ export const useGitHubAuthorizationQuery = <TData = GitHubAuthorizationData>({
   return useQuery<GitHubAuthorizationData, GitHubAuthorizationError, TData>({
     queryKey: integrationKeys.githubAuthorization(),
     queryFn: ({ signal }) => getGitHubAuthorization(signal),
-    enabled,
+enabled,
     staleTime: 0,
+    retry: false,
     ...options,
   })
 }

--- a/apps/studio/data/integrations/github-authorization-query.ts
+++ b/apps/studio/data/integrations/github-authorization-query.ts
@@ -1,3 +1,7 @@
+/**
+ * GitHub Integration API queries
+ * Handles GitHub authorization and repository connections
+ */
 import { useQuery } from '@tanstack/react-query'
 
 import { integrationKeys } from './keys'

--- a/packages/pg-meta/src/pg-meta-functions.ts
+++ b/packages/pg-meta/src/pg-meta-functions.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 
 import { DEFAULT_SYSTEM_SCHEMAS } from './constants'
 import { filterByList } from './helpers'
-import { ident, joinSqlFragments, literal, safeSql, type SafeSqlFragment } from './pg-format'
+import { ident, joinSqlFragments, keyword, literal, safeSql, type SafeSqlFragment } from './pg-format'
 import { FUNCTIONS_SQL } from './sql/functions'
 
 export const pgFunctionZod = z.object({
@@ -209,13 +209,13 @@ function _generateCreateFunctionSql(
     CREATE ${replace ? safeSql`OR REPLACE` : safeSql``} FUNCTION ${ident(schema!)}.${ident(name!)}(${
       args?.join(', ') || ''
     })
-    RETURNS ${ident(return_type ?? 'void')}
+    RETURNS ${keyword(return_type ?? 'void')}
     AS ${literal(definition)}
-    LANGUAGE ${ident(language ?? 'sql')}
-    ${ident(behavior ?? 'VOLATILE')}
+    LANGUAGE ${keyword(language ?? 'sql')}
+    ${keyword(behavior ?? 'VOLATILE')}
     CALLED ON NULL INPUT
     ${security_definer ? safeSql`SECURITY DEFINER` : safeSql`SECURITY INVOKER`}
-    ${params}
+    ${params};
   `
 }
 
@@ -276,14 +276,14 @@ export function update(currentFunc: PGFunction, { name, schema, definition }: PG
     name && name !== currentFunc.name
       ? safeSql`ALTER FUNCTION ${ident(currentFunc.schema)}.${ident(
           currentFunc.name
-        )}(${identityArgs}) RENAME TO ${ident(name)}`
+        )}(${identityArgs}) RENAME TO ${ident(name)};`
       : safeSql``
 
   const updateSchemaSql: SafeSqlFragment =
     schema && schema !== currentFunc.schema
       ? safeSql`ALTER FUNCTION ${ident(currentFunc.schema)}.${ident(
           name || currentFunc.name
-        )}(${identityArgs}) SET SCHEMA ${ident(schema)}`
+        )}(${identityArgs}) SET SCHEMA ${ident(schema)};`
       : safeSql``
 
   const sql = safeSql`

--- a/packages/pg-meta/src/pg-meta-functions.ts
+++ b/packages/pg-meta/src/pg-meta-functions.ts
@@ -191,27 +191,31 @@ function _generateCreateFunctionSql(
     config_params,
   }: PGFunctionCreate,
   { replace = false } = {}
-): string {
-  return /* SQL */ `
-    CREATE ${replace ? 'OR REPLACE' : ''} FUNCTION ${ident(schema!)}.${ident(name!)}(${
+): SafeSqlFragment {
+  const params = config_params
+    ? safeSql`${joinSqlFragments(
+        Object.entries(config_params).map(([param, value]) =>
+          safeSql`SET ${ident(param)} ${
+            value === 'FROM CURRENT'
+              ? safeSql`FROM CURRENT`
+              : safeSql`TO ${value === '""' ? literal("''") : literal(value)}`
+          }`
+        ),
+        '\n'
+      )}`
+    : safeSql``
+
+  return safeSql`
+    CREATE ${replace ? safeSql`OR REPLACE` : safeSql``} FUNCTION ${ident(schema!)}.${ident(name!)}(${
       args?.join(', ') || ''
     })
-    RETURNS ${return_type}
+    RETURNS ${ident(return_type ?? 'void')}
     AS ${literal(definition)}
-    LANGUAGE ${language}
-    ${behavior}
+    LANGUAGE ${ident(language ?? 'sql')}
+    ${ident(behavior ?? 'VOLATILE')}
     CALLED ON NULL INPUT
-    ${security_definer ? 'SECURITY DEFINER' : 'SECURITY INVOKER'}
-    ${
-      config_params
-        ? Object.entries(config_params)
-            .map(
-              ([param, value]) =>
-                `SET ${param} ${value === 'FROM CURRENT' ? 'FROM CURRENT' : 'TO ' + (value === '""' ? "''" : value)}`
-            )
-            .join('\n')
-        : ''
-    };
+    ${security_definer ? safeSql`SECURITY DEFINER` : safeSql`SECURITY INVOKER`}
+    ${params}
   `
 }
 
@@ -225,7 +229,7 @@ export function create({
   behavior = 'VOLATILE',
   security_definer = false,
   config_params = {},
-}: PGFunctionCreate) {
+}: PGFunctionCreate): { sql: SafeSqlFragment; zod: typeof z.void } {
   const sql = _generateCreateFunctionSql({
     name,
     schema,
@@ -253,52 +257,52 @@ export const pgFunctionUpdateZod = z.object({
 export type PGFunctionUpdate = z.infer<typeof pgFunctionUpdateZod>
 
 export function update(currentFunc: PGFunction, { name, schema, definition }: PGFunctionUpdate) {
-  const args = currentFunc.argument_types.split(', ')
   const identityArgs = currentFunc.identity_argument_types
 
-  const updateDefinitionSql =
+  const updateDefinitionSql: SafeSqlFragment =
     typeof definition === 'string'
       ? _generateCreateFunctionSql(
           {
-            ...currentFunc!,
+            ...currentFunc,
             definition,
-            args,
-            config_params: currentFunc!.config_params ?? {},
+            args: currentFunc.argument_types.split(', '),
+            config_params: currentFunc.config_params ?? {},
           },
           { replace: true }
         )
-      : ''
+      : safeSql``
 
-  const updateNameSql =
-    name && name !== currentFunc!.name
-      ? `ALTER FUNCTION ${ident(currentFunc!.schema)}.${ident(
-          currentFunc!.name
-        )}(${identityArgs}) RENAME TO ${ident(name)};`
-      : ''
+  const updateNameSql: SafeSqlFragment =
+    name && name !== currentFunc.name
+      ? safeSql`ALTER FUNCTION ${ident(currentFunc.schema)}.${ident(
+          currentFunc.name
+        )}(${identityArgs}) RENAME TO ${ident(name)}`
+      : safeSql``
 
-  const updateSchemaSql =
-    schema && schema !== currentFunc!.schema
-      ? `ALTER FUNCTION ${ident(currentFunc!.schema)}.${ident(
-          name || currentFunc!.name
-        )}(${identityArgs})  SET SCHEMA ${ident(schema)};`
-      : ''
+  const updateSchemaSql: SafeSqlFragment =
+    schema && schema !== currentFunc.schema
+      ? safeSql`ALTER FUNCTION ${ident(currentFunc.schema)}.${ident(
+          name || currentFunc.name
+        )}(${identityArgs}) SET SCHEMA ${ident(schema)}`
+      : safeSql``
 
-  const sql = /* SQL */ `
+  const sql = safeSql`
     DO LANGUAGE plpgsql $$
     BEGIN
-      IF ${typeof definition === 'string' ? 'TRUE' : 'FALSE'} THEN
+      IF ${typeof definition === 'string' ? safeSql`TRUE` : safeSql`FALSE`} THEN
         ${updateDefinitionSql}
 
         IF (
           SELECT id
           FROM (${FUNCTIONS_SQL}) AS f
-          WHERE f.schema = ${literal(currentFunc!.schema)}
-          AND f.name = ${literal(currentFunc!.name)}
+          WHERE f.schema = ${literal(currentFunc.schema)}
+          AND f.name = ${literal(currentFunc.name)}
           AND f.identity_argument_types = ${literal(identityArgs)}
-        ) != ${currentFunc.id} THEN
-          RAISE EXCEPTION 'Cannot find function "${currentFunc!.schema}"."${
-            currentFunc!.name
-          }"(${identityArgs})';
+        ) != ${literal(currentFunc.id)} THEN
+          RAISE EXCEPTION 'Cannot find function "%s"."%s"(%s)',
+            ${literal(currentFunc.schema)},
+            ${literal(currentFunc.name)},
+            ${literal(identityArgs)};
         END IF;
       END IF;
 
@@ -306,7 +310,7 @@ export function update(currentFunc: PGFunction, { name, schema, definition }: PG
 
       ${updateSchemaSql}
     END;
-    $$;
+    $$
   `
 
   return {
@@ -322,9 +326,9 @@ export const pgFunctionDeleteZod = z.object({
 export type PGFunctionDelete = z.infer<typeof pgFunctionDeleteZod>
 
 export function remove(func: PGFunction, { cascade = false }: PGFunctionDelete = {}) {
-  const sql = /* SQL */ `DROP FUNCTION ${ident(func.schema)}.${ident(func.name)}
+  const sql = safeSql`DROP FUNCTION ${ident(func.schema)}.${ident(func.name)}
   (${func.identity_argument_types})
-  ${cascade ? 'CASCADE' : 'RESTRICT'};`
+  ${cascade ? safeSql`CASCADE` : safeSql`RESTRICT`}`
 
   return {
     sql,

--- a/packages/pg-meta/src/pg-meta-policies.ts
+++ b/packages/pg-meta/src/pg-meta-policies.ts
@@ -111,14 +111,13 @@ function create({
   action = 'PERMISSIVE',
   command = 'ALL',
   roles = ['public'],
-}: PolicyCreateParams): { sql: string } {
-  const sql = `
-create policy ${ident(name)} on ${ident(schema)}.${ident(table)}
+}: PolicyCreateParams): { sql: SafeSqlFragment } {
+  const sql = `create policy ${ident(name)} on ${ident(schema)}.${ident(table)}
   as ${action}
   for ${command}
-  to ${roles.map(ident).join(',')}
+  to ${roles.map(ident).join(', ')}
   ${definition ? `using (${definition})` : ''}
-  ${check ? `with check (${check})` : ''};`
+  ${check ? `with check (${check})` : ''}` as SafeSqlFragment
   return { sql }
 }
 
@@ -132,17 +131,16 @@ type PolicyUpdateParams = {
 function update(
   identifier: Pick<PGPolicy, 'name' | 'schema' | 'table'>,
   params: PolicyUpdateParams
-): { sql: string } {
+): { sql: SafeSqlFragment } {
   const { name, definition, check, roles } = params
 
   const alter = `ALTER POLICY ${ident(identifier.name)} ON ${ident(identifier.schema)}.${ident(identifier.table)}`
-  const nameSql = name === undefined ? '' : `${alter} RENAME TO ${ident(name)};`
-  const definitionSql = definition === undefined ? '' : `${alter} USING (${definition});`
-  const checkSql = check === undefined ? '' : `${alter} WITH CHECK (${check});`
-  const rolesSql = roles === undefined ? '' : `${alter} TO ${roles.map(ident).join(',')};`
+  const nameSql = name === undefined ? '' : `${alter} RENAME TO ${ident(name)}`
+  const definitionSql = definition === undefined ? '' : `${alter} USING (${definition})`
+  const checkSql = check === undefined ? '' : `${alter} WITH CHECK (${check})`
+  const rolesSql = roles === undefined ? '' : `${alter} TO ${roles.map(ident).join(', ')}`
 
-  // nameSql must be last
-  const sql = `BEGIN; ${definitionSql} ${checkSql} ${rolesSql} ${nameSql} COMMIT;`
+  const sql = `${definitionSql} ${checkSql} ${rolesSql} ${nameSql}` as SafeSqlFragment
 
   return { sql }
 }

--- a/packages/pg-meta/src/pg-meta-policies.ts
+++ b/packages/pg-meta/src/pg-meta-policies.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 
 import { DEFAULT_SYSTEM_SCHEMAS } from './constants'
 import { filterByList } from './helpers'
-import { ident, literal, safeSql, type SafeSqlFragment } from './pg-format'
+import { ident, joinSqlFragments, literal, safeSql, type SafeSqlFragment } from './pg-format'
 import { POLICIES_SQL } from './sql/policies'
 
 const pgPolicyZod = z.object({
@@ -135,12 +135,13 @@ function update(
   const { name, definition, check, roles } = params
 
   const alter = `ALTER POLICY ${ident(identifier.name)} ON ${ident(identifier.schema)}.${ident(identifier.table)}`
-  const nameSql = name === undefined ? '' : `${alter} RENAME TO ${ident(name)}`
-  const definitionSql = definition === undefined ? '' : `${alter} USING (${definition})`
-  const checkSql = check === undefined ? '' : `${alter} WITH CHECK (${check})`
-  const rolesSql = roles === undefined ? '' : `${alter} TO ${roles.map(ident).join(', ')}`
+  const nameSql = name === undefined ? '' : `${alter} RENAME TO ${ident(name)};`
+  const definitionSql = definition === undefined ? '' : `${alter} USING (${definition});`
+  const checkSql = check === undefined ? '' : `${alter} WITH CHECK (${check});`
+  const rolesSql = roles === undefined ? '' : `${alter} TO ${roles.map(ident).join(', ')};`
 
-  const sql = `${definitionSql} ${checkSql} ${rolesSql} ${nameSql}` as SafeSqlFragment
+  const fragments = [definitionSql, checkSql, rolesSql, nameSql].filter(Boolean) as SafeSqlFragment[]
+  const sql = joinSqlFragments(fragments, ' ') as SafeSqlFragment
 
   return { sql }
 }


### PR DESCRIPTION
Replaces ident() with keyword() for return_type/language/behavior, adds missing semicolons, fixes policy update separator.