### PR TITLE
docs(examples): point dead reference links at their current pages

### DIFF
--- a/examples/edge-functions/README.md
+++ b/examples/edge-functions/README.md
@@ -14,7 +14,7 @@ We're constantly adding new Function Examples, [check our docs](https://supabase
 - Run `cp ./supabase/.env.local.example ./supabase/.env.local` to create your local `.env` file.
 - Set the required variables for the corresponding edge functions in the `.env.local` file.
 - Run `supabase functions serve --env-file ./supabase/.env.local --no-verify-jwt`
-- Run the CURL command in the example function, or use the [invoke method](https://supabase.com/docs/reference/javascript/invoke) on the Supabase client or use the test client [app](./app/).
+- Run the CURL command in the example function, or use the [invoke method](https://supabase.com/docs/reference/javascript/functions-invoke) on the Supabase client or use the test client [app](./app/).
 
 ## Test Client
 
@@ -102,6 +102,6 @@ verify_jwt = false
 
 ## 👁⚡️👁
 
-\o/ That's it, you can now invoke your Supabase Function via the [`supabase-js`](https://supabase.com/docs/reference/javascript/invoke) and [`supabase-dart`](https://supabase.com/docs/reference/dart/invoke) client libraries. (More client libraries coming soon. Check the [supabase-community](https://github.com/supabase-community#client-libraries) org for details).
+\o/ That's it, you can now invoke your Supabase Function via the [`supabase-js`](https://supabase.com/docs/reference/javascript/functions-invoke) and [`supabase-dart`](https://supabase.com/docs/reference/dart/functions-invoke) client libraries. (More client libraries coming soon. Check the [supabase-community](https://github.com/supabase-community#client-libraries) org for details).
 
 For more info on Supabase Functions, check out the [docs](https://supabase.com/docs/guides/functions) and the [examples](https://github.com/supabase/supabase/tree/master/examples/edge-functions).

--- a/examples/storage/resumable-upload-signed-uppy/README.md
+++ b/examples/storage/resumable-upload-signed-uppy/README.md
@@ -1,6 +1,6 @@
 ## Resumable Uploads with Supabase Storage and Uppy
 
-This example shows how to use signed urls from [Supabase Storage](https://supabase.com/docs/reference/javascript/storage) with [Uppy](https://uppy.io/) to upload files to Supabase Storage using the TUS protocol (signed resumable uploads).
+This example shows how to use signed urls from [Supabase Storage](https://supabase.com/docs/reference/javascript/file-buckets) with [Uppy](https://uppy.io/) to upload files to Supabase Storage using the TUS protocol (signed resumable uploads).
 
 This works by calling `createSignedUploadUrl()` to get a token for each file, and passing that token via the `x-signature` header when uploading the files
 

--- a/examples/storage/resumable-upload-uppy/README.md
+++ b/examples/storage/resumable-upload-uppy/README.md
@@ -1,6 +1,6 @@
 ## Resumable Uploads with Supabase Storage and Uppy
 
-This example shows how to use [Supabase Storage](https://supabase.com/docs/reference/javascript/storage) with [Uppy](https://uppy.io/) to upload files to Supabase Storage using the TUS protocol (resumable uploads).
+This example shows how to use [Supabase Storage](https://supabase.com/docs/reference/javascript/file-buckets) with [Uppy](https://uppy.io/) to upload files to Supabase Storage using the TUS protocol (resumable uploads).
 
 ### Running the example
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs fix (broken links in example READMEs).

## What is the current behavior?

Three example READMEs link to client library reference pages that no longer exist, so following them from GitHub gives a 404:

| link | status | where |
| --- | --- | --- |
| `/docs/reference/javascript/invoke` | 404 | `examples/edge-functions/README.md` (2 places) |
| `/docs/reference/dart/invoke` | 404 | `examples/edge-functions/README.md` |
| `/docs/reference/javascript/storage` | 404 | both `examples/storage/resumable-upload-*/README.md` |

The reference pages moved: the invoke method now lives under `functions-invoke`, and the JavaScript storage section was split into `file-buckets`, `analytics-buckets` and `vector-buckets`. Neither old slug is in the docs sitemap any more, and there is no redirect covering them.

## What is the new behavior?

Each link points at the current page:

- `javascript/invoke` to `javascript/functions-invoke`
- `dart/invoke` to `dart/functions-invoke`
- `javascript/storage` to `javascript/file-buckets`

Five link targets across three files. No prose or link text changed.

For the two storage examples I used `file-buckets` because both are about uploading files (TUS resumable uploads, one with signed URLs), so the file bucket reference is the section that replaced what the old link pointed at. If you would rather those pointed at the storage guide instead of the JS reference, say so and I will switch them.

## Additional context

Found by extracting every `supabase.com/docs` link referenced outside `apps/docs` and `apps/www` (83 distinct URLs across the root READMEs, `apps/ui-library`, `packages` and `examples`) and checking each against the live site. These five were the only real dead ones.

Verified before and after:

- each old slug returns 404 and is absent from the docs sitemap
- `javascript/functions-invoke`, `dart/functions-invoke` and `javascript/file-buckets` all return 200 and are present in the sitemap
- after the change, no old slug remains in `examples`, and I checked that replacing the bare `/storage` string did not corrupt any longer URL such as `storage-from-download`, since that prefix overlap was the obvious way to get this wrong

One unrelated hit I left alone: `packages/ui-patterns/src/CommandMenu/prepackaged/ai/useAiChat.test.ts` references `https://supabase.com/docs/valid/path`, which 404s but is a deliberate test fixture rather than a real link.

Gates run locally: `pnpm test:prettier` passes repo wide, which is the check that applies here since this touches only markdown. I did not run typecheck, unit tests or a build for this one because no code paths change, and I would rather say that than imply I ran more than I did.

I have a few other docs link fixes open right now (#48560, #48562, #48563, #48568, #48629) from the same sweep. This one is separate because it is the examples directory rather than docs content or the redirect table.

Freshman contributor, I put this together with Claude Code's help and checked every URL and sitemap entry myself. Happy to adjust any of the targets if you would prefer different pages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Edge Functions examples with links to the current invocation guidance.
  * Updated resumable upload examples with links to the current Storage file-buckets documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->