### PR TITLE
fix(studio): improve loading states in edge function overview FE-3919

### DIFF
--- a/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionInvocationsSection.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionInvocationsSection.tsx
@@ -75,26 +75,28 @@ export const EdgeFunctionInvocationsSection = ({
           <div className="flex flex-col gap-5">
             <PageSectionMeta className="items-center!">
               <PageSectionSummary>
-                <div className="flex flex-wrap items-start gap-x-8 gap-y-4">
-                  <ChartMetric
-                    label="Total Invocations"
-                    value={totalInvocationCount}
-                    status="default"
-                    tooltip="Total number of invocations"
-                  />
-                  <ChartMetric
-                    label="5xx Rate"
-                    value={formatRate(totalErrorCount, totalInvocationCount)}
-                    status="negative"
-                    tooltip="Share of invocations that returned a 5xx status code"
-                  />
-                  <ChartMetric
-                    label="4xx Rate"
-                    value={formatRate(totalWarningCount, totalInvocationCount)}
-                    status="warning"
-                    tooltip="Share of invocations that returned a 4xx status code"
-                  />
-                </div>
+                <Chart isLoading={isLoadingChart}>
+                  <div className="flex flex-wrap items-start gap-x-8 gap-y-4">
+                    <ChartMetric
+                      label="Total Invocations"
+                      value={totalInvocationCount}
+                      status="default"
+                      tooltip="Total number of invocations"
+                    />
+                    <ChartMetric
+                      label="5xx Rate"
+                      value={formatRate(totalErrorCount, totalInvocationCount)}
+                      status="negative"
+                      tooltip="Share of invocations that returned a 5xx status code"
+                    />
+                    <ChartMetric
+                      label="4xx Rate"
+                      value={formatRate(totalWarningCount, totalInvocationCount)}
+                      status="warning"
+                      tooltip="Share of invocations that returned a 4xx status code"
+                    />
+                  </div>
+                </Chart>
               </PageSectionSummary>
               <PageSectionAside className="flex-wrap @xl:self-center">
                 <div className="flex items-center">

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionOverview.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionOverview.tsx
@@ -1,4 +1,5 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
+import { keepPreviousData } from '@tanstack/react-query'
 import { IS_PLATFORM, useParams } from 'common'
 import { ExternalLink } from 'lucide-react'
 import { useRouter } from 'next/router'
@@ -58,6 +59,7 @@ export const EdgeFunctionOverview = () => {
     },
     {
       enabled: IS_PLATFORM,
+      placeholderData: keepPreviousData,
     }
   )
 

--- a/apps/studio/components/layouts/EdgeFunctionsLayout/EdgeFunctionDetailsLayout.tsx
+++ b/apps/studio/components/layouts/EdgeFunctionsLayout/EdgeFunctionDetailsLayout.tsx
@@ -24,6 +24,7 @@ import {
   PopoverContent,
   PopoverTrigger,
   Separator,
+  Skeleton,
 } from 'ui'
 import { Input } from 'ui-patterns/DataInputs/Input'
 import {
@@ -82,6 +83,7 @@ const EdgeFunctionDetailsLayout = ({
     data: selectedFunction,
     error,
     isError,
+    isPending: isLoadingFunction,
   } = useEdgeFunctionQuery({ projectRef: ref, slug: functionSlug })
   const { data: endpoint } = useProjectApiUrl({ projectRef: ref })
 
@@ -306,53 +308,60 @@ const EdgeFunctionDetailsLayout = ({
                   </ShortcutTooltip>
                 </div>
 
-                <HoverCard
-                  openDelay={250}
-                  closeDelay={100}
-                  open={isTimestampHoverCardOpen}
-                  onOpenChange={setIsTimestampHoverCardOpen}
-                >
-                  <HoverCardTrigger asChild>
-                    <button type="button" tabIndex={0} className="flex items-center gap-2 group">
-                      <Clock size={16} strokeWidth={1.5} className="text-foreground-lighter" />
-                      <span className="transition text-foreground-light group-hover:text-foreground underline decoration-dotted decoration-foreground-muted underline-offset-4">
-                        {updatedRelative ?? 'Deploy status unavailable'}
-                      </span>
-                    </button>
-                  </HoverCardTrigger>
-                  <HoverCardContent side="bottom" align="start" className="w-40 p-0">
-                    {createdRelative && (
-                      <div className="px-4 py-2 space-y-1">
-                        <h3 className="heading-meta text-foreground-light">Created</h3>
-                        {!!selectedFunction && (
-                          <TimestampInfo
-                            className="text-sm"
-                            label={createdRelative}
-                            utcTimestamp={selectedFunction.created_at}
-                          />
-                        )}
-                      </div>
-                    )}
-                    {updatedRelative && (
-                      <div className="px-4 py-2 space-y-1">
-                        <h3 className="heading-meta text-foreground-light">Last deployed</h3>
-                        {!!selectedFunction && (
-                          <TimestampInfo
-                            className="text-sm"
-                            label={updatedRelative}
-                            utcTimestamp={selectedFunction.updated_at}
-                          />
-                        )}
-                      </div>
-                    )}
-                    {selectedFunction?.version !== undefined && (
-                      <div className="px-4 py-2 space-y-1">
-                        <h3 className="heading-meta text-foreground-light">Deployments</h3>
-                        <p className="text-sm text-foreground">{selectedFunction.version}</p>
-                      </div>
-                    )}
-                  </HoverCardContent>
-                </HoverCard>
+                {isLoadingFunction ? (
+                  <div className="flex items-center gap-2">
+                    <Clock size={16} strokeWidth={1.5} className="text-foreground-lighter" />
+                    <Skeleton className="h-4 w-24" />
+                  </div>
+                ) : (
+                  <HoverCard
+                    openDelay={250}
+                    closeDelay={100}
+                    open={isTimestampHoverCardOpen}
+                    onOpenChange={setIsTimestampHoverCardOpen}
+                  >
+                    <HoverCardTrigger asChild>
+                      <button type="button" tabIndex={0} className="flex items-center gap-2 group">
+                        <Clock size={16} strokeWidth={1.5} className="text-foreground-lighter" />
+                        <span className="transition text-foreground-light group-hover:text-foreground underline decoration-dotted decoration-foreground-muted underline-offset-4">
+                          {updatedRelative ?? 'Deploy status unavailable'}
+                        </span>
+                      </button>
+                    </HoverCardTrigger>
+                    <HoverCardContent side="bottom" align="start" className="w-40 p-0">
+                      {createdRelative && (
+                        <div className="px-4 py-2 space-y-1">
+                          <h3 className="heading-meta text-foreground-light">Created</h3>
+                          {!!selectedFunction && (
+                            <TimestampInfo
+                              className="text-sm"
+                              label={createdRelative}
+                              utcTimestamp={selectedFunction.created_at}
+                            />
+                          )}
+                        </div>
+                      )}
+                      {updatedRelative && (
+                        <div className="px-4 py-2 space-y-1">
+                          <h3 className="heading-meta text-foreground-light">Last deployed</h3>
+                          {!!selectedFunction && (
+                            <TimestampInfo
+                              className="text-sm"
+                              label={updatedRelative}
+                              utcTimestamp={selectedFunction.updated_at}
+                            />
+                          )}
+                        </div>
+                      )}
+                      {selectedFunction?.version !== undefined && (
+                        <div className="px-4 py-2 space-y-1">
+                          <h3 className="heading-meta text-foreground-light">Deployments</h3>
+                          <p className="text-sm text-foreground">{selectedFunction.version}</p>
+                        </div>
+                      )}
+                    </HoverCardContent>
+                  </HoverCard>
+                )}
               </PageHeaderDescription>
             </PageHeaderSummary>
 


### PR DESCRIPTION
## Problem

The edge function overview page had a few rough edges in its loading states: the header showed "Deploy status unavailable" whenever the function query was still loading (not only when the timestamp was genuinely missing), the top invocation metrics (Total Invocations, 5xx Rate, 4xx Rate) flashed 0/0% before chart data arrived instead of skeleton-loading like the rest of the page, and switching the interval selector flashed the whole section back to a full loading state even though the previous interval's data was still useful to show.

## Fix

- Show a skeleton in place of the deploy status text while the function query is pending, only falling back to "Deploy status unavailable" once loading has finished and there's genuinely no timestamp.
- Wrap the top invocation metrics in the existing `Chart` loading context so they participate in the skeleton mechanism `ChartMetric` already supports.
- Add `placeholderData: keepPreviousData` to the combined-stats query so interval changes keep showing the previous data while the new interval loads.

## How to test

- Open an edge function's overview page and refresh. The deploy status in the header should show a skeleton, not "Deploy status unavailable", while loading.
- On the same page, refresh and watch the Total Invocations / 5xx Rate / 4xx Rate metrics skeleton-load instead of flashing 0/0%.
- Switch the interval selector (e.g. 15min to 1h) and confirm the chart and metrics don't flash back to the loading skeleton, showing the previous interval's data until the new one resolves.

FE-3919