### PR TITLE
docs: point client library reference links at /introduction instead of dead /start

### DIFF
--- a/apps/docs/content/guides/getting-started/features.mdx
+++ b/apps/docs/content/guides/getting-started/features.mdx
@@ -176,7 +176,7 @@ Manage your projects programmatically. [Docs](/docs/reference/api).
 
 ## Client libraries
 
-Official client libraries for [JavaScript](/docs/reference/javascript/start), [Flutter](/docs/reference/dart/initializing) and [Swift](/docs/reference/swift/introduction).
+Official client libraries for [JavaScript](/docs/reference/javascript/introduction), [Flutter](/docs/reference/dart/initializing) and [Swift](/docs/reference/swift/introduction).
 Unofficial libraries are supported by the community.
 
 ## Feature status

--- a/apps/www/_blog/2023-02-14-flutter-real-time-multiplayer-game.mdx
+++ b/apps/www/_blog/2023-02-14-flutter-real-time-multiplayer-game.mdx
@@ -842,4 +842,4 @@ We learned how to create an interactive shooting game. We took advantage of Flut
 - [Flutter Tutorial: building a Flutter chat app](https://supabase.com/blog/flutter-tutorial-building-a-chat-app)
 - [Flutter Authentication and Authorization with RLS](https://supabase.com/blog/flutter-authentication-and-authorization-with-rls)
 - [Generate Flame template using Very Good CLI](https://verygood.ventures/blog/generate-a-game-with-our-new-template)
-- [Supabase Flutter SDK docs](https://supabase.com/docs/reference/dart/start)
+- [Supabase Flutter SDK docs](https://supabase.com/docs/reference/dart/introduction)

--- a/apps/www/_blog/2024-09-05-flutter-uber-clone.mdx
+++ b/apps/www/_blog/2024-09-05-flutter-uber-clone.mdx
@@ -778,4 +778,4 @@ Want to learn more about Maps and PostGIS? Make sure to follow our [Twitter](ht
 
 - [Flutter Tutorial: building a Flutter chat app](https://supabase.com/blog/flutter-tutorial-building-a-chat-app)
 - [Generate Flame template using Very Good CLI](https://verygood.ventures/blog/generate-a-game-with-our-new-template)
-- [Supabase Flutter SDK docs](https://supabase.com/docs/reference/dart/start)
+- [Supabase Flutter SDK docs](https://supabase.com/docs/reference/dart/introduction)

--- a/apps/www/data/features.tsx
+++ b/apps/www/data/features.tsx
@@ -2696,7 +2696,7 @@ This feature is particularly valuable for developers looking to build dynamic we
     icon: JsIcon,
     products: [ADDITIONAL_PRODUCTS.PLATFORM],
     heroImage: '',
-    docsUrl: 'https://supabase.com/docs/reference/javascript/start',
+    docsUrl: 'https://supabase.com/docs/reference/javascript/introduction',
     slug: 'client-library-javascript',
     status: {
       stage: PRODUCT_STAGES.GA,
@@ -2721,7 +2721,7 @@ This feature is particularly useful for Flutter developers aiming to create resp
     icon: FlutterIcon,
     products: [ADDITIONAL_PRODUCTS.PLATFORM],
     heroImage: '',
-    docsUrl: 'https://supabase.com/docs/reference/dart/start',
+    docsUrl: 'https://supabase.com/docs/reference/dart/introduction',
     slug: 'client-library-flutter',
     status: {
       stage: PRODUCT_STAGES.GA,
@@ -2746,7 +2746,7 @@ This feature is particularly valuable for iOS developers looking to leverage the
     icon: SwiftIcon,
     products: [ADDITIONAL_PRODUCTS.PLATFORM],
     heroImage: '',
-    docsUrl: 'https://supabase.com/docs/reference/swift/start',
+    docsUrl: 'https://supabase.com/docs/reference/swift/introduction',
     slug: 'client-library-swift',
     status: {
       stage: PRODUCT_STAGES.GA,
@@ -2771,7 +2771,7 @@ This feature is especially beneficial for Python developers looking to build rob
     icon: PythonIcon,
     products: [ADDITIONAL_PRODUCTS.PLATFORM],
     heroImage: '',
-    docsUrl: 'https://supabase.com/docs/reference/python/start',
+    docsUrl: 'https://supabase.com/docs/reference/python/introduction',
     slug: 'client-library-python',
     status: {
       stage: PRODUCT_STAGES.BETA,


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs fix (broken links).

## What is the current behavior?

Seven links point at `/docs/reference/<library>/start`, which returns 404 for every client library:

| link | where |
| --- | --- |
| `reference/javascript/start` | `apps/www/data/features.tsx`, `guides/getting-started/features.mdx` |
| `reference/dart/start` | `apps/www/data/features.tsx`, two Flutter blog posts |
| `reference/swift/start` | `apps/www/data/features.tsx` |
| `reference/python/start` | `apps/www/data/features.tsx` |

The `/start` pages are gone and are not in the sitemap. The four in `features.tsx` are the "docs" links on the marketing features page, so those are the client library entry points a reader clicks from there.

## What is the new behavior?

Each one points at that library's `/introduction` page, all of which return 200.

The repo already agrees this is the right target. In `guides/getting-started/features.mdx` the same sentence links JavaScript to `/start` (dead) while Swift already points at `/introduction` (live), so this makes that line internally consistent:

```
Official client libraries for [JavaScript](/docs/reference/javascript/introduction),
[Flutter](/docs/reference/dart/initializing) and [Swift](/docs/reference/swift/introduction).
```

`/introduction` is also where #48453 pointed the in-repo reference links, and where my open #48562 repoints the bare `/docs/reference/<library>` redirects. This PR is the content half: #48562 only changes where the bare path redirects, it does not help a page that links directly to `/start`.

I left the Flutter link in that sentence alone, since `/docs/reference/dart/initializing` returns 200 already.

## Additional context

Files (7 links across 4 files):

- `apps/www/data/features.tsx` (4)
- `apps/www/_blog/2024-09-05-flutter-uber-clone.mdx` (1)
- `apps/www/_blog/2023-02-14-flutter-real-time-multiplayer-game.mdx` (1)
- `apps/docs/content/guides/getting-started/features.mdx` (1)

I did not touch `apps/www/app/api-v2/md/content.generated.ts`, which also contains these strings, since it is generated from the blog MDX and will pick the change up on its next build.

Verification: every `/start` URL confirmed 404, and `javascript`, `dart`, `swift` and `python` `/introduction` all confirmed 200 and present in the sitemap. After the change no `reference/<lib>/start` reference remains in any non-generated source.

Gates run locally: `test:prettier` passes repo wide, `typecheck` passes 16/16, the www vitest suite passes (6 files, 73 tests) and the docs suite passes (22 files, 169 tests, 1 file and 2 tests skipped). I did not run `pnpm build`, which cannot complete here because the docs `build:federated-content` step requires `DOCS_GITHUB_APP_PRIVATE_KEY`.

Found by extracting every absolute `supabase.com/docs` link in `apps/www` and `apps/docs/content` (358 distinct) and checking each against the live site. I am working through the dead ones in small batches, which is why there are a few related PRs open right now (#48560, #48562, #48563, #48568, #48629, #48634, #48655, #48656). Happy to consolidate them if that would be easier to review.

Freshman contributor, put this together with Claude Code's help and checked each URL myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated JavaScript, Flutter, Swift, and Python client library links to the current introduction pages.
  * Replaced outdated Flutter documentation links in getting-started content and blog articles.
  * Ensured client library feature documentation points to valid, up-to-date URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->