### PR TITLE
fix(studio): redirect to feature preview route after enabling

### DIFF
--- a/apps/studio/components/interfaces/App/FeaturePreview/FeaturePreviewModal.tsx
+++ b/apps/studio/components/interfaces/App/FeaturePreview/FeaturePreviewModal.tsx
@@ -94,13 +94,17 @@ export const FeaturePreviewModal = () => {
       return
     }
 
-    toggleFeaturePreviewModal(false)
     if (hasRoute) {
+      // Navigating away drops the `featurePreviewModal` query param, which is
+      // what closes the modal. Don't also close it via
+      // toggleFeaturePreviewModal — its queued nuqs URL update races the push
+      // and can navigate back to the current page, swallowing the redirect.
       router.push(selectedFeatureRoute)
       toast.success(`${selectedFeature.name} enabled`, {
         description: "We've taken you to where you can try it out.",
       })
     } else {
+      toggleFeaturePreviewModal(false)
       toast.success(`${selectedFeature.name} enabled`, {
         description: "It's now active across the dashboard.",
       })


### PR DESCRIPTION
Enabling a feature preview that has a route (e.g. Column-level privileges) closed the modal but never navigated to the feature's page on the TanStack runtime (local + staging). The modal closed itself via a nuqs query-param update *and* called `router.push` — the queued nuqs flush navigates to the pathname it captured before the push, landing after the redirect and reverting it. The Next runtime was unaffected because the stock nuqs pages adapter patches the URL shallowly via the history API instead of navigating.

**Changed:**

- When the enabled preview has a `getRoute`, skip the explicit `toggleFeaturePreviewModal(false)` — `router.push(route)` navigates without the `featurePreviewModal` param, which is what closes the modal. One URL update instead of two racing ones; works on both runtimes.
- Previews without a route keep the explicit close (unchanged behavior).

## To test

- On a project page, open Feature Previews (avatar menu), select **Column-level privileges**, click **Enable feature** → modal closes and you land on `/project/{ref}/database/column-privileges` with the "We've taken you to where you can try it out." toast (no bounce back to the previous page)
- Repeat with **Disable Advisor rules** → lands on `/project/{ref}/advisors/rules/security`
- Enable a preview without a route (e.g. **PG Delta Diff**) → modal closes, stays on the current page, "It's now active across the dashboard." toast
- Disable a preview → modal stays open, "disabled" toast, no navigation
- Verified locally on the TanStack runtime; worth a quick click-through on the Vercel preview (Next runtime) too

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved feature activation navigation to prevent conflicting URL updates.
  * Non-route features continue to close the preview modal and display the activation confirmation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->