### PR TITLE
let inline error callers own mutation failures

### DIFF
--- a/apps/studio/components/interfaces/Organization/CloudMarketplace/AwsMarketplaceOnboarding.tsx
+++ b/apps/studio/components/interfaces/Organization/CloudMarketplace/AwsMarketplaceOnboarding.tsx
@@ -77,7 +77,6 @@ export const AwsMarketplaceOnboardingScreen = ({ buyerId }: { buyerId?: string }
     onSuccess: (_, variables) => {
       setLinkedOrgSlug(variables.slug)
     },
-    onError: () => undefined,
   })
   const linkError = linkOrganizationError
     ? `Failed to link organization: ${linkOrganizationError.message}`

--- a/apps/studio/components/interfaces/Organization/ProjectClaim/confirm.tsx
+++ b/apps/studio/components/interfaces/Organization/ProjectClaim/confirm.tsx
@@ -34,7 +34,7 @@ export const ProjectClaimConfirm = ({
   const { invalidateProjectsQuery } = useInvalidateProjectsInfiniteQuery()
 
   const { mutateAsync: approveRequest, isPending: isApproving } =
-    useApiAuthorizationApproveMutation({ onError: () => {} })
+    useApiAuthorizationApproveMutation()
 
   const { mutateAsync: claimProject, isPending: isClaiming } = useOrganizationProjectClaimMutation()
 

--- a/apps/studio/components/interfaces/OrganizationInvite/OrganizationInvite.tsx
+++ b/apps/studio/components/interfaces/OrganizationInvite/OrganizationInvite.tsx
@@ -78,8 +78,6 @@ export const OrganizationInvite = () => {
     onSuccess: () => {
       router.push('/organizations')
     },
-    // [Joshen] Silence the default toast handler
-    onError: () => {},
   })
 
   async function handleJoinOrganization() {

--- a/apps/studio/data/api-authorization/api-authorization-approve-mutation.ts
+++ b/apps/studio/data/api-authorization/api-authorization-approve-mutation.ts
@@ -1,5 +1,4 @@
 import { useMutation } from '@tanstack/react-query'
-import { toast } from 'sonner'
 
 import { handleError, post } from '@/data/fetchers'
 import type { ResponseError, UseCustomMutationOptions } from '@/types'
@@ -29,26 +28,18 @@ export async function approveApiAuthorization({ id, slug }: ApiAuthorizationAppr
 
 type ApiAuthorizationApproveData = Awaited<ReturnType<typeof approveApiAuthorization>>
 
-export const useApiAuthorizationApproveMutation = ({
-  onError,
-  ...options
-}: Omit<
-  UseCustomMutationOptions<
-    ApiAuthorizationApproveData,
-    ResponseError,
-    ApiAuthorizationApproveVariables
-  >,
-  'mutationFn'
-> = {}) => {
+export const useApiAuthorizationApproveMutation = (
+  options: Omit<
+    UseCustomMutationOptions<
+      ApiAuthorizationApproveData,
+      ResponseError,
+      ApiAuthorizationApproveVariables
+    >,
+    'mutationFn'
+  > = {}
+) => {
   return useMutation<ApiAuthorizationApproveData, ResponseError, ApiAuthorizationApproveVariables>({
     mutationFn: (vars) => approveApiAuthorization(vars),
-    async onError(data, variables, context) {
-      if (onError === undefined) {
-        toast.error(`Failed to approve authorization request: ${data.message}`)
-      } else {
-        onError(data, variables, context)
-      }
-    },
     ...options,
   })
 }

--- a/apps/studio/data/api-authorization/api-authorization-decline-mutation.ts
+++ b/apps/studio/data/api-authorization/api-authorization-decline-mutation.ts
@@ -1,5 +1,4 @@
 import { useMutation } from '@tanstack/react-query'
-import { toast } from 'sonner'
 
 import { del, handleError } from '@/data/fetchers'
 import type { ResponseError, UseCustomMutationOptions } from '@/types'
@@ -28,26 +27,18 @@ export async function declineApiAuthorization({ id, slug }: ApiAuthorizationDecl
 
 type ApiAuthorizationDeclineData = Awaited<ReturnType<typeof declineApiAuthorization>>
 
-export const useApiAuthorizationDeclineMutation = ({
-  onError,
-  ...options
-}: Omit<
-  UseCustomMutationOptions<
-    ApiAuthorizationDeclineData,
-    ResponseError,
-    ApiAuthorizationDeclineVariables
-  >,
-  'mutationFn'
-> = {}) => {
+export const useApiAuthorizationDeclineMutation = (
+  options: Omit<
+    UseCustomMutationOptions<
+      ApiAuthorizationDeclineData,
+      ResponseError,
+      ApiAuthorizationDeclineVariables
+    >,
+    'mutationFn'
+  > = {}
+) => {
   return useMutation<ApiAuthorizationDeclineData, ResponseError, ApiAuthorizationDeclineVariables>({
     mutationFn: (vars) => declineApiAuthorization(vars),
-    async onError(data, variables, context) {
-      if (onError === undefined) {
-        toast.error(`Failed to decline authorization request: ${data.message}`)
-      } else {
-        onError(data, variables, context)
-      }
-    },
     ...options,
   })
 }

--- a/apps/studio/data/organization-members/organization-invitation-accept-mutation.ts
+++ b/apps/studio/data/organization-members/organization-invitation-accept-mutation.ts
@@ -1,5 +1,4 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { toast } from 'sonner'
 
 import { handleError, post } from '@/data/fetchers'
 import { invalidateOrganizationsQuery } from '@/data/organizations/organizations-query'
@@ -28,7 +27,6 @@ type OrganizationMemberUpdateData = Awaited<ReturnType<typeof acceptOrganization
 
 export const useOrganizationAcceptInvitationMutation = ({
   onSuccess,
-  onError,
   ...options
 }: Omit<
   UseCustomMutationOptions<
@@ -54,13 +52,6 @@ export const useOrganizationAcceptInvitationMutation = ({
         invalidatePermissionsQuery(queryClient),
       ])
       await onSuccess?.(data, variables, context)
-    },
-    async onError(data, variables, context) {
-      if (onError === undefined) {
-        toast.error(`Failed to accept invitation: ${data.message}`)
-      } else {
-        onError(data, variables, context)
-      }
     },
     ...options,
   })

--- a/apps/studio/data/organizations/organization-link-aws-marketplace-mutation.ts
+++ b/apps/studio/data/organizations/organization-link-aws-marketplace-mutation.ts
@@ -1,5 +1,4 @@
 import { useMutation } from '@tanstack/react-query'
-import { toast } from 'sonner'
 
 import { handleError, put } from '@/data/fetchers'
 import type { ResponseError, UseCustomMutationOptions } from '@/types'
@@ -26,7 +25,6 @@ type LinkOrganizationData = Awaited<ReturnType<typeof linkOrganization>>
 
 export const useOrganizationLinkAwsMarketplaceMutation = ({
   onSuccess,
-  onError,
   ...options
 }: Omit<
   UseCustomMutationOptions<
@@ -40,13 +38,6 @@ export const useOrganizationLinkAwsMarketplaceMutation = ({
     mutationFn: (vars) => linkOrganization(vars),
     async onSuccess(data, variables, context) {
       await onSuccess?.(data, variables, context)
-    },
-    async onError(data, variables, context) {
-      if (onError === undefined) {
-        toast.error(`Failed to link organization to AWS Marketplace: ${data.message}`)
-      } else {
-        onError(data, variables, context)
-      }
     },
     ...options,
   })

--- a/apps/studio/data/partners/stripe-projects-confirm-mutation.ts
+++ b/apps/studio/data/partners/stripe-projects-confirm-mutation.ts
@@ -1,5 +1,4 @@
 import { useMutation } from '@tanstack/react-query'
-import { toast } from 'sonner'
 
 import { handleError, post } from '@/data/fetchers'
 import type { ResponseError, UseCustomMutationOptions } from '@/types'
@@ -24,7 +23,6 @@ type ConfirmAccountRequestData = Awaited<ReturnType<typeof confirmAccountRequest
 
 export const useConfirmAccountRequestMutation = ({
   onSuccess,
-  onError,
   ...options
 }: Omit<
   UseCustomMutationOptions<
@@ -38,13 +36,6 @@ export const useConfirmAccountRequestMutation = ({
     mutationFn: (vars) => confirmAccountRequest(vars),
     async onSuccess(data, variables, context) {
       await onSuccess?.(data, variables, context)
-    },
-    async onError(data, variables, context) {
-      if (onError === undefined) {
-        toast.error(`Failed to confirm account request: ${data.message}`)
-      } else {
-        onError(data, variables, context)
-      }
     },
     ...options,
   })

--- a/apps/studio/pages/partners/stripe/projects/login.tsx
+++ b/apps/studio/pages/partners/stripe/projects/login.tsx
@@ -51,9 +51,7 @@ export const StripeProjectsLoginPage: NextPageWithLayout = () => {
     isSuccess: isConfirmationSuccess,
     error: confirmationMutationError,
     reset: resetConfirmationError,
-  } = useConfirmAccountRequestMutation({
-    onError: () => undefined,
-  })
+  } = useConfirmAccountRequestMutation()
   const confirmationError = confirmationMutationError
     ? `Failed to authorize Stripe Projects: ${confirmationMutationError.message}`
     : undefined


### PR DESCRIPTION
## What kind of change does this PR introduce?

Code clean-up following #48470, #48471, #48472, #48473, and #48474.

## What is the current behavior?

Mutation hooks provide fallback error toasts, so callers that already render errors inline must suppress those toasts with empty `onError` handlers.

## What is the new behavior?

The affected callers own their error presentation. Inline interstitial errors remain unchanged, API authorisation retains its state-reset handlers, and Project Claim retains its combined caller-owned toast.

## To test

There is no useful before-and-after visual check for this PR: the rendered error states should be identical on `master` and this branch. The change only removes the default-toast and no-op-handler pair underneath the UI.

The existing [Organisation Invite](https://github.com/supabase/supabase/pull/48470), [API authorisation, AWS Marketplace](https://github.com/supabase/supabase/pull/48471), and [Stripe Projects](https://github.com/supabase/supabase/pull/48472) failure tests cover the inline errors and confirm that no duplicate toast appears.
