### PR TITLE
docs: add SuperSend TX to custom SMTP provider list

### DIFF
--- a/apps/docs/content/guides/auth/auth-smtp.mdx
+++ b/apps/docs/content/guides/auth/auth-smtp.mdx
@@ -47,6 +47,7 @@ A non-exhaustive list of services that work with Supabase Auth is:
 - [Twilio SendGrid](https://www.twilio.com/docs/sendgrid/for-developers/sending-email/getting-started-smtp)
 - [ZeptoMail](https://www.zoho.com/zeptomail/help/smtp-home.html)
 - [Brevo](https://help.brevo.com/hc/en-us/articles/7924908994450-Send-transactional-emails-using-Brevo-SMTP)
+- [SuperSend TX](https://docs.supersendtx.com/guides/supabase)
 
 Once you've set up your account with an email sending service, head to the [Authentication settings page](/dashboard/project/_/auth/smtp) to enable and configure custom SMTP.
 

--- a/supa-mdx-lint/Rule003Spelling.toml
+++ b/supa-mdx-lint/Rule003Spelling.toml
@@ -388,6 +388,7 @@ allow_list = [
     "SQLite",
     "SecureStore",
     "SendGrid",
+    "SuperSend",
     "Session Timebox",
     "sigstore",
     "Snapchat",


### PR DESCRIPTION
## What
Adds **SuperSend TX** to the non-exhaustive custom SMTP provider list on the [Send emails with custom SMTP](https://supabase.com/docs/guides/auth/auth-smtp) guide.

## Why
Teams leaving Supabase’s default mailer need a production SMTP provider. SuperSend TX supports Supabase Auth via:
- Custom SMTP (`smtp.supersendtx.com`) pasted into Authentication → SMTP
- Optional Send Email hook + Edge Function for custom templates

Guide: https://docs.supersendtx.com/guides/supabase

Same shape as the existing Resend / Postmark / Brevo bullets.

## Checklist
- [ ] Preview shows SuperSend TX under the provider list
- [ ] Link resolves


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added SuperSend TX to the list of SMTP providers compatible with Supabase Auth.
  - Updated documentation spelling validation to recognize the provider name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->