### PR TITLE
chore(studio): tidy up scoped pat admonition

### DIFF
--- a/apps/studio/components/interfaces/Account/AccessTokens/MigrationAdmonition.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/MigrationAdmonition.tsx
@@ -1,7 +1,6 @@
 import { LOCAL_STORAGE_KEYS } from 'common'
-import { X } from 'lucide-react'
 import Link from 'next/link'
-import { Button } from 'ui'
+import { Badge, Button } from 'ui'
 import { Admonition } from 'ui-patterns/Admonition'
 
 import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
@@ -19,28 +18,29 @@ export const MigrationAdmonition = () => {
     <Admonition
       type="default"
       title="We're moving to scoped access tokens"
-      className="relative"
+      className="relative mb-5"
       actions={
-        <Button
-          variant="text"
-          icon={<X />}
-          className="absolute right-2.5 top-2.5 h-7 w-7"
-          onClick={() => setIsDismissed(true)}
-          aria-label="Close"
-        />
+        <>
+          {/* Awaiting correct documentation link */}
+          <Button asChild variant="default" size="tiny">
+            <Link href={`${DOCS_URL}/guides/api`} target="_blank" rel="noreferrer">
+              Learn more
+            </Link>
+          </Button>
+          <Button variant="text" onClick={() => setIsDismissed(true)} aria-label="Close">
+            Dismiss
+          </Button>
+        </>
       }
     >
-      <div className="space-y-3">
+      <div className="flex flex-col gap-y-1.5">
         <p className="text-sm text-foreground-light">
-          Your existing classic tokens keep working. New tokens are now scoped — we recommend
-          granting each token the minimum access its integration needs.
+          We recommend granting each new token the minimum access its integration needs.
         </p>
-        <Button asChild variant="default" size="tiny">
-          {/* TODO: replace with the scoped tokens docs route once published */}
-          <Link href={`${DOCS_URL}/guides/api`} target="_blank" rel="noreferrer">
-            Learn more
-          </Link>
-        </Button>
+        <span className="text-sm text-foreground-light">
+          Pre-existing tokens are marked with a <Badge>Legacy</Badge> badge and will continue to
+          work until expiry or deletion.
+        </span>
       </div>
     </Admonition>
   )

--- a/packages/ui-patterns/src/Admonition/Admonition.tsx
+++ b/packages/ui-patterns/src/Admonition/Admonition.tsx
@@ -98,7 +98,7 @@ export const Admonition = forwardRef<
             {actions && (
               <div
                 className={cn(
-                  'flex flex-row gap-3',
+                  'flex flex-row gap-2',
                   layout === 'vertical' && 'mt-3 items-start',
                   layout === 'horizontal' && 'items-center',
                   layout === 'responsive' && 'mt-3 items-start @md:mt-0 @md:items-center'


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

@w3b6x9 initial pass at the announcement banner here. Please have a read of the copy and feel free to improve where you see fit. I also corrected how the actions are passed to our `<Admonition />` component. There's also an inline comment to remind us to update the `Learn more` link when we go live.

| Before | After |
|--------|--------|
| <img width="755" height="264" alt="Screenshot 2026-08-03 at 14 03 34" src="https://github.com/user-attachments/assets/05b9e577-4d56-4c42-961a-37ac1e753141" /> | <img width="769" height="300" alt="Screenshot 2026-08-03 at 14 03 46" src="https://github.com/user-attachments/assets/11b7bdef-f7a3-47e5-a8b5-a021aafb0bca" /> | 



