### PR TITLE
chore(self-hosted): update 2026-08-03

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -11,8 +11,45 @@ See per-service updates below for details. Only the most important changes relev
 ---
 
 ## Unreleased
+- Self-hosted Supabase: Envoy becomes the default API gateway (breaking change) [#48048](https://github.com/orgs/supabase/discussions/48048) (PR [#](https://github.com/supabase/supabase/pull/48153))
 
 Check the main Supabase [changelog](https://github.com/orgs/supabase/discussions/categories/changelog?discussions_q=is%3Aopen+category%3AChangelog+label%3Aself-hosted) for updates.
+
+---
+
+## [0.7.1](https://github.com/supabase/supabase/releases/tag/self-hosted/v0.7.1) - 2026-08-03
+
+### Configuration
+- Added `SUPABASE_JWKS` to `docker-compose.yml` - PR [#45635](https://github.com/supabase/supabase/pull/45635)
+- Added `upgrades.json` - a version-keyed manifest to gate breaking changes (required for `update.sh`) - PR [#47851](https://github.com/supabase/supabase/pull/47851)
+- Updated `.gitignore` (required for `update.sh`)
+
+### Documentation
+- Added new how-to guides ([Custom Postgres Extensions](https://supabase.com/docs/guides/self-hosting/custom-postgres-extensions) and [Update Your Self-Hosted Deployment](https://supabase.com/docs/guides/self-hosting/updating)) - PR [#48203](https://github.com/supabase/supabase/pull/48203), PR [#48535](https://github.com/supabase/supabase/pull/48535)
+
+### Utils and tests
+- Added base version stamp to `setup.sh` (in `.supabase-version`, required for `update.sh`) - PR [#47848](https://github.com/supabase/supabase/pull/47848)
+- Added `update.sh`. Refer to [Update Your Self-Hosted Deployment](https://supabase.com/docs/guides/self-hosting/updating) - PR [#47851](https://github.com/supabase/supabase/pull/47851)
+- Added `SUPABASE_JWKS` configuration for Edge Functions to `utils/add-new-auth-keys.sh` - PR [#45635](https://github.com/supabase/supabase/pull/45635)
+- Updated `tests/test-s3.sh` and `test-s3-backend.sh` - PR [#48500](https://github.com/supabase/supabase/pull/48500)
+
+### API gateway
+- Updated Kong to `3.9.3`
+- Added `KONG_DNS_VALID_TTL` configuration (requires `docker-compose.yml` update) - PR [#47846](https://github.com/supabase/supabase/pull/47846)
+- Updated Envoy to `1.39.0` (requies `docker-compose.envoy.yml` update)
+- Updated [nginx-certbot](https://github.com/JonasAlfredsson/docker-nginx-certbot) to `6.2.0-nginx1.31.3`
+
+### Studio
+- Updated to `2026.03.08-sha-xxxxxxx`
+- Fixed URL generation for Edge Functions - PR [#47861](https://github.com/supabase/supabase/pull/47861) (via [@7ttp](https://github.com/7ttp))
+- Fixed the Logs tab visibility in **Auth > Users** - PR [#48122](https://github.com/supabase/supabase/pull/48122) (via [@luizfelmach](https://github.com/luizfelmach/))
+
+### Storage
+- Changed RustFS image to `rustfs/rustfs:1.0.0-beta.11` temporarily (requires `docker-compose.rustfs.yml` update) - PR [#48500](https://github.com/supabase/supabase/pull/48500)
+
+### Edge Runtime
+- Added healthcheck for `functions` (requires `docker-compose.yml` update) - PR [#46655](https://github.com/supabase/supabase/pull/46655)
+- Changed JWKS configuration mechanism for main worker (requires `docker-compose.yml` and `volumes/functions/main/index.ts` update) - PR [#45635](https://github.com/supabase/supabase/pull/45635)
 
 ---
 
@@ -42,8 +79,8 @@ Check the main Supabase [changelog](https://github.com/orgs/supabase/discussions
 ### Studio
 - Updated to `2026.07.07-sha-a6a04f2`
 - Fixed the local SQL snippets not being shown in the SQL Editor - PR [#47403](https://github.com/supabase/supabase/pull/47403), PR [#47409](https://github.com/supabase/supabase/pull/47409)
-- Fixed the exposed schemas and tables UI to properly reflect non-platform configuration (Data API > Settings) - PR [#47511](https://github.com/supabase/supabase/pull/47511)
-- Fixed the behavior of the type generator (Data API > Docs) - PR [#47577](https://github.com/supabase/supabase/pull/47577)
+- Fixed the exposed schemas and tables UI to properly reflect non-platform configuration (**Data API > Settings**) - PR [#47511](https://github.com/supabase/supabase/pull/47511)
+- Fixed the behavior of the type generator (**Data API > Docs**) - PR [#47577](https://github.com/supabase/supabase/pull/47577)
 
 ### Auth
 - ⚠️ Changed Auth configuration placeholders to match the new default `API_EXTERNAL_URL` (requires `docker-compose.yml` update) - PR [#47640](https://github.com/supabase/supabase/pull/47640)

--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -11,16 +11,16 @@ See per-service updates below for details. Only the most important changes relev
 ---
 
 ## Unreleased
-- Self-hosted Supabase: Envoy becomes the default API gateway (breaking change) [#48048](https://github.com/orgs/supabase/discussions/48048) (PR [#](https://github.com/supabase/supabase/pull/48153))
+- Self-hosted Supabase: Envoy becomes the default API gateway (breaking change) [#48048](https://github.com/orgs/supabase/discussions/48048) (PR [#48153](https://github.com/supabase/supabase/pull/48153))
 
-Check the main Supabase [changelog](https://github.com/orgs/supabase/discussions/categories/changelog?discussions_q=is%3Aopen+category%3AChangelog+label%3Aself-hosted) for updates.
+(Check the main Supabase [changelog](https://github.com/orgs/supabase/discussions/categories/changelog?discussions_q=is%3Aopen+category%3AChangelog+label%3Aself-hosted) for updates.)
 
 ---
 
 ## [0.7.1](https://github.com/supabase/supabase/releases/tag/self-hosted/v0.7.1) - 2026-08-03
 
 ### Configuration
-- Added `SUPABASE_JWKS` to `docker-compose.yml` - PR [#45635](https://github.com/supabase/supabase/pull/45635)
+- Added `SUPABASE_JWKS` configuration for Edge Functions to `docker-compose.yml` - PR [#45635](https://github.com/supabase/supabase/pull/45635)
 - Added `upgrades.json` - a version-keyed manifest to gate breaking changes (required for `update.sh`) - PR [#47851](https://github.com/supabase/supabase/pull/47851)
 - Updated `.gitignore` (required for `update.sh`)
 
@@ -28,16 +28,16 @@ Check the main Supabase [changelog](https://github.com/orgs/supabase/discussions
 - Added new how-to guides ([Custom Postgres Extensions](https://supabase.com/docs/guides/self-hosting/custom-postgres-extensions) and [Update Your Self-Hosted Deployment](https://supabase.com/docs/guides/self-hosting/updating)) - PR [#48203](https://github.com/supabase/supabase/pull/48203), PR [#48535](https://github.com/supabase/supabase/pull/48535)
 
 ### Utils and tests
-- Added base version stamp to `setup.sh` (in `.supabase-version`, required for `update.sh`) - PR [#47848](https://github.com/supabase/supabase/pull/47848)
+- Added base version stamp to `setup.sh` (saved in `.supabase-version`, required for `update.sh`) - PR [#47848](https://github.com/supabase/supabase/pull/47848)
 - Added `update.sh`. Refer to [Update Your Self-Hosted Deployment](https://supabase.com/docs/guides/self-hosting/updating) - PR [#47851](https://github.com/supabase/supabase/pull/47851)
 - Added `SUPABASE_JWKS` configuration for Edge Functions to `utils/add-new-auth-keys.sh` - PR [#45635](https://github.com/supabase/supabase/pull/45635)
 - Updated `tests/test-s3.sh` and `test-s3-backend.sh` - PR [#48500](https://github.com/supabase/supabase/pull/48500)
 
 ### API gateway
 - Updated Kong to `3.9.3`
-- Added `KONG_DNS_VALID_TTL` configuration (requires `docker-compose.yml` update) - PR [#47846](https://github.com/supabase/supabase/pull/47846)
-- Updated Envoy to `1.39.0` (requies `docker-compose.envoy.yml` update)
-- Updated [nginx-certbot](https://github.com/JonasAlfredsson/docker-nginx-certbot) to `6.2.0-nginx1.31.3`
+- Added `KONG_DNS_VALID_TTL` configuration environment variable (requires `docker-compose.yml` update) - PR [#47846](https://github.com/supabase/supabase/pull/47846)
+- Updated Envoy to `1.39.0` (requires `docker-compose.envoy.yml` update)
+- Updated [nginx-certbot](https://github.com/JonasAlfredsson/docker-nginx-certbot) to `6.2.0-nginx1.31.3` (requires `docker-compose.nginx.yml` update)
 
 ### Studio
 - Updated to `2026.03.08-sha-xxxxxxx`
@@ -45,10 +45,9 @@ Check the main Supabase [changelog](https://github.com/orgs/supabase/discussions
 - Fixed the Logs tab visibility in **Auth > Users** - PR [#48122](https://github.com/supabase/supabase/pull/48122) (via [@luizfelmach](https://github.com/luizfelmach/))
 
 ### Storage
-- Changed RustFS image to `rustfs/rustfs:1.0.0-beta.11` temporarily (requires `docker-compose.rustfs.yml` update) - PR [#48500](https://github.com/supabase/supabase/pull/48500)
+- Changed RustFS image to `1.0.0-beta.11` temporarily (requires `docker-compose.rustfs.yml` update) - PR [#48500](https://github.com/supabase/supabase/pull/48500)
 
 ### Edge Runtime
-- Added healthcheck for `functions` (requires `docker-compose.yml` update) - PR [#46655](https://github.com/supabase/supabase/pull/46655)
 - Changed JWKS configuration mechanism for main worker (requires `docker-compose.yml` and `volumes/functions/main/index.ts` update) - PR [#45635](https://github.com/supabase/supabase/pull/45635)
 
 ---

--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -38,7 +38,7 @@ See per-service updates below for details. Only the most important changes relev
 - Updated [nginx-certbot](https://github.com/JonasAlfredsson/docker-nginx-certbot) to `6.2.0-nginx1.31.3` (requires `docker-compose.nginx.yml` update)
 
 ### Studio
-- Updated to `2026.03.08-sha-xxxxxxx`
+- Updated to `2026.08.03-sha-022b374`
 - Fixed URL generation for Edge Functions - PR [#47861](https://github.com/supabase/supabase/pull/47861) (via [@7ttp](https://github.com/7ttp))
 - Fixed the Logs tab visibility in **Auth > Users** - PR [#48122](https://github.com/supabase/supabase/pull/48122) (via [@luizfelmach](https://github.com/luizfelmach/))
 

--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -13,8 +13,6 @@ See per-service updates below for details. Only the most important changes relev
 ## Unreleased
 - Self-hosted Supabase: Envoy becomes the default API gateway (breaking change) [#48048](https://github.com/orgs/supabase/discussions/48048) (PR [#48153](https://github.com/supabase/supabase/pull/48153))
 
-(Check the main Supabase [changelog](https://github.com/orgs/supabase/discussions/categories/changelog?discussions_q=is%3Aopen+category%3AChangelog+label%3Aself-hosted) for updates.)
-
 ---
 
 ## [0.7.1](https://github.com/supabase/supabase/releases/tag/self-hosted/v0.7.1) - 2026-08-03

--- a/docker/docker-compose.envoy.yml
+++ b/docker/docker-compose.envoy.yml
@@ -16,7 +16,7 @@ services:
   # Envoy API gateway
   api-gw:
     container_name: supabase-envoy
-    image: envoyproxy/envoy:v1.38.0
+    image: envoyproxy/envoy:v1.39.0
     restart: unless-stopped
     ports:
       - ${KONG_HTTP_PORT}:8000/tcp

--- a/docker/docker-compose.nginx.yml
+++ b/docker/docker-compose.nginx.yml
@@ -20,7 +20,7 @@ services:
 
   nginx:
     container_name: supabase-nginx
-    image: jonasal/nginx-certbot:6.2.0-nginx1.31.0
+    image: jonasal/nginx-certbot:6.2.0-nginx1.31.3
     restart: unless-stopped
     ports:
       - "80:80"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -67,7 +67,7 @@ services:
 
   kong:
     container_name: supabase-kong
-    image: kong/kong:3.9.1
+    image: kong/kong:3.9.3
     restart: unless-stopped
     networks:
       default:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,7 +14,7 @@ services:
 
   studio:
     container_name: supabase-studio
-    image: supabase/studio:2026.07.07-sha-a6a04f2
+    image: supabase/studio:2026.08.03-sha-022b374
     restart: unless-stopped
     healthcheck:
       test:

--- a/docker/versions.md
+++ b/docker/versions.md
@@ -1,4 +1,8 @@
-# Docker Image Versions
+# Docker image version updates in docker-compose.yml
+
+## 2026-08-03
+- supabase/studio:2026.03.08-sha-xxxxxxx (prev supabase/studio:2026.07.07-sha-a6a04f2)
+- kong/kong:3.9.3 (prev kong/kong:3.9.1)
 
 ## 2026-07-07
 - supabase/studio:2026.07.07-sha-a6a04f2 (prev supabase/studio:2026.06.03-sha-0bca601)

--- a/docker/versions.md
+++ b/docker/versions.md
@@ -1,7 +1,7 @@
 # Docker image version updates in docker-compose.yml
 
 ## 2026-08-03
-- supabase/studio:2026.03.08-sha-xxxxxxx (prev supabase/studio:2026.07.07-sha-a6a04f2)
+- supabase/studio:2026.08.03-sha-022b374 (prev supabase/studio:2026.07.07-sha-a6a04f2)
 - kong/kong:3.9.3 (prev kong/kong:3.9.1)
 
 ## 2026-07-07


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Add:
- New utility script - `update.sh` (PR #47851; see the [how-to](https://supabase.com/docs/guides/self-hosting/updating) for more information)

Update images:
- docker-compose.yml:
  - `supabase/studio:2026.08.03-sha-022b374`
  - `kong/kong:3.9.3`
- Overrides:
  - `envoyproxy/envoy:v1.39.0`
  - `jonasal/nginx-certbot:6.2.0-nginx1.31.3`

Update [CHANGELOG.md](https://github.com/supabase/supabase/blob/master/docker/CHANGELOG.md) to include changes since [self-hosted/v0.7.0](https://github.com/supabase/supabase/releases/tag/self-hosted%2Fv0.7.0)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Envoy is now the default API gateway, representing a breaking configuration change.
  * Added release notes for version 0.7.1, including updates across configuration, Studio, storage, utilities, and edge runtime.

* **Chores**
  * Updated Docker images for Envoy, nginx, Studio, and Kong.
  * Added the latest Docker Compose version information to the release documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->