### PR TITLE
Update pg_net schema

### DIFF
--- a/apps/docs/content/guides/database/extensions/pg_net.mdx
+++ b/apps/docs/content/guides/database/extensions/pg_net.mdx
@@ -34,8 +34,8 @@ It eliminates the need for servers to continuously poll for database changes and
 
 ```sql
 -- Example: enable the "pg_net" extension.
-create extension pg_net;
--- Note: The extension creates its own schema/namespace named "net" to avoid naming conflicts.
+create extension pg_net with schema "extensions";
+-- Note: The extension creates its own schema/namespace named "net" to avoid naming conflicts. Registering it in the extensions schema avoids exposing it in public and satisfies the Security Advisor check.
 
 -- Example: disable the "pg_net" extension
 drop extension if exists pg_net;


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The create extension snippet defaults to public which trips the Security Advisor check "0014_extension_in_public".

The extension either way creates its own "net" schema.

## What is the new behavior?

Register pg_net in the extensions schema.
This is also the default when installing the extension from the dashboard.

<img width="425" height="224" alt="image" src="https://github.com/user-attachments/assets/160309c0-9d35-4de7-b583-32f5db310a96" />


## Additional context
When no schema is specified, defaults to public which trips the Security Advisor check:

<img width="1084" height="250" alt="image" src="https://github.com/user-attachments/assets/ac5f2859-17bf-4763-9880-453b0f414b4f" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the pg_net installation example to place the extension in the `extensions` schema.
  * Clarified that this configuration keeps pg_net out of `public` and satisfies the Security Advisor check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->