### PR TITLE
docs: supabase evals note in AI tools page

### DIFF
--- a/apps/docs/content/guides/ai-tools.mdx
+++ b/apps/docs/content/guides/ai-tools.mdx
@@ -8,7 +8,7 @@ Supabase provides everything you need to connect an AI coding agent to your proj
 
 <Admonition type="note">
 
-See how these tools perform on real Supabase tasks in [Supabase Evals](/evals), our open source benchmark for AI coding agents.
+See how these tools perform on real Supabase tasks in [Supabase Evals](/evals), our open-source benchmark for AI coding agents.
 
 </Admonition>
 

--- a/apps/docs/content/guides/ai-tools.mdx
+++ b/apps/docs/content/guides/ai-tools.mdx
@@ -6,6 +6,12 @@ subtitle: 'Connect your AI coding agent to Supabase.'
 
 Supabase provides everything you need to connect an AI coding agent to your project: a live connection to your database and platform (MCP), portable instructions your agent can reuse (Agent Skills), a one-step bundle of both (Plugin), and copy-paste prompts for tools that don't support any of the above.
 
+<Admonition type="note">
+
+See how these tools perform on real Supabase tasks in [Supabase Evals](https://supabase.com/evals), our open source benchmark for AI coding agents.
+
+</Admonition>
+
 ## Pick your agent
 
 <ContentListings id="ai-tools-supported-agents" />

--- a/apps/docs/content/guides/ai-tools.mdx
+++ b/apps/docs/content/guides/ai-tools.mdx
@@ -8,7 +8,7 @@ Supabase provides everything you need to connect an AI coding agent to your proj
 
 <Admonition type="note">
 
-See how these tools perform on real Supabase tasks in [Supabase Evals](https://supabase.com/evals), our open source benchmark for AI coding agents.
+See how these tools perform on real Supabase tasks in [Supabase Evals](/evals), our open source benchmark for AI coding agents.
 
 </Admonition>
 

--- a/supa-mdx-lint/Rule003Spelling.toml
+++ b/supa-mdx-lint/Rule003Spelling.toml
@@ -235,6 +235,7 @@ allow_list = [
     "EnterpriseDB",
     "Entra",
     "[Ee]nvoy",
+    "[Ee]vals",
     "ePHI",
     "Erlang",
     "ESZip",


### PR DESCRIPTION
Following announcement https://supabase.com/blog/introducing-supabase-evals

Adds an admonition to the [AI Tools](https://supabase.com/docs/guides/ai-tools) overview calling out the recently launched [Supabase Evals](https://supabase.com/blog/introducing-supabase-evals) project to demonstrate performance of (some of) the tools shown.

Preview: https://docs-git-mattrossman-ai-969-link-to-evals-from-47d719-supabase.vercel.app/docs/guides/ai-tools

<img width="3600" height="1606" alt="CleanShot 2026-08-03 at 15 13 06@2x" src="https://github.com/user-attachments/assets/8ea23f6c-fde0-4b04-bed1-035941570ac1" />

If preferred, we can move it below the fold, I just figure it's good for visibility on the recent launch and it helps sell the "why" for using these tools.

Closes AI-969


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Added a link and note about Supabase Evals, an open-source benchmark for AI coding agents.
* **Chores**
  * Updated spelling checks to recognize “eval” in any capitalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->