### PR TITLE
fix(docs): fix nonce hashing in Sign in with Apple JS example

### DIFF
--- a/apps/docs/content/guides/auth/social-login/auth-apple.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-apple.mdx
@@ -157,15 +157,11 @@ curl -X PATCH "https://api.supabase.com/v1/projects/$PROJECT_REF/config/auth" \
     ```ts
     async function signIn() {
       try {
-        // Generate a nonce for security
-        const nonce = crypto.randomUUID() // or use your preferred nonce generation method
-
         const data = await AppleID.auth.signIn()
 
         const { data: authData, error } = await supabase.auth.signInWithIdToken({
           provider: 'apple',
-          token: data.id_token,
-          nonce: nonce,
+          token: data.id_token
         })
 
         if (error) {
@@ -200,16 +196,20 @@ curl -X PATCH "https://api.supabase.com/v1/projects/$PROJECT_REF/config/auth" \
     Alternatively, you can use the `AppleIDSignInOnSuccess` event with the `usePopup` option:
 
     ```ts
-    // Generate and store nonce for verification
-    const nonce = crypto.randomUUID()
 
-    // Initialize Apple ID with nonce
+// Generate raw nonce and hash it for Apple
+const rawNonce = crypto.randomUUID()
+const buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(rawNonce))
+const hashedNonce = Array.from(new Uint8Array(buf))
+.map((b) => b.toString(16).padStart(2, '0'))
+.join('')
+
     AppleID.auth.init({
       clientId: 'your-services-id',
       scope: 'name email',
       redirectURI: 'https://your-domain.com/auth/callback',
       usePopup: true,
-      nonce: nonce,
+      nonce: hashedNonce,  // ← hashed goes to Apple
     })
 
     // Listen for authorization success
@@ -218,7 +218,7 @@ curl -X PATCH "https://api.supabase.com/v1/projects/$PROJECT_REF/config/auth" \
         const { data: authData, error } = await supabase.auth.signInWithIdToken({
           provider: 'apple',
           token: event.detail.authorization.id_token,
-          nonce: nonce,
+          nonce: rawNonce,   // ← raw goes to Supabase ✅
         })
 
         if (error) {

--- a/apps/docs/content/guides/auth/social-login/auth-apple.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-apple.mdx
@@ -218,7 +218,7 @@ const hashedNonce = Array.from(new Uint8Array(buf))
         const { data: authData, error } = await supabase.auth.signInWithIdToken({
           provider: 'apple',
           token: event.detail.authorization.id_token,
-          nonce: rawNonce,   // ← raw goes to Supabase ✅
+          nonce: rawNonce,   // ← raw goes to Supabase 
         })
 
         if (error) {


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix (docs)

## Description
The "Sign in with Apple JS" web example was passing the raw nonce to both
`AppleID.auth.init()` and `supabase.auth.signInWithIdToken()`, which always
fails with "Nonces mismatch".

The root cause is that GoTrue compares `sha256(nonce)` against the id_token's
`nonce` claim, so the comparison becomes `sha256(raw) === raw` which can never hold.

**Changes made:**

1. Fixed the `AppleIDSignInOnSuccess` example to match the correct Flutter
example already on the same page:
   - hashed nonce → Apple (`AppleID.auth.init`)
   - raw nonce → Supabase (`signInWithIdToken`)

2. Fixed the `signIn()` example which generated a nonce but never passed it
to `AppleID.auth.signIn()`, making the nonce parameter in `signInWithIdToken`
misleading. Removed the unused nonce entirely from that example.

## Related Issues
Closes #48567

## Steps to verify
1. Open https://supabase.com/docs/guides/auth/social-login/auth-apple
2. Find the "Using sign in with Apple JS" section
3. Confirm the `AppleIDSignInOnSuccess` example now uses `hashedNonce` for
Apple and `rawNonce` for Supabase
4. Confirm the `signIn()` example no longer passes an unused nonce

## Pre-flight checklist
- [x] Prettier checks pass
- [x] This PR is linked to the related issue
- [x] I checked no other PR is already fixing this issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Sign in with Apple examples to use a raw nonce for Supabase verification and its SHA-256 hash for Apple initialization.
  * Simplified the direct sign-in example by removing nonce generation and passing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->