### PR TITLE
fix(docs): fix broken high availability badge link

### DIFF
--- a/apps/studio/components/interfaces/ProjectHome/HighAvailabilityBadge.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/HighAvailabilityBadge.tsx
@@ -37,7 +37,7 @@ export function HighAvailabilityBadge({ size = 'default' }: HighAvailabilityBadg
             globally distributed deployments.
           </p>
           <Link
-            href={`${DOCS_URL}/guides/deployment/high-availability`}
+            href={`${DOCS_URL}/guides/deployment`}
             target="_blank"
             rel="noopener noreferrer"
             className="mt-1 inline-flex items-center gap-1 text-xs text-foreground-lighter transition-colors hover:text-foreground"


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix

## Description
Fixes the broken "Read more" link in the High Availability badge on the 
project overview page.

`HighAvailabilityBadge.tsx` links to `/guides/deployment/high-availability` 
which returns a 404. Updated the link to point to `/guides/deployment` which 
is a valid existing page.

## Related Issues
Closes #48558

## Steps to verify
1. Open https://supabase.com/docs/guides/deployment — confirms target page exists
2. Open https://supabase.com/docs/guides/deployment/high-availability — confirms old link 404s

## Pre-flight checklist
- [ ] I ran `npm run build` locally and it passes
- [ ] Prettier checks pass
- [ ] This PR is linked to the related issue
- [ ] I checked no other PR is already fixing this issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the High Availability badge’s documentation link to direct users to the deployment guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->