### PR TITLE
Mention Google Auth not usable in Expo Go

### DIFF
--- a/apps/docs/content/guides/auth/social-login/auth-google.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-google.mdx
@@ -81,7 +81,11 @@ Regardless of whether you use application code or Google's pre-built solutions t
    - For iOS, use the instructions on screen to provide the app Bundle ID, and App Store ID and Team ID if the app is already published on the Apple App Store.
 1. Register the Client ID in the [Google provider page on the Dashboard](/dashboard/project/_/auth/providers?provider=Google).
 
-  </TabPanel>
+<Admonition type="note">
+  You will not be able to setup Google authentication on Expo Go and must use a development build.
+</Admonition>
+
+</TabPanel>
 
   <TabPanel id="flutter-mobile" label="Flutter (iOS and Android)">
 

--- a/apps/docs/content/guides/auth/social-login/auth-google.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-google.mdx
@@ -82,7 +82,7 @@ Regardless of whether you use application code or Google's pre-built solutions t
 1. Register the Client ID in the [Google provider page on the Dashboard](/dashboard/project/_/auth/providers?provider=Google).
 
 <Admonition type="note">
-  You will not be able to setup Google authentication on Expo Go and must use a development build.
+  You will not be able to set up Google authentication on Expo Go and must use a development build.
 </Admonition>
 
 </TabPanel>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Doc Update 

## What is the current behavior?

[Currently](https://supabase.com/docs/guides/auth/social-login/auth-google?queryGroups=platform&platform=react-native&queryGroups=framework&framework=sveltekit) google login with Expo does not mention that Expo go [does not support](https://docs.expo.dev/guides/google-authentication/#prerequisites) Google Authentication and that a development build is needed instead. 

## What is the new behavior?

Added a note to mention this

## Additional context
None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an Expo-specific note to the React Native Google authentication setup.
  * Clarified that Google authentication requires a development build and is unavailable in Expo Go.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->