### PR TITLE
perf(pg-meta): drive getTableColumnsSql off OIDs instead of quoted names

### DIFF
--- a/apps/studio/components/ui/CodeEditor/Providers/PgSQLCompletionProvider.ts
+++ b/apps/studio/components/ui/CodeEditor/Providers/PgSQLCompletionProvider.ts
@@ -55,6 +55,8 @@ function startingQuoteScenarioSuggestions(monaco: any, pgInfoRef: RefObject<any>
 
     if (!table) return { suggestions: items }
     table.columns.forEach((field: any) => {
+      if (!field) return
+
       items.push({
         label: field.attname,
         kind: monaco.languages.CompletionItemKind.Property,
@@ -123,6 +125,8 @@ function dotScenarioSuggestions(monaco: any, pgInfoRef: RefObject<any>, iterator
 
   if (table) {
     table.columns.forEach((field: any) => {
+      if (!field) return
+
       items.push({
         label: field.attname,
         kind: monaco.languages.CompletionItemKind.Property,

--- a/apps/studio/data/database/table-columns-query.ts
+++ b/apps/studio/data/database/table-columns-query.ts
@@ -2,6 +2,7 @@ import { getTableColumnsSql } from '@supabase/pg-meta'
 import { useQuery } from '@tanstack/react-query'
 
 import { databaseKeys } from './keys'
+import { isScopedIntrospection, scopedIntrospectionReady } from '@/data/scoped-introspection'
 import { executeSql } from '@/data/sql/execute-sql-mutation'
 import { ResponseError, UseCustomQueryOptions } from '@/types'
 
@@ -10,7 +11,14 @@ export type TableColumn = {
   tablename: string
   quoted_name: string
   is_table: boolean
-  columns: any[]
+  /**
+   * The legacy (pgMetaScopedIntrospection off) query also carries attrelid,
+   * attnum and attisdropped, and emits a single `null` entry for a relation the
+   * role can access but has no readable column on. The scoped query emits only
+   * these two fields, ordered by attnum, and an empty array in that case --
+   * so consumers must still tolerate null entries until the flag is cleaned up.
+   */
+  columns: Array<{ attname: string; data_type: string } | null>
 }
 
 export type TableColumnsVariables = {
@@ -24,7 +32,9 @@ export async function getTableColumns(
   { projectRef, connectionString, table, schema }: TableColumnsVariables,
   signal?: AbortSignal
 ) {
-  const sql = getTableColumnsSql({ table, schema })
+  // Cold-load race guard -- see the module comment on scoped-introspection.ts.
+  await scopedIntrospectionReady()
+  const sql = getTableColumnsSql({ table, schema, scoped: isScopedIntrospection() })
 
   const { result } = await executeSql(
     { projectRef, connectionString, sql, queryKey: ['table-columns', schema, table] },

--- a/packages/pg-meta/src/sql/studio/database/columns.ts
+++ b/packages/pg-meta/src/sql/studio/database/columns.ts
@@ -1,24 +1,55 @@
 import { joinSqlFragments, literal, safeSql, type SafeSqlFragment } from '../../../pg-format'
 
+/**
+ * Table/column listing for the SQL Editor intellisense and the Create Index panel.
+ *
+ * The legacy shape resolved `quote_ident(nspname) || '.' || quote_ident(relname)`
+ * back to an OID on every catalog row (text-overload has_table_privilege /
+ * has_column_privilege plus a ::regclass cast) and scanned pg_class twice via
+ * `union all`. The scoped shape drives everything off c.oid, reads pg_class once,
+ * and short-circuits the per-column privilege check when pg_attribute.attacl is
+ * null -- on a bloated ~21k-relation catalog that is ~1.6x faster (131ms -> 80ms)
+ * with 5.4x fewer buffer hits (479k -> 89k) and half the JSON payload.
+ *
+ * That NEW behavior is gated behind `scoped` (default false = legacy behavior) so
+ * Studio can roll it out behind the pgMetaScopedIntrospection feature flag.
+ * Equivalence between the two forms is enforced by execution-based tests in
+ * test/sql/studio/table-columns.test.ts.
+ *
+ * The scoped form returns the same relation set as legacy and differs only in two
+ * ways, both covered by those tests: it orders columns by attnum instead of
+ * leaving it to the join, and it emits an empty column array where legacy emitted
+ * `[null]`. Extending the relkind filter to partitioned ('p') and foreign ('f')
+ * tables, which both forms currently omit, is deliberately left to a follow-up.
+ *
+ * The two branches are kept as complete, standalone templates (no interpolated
+ * conditional fragments) so each rendered statement is easy to read and diff.
+ */
 export const getTableColumnsSql = ({
   table,
   schema,
+  scoped = false,
 }: {
   table?: string
   schema?: string
+  scoped?: boolean
 }): SafeSqlFragment => {
-  const conditions: Array<SafeSqlFragment> = []
-  if (table) {
-    conditions.push(safeSql`tablename = ${literal(table)}`)
-  }
-  if (schema) {
-    conditions.push(safeSql`schemaname = ${literal(schema)}`)
-  }
+  if (!scoped) {
+    const conditions: Array<SafeSqlFragment> = []
+    if (table) {
+      conditions.push(safeSql`tablename = ${literal(table)}`)
+    }
+    if (schema) {
+      conditions.push(safeSql`schemaname = ${literal(schema)}`)
+    }
 
-  const whereClause =
-    conditions.length > 0 ? safeSql`WHERE ${joinSqlFragments(conditions, ' AND ')}` : safeSql``
+    const whereClause =
+      conditions.length > 0 ? safeSql`WHERE ${joinSqlFragments(conditions, ' AND ')}` : safeSql``
 
-  return safeSql`
+    // FROZEN legacy path: served while the pgMetaScopedIntrospection flag is off.
+    // Do not edit -- it must keep matching production behavior until the flag
+    // cleanup deletes it. The scoped branch below is the replacement.
+    return safeSql`
 
   SELECT
     tbl.schemaname,
@@ -77,5 +108,62 @@ export const getTableColumnsSql = ({
     )
   ${whereClause}
   GROUP BY schemaname, tablename, quoted_name, is_table;
+`
+  }
+
+  const conditions: Array<SafeSqlFragment> = []
+  if (table) {
+    conditions.push(safeSql`c.relname = ${literal(table)}`)
+  }
+  if (schema) {
+    conditions.push(safeSql`n.nspname = ${literal(schema)}`)
+  }
+
+  // Filters go inside the scan rather than above the join, so a table/schema
+  // lookup can use pg_class_relname_nsp_index instead of relying on qual pushdown.
+  const filterClause =
+    conditions.length > 0 ? safeSql`AND ${joinSqlFragments(conditions, ' AND ')}` : safeSql``
+
+  // Privilege checks take OIDs, not quoted names: the text overloads re-resolve
+  // schema.table to an OID on every catalog row, and ::regclass additionally
+  // errors if a relation is dropped mid-scan. attacl is null for all but a
+  // handful of columns, and when it is, column privileges come entirely from the
+  // table ACL -- so the per-column check collapses to a per-table one.
+  return safeSql`
+  SELECT
+    n.nspname AS schemaname,
+    c.relname AS tablename,
+    quote_ident(n.nspname) || '.' || quote_ident(c.relname) AS quoted_name,
+    c.relkind = 'r' AS is_table,
+    COALESCE(
+      json_agg(
+        json_build_object(
+          'attname', a.attname,
+          'data_type', format_type(a.atttypid, a.atttypmod)
+        ) ORDER BY a.attnum
+      ) FILTER (WHERE a.attname IS NOT NULL),
+      '[]'::json
+    ) AS columns
+  FROM
+    pg_catalog.pg_class c
+    JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+    LEFT JOIN pg_catalog.pg_attribute a
+      ON a.attrelid = c.oid
+      AND a.attnum > 0
+      AND NOT a.attisdropped
+      AND CASE
+            WHEN a.attacl IS NULL
+              THEN has_table_privilege(c.oid, 'SELECT, INSERT, UPDATE, REFERENCES')
+            ELSE has_column_privilege(a.attrelid, a.attnum, 'SELECT, INSERT, UPDATE, REFERENCES')
+          END
+  WHERE
+    c.relkind = ANY ('{r,v,m}'::"char"[])
+    AND n.nspname NOT IN ('information_schema', 'pg_catalog', 'pg_toast')
+    AND n.nspname NOT LIKE 'pg_temp_%'
+    AND n.nspname NOT LIKE 'pg_toast_temp_%'
+    AND has_schema_privilege(n.oid, 'USAGE')
+    AND has_table_privilege(c.oid, 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER')
+    ${filterClause}
+  GROUP BY n.nspname, c.relname, c.oid, c.relkind;
 `
 }

--- a/packages/pg-meta/test/sql/studio/catalog-plan-guard.test.ts
+++ b/packages/pg-meta/test/sql/studio/catalog-plan-guard.test.ts
@@ -218,8 +218,33 @@ test('getTablesPaginatedSql: plan stays scoped for a schema page', async () => {
 
 // ── getTableColumnsSql (database/columns.ts) — per-table ─────────────────────
 test('getTableColumnsSql: plan stays scoped for a single table', async () => {
-  const result = await explainAnalyze(db, getTableColumnsSql({ table: 't_1000', schema: 'stress' }))
+  const result = await explainAnalyze(
+    db,
+    getTableColumnsSql({ table: 't_1000', schema: 'stress', scoped: true })
+  )
   assertPlanWithinBudget(result, {})
+}, 60_000)
+
+// ── getTableColumnsSql — whole-catalog (SQL Editor intellisense) ─────────────
+// useAddDefinitions calls this with no schema/table, so this shape is inherently
+// O(catalog) and cannot be index-driven: pg_class has no index on relkind or
+// relnamespace. What the budget pins is that it stays at ONE pg_class scan --
+// the previous `union all` over relkind='r' then ('v','m') scanned it twice --
+// and that pg_attribute is reached by index rather than scanned.
+test('getTableColumnsSql: whole-catalog plan scans pg_class once and indexes pg_attribute', async () => {
+  const result = await explainAnalyze(db, getTableColumnsSql({ scoped: true }))
+  assertPlanWithinBudget(result, {
+    allowedSeqScans: {
+      pg_class: {
+        max: 1,
+        reason:
+          'unfiltered intellisense fetch enumerates every relation; no index on relkind/relnamespace',
+      },
+    },
+    // Whole-catalog work on the stress catalog; the seq-scan budget above is the
+    // real guard here, this only catches a gross regression.
+    maxExecutionTimeMs: 6000,
+  })
 }, 60_000)
 
 // ── getIndexesSQL (database/indexes.ts) — per-schema list ────────────────────

--- a/packages/pg-meta/test/sql/studio/table-columns.test.ts
+++ b/packages/pg-meta/test/sql/studio/table-columns.test.ts
@@ -1,0 +1,256 @@
+import { afterAll, expect, test } from 'vitest'
+
+import { getTableColumnsSql } from '../../../src'
+import { cleanupRoot, createTestDatabase } from '../../db/utils'
+
+afterAll(async () => {
+  await cleanupRoot()
+})
+
+/**
+ * Equivalence guard for the scoped getTableColumnsSql path.
+ *
+ * The legacy shape resolved `quote_ident(nspname) || '.' || quote_ident(relname)`
+ * back to an OID on every catalog row (text-overload has_table_privilege /
+ * has_column_privilege, plus a ::regclass cast) and scanned pg_class twice via
+ * `union all`. The scoped shape drives everything off c.oid, and short-circuits
+ * the per-column privilege check when pg_attribute.attacl is null.
+ *
+ * That short-circuit is the only semantically interesting part: when attacl is
+ * null a column's privileges come entirely from the table ACL, so the per-column
+ * check is redundant. These tests pin that claim by executing BOTH renderings
+ * against a fixture that deliberately exercises table-, column- and schema-level
+ * grants -- there is no byte-identity snapshot, the comparison is behavioural.
+ *
+ * The relation set must match exactly. Two differences are intended and asserted
+ * rather than smoothed over: scoped orders columns by attnum, and emits `[]`
+ * where legacy emitted `[null]`.
+ */
+
+const legacySql = (vars: { table?: string; schema?: string } = {}) =>
+  String(getTableColumnsSql(vars))
+const scopedSql = (vars: { table?: string; schema?: string } = {}) =>
+  String(getTableColumnsSql({ ...vars, scoped: true }))
+
+// A column-level REVOKE against a table-level GRANT is a no-op in Postgres, so
+// populating attacl requires explicit column-level GRANTs.
+// Roles are cluster-wide while createTestDatabase() gives us a fresh database,
+// so role creation has to be idempotent across test files.
+const FIXTURE = `
+  do $$ begin
+    if not exists (select from pg_roles where rolname = 'probe_login') then
+      create role probe_login login password 'probe';
+    end if;
+    if not exists (select from pg_roles where rolname = 'probe_group') then
+      create role probe_group nologin;
+    end if;
+  end $$;
+  grant probe_group to probe_login;
+
+  create schema visible;
+  create schema hidden;
+  grant usage on schema visible to probe_group;
+
+  -- plain table, table-wide grant: attacl null everywhere (the fast path)
+  create table visible.all_cols (id bigint, name text, qty int, at timestamptz);
+  grant select, insert, update, delete, truncate, references, trigger
+    on visible.all_cols to probe_group;
+
+  -- table-wide grant PLUS a column grant to another role: attacl populated,
+  -- but the probe role still has table-wide access (slow path, same answer)
+  create table visible.extra_colacl (id bigint, name text, secret text);
+  grant select, insert, update, delete, truncate, references, trigger
+    on visible.extra_colacl to probe_group;
+  grant update (name) on visible.extra_colacl to probe_group;
+
+  -- only column-level grants, no table-level: excluded by the outer
+  -- has_table_privilege filter in BOTH shapes
+  create table visible.col_only (id bigint, name text);
+  grant select (id) on visible.col_only to probe_group;
+
+  -- passes the outer filter but holds none of SELECT/INSERT/UPDATE/REFERENCES,
+  -- so no column is visible
+  create table visible.trigger_only (id bigint, v text);
+  grant trigger, truncate on visible.trigger_only to probe_group;
+
+  -- view, matview, partitioned table, dropped column
+  create view visible.a_view as select id, name from visible.all_cols;
+  grant select on visible.a_view to probe_group;
+  create materialized view visible.a_matview as select id from visible.all_cols;
+  grant select on visible.a_matview to probe_group;
+  create table visible.parted (id bigint, at date) partition by range (at);
+  grant select on visible.parted to probe_group;
+  -- a grant on the parent does not cascade to partitions, so the children below
+  -- cover both the granted and the ungranted case
+  create table visible.parted_2024 partition of visible.parted
+    for values from ('2024-01-01') to ('2025-01-01');
+  grant select on visible.parted_2024 to probe_group;
+  create table visible.parted_2025 partition of visible.parted
+    for values from ('2025-01-01') to ('2026-01-01');
+  create table visible.with_dropped (id bigint, gone text, kept text);
+  grant select on visible.with_dropped to probe_group;
+  alter table visible.with_dropped drop column gone;
+
+  -- in a schema the probe role has no USAGE on
+  create table hidden.nope (id bigint);
+  grant select on hidden.nope to probe_group;
+`
+
+type Row = {
+  schemaname: string
+  tablename: string
+  quoted_name: string
+  is_table: boolean
+  columns: Array<{ attname: string; data_type: string } | null>
+}
+
+const normalize = (rows: Row[]) =>
+  rows
+    .map((r) => ({
+      key: `${r.schemaname}.${r.tablename}`,
+      quoted_name: r.quoted_name,
+      is_table: r.is_table,
+      // legacy emits [null] where scoped emits []; compare only real columns
+      cols: (r.columns ?? [])
+        .filter((c): c is { attname: string; data_type: string } => c != null)
+        .map((c) => `${c.attname}:${c.data_type}`),
+    }))
+    .sort((a, b) => a.key.localeCompare(b.key))
+
+const withProbeDatabase = (
+  name: string,
+  fn: (run: <T>(sql: string) => Promise<T>) => Promise<void>
+) => {
+  test(
+    name,
+    async () => {
+      const db = await createTestDatabase()
+      try {
+        await db.executeQuery(FIXTURE)
+        // Run the introspection as the low-privilege role, not the owner --
+        // a superuser short-circuits every ACL check and would hide any
+        // privilege-filtering difference between the two shapes.
+        const run = <T>(sql: string) =>
+          db.executeQuery<T>(
+            `set local role probe_login; set local search_path = pg_catalog; ${sql}`
+          )
+        await fn(run)
+      } finally {
+        await db.cleanup()
+      }
+    },
+    60_000
+  )
+}
+
+withProbeDatabase('scoped returns exactly the same relations as legacy', async (run) => {
+  const legacy = normalize(await run<Row[]>(legacySql()))
+  const scoped = normalize(await run<Row[]>(scopedSql()))
+
+  expect(legacy.length).toBeGreaterThan(0)
+  expect(scoped.map((r) => r.key)).toEqual(legacy.map((r) => r.key))
+
+  // Columns compared as sets: the legacy json_agg had no ORDER BY, so its order
+  // was whatever the join emitted (hash join on a small catalog, index order on a
+  // large one). The scoped form pins it to attnum -- see the ordering test below.
+  const scopedByKey = new Map(scoped.map((r) => [r.key, r]))
+  for (const row of legacy) {
+    const match = scopedByKey.get(row.key)!
+    expect([...match.cols].sort(), `${row.key} column set changed`).toEqual([...row.cols].sort())
+    expect(match.quoted_name).toBe(row.quoted_name)
+    expect(match.is_table).toBe(row.is_table)
+  }
+})
+
+withProbeDatabase(
+  'neither form returns partitioned parents (follow-up, not this PR)',
+  async (run) => {
+    const legacy = normalize(await run<Row[]>(legacySql())).map((r) => r.key)
+    const scoped = normalize(await run<Row[]>(scopedSql())).map((r) => r.key)
+
+    // visible.parted is relkind 'p'; both filters omit it. Its children are 'r'
+    // and are returned (subject to their own grants) -- see the filtering test.
+    expect(legacy).not.toContain('visible.parted')
+    expect(scoped).not.toContain('visible.parted')
+  }
+)
+
+withProbeDatabase('scoped orders columns by attnum regardless of plan shape', async (run) => {
+  const rows = normalize(await run<Row[]>(scopedSql()))
+
+  // declared id, name, qty, at -- must come back in that order, not join order
+  expect(rows.find((r) => r.key === 'visible.all_cols')!.cols).toEqual([
+    'id:bigint',
+    'name:text',
+    'qty:integer',
+    'at:timestamp with time zone',
+  ])
+  expect(rows.find((r) => r.key === 'visible.a_view')!.cols).toEqual(['id:bigint', 'name:text'])
+})
+
+// Privilege filtering must be identical on both sides of the flag.
+for (const [label, render] of [
+  ['legacy', legacySql],
+  ['scoped', scopedSql],
+] as const) {
+  withProbeDatabase(
+    `${label} applies schema, table and column privilege filtering`,
+    async (run) => {
+      const rows = normalize(await run<Row[]>(render()))
+      const keys = rows.map((r) => r.key)
+
+      // no USAGE on the schema
+      expect(keys).not.toContain('hidden.nope')
+      // column-level grants only, so it fails the table-level filter
+      expect(keys).not.toContain('visible.col_only')
+      // partition children are ordinary tables, included on their own grant only
+      expect(keys).toContain('visible.parted_2024')
+      expect(keys).not.toContain('visible.parted_2025')
+
+      // holds TRIGGER/TRUNCATE but none of SELECT/INSERT/UPDATE/REFERENCES,
+      // so it is present with no readable column
+      expect(rows.find((r) => r.key === 'visible.trigger_only')!.cols).toEqual([])
+
+      // table-wide access wins even though attacl is populated on one column
+      expect(rows.find((r) => r.key === 'visible.extra_colacl')!.cols.sort()).toEqual([
+        'id:bigint',
+        'name:text',
+        'secret:text',
+      ])
+
+      // dropped columns excluded
+      expect(rows.find((r) => r.key === 'visible.with_dropped')!.cols.sort()).toEqual([
+        'id:bigint',
+        'kept:text',
+      ])
+
+      // views and matviews are reported as non-tables
+      expect(rows.find((r) => r.key === 'visible.a_view')!.is_table).toBe(false)
+      expect(rows.find((r) => r.key === 'visible.a_matview')!.is_table).toBe(false)
+    }
+  )
+
+  withProbeDatabase(`${label} scoping by schema and table returns the same row`, async (run) => {
+    const all = normalize(await run<Row[]>(render()))
+    const one = normalize(await run<Row[]>(render({ schema: 'visible', table: 'all_cols' })))
+
+    // Column order is compared sorted: legacy's unordered json_agg emits a
+    // different order for the scoped lookup (index scan) than for the
+    // whole-catalog run (hash join). Scoped pins the order; see the test above.
+    const sortCols = (r?: { cols: string[] }) => r && { ...r, cols: [...r.cols].sort() }
+
+    expect(one).toHaveLength(1)
+    expect(sortCols(one[0])).toEqual(sortCols(all.find((r) => r.key === 'visible.all_cols')))
+  })
+}
+
+// The empty-column-list representation is the one place the two renderings
+// deliberately disagree; Studio's TableColumn type and PgSQLCompletionProvider
+// both still tolerate the legacy `null` entry.
+withProbeDatabase('legacy emits [null] where scoped emits []', async (run) => {
+  const [legacyRow] = await run<Row[]>(legacySql({ schema: 'visible', table: 'trigger_only' }))
+  const [scopedRow] = await run<Row[]>(scopedSql({ schema: 'visible', table: 'trigger_only' }))
+
+  expect(legacyRow.columns).toEqual([null])
+  expect(scopedRow.columns).toEqual([])
+})


### PR DESCRIPTION
## What

The SQL Editor intellisense query — `getTableColumnsSql`, called with no `schema`/`table` from `useAddDefinitions` — was logged at **20.3s** on a customer project. This rewrites it to work from `c.oid` rather than from a reconstructed `schema.table` string, behind the existing `pgMetaScopedIntrospection` flag.

Same results, less work. This does **not** on its own make the whole-catalog fetch cheap — it is still O(catalog). Scoping what the SQL Editor asks for is separate follow-up work.

## Why it was slow

Three problems, all independent of the catalog merely being large:

1. **Text-overload privilege checks.** `has_table_privilege(quote_ident(nspname) || '.' || quote_ident(relname), ...)` appeared as a **Join Filter**, so nearly every `relkind='r'` row paid a full name → OID resolution before the ACL check. Measured in isolation, the per-column variant `has_column_privilege(text, text, text)` alone was **71% of the query's buffer traffic** (210k of 296k hits). Note the query already used the OID form for `has_schema_privilege` — this was an inconsistency, not a constraint.
2. **`tbl.quoted_name::regclass` in the join condition.** A second name resolution per row, recomputed to build the `Index Cond` on `pg_attribute_relid_attnum_index`. It also **errors outright** if a relation is dropped between the `pg_class` read and the cast, so this was a live source of intermittent `relation "x.y" does not exist` failures on busy databases.
3. **Two scans of `pg_class`.** The `union all` over `relkind='r'` then `('v','m')` produced a `Parallel Append` of two full scans.

## What changed

- One pass over `pg_class`; `relkind = ANY('{r,v,m}')`.
- `has_table_privilege(c.oid, ...)`; `pg_attribute` joined on `a.attrelid = c.oid`, dropping the `::regclass` cast.
- Per-column privilege check short-circuited on `pg_attribute.attacl IS NULL` — when it is null, a column's privileges come entirely from the table ACL, so the per-column call is redundant. This is the single biggest win.
- Payload reduced to the two fields `PgSQLCompletionProvider` actually reads (`attname`, `data_type`); `attrelid`/`attnum`/`attisdropped` were dead weight.
- Filters pushed inside the scan rather than above the join. (The old outer `WHERE` was already being pushed down by the planner and did use `pg_class_relname_nsp_index`, so this is robustness, not a measured win.)

## Numbers

Synthetic 21k-relation catalog, 85% dead tuples in `pg_class`, queried as a non-superuser with a layered role graph. Median of 15 runs:

| | legacy | scoped |
|---|---|---|
| execution time | 130.6 ms | **79.8 ms** |
| buffer hits | 478,639 | **89,073** |
| column JSON | 4,716 kB | **2,353 kB** |
| rows returned | 4,445 | 4,445 |

1.6x faster, 5.4x fewer buffers, half the payload, identical result set.

## Two latent bugs fixed on the scoped path

- **`json_agg` had no `ORDER BY`**, so autocomplete column order was plan-dependent. A test caught the legacy query returning `name, id` for a view whose attnums are `id=1, name=2` (hash join on a small catalog, index order on a large one). Scoped pins it to `attnum`.
- A relation the role can reach but has **no readable column** on (e.g. holds only `TRIGGER`/`TRUNCATE`) produced `columns: [null]`, which `PgSQLCompletionProvider` dereferenced as `field.attname`. The `try/catch` in `provideCompletionItems` swallowed it, silently dropping that table's column completions. Scoped emits `[]`. The legacy path still emits `[null]`, so the null guard is added to the two unguarded provider sites and `| null` is kept in the `TableColumn` type until the flag is cleaned up.

## Rollout

Gated behind `scoped` (default `false`), consumed via `isScopedIntrospection()` / `scopedIntrospectionReady()` exactly like `column-privileges-query.ts`. Flag stays out of the React Query key.

I verified the legacy branch renders **byte-identical** to `master` for all four argument shapes (`{}`, schema-only, table-only, both).

## Testing

- New `packages/pg-meta/test/sql/studio/table-columns.test.ts` — executes **both** renderings against a fixture built for this (table-, column- and schema-level grants, populated `attacl`, dropped column, view/matview/partition children, a schema without `USAGE`), run as a low-privilege role since a superuser short-circuits every ACL check. Asserts exact relation-set equality, identical column sets, identical privilege filtering on both sides of the flag, plus the two intended divergences. No byte-identity snapshot — the comparison is behavioural.
- New whole-catalog case in `catalog-plan-guard.test.ts`. The per-table shape was already guarded; the unfiltered shape that was actually slow in production was not. Budget pins it to **one** `pg_class` scan with `pg_attribute` reached by index. I confirmed the budget **rejects** the pre-rewrite shape, so it is a real guard.
- 29/29 passing. `tsc --noEmit` clean for `packages/pg-meta` and `apps/studio`. Validated on PG 14.1 and PG 17.10.

Note on CI: the full `pg-meta` suite is flaky in local runs against a single shared container (~80 `createTestDatabase` timeouts, a different set each run, identical on a clean tree). I verified the targeted files and baselined against a stash rather than reading the full-suite result.

## Deliberately not in scope

- **Partitioned (`'p'`) and foreign (`'f'`) tables** are still omitted by both paths. Adding them is a real fix — partition-heavy catalogs are exactly the ones hitting this — but it changes autocomplete contents rather than just speed, so it belongs in its own PR.
- **Reducing how often / how much this runs.** `staleTime` is 60s with `refetchOnWindowFocus` enabled, and `databaseKeys.tableColumns` is never invalidated anywhere in Studio, so that refetch behaviour is currently the only freshness mechanism. Raising it safely requires wiring invalidation into the DDL paths first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
