### PR TITLE
docs(database): add Drizzle serverless deploy template

### DIFF
--- a/apps/docs/content/guides/database/connecting-to-postgres/serverless-drivers.mdx
+++ b/apps/docs/content/guides/database/connecting-to-postgres/serverless-drivers.mdx
@@ -38,6 +38,15 @@ Choose one of these Vercel Deploy Templates which use our [Vercel Deploy Integra
         Basic Next.js template that uses Supabase as the database and Kysely as the query builder.
       </GlassPanel>
     </Link>
+    <Link
+      href="https://supabase.link/nextjs-supabase-drizzle"
+      className="col-span-12 md:col-span-6 xl:col-span-4"
+      passHref
+    >
+      <GlassPanel title="Drizzle" hasLightIcon={true} showIconBg={true}>
+        Basic Next.js template that uses Supabase as the database and Drizzle as the ORM.
+      </GlassPanel>
+    </Link>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary

Adds the missing Drizzle deploy-template card to the Serverless Drivers quickstart.

The page already includes a Drizzle manual configuration example, but the quickstart template cards only surfaced `supabase-js` and Kysely. This adds the existing `https://supabase.link/nextjs-supabase-drizzle` template alongside the other Vercel deploy templates.

Closes https://github.com/supabase/supabase/issues/46529

## Validation

- Confirmed `https://supabase.link/nextjs-supabase-drizzle` returns `200`.
- Confirmed the shortlink resolves to the Vercel deploy flow for the Drizzle Next.js starter.
- Kept the change scoped to `serverless-drivers.mdx`; no runtime code changes.

## Notes

I did not run the full docs build locally because this is a single MDX quickstart-card change in a sparse checkout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Vercel Deploy Template link for a basic Next.js application using Supabase and Drizzle ORM.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->