### PR TITLE
chore(www): update Edge Functions customer quote to eXp Realty

### DIFF
--- a/apps/www/app/(products)/edge-functions/_components/EdgeFunctionsContent.tsx
+++ b/apps/www/app/(products)/edge-functions/_components/EdgeFunctionsContent.tsx
@@ -17,13 +17,13 @@ export function EdgeFunctionsContent() {
       </section>
       <section id="quote" className="border-t border-border" aria-label="Customer quote">
         <QuoteSection
-          quote="Supabase gave us the flexibility and scalability needed at every growth stage."
-          highlight="It's rare to find a tool that works just as well for startups as it does for large-scale operations."
+          quote="The thing that makes everything possible, all of our rapid development now and AI-generated or assisted development, is Supabase."
+          highlight="That's the giant whose shoulders we can stand on."
           author={{
-            name: 'Zeno Rocha',
-            role: 'CEO at Resend',
-            image: '/images/blog/avatars/zeno-rocha.png',
-            link: '/customers/resend',
+            name: 'Seth Siegler',
+            role: 'Chief Innovation Officer at eXp Realty',
+            image: '/images/blog/avatars/seth-siegler.jpg',
+            link: '/customers/exprealty',
           }}
         />
       </section>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- Updates the customer testimonial on the Edge Functions product page

## What is the current behavior?

The Edge Functions page shows an older customer quote.

## What is the new behavior?

- The quote is from Seth Siegler, Chief Innovation Officer at eXp Realty
- The quote is taken verbatim from the published eXp Realty customer story
- The attribution links to /customers/exprealty
- Uses the existing seth-siegler.jpg avatar already in the repo; no new assets

## Additional context

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Updated the Edge Functions customer testimonial with a new quote, customer attribution, profile image, role, and link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->