### PR TITLE
docs: point anchor links at their current heading ids

### DIFF
--- a/apps/docs/content/guides/ai/choosing-compute-addon.mdx
+++ b/apps/docs/content/guides/ai/choosing-compute-addon.mdx
@@ -76,7 +76,7 @@ This benchmark uses the [gist-960](http://corpus-texmex.irisa.fr/) dataset, whic
 
 Accuracy was 0.99 for benchmarks.
 
-QPS can also be improved by increasing [`m` and `ef_construction`](/docs/guides/ai/going-to-prod#hnsw-understanding-efconstruction--efsearch--and-m). This will allow you to use a smaller value for `ef_search` and increase QPS.
+QPS can also be improved by increasing [`m` and `ef_construction`](/docs/guides/ai/going-to-prod#hnsw-understanding-efconstruction--efsearch--and-). This will allow you to use a smaller value for `ef_search` and increase QPS.
 
 </TabPanel>
 </Tabs>
@@ -109,7 +109,7 @@ This benchmark uses the [dbpedia-entities-openai-1M](https://huggingface.co/data
 
 Accuracy was 0.99 for benchmarks.
 
-QPS can also be improved by increasing [`m` and `ef_construction`](/docs/guides/ai/going-to-prod#hnsw-understanding-efconstruction--efsearch--and-m). This will allow you to use a smaller value for `ef_search` and increase QPS. For example, increasing `m` to 32 and `ef_construction` to 80 for 4XL will increase QPS to 1280.
+QPS can also be improved by increasing [`m` and `ef_construction`](/docs/guides/ai/going-to-prod#hnsw-understanding-efconstruction--efsearch--and-). This will allow you to use a smaller value for `ef_search` and increase QPS. For example, increasing `m` to 32 and `ef_construction` to 80 for 4XL will increase QPS to 1280.
 
 </TabPanel>
 </Tabs>

--- a/apps/docs/content/guides/database/extensions/pg_graphql.mdx
+++ b/apps/docs/content/guides/database/extensions/pg_graphql.mdx
@@ -106,7 +106,7 @@ Note that `pg_graphql` supports schema introspection, so you can connect any Gra
 comment on schema public is e'@graphql({"introspection": true})';
 ```
 
-See the [upgrade notes](/guides/platform/upgrading#upgrading-to-pg_graphql-160) for details.
+See the [upgrade notes](/guides/platform/upgrading#upgrading-to-pggraphql-160) for details.
 
 ## API
 

--- a/apps/docs/content/guides/database/postgres/dropping-all-tables-in-schema.mdx
+++ b/apps/docs/content/guides/database/postgres/dropping-all-tables-in-schema.mdx
@@ -25,4 +25,4 @@ end $$;
 
 This query works by listing out all the tables in the given schema and then executing a `drop table` for each (hence the `for... loop`).
 
-You can run this query using the [SQL Editor](/dashboard/project/_/sql) in the Supabase Dashboard, or via `psql` if you're [connecting directly to the database](/docs/guides/database/connecting-to-postgres#direct-connections).
+You can run this query using the [SQL Editor](/dashboard/project/_/sql) in the Supabase Dashboard, or via `psql` if you're [connecting directly to the database](/docs/guides/database/connecting-to-postgres#direct-connection).

--- a/apps/docs/content/guides/database/postgres/first-row-in-group.mdx
+++ b/apps/docs/content/guides/database/postgres/first-row-in-group.mdx
@@ -42,4 +42,4 @@ The important bits here are:
 - The `desc` keyword to order the `points` from highest to lowest.
 - The `distinct` keyword that tells Postgres to only return a single row per team.
 
-This query can also be executed via `psql` or any other query editor if you prefer to [connect directly to the database](/docs/guides/database/connecting-to-postgres#direct-connections).
+This query can also be executed via `psql` or any other query editor if you prefer to [connect directly to the database](/docs/guides/database/connecting-to-postgres#direct-connection).

--- a/apps/docs/content/guides/database/postgres/indexes.mdx
+++ b/apps/docs/content/guides/database/postgres/indexes.mdx
@@ -28,7 +28,7 @@ create table persons (
 
 <Admonition type="note">
 
-All the queries in this guide can be run using the [SQL Editor](/dashboard/project/_/sql) in the Supabase Dashboard, or via `psql` if you're [connecting directly to the database](/docs/guides/database/connecting-to-postgres#direct-connections).
+All the queries in this guide can be run using the [SQL Editor](/dashboard/project/_/sql) in the Supabase Dashboard, or via `psql` if you're [connecting directly to the database](/docs/guides/database/connecting-to-postgres#direct-connection).
 
 </Admonition>
 

--- a/apps/docs/content/guides/database/postgres/which-version-of-postgres.mdx
+++ b/apps/docs/content/guides/database/postgres/which-version-of-postgres.mdx
@@ -19,4 +19,4 @@ Which should return something like:
 PostgreSQL 15.1 on aarch64-unknown-linux-gnu, compiled by gcc (Ubuntu 10.3.0-1ubuntu1~20.04) 10.3.0, 64-bit
 ```
 
-This query can also be executed via `psql` or any other query editor if you prefer to [connect directly to the database](/docs/guides/database/connecting-to-postgres#direct-connections).
+This query can also be executed via `psql` or any other query editor if you prefer to [connect directly to the database](/docs/guides/database/connecting-to-postgres#direct-connection).

--- a/apps/docs/content/guides/database/tables.mdx
+++ b/apps/docs/content/guides/database/tables.mdx
@@ -323,7 +323,7 @@ For example, if you wanted to load a CSV file into your movies table:
 "Return of the Jedi", "After a daring mission to rescue Han Solo from Jabba the Hutt, the Rebels dispatch to Endor to destroy the second Death Star."
 ```
 
-You would [connect](../../guides/database/connecting-to-postgres#direct-connections) to your database directly and load the file with the COPY command:
+You would [connect](../../guides/database/connecting-to-postgres#direct-connection) to your database directly and load the file with the COPY command:
 
 ```bash
 psql -h DATABASE_URL -p 5432 -d postgres -U postgres \

--- a/apps/docs/content/guides/monitoring-and-debugging/reports.mdx
+++ b/apps/docs/content/guides/monitoring-and-debugging/reports.mdx
@@ -310,7 +310,7 @@ Actions you can take:
 
 ### Query Performance
 
-Links to the [Query Performance Advisory page](/docs/guides/platform/performance#examine-query-performance) in the dashboard, which provides a detailed analysis of slow database queries
+Links to the [Query Performance Advisory page](/docs/guides/platform/performance#examining-query-performance) in the dashboard, which provides a detailed analysis of slow database queries
 
 ### Database connections
 

--- a/apps/docs/content/guides/platform/backups.mdx
+++ b/apps/docs/content/guides/platform/backups.mdx
@@ -141,7 +141,7 @@ After selecting your desired recovery point, the Dashboard prompts you to review
 
 ### Downloading backups after disabling PITR
 
-When you disable PITR, we still take all new backups as physical backups only. You can still use physical backups for restoration, but they are not available for direct download. If you need to download a backup after disabling PITR, you need to take a manual [legacy logical backup using the Supabase CLI or pg_dump](/docs/guides/platform/migrating-within-supabase/backup-restore#backup-database-using-the-cli).
+When you disable PITR, we still take all new backups as physical backups only. You can still use physical backups for restoration, but they are not available for direct download. If you need to download a backup after disabling PITR, you need to take a manual [legacy logical backup using the Supabase CLI or pg_dump](/docs/guides/platform/migrating-within-supabase/backup-restore#back-up-database-using-the-cli).
 
 ## Restore to a new project
 

--- a/apps/docs/content/guides/realtime/authorization.mdx
+++ b/apps/docs/content/guides/realtime/authorization.mdx
@@ -400,7 +400,7 @@ Client access policies are cached for the duration of the connection. Your datab
 Realtime updates the access policy cache for a client based on your RLS policies when:
 
 - A client connects to Realtime and subscribes to a Channel
-- A new JWT is sent to Realtime from a client via the [`access_token` message](/docs/guides/realtime/protocol#access-token)
+- A new JWT is sent to Realtime from a client via the [`access_token` message](/docs/guides/realtime/protocol#accesstoken)
 
 If a new JWT is never received on the Channel, the client will be disconnected when the JWT expires.
 

--- a/apps/docs/content/troubleshooting/download-logical-backups.mdx
+++ b/apps/docs/content/troubleshooting/download-logical-backups.mdx
@@ -8,6 +8,6 @@ database_id = "91ae4c49-bf22-4b8c-b96b-cd11f1c38158"
 
 When Point-in-Time Recovery (PITR) or physical backups are enabled, Supabase no longer generates the downloadable logical backup file (backup.gz). This is expected, as the backup pipeline switches entirely to physical backups. You can still download backups via the [Supabase CLI `db dump` command](/docs/reference/cli/supabase-db-dump) or using [`pg_dump`](https://www.postgresql.org/docs/current/app-pgdump.html).
 
-For step-by-step instructions using the Supabase CLI, check out the [Backup database using the CLI](/docs/guides/platform/migrating-within-supabase/backup-restore#backup-database-using-the-cli) guide.
+For step-by-step instructions using the Supabase CLI, check out the [Backup database using the CLI](/docs/guides/platform/migrating-within-supabase/backup-restore#back-up-database-using-the-cli) guide.
 
 You can also learn more about how backups work in Supabase here: [Database Backups](/docs/guides/platform/backups).

--- a/apps/www/_blog/2024-01-16-ipv6.mdx
+++ b/apps/www/_blog/2024-01-16-ipv6.mdx
@@ -54,7 +54,7 @@ After your ISP receives this address, it is responsible for routing all traffic 
 Here are some of the ways that you will be affected when domains/servers start resolving to IPv6 instead of IPv4, if your ISP doesn't support IPv6:
 
 - Do you have a web server set up in AWS? You won't be able to SSH into it.
-- Are you connected to a Supabase database from your local machine using the [direct connection](https://supabase.com/docs/guides/database/connecting-to-postgres#direct-connections)? You need to use the [connection pooler](https://supabase.com/docs/guides/database/connecting-to-postgres#connection-pooler) which will resolve as IPv4 instead (we will pay for IPv4 addresses on these).
+- Are you connected to a Supabase database from your local machine using the [direct connection](https://supabase.com/docs/guides/database/connecting-to-postgres#direct-connection)? You need to use the [connection pooler](https://supabase.com/docs/guides/database/connecting-to-postgres#connection-pooler) which will resolve as IPv4 instead (we will pay for IPv4 addresses on these).
 - Are you connecting to any AWS server from Vercel? That will start [failing](https://github.com/orgs/vercel/discussions/47) soon if you don't set up an IPv4 address for that server.
 
 ## Tooling support


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs fix (broken anchor links).

## What is the current behavior?

Six anchor links point at heading ids that do not exist on the destination page, so instead of jumping to the section they silently drop the reader at the top of the page. The page itself loads fine in every case, which is why these are easy to miss.

| link fragment | id actually on the page |
| --- | --- |
| `platform/upgrading#upgrading-to-pg_graphql-160` | `upgrading-to-pggraphql-160` |
| `platform/performance#examine-query-performance` | `examining-query-performance` |
| `database/connecting-to-postgres#direct-connections` | `direct-connection` |
| `platform/migrating-within-supabase/backup-restore#backup-database-using-the-cli` | `back-up-database-using-the-cli` |
| `ai/going-to-prod#hnsw-understanding-efconstruction--efsearch--and-m` | `hnsw-understanding-efconstruction--efsearch--and-` |
| `realtime/protocol#access-token` | `accesstoken` |

Most of these look like the heading slugifier and the link drifting apart. The pg_graphql one loses the underscore (`pg_graphql` becomes `pggraphql`), the realtime one loses the hyphen (`access_token` becomes `accesstoken`), and the trailing `m` is dropped from the HNSW heading id. The others are wording changes to the heading itself, for example the backup guide's heading is "Back up database using the CLI" while the link still says `backup-`.

This is the same class as the dead heading anchors @czenko cleaned up in #48453.

## What is the new behavior?

Each link now points at the id that is actually rendered on the destination page. Only the fragment changes, no prose and no link text was touched.

## Additional context

13 occurrences across 12 files. The `#direct-connections` one accounts for 6 of them, in three different link styles (relative `../../guides/...`, absolute `/docs/guides/...`, and one full `https://supabase.com/docs/...` in a blog post), which is why one `apps/www` file is included alongside the docs content.

How I verified each one:

1. Extracted every anchor-bearing link in `apps/docs/content` and `apps/www`, grouped them by destination page, fetched each page once and compared the fragment against the set of `id="..."` values actually present in the HTML.
2. For each fix, confirmed the old fragment is absent and the new one is present on the live page.
3. Re-ran the extraction afterwards: zero of the old fragments remain, and `#access-token-refresh` on the same realtime page is untouched.

I deliberately kept this to the cases where the intended target is unambiguous. The scan also flagged anchors on pages like `guides/platform/backups` (`#daily-backups`, `#frequency-of-backups`) where the closest heading is a real judgment call, and pages such as `database/extensions/pg_cron` where the server HTML contains no content heading ids at all so my check cannot tell whether the anchor resolves. I left all of those alone rather than guess.

Gates run locally: `test:prettier` passed repo wide, `typecheck` passed 15/15, and the docs vitest suite passed (22 files, 167 tests, 1 file and 2 tests skipped).

Two honest notes on what I could not run. `pnpm run build` does not complete in my environment because the docs `build:federated-content` step needs `DOCS_GITHUB_APP_PRIVATE_KEY`, which I do not have, and it fails before Next compiles. `pnpm run lint` also fails repo wide here, but it fails identically on a clean master (`docs#lint` and `studio:lint`), so it is not something this branch introduced, and none of the reported problems are in the files I touched.

Found this while checking docs links across the repo, and I checked every status code and heading id myself, with Claude Code's help along the way. Freshman contributor, so if any of these anchors were meant to point somewhere else, tell me and I will fix them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected outdated links and page anchors across AI, database, monitoring, backups, Realtime, troubleshooting, and IPv6 documentation.
  * Updated references for direct database connections, PostgreSQL guidance, CLI backups, query performance, JWT refresh, and HNSW benchmarks.
  * Improved navigation to the relevant upgrade notes and backup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->