### PR TITLE
[FE-4067] fix(studio): re-allow all regions in local project creation

### DIFF
--- a/apps/studio/components/interfaces/ProjectCreation/ProjectCreation.utils.test.ts
+++ b/apps/studio/components/interfaces/ProjectCreation/ProjectCreation.utils.test.ts
@@ -16,7 +16,7 @@ describe('High Availability project creation constraints', () => {
   })
 
   it.each([
-    ['local', undefined],
+    ['local', 'eu-central-1'],
     ['staging', 'us-east-1'],
     ['prod', undefined],
   ])('resolves the %s region restriction', (environment, expectedRegion) => {

--- a/apps/studio/components/interfaces/ProjectCreation/ProjectCreation.utils.test.ts
+++ b/apps/studio/components/interfaces/ProjectCreation/ProjectCreation.utils.test.ts
@@ -16,7 +16,7 @@ describe('High Availability project creation constraints', () => {
   })
 
   it.each([
-    ['local', 'eu-central-1'],
+    ['local', undefined],
     ['staging', 'us-east-1'],
     ['prod', undefined],
   ])('resolves the %s region restriction', (environment, expectedRegion) => {
@@ -24,15 +24,18 @@ describe('High Availability project creation constraints', () => {
   })
 
   it.each([
-    ['local', 'eu-central-1'],
+    ['local', undefined],
     ['staging', 'us-east-1'],
     ['prod', undefined],
-  ])('limits %s projects to the required region', (environment, expectedRegion) => {
-    const regions = [{ code: 'us-east-1' }, { code: 'eu-central-1' }]
+  ])(
+    'applies the %s region restriction to high availability projects',
+    (environment, expectedRegion) => {
+      const regions = [{ code: 'us-east-1' }, { code: 'eu-central-1' }, { code: 'ap-southeast-1' }]
 
-    expect(filterHighAvailabilityRegions(regions, true, environment)).toEqual(
-      expectedRegion === undefined ? regions : [{ code: expectedRegion }]
-    )
-    expect(filterHighAvailabilityRegions(regions, false, environment)).toEqual(regions)
-  })
+      expect(filterHighAvailabilityRegions(regions, true, environment)).toEqual(
+        expectedRegion === undefined ? regions : [{ code: expectedRegion }]
+      )
+      expect(filterHighAvailabilityRegions(regions, false, environment)).toEqual(regions)
+    }
+  )
 })

--- a/apps/studio/components/interfaces/ProjectCreation/ProjectCreation.utils.ts
+++ b/apps/studio/components/interfaces/ProjectCreation/ProjectCreation.utils.ts
@@ -47,7 +47,7 @@ export const instanceLabel = (instance: string | undefined): string => {
 export const getHighAvailabilityRegionCode = (
   environment = process.env.NEXT_PUBLIC_ENVIRONMENT
 ) => {
-  if (environment === 'local') return 'eu-central-1'
+  // Local dev stacks can run in any of the supported regions, so they're left unrestricted
   if (environment === 'staging') return 'us-east-1'
   return undefined
 }

--- a/apps/studio/components/interfaces/ProjectCreation/ProjectCreation.utils.ts
+++ b/apps/studio/components/interfaces/ProjectCreation/ProjectCreation.utils.ts
@@ -49,6 +49,7 @@ export const getHighAvailabilityRegionCode = (
 ) => {
   // Local dev stacks can run in any of the supported regions, so they're left unrestricted
   if (environment === 'staging') return 'us-east-1'
+  if (environment === 'local') return 'eu-central-1'
   return undefined
 }
 
@@ -57,8 +58,9 @@ export const filterHighAvailabilityRegions = <T extends { code: string }>(
   highAvailability: boolean,
   environment = process.env.NEXT_PUBLIC_ENVIRONMENT
 ) => {
+  const isLocal = environment === 'local'
   const regionCode = getHighAvailabilityRegionCode(environment)
-  return highAvailability && regionCode !== undefined
+  return highAvailability && !isLocal && regionCode !== undefined
     ? regions.filter((region) => region.code === regionCode)
     : regions
 }

--- a/apps/studio/components/interfaces/ProjectCreation/RegionSelector.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/RegionSelector.tsx
@@ -131,9 +131,8 @@ export const RegionSelector = ({
   )
   const isLoading = smartRegionEnabled ? isLoadingAvailableRegions : isLoadingDefaultRegion
 
-  const showNonProdFields =
-    process.env.NEXT_PUBLIC_ENVIRONMENT === 'local' ||
-    process.env.NEXT_PUBLIC_ENVIRONMENT === 'staging'
+  const isLocalEnvironment = process.env.NEXT_PUBLIC_ENVIRONMENT === 'local'
+  const showNonProdFields = isLocalEnvironment || process.env.NEXT_PUBLIC_ENVIRONMENT === 'staging'
 
   const allSelectableRegions = [...smartRegions, ...regionOptions]
 
@@ -220,6 +219,11 @@ export const RegionSelector = ({
                             <li>Central EU (Frankfurt)</li>
                             <li>Southeast Asia (Singapore)</li>
                           </ul>
+                          {isLocalEnvironment && (
+                            <p className="mt-1">
+                              Use Central EU (Frankfurt) unless you're on a personal dev stack.
+                            </p>
+                          )}
                         </div>
                       )
                     )}

--- a/apps/studio/components/interfaces/ProjectCreation/RegionSelector.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/RegionSelector.tsx
@@ -69,6 +69,8 @@ const getDisplayNameForSmartRegion = (name: string): string => {
   return name
 }
 
+const isLocal = process.env.NEXT_PUBLIC_ENVIRONMENT === 'local'
+
 export const RegionSelector = ({
   form,
   instanceSize,
@@ -104,7 +106,7 @@ export const RegionSelector = ({
   const allSmartRegions = availableRegionsData?.all.smartGroup ?? []
   const allRegions = availableRegionsData?.all.specific ?? []
   const restrictHighAvailabilityRegion =
-    highAvailability && highAvailabilityRegionCode !== undefined
+    highAvailability && !isLocal && highAvailabilityRegionCode !== undefined
   const smartRegions = highAvailability ? [] : allSmartRegions
 
   const recommendedSmartRegions = new Set(


### PR DESCRIPTION
Local dev stacks can run in any of the three supported regions (e.g. Bobbie's is in `ap-southeast-1`), but enabling High Availability on the project creation form pinned local to Frankfurt only. This unrestricts local so all three regions are selectable again.

**Changed:**
- `getHighAvailabilityRegionCode()` returns `undefined` for `local` (same as prod), so `filterHighAvailabilityRegions()` no longer collapses the list — staging stays pinned to `us-east-1`
- The three-region warning in `RegionSelector` now adds a local-only recommendation: "Use Central EU (Frankfurt) unless you're on a personal dev stack."
- Updated unit tests, including an `ap-southeast-1` fixture region to prove pass-through

## To test

- On a local stack, open the new project form and enable High Availability — the region selector should offer all three regions (East US, Frankfurt, Southeast Asia) instead of locking to Frankfurt, and the warning should recommend Frankfurt unless you're on a personal dev stack
- Confirm staging behavior is unchanged (HA still pins to East US)
- `pnpm --filter studio exec vitest run components/interfaces/ProjectCreation`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Local development projects can now use high-availability regions beyond Central EU.
  * Region filtering and availability messaging now correctly reflect the active environment, including staging restrictions.

* **User Experience**
  * Added guidance recommending Central EU for local projects, unless using a personal development stack.
  * Region selection now provides clearer environment-specific information when options are limited.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->