### PR TITLE
[FE-4070] fix(studio): allow adding expressions to RLS policies

### DIFF
--- a/apps/studio/components/interfaces/Database/Policies/PolicyEditorPanel/PolicyEditorPanel.utils.test.ts
+++ b/apps/studio/components/interfaces/Database/Policies/PolicyEditorPanel/PolicyEditorPanel.utils.test.ts
@@ -1,0 +1,102 @@
+import type { PGPolicy } from '@supabase/pg-meta'
+import { describe, expect, it } from 'vitest'
+
+import { generateUpdatePolicyPayload } from './PolicyEditorPanel.utils'
+
+type PolicyFixture = Pick<PGPolicy, 'name' | 'roles' | 'command' | 'definition' | 'check'>
+
+const mockPolicy = (overrides: Partial<PolicyFixture> = {}): PolicyFixture => ({
+  name: 'my_policy',
+  roles: ['authenticated'],
+  command: 'DELETE',
+  definition: 'user_id = auth.uid()',
+  check: null,
+  ...overrides,
+})
+
+const baseForm = {
+  name: 'my_policy',
+  roles: ['authenticated'],
+  // The panel prefills editors with two leading spaces of indentation
+  using: '  user_id = auth.uid()',
+  check: undefined,
+}
+
+describe('generateUpdatePolicyPayload', () => {
+  it('returns an empty payload when nothing changed', () => {
+    expect(generateUpdatePolicyPayload(mockPolicy(), baseForm)).toEqual({})
+  })
+
+  it('includes the definition when a policy with a null definition gains a using expression', () => {
+    const payload = generateUpdatePolicyPayload(mockPolicy({ definition: null }), {
+      ...baseForm,
+      using: 'true',
+    })
+    expect(payload).toEqual({ definition: 'true' })
+  })
+
+  it('includes the definition when the using expression changed', () => {
+    const payload = generateUpdatePolicyPayload(mockPolicy(), { ...baseForm, using: 'true' })
+    expect(payload).toEqual({ definition: 'true' })
+  })
+
+  it('omits the definition when the using expression is empty', () => {
+    expect(generateUpdatePolicyPayload(mockPolicy(), { ...baseForm, using: '' })).toEqual({})
+    expect(generateUpdatePolicyPayload(mockPolicy(), { ...baseForm, using: '   ' })).toEqual({})
+    expect(generateUpdatePolicyPayload(mockPolicy(), { ...baseForm, using: undefined })).toEqual({})
+  })
+
+  it('includes the check when a policy with a null check gains a check expression', () => {
+    const payload = generateUpdatePolicyPayload(mockPolicy({ command: 'UPDATE' }), {
+      ...baseForm,
+      check: 'is_admin()',
+    })
+    expect(payload).toEqual({ check: 'is_admin()' })
+  })
+
+  it('includes the check when the check expression changed', () => {
+    const payload = generateUpdatePolicyPayload(
+      mockPolicy({ command: 'UPDATE', check: 'is_admin()' }),
+      { ...baseForm, check: 'is_owner()' }
+    )
+    expect(payload).toEqual({ check: 'is_owner()' })
+  })
+
+  it('omits the check when the check expression is unchanged or empty', () => {
+    const withCheck = mockPolicy({ command: 'UPDATE', check: 'is_admin()' })
+    expect(generateUpdatePolicyPayload(withCheck, { ...baseForm, check: '  is_admin()' })).toEqual(
+      {}
+    )
+    expect(generateUpdatePolicyPayload(withCheck, { ...baseForm, check: '' })).toEqual({})
+  })
+
+  it('maps the using editor to the check field for INSERT policies', () => {
+    const insertPolicy = mockPolicy({ command: 'INSERT', definition: null, check: null })
+    const payload = generateUpdatePolicyPayload(insertPolicy, { ...baseForm, using: 'true' })
+    expect(payload).toEqual({ check: 'true' })
+  })
+
+  it('never includes a definition for INSERT policies', () => {
+    const insertPolicy = mockPolicy({ command: 'INSERT', definition: null, check: 'true' })
+    const payload = generateUpdatePolicyPayload(insertPolicy, {
+      ...baseForm,
+      using: 'is_admin()',
+      check: 'ignored',
+    })
+    expect(payload).toEqual({ check: 'is_admin()' })
+  })
+
+  it('omits the check for INSERT policies when the expression is unchanged', () => {
+    const insertPolicy = mockPolicy({ command: 'INSERT', definition: null, check: 'true' })
+    expect(generateUpdatePolicyPayload(insertPolicy, { ...baseForm, using: '  true' })).toEqual({})
+  })
+
+  it('includes the name and roles when they changed', () => {
+    const payload = generateUpdatePolicyPayload(mockPolicy(), {
+      ...baseForm,
+      name: 'renamed_policy',
+      roles: ['anon', 'authenticated'],
+    })
+    expect(payload).toEqual({ name: 'renamed_policy', roles: ['anon', 'authenticated'] })
+  })
+})

--- a/apps/studio/components/interfaces/Database/Policies/PolicyEditorPanel/PolicyEditorPanel.utils.ts
+++ b/apps/studio/components/interfaces/Database/Policies/PolicyEditorPanel/PolicyEditorPanel.utils.ts
@@ -1,5 +1,12 @@
 import type { PGPolicy } from '@supabase/pg-meta'
-import { ident, keyword, safeSql, type SafeSqlFragment } from '@supabase/pg-meta/src/pg-format'
+import {
+  ident,
+  keyword,
+  safeSql,
+  untrustedSql,
+  type SafeSqlFragment,
+  type UntrustedSqlFragment,
+} from '@supabase/pg-meta/src/pg-format'
 import { isEqual } from 'lodash'
 
 // [Joshen] Not used but keeping this for now in case we do an inline editor
@@ -75,6 +82,55 @@ export const generateCreatePolicyQuery = ({
     return safeSql`${withUsing} with check (${check ?? safeSql``});`
   }
   return safeSql`${withUsing};`
+}
+
+/**
+ * Diffs the editor form against the stored policy and returns only the fields
+ * that changed — an empty result means there is nothing to save. A stored
+ * `null` definition/check (policy created without that clause) counts as
+ * empty, so typing an expression into a previously empty editor is a change.
+ * Empty form values never produce a payload field, because ALTER POLICY can
+ * only replace an expression, not remove it.
+ *
+ * Expressions are returned as UntrustedSqlFragment — the caller promotes them
+ * with acceptUntrustedSql in the submit handler.
+ */
+export const generateUpdatePolicyPayload = (
+  selectedPolicy: Pick<PGPolicy, 'name' | 'roles' | 'command' | 'definition' | 'check'>,
+  policyForm: {
+    name: string
+    roles: string[]
+    using?: string
+    check?: string
+  }
+): {
+  name?: string
+  roles?: string[]
+  definition?: UntrustedSqlFragment
+  check?: UntrustedSqlFragment
+} => {
+  const payload: {
+    name?: string
+    roles?: string[]
+    definition?: UntrustedSqlFragment
+    check?: UntrustedSqlFragment
+  } = {}
+  const usingVal = policyForm.using?.trim()
+  const checkVal = policyForm.check?.trim()
+
+  if (policyForm.name !== selectedPolicy.name) payload.name = policyForm.name
+  if (!isEqual(selectedPolicy.roles, policyForm.roles)) payload.roles = policyForm.roles
+
+  if (selectedPolicy.command === 'INSERT') {
+    // For INSERT policies editor one holds the with check expression
+    if (!!usingVal && usingVal !== selectedPolicy.check) payload.check = untrustedSql(usingVal)
+  } else {
+    if (!!usingVal && usingVal !== selectedPolicy.definition)
+      payload.definition = untrustedSql(usingVal)
+    if (!!checkVal && checkVal !== selectedPolicy.check) payload.check = untrustedSql(checkVal)
+  }
+
+  return payload
 }
 
 export const checkIfPolicyHasChanged = (

--- a/apps/studio/components/interfaces/Database/Policies/PolicyEditorPanel/index.tsx
+++ b/apps/studio/components/interfaces/Database/Policies/PolicyEditorPanel/index.tsx
@@ -12,7 +12,6 @@ import {
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useQueryClient } from '@tanstack/react-query'
 import { useParams } from 'common'
-import { isEqual } from 'lodash'
 import { memo, useCallback, useEffect, useRef, useState } from 'react'
 import { useForm, useWatch } from 'react-hook-form'
 import { toast } from 'sonner'
@@ -35,7 +34,11 @@ import * as z from 'zod'
 
 import { LockedCreateQuerySection, LockedRenameQuerySection } from './LockedQuerySection'
 import { PolicyDetailsV2 } from './PolicyDetailsV2'
-import { checkIfPolicyHasChanged, generateCreatePolicyQuery } from './PolicyEditorPanel.utils'
+import {
+  checkIfPolicyHasChanged,
+  generateCreatePolicyQuery,
+  generateUpdatePolicyPayload,
+} from './PolicyEditorPanel.utils'
 import { PolicyEditorPanelHeader } from './PolicyEditorPanelHeader'
 import { PolicyTemplates } from './PolicyTemplates'
 import { QueryError } from './QueryError'
@@ -222,34 +225,21 @@ export const PolicyEditorPanel = memo(function ({
         },
       })
     } else if (selectedProject !== undefined) {
-      const payload: {
-        name?: string
-        definition?: SafeSqlFragment
-        check?: SafeSqlFragment
-        roles?: Array<string>
-      } = {}
       const updatedRoles = roles.length === 0 ? ['public'] : roles.split(', ')
-      // Trim for string comparison against the stored policy values. The Save click is the
-      // explicit user gesture that promotes editor content to executable SQL.
-      const usingVal = using?.trim()
-      const checkVal = check?.trim()
 
-      if (name !== selectedPolicy.name) payload.name = name
-      if (!isEqual(selectedPolicy.roles, updatedRoles)) payload.roles = updatedRoles
-      if (selectedPolicy.definition !== null && selectedPolicy.definition !== usingVal)
-        payload.definition =
-          usingVal === undefined ? undefined : acceptUntrustedSql(untrustedSql(usingVal))
-
-      if (selectedPolicy.command === 'INSERT') {
-        // [Joshen] Cause editor one will be the check statement in this scenario
-        if (selectedPolicy.check !== usingVal)
-          payload.check =
-            usingVal === undefined ? undefined : acceptUntrustedSql(untrustedSql(usingVal))
-      } else {
-        if (selectedPolicy.check !== checkVal)
-          payload.check =
-            checkVal === undefined ? undefined : acceptUntrustedSql(untrustedSql(checkVal))
+      // ALTER POLICY can only replace an expression, not remove it
+      if (selectedPolicy.command !== 'INSERT' && selectedPolicy.check !== null && !check?.trim()) {
+        return setFieldError(
+          'The WITH CHECK expression cannot be removed. Provide a new expression, or delete and recreate the policy without it.'
+        )
       }
+
+      const payload = generateUpdatePolicyPayload(selectedPolicy, {
+        name,
+        roles: updatedRoles,
+        using,
+        check,
+      })
 
       if (Object.keys(payload).length === 0) return onSelectCancel()
 
@@ -257,7 +247,15 @@ export const PolicyEditorPanel = memo(function ({
         projectRef: selectedProject.ref,
         connectionString: selectedProject?.connectionString,
         originalPolicy: selectedPolicy,
-        payload,
+        // The Save click is the explicit user gesture that promotes editor content
+        // to executable SQL.
+        payload: {
+          name: payload.name,
+          roles: payload.roles,
+          definition:
+            payload.definition === undefined ? undefined : acceptUntrustedSql(payload.definition),
+          check: payload.check === undefined ? undefined : acceptUntrustedSql(payload.check),
+        },
       })
     }
   }

--- a/apps/studio/components/interfaces/Database/Policies/PolicyEditorPanel/index.tsx
+++ b/apps/studio/components/interfaces/Database/Policies/PolicyEditorPanel/index.tsx
@@ -195,15 +195,14 @@ export const PolicyEditorPanel = memo(function ({
     const usingExpr = command !== 'insert' ? using : undefined
     const checkExpr = command === 'insert' ? using : check
 
-    if (command === 'insert' && !checkExpr?.trim()) {
-      return setFieldError('Please provide a SQL expression for the WITH CHECK statement')
-    } else if (command !== 'insert' && !usingExpr?.trim()) {
-      return setFieldError('Please provide a SQL expression for the USING statement')
-    } else {
-      setFieldError(undefined)
-    }
-
     if (selectedPolicy === undefined) {
+      if (command === 'insert' && !checkExpr?.trim()) {
+        return setFieldError('Please provide a SQL expression for the WITH CHECK statement')
+      } else if (command !== 'insert' && !usingExpr?.trim()) {
+        return setFieldError('Please provide a SQL expression for the USING statement')
+      }
+      setFieldError(undefined)
+
       const sql = generateCreatePolicyQuery({
         name,
         schema,
@@ -227,12 +226,28 @@ export const PolicyEditorPanel = memo(function ({
     } else if (selectedProject !== undefined) {
       const updatedRoles = roles.length === 0 ? ['public'] : roles.split(', ')
 
-      // ALTER POLICY can only replace an expression, not remove it
-      if (selectedPolicy.command !== 'INSERT' && selectedPolicy.check !== null && !check?.trim()) {
-        return setFieldError(
-          'The WITH CHECK expression cannot be removed. Provide a new expression, or delete and recreate the policy without it.'
-        )
+      // A null definition/check is valid (the policy was created without that clause), so
+      // updates only require an expression where the policy already has one — ALTER POLICY
+      // can only replace an expression, not remove it.
+      if (selectedPolicy.command === 'INSERT') {
+        if (selectedPolicy.check !== null && !using?.trim()) {
+          return setFieldError(
+            'The WITH CHECK expression cannot be removed. Provide a new expression, or delete and recreate the policy without it.'
+          )
+        }
+      } else {
+        if (selectedPolicy.definition !== null && !using?.trim()) {
+          return setFieldError(
+            'The USING expression cannot be removed. Provide a new expression, or delete and recreate the policy without it.'
+          )
+        }
+        if (selectedPolicy.check !== null && !check?.trim()) {
+          return setFieldError(
+            'The WITH CHECK expression cannot be removed. Provide a new expression, or delete and recreate the policy without it.'
+          )
+        }
       }
+      setFieldError(undefined)
 
       const payload = generateUpdatePolicyPayload(selectedPolicy, {
         name,

--- a/apps/studio/components/interfaces/Database/Policies/PolicyEditorPanel/index.tsx
+++ b/apps/studio/components/interfaces/Database/Policies/PolicyEditorPanel/index.tsx
@@ -175,12 +175,15 @@ export const PolicyEditorPanel = memo(function ({
             name,
             roles: roles.length === 0 ? ['public'] : roles.split(', '),
             definition: editorOneFormattedValue,
-            check: command === 'INSERT' ? editorOneFormattedValue : editorTwoFormattedValue,
+            check:
+              selectedPolicy.command === 'INSERT'
+                ? editorOneFormattedValue
+                : editorTwoFormattedValue,
           })
         : false
 
     return policyCreateUnsaved || policyUpdateUnsaved
-  }, [command, name, roles, selectedPolicy])
+  }, [name, roles, selectedPolicy])
 
   const { confirmOnClose, handleOpenChange, modalProps } = useConfirmOnClose({
     checkIsDirty: hasUnsavedChanges,


### PR DESCRIPTION
A table RLS policy created via SQL without a `USING`/`WITH CHECK` clause stores `null` for that field, and the policy editor's payload diff skipped `null` fields entirely — so adding an expression later through the dashboard closed the panel as if saved but persisted nothing. This fixes the diff so those policies are editable, and cleans up adjacent issues in the same code path.

**Changed:**
- Extracted the update-payload diff from `PolicyEditorPanel`'s submit handler into a pure `generateUpdatePolicyPayload()` in `PolicyEditorPanel.utils.ts`. A stored `null` definition/check now counts as empty, so typing an expression into a previously empty editor produces a payload field. The diff is branched by command so INSERT policies only ever emit `WITH CHECK`, never an invalid `USING` clause.
- The required-expression validation ("Please provide a SQL expression…") now applies only when creating a policy. When updating, a `null` clause is valid, so rename-only and role-only saves on such policies work; the update path instead rejects attempts to clear an existing `USING`/`WITH CHECK` expression with an inline error (`ALTER POLICY` can only replace an expression, not remove it).
- Saving with no changes now closes the panel without a round trip — previously a null-vs-undefined comparison injected a present-but-`undefined` payload key, which sent a literal `BEGIN; COMMIT;` to the user's database.
- Fixed the unsaved-changes check comparing the form's lowercase command against `'INSERT'` (never matched), which made closing an untouched INSERT policy editor prompt about unsaved changes. It now compares `selectedPolicy.command`.

**Added:**
- `PolicyEditorPanel.utils.test.ts` — 11 unit tests covering null→value transitions for definition and check, INSERT command mapping, value→value updates, no-op saves, and empty-value handling.

## To test

- Run in the SQL editor: `create policy "p1" on <table> for delete to authenticated;` (no `USING` clause), then edit `p1` in Database → Policies, add a `USING` expression, and save. Confirm via `select pg_get_expr(polqual, polrelid) from pg_policy where polname = 'p1'` that the expression persisted.
- Same for INSERT: `create policy "p2" on <table> for insert to authenticated;`, then add a `WITH CHECK` expression via the editor and confirm `polwithcheck` is set (and `polqual` stays null).
- On `p1` (still without a `USING` expression? recreate it if you added one), rename the policy without touching the expression editors — the rename should save successfully.
- Edit a policy that already has a `USING` expression, change it, and confirm the new expression persists (regression).
- Open a policy and save without changing anything — the panel should close with no `policy-update` network request.
- On a policy with an existing `USING` (or `WITH CHECK`) expression, clear that editor and save — an inline error should appear and no request should fire.
- Open an INSERT policy that has a `WITH CHECK` expression, change nothing, and close the panel — it should close without an "Unsaved changes" prompt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Policy updates now submit only changed fields.
  * Improved handling of policy expressions, including INSERT-specific mappings.
  * Prevented removal of existing `USING` or `WITH CHECK` expressions where unsupported.
  * Empty expressions are omitted from update requests.
  * Updates are canceled when no changes are detected.

* **Tests**
  * Added coverage for unchanged policies, expression updates, name and role changes, and INSERT policy behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->