### PR TITLE
fix(studio): classify errors from the fetch helpers, not just the openapi client

### DIFF
--- a/apps/studio/components/interfaces/ErrorHandling/README.md
+++ b/apps/studio/components/interfaces/ErrorHandling/README.md
@@ -42,24 +42,23 @@ export class YourError extends ResponseError {
   readonly errorType = 'your-error' as const
 }
 
-export type ClassifiedError = ConnectionTimeoutError | FailedToRetrieveProjectsError | YourError
+export type ClassifiedError = ConnectionTimeoutError | UnknownAPIResponseError | YourError
 ```
 
 **2. Add a pattern entry to `data/error-patterns.ts`**
 
+Patterns live in a `Map` keyed by the error class, so a class can only be registered once:
+
 ```ts
 import { YourError } from 'types/api-errors'
 
-export const ERROR_PATTERNS: ErrorPattern[] = [
+const ERROR_PATTERN_MAP = new Map<ErrorConstructor, RegExp>([
   // existing...
-  {
-    pattern: /YOUR_ERROR_PATTERN/i,
-    ErrorClass: YourError,
-  },
-]
+  [YourError, /YOUR_ERROR_PATTERN/i],
+])
 ```
 
-`handleError` picks this up automatically — any matching API error will be thrown as a `YourError` instance.
+`createClassifiedError` picks this up automatically — any matching API error becomes a `YourError` instance, whether it came from the openapi-fetch client (`handleError`) or from the `fetchGet`/`fetchPost` helpers. Messages that match nothing fall back to `UnknownAPIResponseError`.
 
 **3. Create `errorMappings/YourError.tsx`**
 
@@ -108,17 +107,18 @@ export function YourErrorTroubleshooting() {
 
 **4. Add it to `error-mappings.tsx`**
 
+Mappings are keyed by the error class, and `getMappingForError` finds the first entry the error is an `instanceof`:
+
 ```tsx
 import { YourErrorTroubleshooting } from './errorMappings/YourError'
 
-export const ERROR_MAPPINGS: Record<KnownErrorType, ErrorMapping> = {
+export const ERROR_MAPPINGS = new Map<ErrorConstructor, ErrorMapping>([
   // existing...
-  'your-error': {
-    id: 'your-error',
-    Troubleshooting: YourErrorTroubleshooting,
-  },
-}
+  [YourError, { id: 'your-error', Troubleshooting: YourErrorTroubleshooting }],
+])
 ```
+
+If you ever register a class and one of its subclasses, put the subclass first — the lookup returns the first match.
 
 That's it. `ErrorMatcher` picks it up automatically.
 

--- a/apps/studio/data/error-patterns.test.ts
+++ b/apps/studio/data/error-patterns.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 
-import { ERROR_PATTERNS } from './error-patterns'
+import { createClassifiedError, ERROR_PATTERNS } from './error-patterns'
+import { ConnectionTimeoutError, UnknownAPIResponseError } from '@/types/api-errors'
+import { ResponseError } from '@/types/base'
 
 // Representative sample messages for each error class.
 // Keep this in sync when adding new patterns — the test will fail if you don't.
@@ -58,5 +60,80 @@ describe('ERROR_PATTERNS registry', () => {
       const matched = ERROR_PATTERNS.filter(({ pattern }) => pattern.test(msg))
       expect(matched.length).toBe(1)
     })
+  })
+})
+
+describe('createClassifiedError', () => {
+  it('returns the matching subclass for a known pattern', () => {
+    const error = createClassifiedError('CONNECTION TERMINATED DUE TO CONNECTION TIMEOUT')
+    expect(error).toBeInstanceOf(ConnectionTimeoutError)
+    expect(error.errorType).toBe('connection-timeout')
+  })
+
+  it('matches case-insensitively', () => {
+    expect(createClassifiedError('connection terminated due to connection timeout')).toBeInstanceOf(
+      ConnectionTimeoutError
+    )
+  })
+
+  it('matches a pattern embedded in a longer message', () => {
+    expect(
+      createClassifiedError(
+        'ERROR: FAILED TO RUN SQL QUERY: CONNECTION TERMINATED DUE TO CONNECTION TIMEOUT.'
+      )
+    ).toBeInstanceOf(ConnectionTimeoutError)
+  })
+
+  it('falls back to UnknownAPIResponseError for an unmatched message', () => {
+    const error = createClassifiedError('something went wrong')
+    expect(error).toBeInstanceOf(UnknownAPIResponseError)
+    expect(error).toBeInstanceOf(ResponseError)
+  })
+
+  it('falls back to UnknownAPIResponseError for an empty message', () => {
+    expect(createClassifiedError('')).toBeInstanceOf(UnknownAPIResponseError)
+  })
+
+  it('falls back to UnknownAPIResponseError for an undefined message', () => {
+    expect(createClassifiedError(undefined)).toBeInstanceOf(UnknownAPIResponseError)
+  })
+
+  it('always returns a ResponseError instance', () => {
+    expect(createClassifiedError('anything')).toBeInstanceOf(ResponseError)
+  })
+
+  it('forwards every constructor argument to the chosen class', () => {
+    const metadata = { cost: 12, sql: 'select 1' }
+    const error = createClassifiedError(
+      'CONNECTION TERMINATED DUE TO CONNECTION TIMEOUT',
+      503,
+      'req-abc',
+      30,
+      '/rest/v1/table',
+      metadata,
+      'ERROR: 08000: CONNECTION TERMINATED'
+    )
+
+    expect(error).toBeInstanceOf(ConnectionTimeoutError)
+    expect(error.message).toBe('CONNECTION TERMINATED DUE TO CONNECTION TIMEOUT')
+    expect(error.code).toBe(503)
+    expect(error.requestId).toBe('req-abc')
+    expect(error.retryAfter).toBe(30)
+    expect(error.requestPathname).toBe('/rest/v1/table')
+    expect(error.metadata).toEqual(metadata)
+    expect(error.formattedError).toBe('ERROR: 08000: CONNECTION TERMINATED')
+  })
+
+  it('forwards constructor arguments on the fallback path too', () => {
+    const error = createClassifiedError('some error', 500, 'req-xyz')
+    expect(error).toBeInstanceOf(UnknownAPIResponseError)
+    expect(error.code).toBe(500)
+    expect(error.requestId).toBe('req-xyz')
+  })
+
+  it('applies the ResponseError default message when message is undefined', () => {
+    expect(createClassifiedError(undefined).message).toBe(
+      'API error happened while trying to communicate with the server.'
+    )
   })
 })

--- a/apps/studio/data/error-patterns.ts
+++ b/apps/studio/data/error-patterns.ts
@@ -1,4 +1,4 @@
-import { ConnectionTimeoutError } from '@/types/api-errors'
+import { ConnectionTimeoutError, UnknownAPIResponseError } from '@/types/api-errors'
 import type { ClassifiedError } from '@/types/api-errors'
 import type { ResponseError } from '@/types/base'
 
@@ -23,3 +23,21 @@ const ERROR_PATTERN_MAP = new Map<ErrorConstructor, RegExp>([
 export const ERROR_PATTERNS: ErrorPattern[] = Array.from(ERROR_PATTERN_MAP.entries()).map(
   ([ErrorClass, pattern]) => ({ ErrorClass, pattern })
 )
+
+/**
+ * Builds the error instance for an API error message, picking the subclass whose
+ * pattern matches and falling back to `UnknownAPIResponseError`.
+ *
+ * Every entry point in the data layer goes through this so that an error carries
+ * the same class regardless of which fetch helper produced it — `ErrorMatcher`
+ * keys its troubleshooting steps off that class.
+ */
+export function createClassifiedError(
+  ...args: ConstructorParameters<typeof ResponseError>
+): ClassifiedError {
+  const [message] = args
+  const matched = message ? ERROR_PATTERNS.find(({ pattern }) => pattern.test(message)) : undefined
+  const ErrorClass = matched?.ErrorClass ?? UnknownAPIResponseError
+
+  return new ErrorClass(...args)
+}

--- a/apps/studio/data/fetchers.test.ts
+++ b/apps/studio/data/fetchers.test.ts
@@ -40,7 +40,7 @@ describe('fetch helpers — error classification', () => {
     const error = await fetchGet('http://localhost/test')
 
     expect(error).toBeInstanceOf(ConnectionTimeoutError)
-    expect((error as ConnectionTimeoutError).errorType).toBe('connection-timeout')
+    expect(error).toMatchObject({ errorType: 'connection-timeout' })
   })
 
   it('classifies a known error returned by fetchPost', async () => {
@@ -78,18 +78,16 @@ describe('fetch helpers — error classification', () => {
     const error = await fetchGet('http://localhost/test')
 
     expect(error).toBeInstanceOf(UnknownAPIResponseError)
-    expect((error as ResponseError).message).toBe('An error has occurred: 500')
+    expect(error).toMatchObject({ message: 'An error has occurred: 500' })
   })
 
   it('preserves status and the legacy `error` self-reference', async () => {
     mockFailedResponse({ message: TIMEOUT_MESSAGE }, 503)
 
-    const error = (await fetchGet('http://localhost/test')) as ResponseError & {
-      error: ResponseError
-    }
+    const error = await fetchGet('http://localhost/test')
 
-    expect(error.code).toBe(503)
-    expect(error.error).toBe(error)
+    expect(error).toMatchObject({ code: 503 })
+    expect(error).toHaveProperty('error', error)
   })
 
   it('classifies a thrown network error', async () => {

--- a/apps/studio/data/fetchers.test.ts
+++ b/apps/studio/data/fetchers.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ConnectionTimeoutError, UnknownAPIResponseError } from '@/types/api-errors'
+import { ResponseError } from '@/types/base'
+
+vi.mock('@sentry/nextjs', () => ({ captureException: vi.fn() }))
+vi.mock('common', () => ({ IS_PLATFORM: false, getAccessToken: vi.fn() }))
+vi.mock('@/lib/constants', () => ({ API_URL: 'http://localhost' }))
+vi.mock('@/lib/helpers', () => ({ uuidv4: () => 'test-uuid' }))
+
+// Import after mocks are set up
+const { fetchGet, fetchPost } = await import('./fetchers')
+
+function mockFailedResponse(body: Record<string, unknown>, status = 500) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
+  )
+}
+
+const TIMEOUT_MESSAGE = 'CONNECTION TERMINATED DUE TO CONNECTION TIMEOUT'
+
+/**
+ * `fetchGet`/`fetchPost` and the openapi-fetch client used to build errors through
+ * two different paths, and only the latter ran pattern classification. These assert
+ * both paths produce the same class so troubleshooting steps render either way.
+ */
+describe('fetch helpers — error classification', () => {
+  beforeEach(() => vi.clearAllMocks())
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('classifies a known error returned by fetchGet', async () => {
+    mockFailedResponse({ message: TIMEOUT_MESSAGE }, 503)
+
+    const error = await fetchGet('http://localhost/test')
+
+    expect(error).toBeInstanceOf(ConnectionTimeoutError)
+    expect((error as ConnectionTimeoutError).errorType).toBe('connection-timeout')
+  })
+
+  it('classifies a known error returned by fetchPost', async () => {
+    mockFailedResponse({ message: TIMEOUT_MESSAGE }, 503)
+
+    const error = await fetchPost('http://localhost/test', {})
+
+    expect(error).toBeInstanceOf(ConnectionTimeoutError)
+  })
+
+  it('reads the message from the msg field', async () => {
+    mockFailedResponse({ msg: TIMEOUT_MESSAGE }, 503)
+
+    expect(await fetchGet('http://localhost/test')).toBeInstanceOf(ConnectionTimeoutError)
+  })
+
+  it('reads the message from the error field', async () => {
+    mockFailedResponse({ error: TIMEOUT_MESSAGE }, 503)
+
+    expect(await fetchGet('http://localhost/test')).toBeInstanceOf(ConnectionTimeoutError)
+  })
+
+  it('falls back to UnknownAPIResponseError for an unmatched message', async () => {
+    mockFailedResponse({ message: 'some other failure' }, 500)
+
+    const error = await fetchGet('http://localhost/test')
+
+    expect(error).toBeInstanceOf(UnknownAPIResponseError)
+    expect(error).toBeInstanceOf(ResponseError)
+  })
+
+  it('falls back to UnknownAPIResponseError when the body carries no message', async () => {
+    mockFailedResponse({}, 500)
+
+    const error = await fetchGet('http://localhost/test')
+
+    expect(error).toBeInstanceOf(UnknownAPIResponseError)
+    expect((error as ResponseError).message).toBe('An error has occurred: 500')
+  })
+
+  it('preserves status and the legacy `error` self-reference', async () => {
+    mockFailedResponse({ message: TIMEOUT_MESSAGE }, 503)
+
+    const error = (await fetchGet('http://localhost/test')) as ResponseError & {
+      error: ResponseError
+    }
+
+    expect(error.code).toBe(503)
+    expect(error.error).toBe(error)
+  })
+
+  it('classifies a thrown network error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error(TIMEOUT_MESSAGE)))
+
+    expect(await fetchGet('http://localhost/test')).toBeInstanceOf(ConnectionTimeoutError)
+  })
+})

--- a/apps/studio/data/fetchers.ts
+++ b/apps/studio/data/fetchers.ts
@@ -4,7 +4,7 @@ import { getAccessToken, IS_PLATFORM } from 'common'
 import createClient from 'openapi-fetch'
 
 import type { paths } from './api'
-import { ERROR_PATTERNS } from './error-patterns'
+import { createClassifiedError } from './error-patterns'
 import { API_URL } from '@/lib/constants'
 import { uuidv4 } from '@/lib/helpers'
 import { ResponseError } from '@/types'
@@ -208,26 +208,15 @@ export const handleError = (error: unknown, options: HandleErrorOptions = {}): n
         : undefined
 
     if (errorMessage) {
-      const matched = ERROR_PATTERNS.find(({ pattern }) => pattern.test(errorMessage))
-      throw matched
-        ? new matched.ErrorClass(
-            errorMessage,
-            errorCode,
-            requestId,
-            retryAfter,
-            requestPathname,
-            metadata,
-            formattedError
-          )
-        : new UnknownAPIResponseError(
-            errorMessage,
-            errorCode,
-            requestId,
-            retryAfter,
-            requestPathname,
-            metadata,
-            formattedError
-          )
+      throw createClassifiedError(
+        errorMessage,
+        errorCode,
+        requestId,
+        retryAfter,
+        requestPathname,
+        metadata,
+        formattedError
+      )
     }
   }
 
@@ -303,7 +292,7 @@ async function handleFetchError(response: unknown): Promise<ResponseError> {
       : null
   const retryAfter = retryAfterHeader ? parseInt(retryAfterHeader) : undefined
 
-  let error = new ResponseError(message, status, undefined, retryAfter)
+  let error = createClassifiedError(message, status, undefined, retryAfter)
 
   // @ts-expect-error - [Alaister] many of our local api routes check `if (response.error)`.
   // This is a fix to keep those checks working without breaking changes.


### PR DESCRIPTION

fix(studio): classify errors from the fetch helpers, not just the openapi client

Closes : #48647

## What

`ErrorMatcher` shows troubleshooting steps by checking which `ResponseError`
subclass an error is. Classification happens in the data layer — but only on one
of the two paths that build errors.

`handleError` (the openapi-fetch client path) matches the message against
`ERROR_PATTERNS` and constructs the matching subclass. `handleFetchError` — used by
`fetchGet`, `fetchPost`, `fetchPut`, `fetchDelete` and `fetchHeadWithTimeout` —
built a bare `ResponseError` and skipped classification entirely.

So the same backend error produced a different class depending on which helper the
calling hook happened to use. Via the client it became `ConnectionTimeoutError` and
rendered troubleshooting steps; via `fetchGet` it stayed a plain `ResponseError`,
`getMappingForError` returned `null`, and the user got a generic error card with no
guidance. The telemetry drifted the same way — `errorType` and `hasTroubleshooting`
on `dashboard_error_created` were unset for the whole `fetch*` path.

## Change

Extract the registry lookup into `createClassifiedError()` in `data/error-patterns.ts`
and route both paths through it, so the class an error carries no longer depends on
which fetch helper produced it.

Behavior differences:

- Errors from the `fetch*` helpers are now classified (the fix).
- Unmatched errors from those helpers are now `UnknownAPIResponseError` rather than a
  bare `ResponseError`. That already matched what `handleError` did, and
  `UnknownAPIResponseError extends ResponseError`, so `instanceof ResponseError`
  checks are unaffected. I grepped for `constructor ===` identity checks — there are
  none.

`handleFetchError` still returns rather than throws, and still sets the legacy
`error.error` self-reference, so existing `if (response.error)` callers are unchanged.

## Tests

- `data/error-patterns.test.ts` — unit tests for `createClassifiedError`: match,
  case-insensitivity, embedded match, fallback for unmatched/empty/undefined messages,
  and full constructor-argument forwarding on both the matched and fallback paths.
- `data/fetchers.test.ts` (new) — regression tests driving `fetchGet`/`fetchPost` with a
  stubbed `fetch`, asserting a known message yields `ConnectionTimeoutError` through the
  helper path, that `message`/`msg`/`error` body fields are all read, that unmatched
  errors fall back to `UnknownAPIResponseError`, that status and the legacy `error`
  self-reference survive, and that a thrown network error is classified too.

The existing `data/handleError.test.ts` covers the client path and is unchanged — it
already asserted the contract this change extends to the other path.

## Docs

`components/interfaces/ErrorHandling/README.md` had three snippets that no longer
matched the code, which would misdirect the next person adding a mapping:

- `ClassifiedError` example referenced `FailedToRetrieveProjectsError`, which does not exist.
- Step 2 showed `ERROR_PATTERNS` as an array literal; it is derived from a `Map` keyed by
  error class.
- Step 4 showed `ERROR_MAPPINGS` as `Record<KnownErrorType, ErrorMapping>`; it is a
  `Map<ErrorConstructor, ErrorMapping>` and the lookup is an `instanceof` scan, so
  registration order matters when a class and its subclass are both registered.

Note: `.claude/skills/studio-error-handling/SKILL.md` describes the same two structures
the old way ("`Record<KnownErrorType, …>`", "O(1) lookup"). Left out of this PR to keep it


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error classification for API and network requests.
  * Added case-insensitive matching across supported error message fields.
  * Unrecognized or missing errors now receive a consistent fallback error type and message.
  * Preserved response status details and legacy error information during error handling.

* **Documentation**
  * Updated error-handling guidance with the latest classification and troubleshooting patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->