### PR TITLE
docs(www): add launch video to Supabase Pipelines feature page

### DIFF
--- a/apps/www/data/features.tsx
+++ b/apps/www/data/features.tsx
@@ -672,7 +672,7 @@ Schema change support is currently in beta and limited to supported BigQuery cha
 Pipelines keeps the current destination table state synchronized. It does not automatically create a queryable history of every row version.`,
     icon: CloudCog,
     products: [PRODUCT_SHORTNAMES.DATABASE],
-    heroImage: '',
+    heroImage: 'https://www.youtube-nocookie.com/embed/8o3duiYqppA',
     docsUrl: 'https://supabase.com/docs/guides/database/replication/pipelines',
     slug: 'supabase-pipelines',
     status: {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- Sets `heroImage` on the `supabase-pipelines` entry in `apps/www/data/features.tsx` to the "Introducing Supabase Pipelines" YouTube embed

## What is the current behavior?

`/features/supabase-pipelines` has an empty `heroImage`, so the hero renders the fallback icon block instead of media.

## What is the new behavior?

- The feature page hero renders the launch video, using the same `youtube-nocookie.com/embed/<id>` format as the other 22 feature entries with video heroes

## Additional context

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Updated the Supabase Pipelines feature presentation to display a YouTube video as its hero visual.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->