### PR TITLE
Add categories for feature previews

### DIFF
--- a/apps/studio/components/interfaces/App/FeaturePreview/FeaturePreviewModal.tsx
+++ b/apps/studio/components/interfaces/App/FeaturePreview/FeaturePreviewModal.tsx
@@ -5,6 +5,10 @@ import { useRouter } from 'next/router'
 import { ReactNode } from 'react'
 import { toast } from 'sonner'
 import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
   Badge,
   Button,
   cn,
@@ -81,6 +85,10 @@ export const FeaturePreviewModal = () => {
   const selectedFeatureRoute = selectedFeature?.getRoute?.(ref)
   const hasRoute = selectedFeatureRoute !== undefined && ref !== undefined
 
+  const categories = (
+    [...new Set(allFeaturePreviews.map((preview) => preview.category).filter(Boolean))] as string[]
+  ).concat(['others'])
+
   const toggleFeature = () => {
     if (!selectedFeature) return
 
@@ -128,14 +136,44 @@ export const FeaturePreviewModal = () => {
             <div className="max-h-full flex-1 min-h-0 h-full flex flex-col gap-y-1 md:gap-y-4 md:flex-row">
               <div>
                 <ScrollArea className="hidden md:block h-[550px] w-[280px] border-r">
-                  {allFeaturePreviews.map((feature) => (
+                  <Accordion type="multiple" defaultValue={categories}>
+                    {categories.map((category) => {
+                      const items =
+                        category === 'others'
+                          ? allFeaturePreviews.filter((x) => x.category === undefined)
+                          : allFeaturePreviews.filter((x) => x.category === category)
+                      return (
+                        <AccordionItem
+                          key={category}
+                          value={category}
+                          className="data-[state=open]:border-b-0"
+                        >
+                          <AccordionTrigger className="text-xs font-mono uppercase tracking-tight px-4 text-foreground-lighter py-2">
+                            {category}
+                          </AccordionTrigger>
+                          <AccordionContent className="[&>div]:pb-0">
+                            {items.map((feature) => (
+                              <FeaturePreviewItem
+                                key={feature.key}
+                                feature={feature}
+                                selectedFeature={selectedFeature}
+                                selectFeaturePreview={selectFeaturePreview}
+                              />
+                            ))}
+                          </AccordionContent>
+                        </AccordionItem>
+                      )
+                    })}
+                  </Accordion>
+
+                  {/* {allFeaturePreviews.map((feature) => (
                     <FeaturePreviewItem
                       key={feature.key}
                       feature={feature}
                       selectedFeature={selectedFeature}
                       selectFeaturePreview={selectFeaturePreview}
                     />
-                  ))}
+                  ))} */}
                 </ScrollArea>
               </div>
               <div className="block md:hidden px-4 pt-4">

--- a/apps/studio/components/interfaces/App/FeaturePreview/useFeaturePreviews.ts
+++ b/apps/studio/components/interfaces/App/FeaturePreview/useFeaturePreviews.ts
@@ -12,6 +12,8 @@ export type FeaturePreview = {
   isDefaultOptIn: boolean
   /** Visibility in the feature preview modal (For feature flagging a feature preview) */
   enabled: boolean
+  /** Optional category that the feature preview falls under, defaults to "Others" in the UI otherwise */
+  category?: 'observability' | 'database'
   /**
    * Where to send the user after enabling, to try the feature out. Omit if the
    * feature has no single destination (e.g. a global layout change).
@@ -28,106 +30,109 @@ export const useFeaturePreviews = (): FeaturePreview[] => {
 
   const unifiedLogsDefaultOptIn = useFlag('unifiedLogsDefaultOptIn')
 
-  return useMemo(
-    () =>
-      [
-        {
-          key: LOCAL_STORAGE_KEYS.UI_PREVIEW_UNIFIED_LOGS,
-          name: 'Updated Logs interface',
-          discussionsUrl: 'https://github.com/orgs/supabase/discussions/37234',
-          enabled: true,
-          isNew: true,
-          isPlatformOnly: true,
-          isDefaultOptIn: unifiedLogsDefaultOptIn,
-          getRoute: (ref?: string) => `/project/${ref}/logs`,
-        },
-        {
-          key: LOCAL_STORAGE_KEYS.UI_PREVIEW_ADVISOR_RULES,
-          name: 'Disable Advisor rules',
-          discussionsUrl: undefined,
-          enabled: true,
-          isNew: false,
-          isPlatformOnly: true,
-          isDefaultOptIn: false,
-          getRoute: (ref?: string) => `/project/${ref}/advisors/rules/security`,
-        },
-
-        {
-          key: LOCAL_STORAGE_KEYS.UI_PREVIEW_PG_DELTA_DIFF,
-          name: 'PG Delta Diff',
-          discussionsUrl: undefined,
-          isNew: false,
-          isPlatformOnly: true,
-          isDefaultOptIn: true,
-          enabled: true,
-        },
-        {
-          key: LOCAL_STORAGE_KEYS.UI_PREVIEW_PLATFORM_WEBHOOKS,
-          name: 'Platform webhooks',
-          discussionsUrl: undefined,
-          isNew: false,
-          isPlatformOnly: true,
-          isDefaultOptIn: false,
-          enabled: isPlatformWebhooksEnabled,
-          getRoute: (ref?: string) => `/project/${ref}/settings/webhooks`,
-        },
-        {
-          key: LOCAL_STORAGE_KEYS.UI_PREVIEW_JIT_DB_ACCESS,
-          name: 'Temporary database access',
-          discussionsUrl: undefined,
-          isNew: false,
-          isPlatformOnly: true,
-          isDefaultOptIn: false,
-          enabled: jitDbAccessEnabled,
-          getRoute: (ref?: string) => `/project/${ref}/database/settings`,
-        },
-        {
-          key: LOCAL_STORAGE_KEYS.UI_PREVIEW_CLS,
-          name: 'Column-level privileges',
-          discussionsUrl: 'https://github.com/orgs/supabase/discussions/20295',
-          enabled: true,
-          isNew: false,
-          isPlatformOnly: false,
-          isDefaultOptIn: false,
-          getRoute: (ref?: string) => `/project/${ref}/database/column-privileges`,
-        },
-        {
-          key: LOCAL_STORAGE_KEYS.UI_PREVIEW_MARKETPLACE,
-          name: 'One-Click Integrations',
-          discussionsUrl: undefined,
-          enabled: isMarketplaceEnabled,
-          isNew: true,
-          isPlatformOnly: false,
-          isDefaultOptIn: true,
-          getRoute: (ref?: string) => `/project/${ref}/integrations`,
-        },
-        {
-          key: LOCAL_STORAGE_KEYS.UI_PREVIEW_SQL_EDITOR_MANUAL_SAVE,
-          name: 'Disable snippet auto-saving',
-          discussionsUrl: undefined,
-          isNew: true,
-          isPlatformOnly: true,
-          isDefaultOptIn: false,
-          enabled: isSqlEditorManualSaveEnabled,
-        },
-        {
-          key: LOCAL_STORAGE_KEYS.UI_PREVIEW_DATABASE_CONNECTIONS,
-          name: 'Diagnose blocked queries',
-          discussionsUrl: 'https://github.com/orgs/supabase/discussions/48639',
-          isNew: true,
-          isPlatformOnly: false,
-          isDefaultOptIn: false,
-          enabled: isDatabaseConnectionsEnabled,
-          getRoute: (ref?: string) => `/project/${ref}/observability/connections`,
-        },
-      ].sort((a, b) => Number(b.isNew) - Number(a.isNew)),
-    [
-      unifiedLogsDefaultOptIn,
-      isPlatformWebhooksEnabled,
-      jitDbAccessEnabled,
-      isMarketplaceEnabled,
-      isSqlEditorManualSaveEnabled,
-      isDatabaseConnectionsEnabled,
+  return useMemo(() => {
+    const previews: FeaturePreview[] = [
+      {
+        key: LOCAL_STORAGE_KEYS.UI_PREVIEW_UNIFIED_LOGS,
+        name: 'Updated Logs interface',
+        category: 'observability',
+        discussionsUrl: 'https://github.com/orgs/supabase/discussions/37234',
+        enabled: true,
+        isNew: true,
+        isPlatformOnly: true,
+        isDefaultOptIn: unifiedLogsDefaultOptIn,
+        getRoute: (ref?: string) => `/project/${ref}/logs`,
+      },
+      {
+        key: LOCAL_STORAGE_KEYS.UI_PREVIEW_ADVISOR_RULES,
+        name: 'Disable Advisor rules',
+        discussionsUrl: undefined,
+        enabled: true,
+        isNew: false,
+        isPlatformOnly: true,
+        isDefaultOptIn: false,
+        getRoute: (ref?: string) => `/project/${ref}/advisors/rules/security`,
+      },
+      {
+        key: LOCAL_STORAGE_KEYS.UI_PREVIEW_PG_DELTA_DIFF,
+        name: 'PG Delta Diff',
+        discussionsUrl: undefined,
+        isNew: false,
+        isPlatformOnly: true,
+        isDefaultOptIn: true,
+        enabled: true,
+      },
+      {
+        key: LOCAL_STORAGE_KEYS.UI_PREVIEW_PLATFORM_WEBHOOKS,
+        name: 'Platform webhooks',
+        discussionsUrl: undefined,
+        isNew: false,
+        isPlatformOnly: true,
+        isDefaultOptIn: false,
+        enabled: isPlatformWebhooksEnabled,
+        getRoute: (ref?: string) => `/project/${ref}/settings/webhooks`,
+      },
+      {
+        key: LOCAL_STORAGE_KEYS.UI_PREVIEW_JIT_DB_ACCESS,
+        name: 'Temporary database access',
+        category: 'database',
+        discussionsUrl: undefined,
+        isNew: false,
+        isPlatformOnly: true,
+        isDefaultOptIn: false,
+        enabled: jitDbAccessEnabled,
+        getRoute: (ref?: string) => `/project/${ref}/database/settings`,
+      },
+      {
+        key: LOCAL_STORAGE_KEYS.UI_PREVIEW_CLS,
+        name: 'Column-level privileges',
+        category: 'database',
+        discussionsUrl: 'https://github.com/orgs/supabase/discussions/20295',
+        enabled: true,
+        isNew: false,
+        isPlatformOnly: false,
+        isDefaultOptIn: false,
+        getRoute: (ref?: string) => `/project/${ref}/database/column-privileges`,
+      },
+      {
+        key: LOCAL_STORAGE_KEYS.UI_PREVIEW_MARKETPLACE,
+        name: 'One-Click Integrations',
+        discussionsUrl: undefined,
+        enabled: isMarketplaceEnabled,
+        isNew: true,
+        isPlatformOnly: false,
+        isDefaultOptIn: true,
+        getRoute: (ref?: string) => `/project/${ref}/integrations`,
+      },
+      {
+        key: LOCAL_STORAGE_KEYS.UI_PREVIEW_SQL_EDITOR_MANUAL_SAVE,
+        name: 'Disable snippet auto-saving',
+        discussionsUrl: undefined,
+        isNew: true,
+        isPlatformOnly: true,
+        isDefaultOptIn: false,
+        enabled: isSqlEditorManualSaveEnabled,
+      },
+      {
+        key: LOCAL_STORAGE_KEYS.UI_PREVIEW_DATABASE_CONNECTIONS,
+        name: 'Diagnose blocked queries',
+        category: 'observability',
+        discussionsUrl: 'https://github.com/orgs/supabase/discussions/48639',
+        isNew: true,
+        isPlatformOnly: false,
+        isDefaultOptIn: false,
+        enabled: isDatabaseConnectionsEnabled,
+        getRoute: (ref?: string) => `/project/${ref}/observability/connections`,
+      },
     ]
-  )
+
+    return previews.sort((a, b) => Number(b.isNew) - Number(a.isNew))
+  }, [
+    unifiedLogsDefaultOptIn,
+    isPlatformWebhooksEnabled,
+    jitDbAccessEnabled,
+    isMarketplaceEnabled,
+    isSqlEditorManualSaveEnabled,
+    isDatabaseConnectionsEnabled,
+  ])
 }


### PR DESCRIPTION
## Context

Given that our number of feature previews have been expanding, am opting to group them into categories for easier understanding of the context of each feature preview.

Ideally we're able to tag all feature previews into categories (or add more categories), but leaving the unclassified ones under "others" for now

<img width="936" height="661" alt="image" src="https://github.com/user-attachments/assets/b48bd9a2-fe33-4cb0-9288-1cd9c8264da0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Feature previews are now organized into expandable categories.
  * Observability and database previews are grouped for easier browsing.
  * Uncategorized previews remain available under an “Others” section.
  * Existing feature selection options and sorting behavior are preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->