### PR TITLE
fix(pg-meta): exclude extension-owned functions from SECURITY DEFINER lints

### DIFF
--- a/packages/pg-meta/src/sql/studio/advisor/lints.ts
+++ b/packages/pg-meta/src/sql/studio/advisor/lints.ts
@@ -1685,8 +1685,12 @@ from
                 on p.pronamespace = n.oid
             join pg_catalog.pg_language l
                 on p.prolang = l.oid
+            left join pg_catalog.pg_depend dep
+                on p.oid = dep.objid
+                and dep.deptype = 'e'
         where
             p.prosecdef = true
+            and dep.objid is null -- exclude functions owned by extensions
             and pg_catalog.has_function_privilege('anon', p.oid, 'EXECUTE')
             and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
             and n.nspname not in (
@@ -1740,8 +1744,12 @@ from
                 on p.pronamespace = n.oid
             join pg_catalog.pg_language l
                 on p.prolang = l.oid
+            left join pg_catalog.pg_depend dep
+                on p.oid = dep.objid
+                and dep.deptype = 'e'
         where
             p.prosecdef = true
+            and dep.objid is null -- exclude functions owned by extensions
             and pg_catalog.has_function_privilege('authenticated', p.oid, 'EXECUTE')
             and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
             and n.nspname not in (


### PR DESCRIPTION
## Summary

The two lints added for SECURITY DEFINER functions callable by the `anon` and `authenticated` roles (`0028_anon_security_definer_function_executable`, `0029_authenticated_security_definer_function_executable`) are missing the extension-owned-object exclusion that every other lint in this file uses.

Every other lint joins `pg_catalog.pg_depend dep on <obj>.oid = dep.objid and dep.deptype = 'e'` and filters with `dep.objid is null` to skip extension-installed objects. The two new security-definer lints query `pg_catalog.pg_proc` directly without this guard.

Extensions like PostGIS, pg_cron, and pgsodium install `SECURITY DEFINER` functions in public-accessible schemas. Without the exclusion, those functions appear as unresolvable false-positive warnings in the Security Advisor for every project with those extensions enabled.

## Fix

Add the same `left join pg_catalog.pg_depend` guard to both lints, matching the pattern already in use for the existing function lints immediately above them.

```sql
-- added to both lints
left join pg_catalog.pg_depend dep
    on p.oid = dep.objid
    and dep.deptype = 'e'
...
and dep.objid is null -- exclude functions owned by extensions
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Security advisor checks now exclude extension-owned functions when reporting security-definer function issues for anonymous and authenticated users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->