### PR TITLE
feat(docs) Add RLS Quickstart prompt

### DIFF
--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -5,6 +5,8 @@ description: 'Secure your data using Postgres Row Level Security.'
 subtitle: 'Secure your data using Postgres Row Level Security.'
 ---
 
+<AiPrompt id="row-level-security" />
+
 When you need granular authorization rules, nothing beats Postgres's [Row Level Security (RLS)](https://www.postgresql.org/docs/current/ddl-rowsecurity.html).
 
 ## Row Level Security in Supabase

--- a/apps/docs/data/ai-prompts.data.ts
+++ b/apps/docs/data/ai-prompts.data.ts
@@ -228,8 +228,9 @@ Follow these rules:
     operation: \`results_eq()\` for visibility, \`lives_ok()\` for a permitted
     write, and \`throws_ok(..., '42501', ...)\` where a \`with check\` or a missing
     grant rejects the statement. A denied \`update\` or \`delete\` raises nothing,
-    because \`using\` filters the rows out, so assert that it changed no rows
-    instead. Use \`policies_are()\` to confirm the policy set.
+    because \`using\` filters the rows out, so run it with \`lives_ok()\` and then
+    assert with \`results_eq()\` that the row is unchanged. Use \`policies_are()\`
+    to confirm the policy set.
 11. Plain pgTAP needs no extra packages. If you want helpers like
     \`tests.create_supabase_user()\`, \`tests.authenticate_as()\`, and
     \`tests.rls_enabled()\`, install \`basejump-supabase_test_helpers\` with dbdev

--- a/apps/docs/data/ai-prompts.data.ts
+++ b/apps/docs/data/ai-prompts.data.ts
@@ -177,6 +177,45 @@ database.new and run the instruments table SQL. Then:
 
 REFERENCE
 https://supabase.com/docs/guides/getting-started/quickstarts/refine.md`,
+  'row-level-security': `Help me write secure, performant Row Level Security (RLS) policies for my
+Supabase Postgres database. Follow these rules:
+1. Enable RLS on every table in an exposed schema (typically \`public\`) before
+   writing any policies: \`alter table <table> enable row level security;\`.
+   Also run \`alter table <table> force row level security;\` if the table
+   should be protected even from its owning role, since table owners and
+   superusers otherwise bypass RLS entirely.
+2. Write one policy per operation (\`select\`, \`insert\`, \`update\`, \`delete\`)
+   and always scope it with \`to authenticated\` or \`to anon\` — never leave the
+   role unspecified. Remember \`insert\` only uses \`with check\`, \`delete\` only
+   uses \`using\`, and \`update\` needs both.
+3. Wrap row-invariant helper calls in \`select\` so Postgres computes them once
+   per statement instead of once per row, e.g. use
+   \`(select auth.uid()) = user_id\` instead of \`auth.uid() = user_id\`. This
+   only helps for \`stable\`/\`immutable\` functions — a \`volatile\` function can
+   still run per row regardless of the wrapper.
+4. Add a btree index on every column referenced in a policy's \`using\` or
+   \`with check\` expression, e.g.
+   \`create index on <table> using btree (<column>);\`.
+5. Avoid joins inside policies. Instead of joining the target table to the
+   source table's column, select the matching set from the target table
+   (filtered by \`(select auth.uid())\`) and use \`in\`/\`any\` against it.
+6. For checks that need to bypass RLS on a lookup table (e.g. team membership
+   or role checks), use a \`security definer\` function in a private,
+   non-exposed schema, with \`execute\` revoked from \`public\`, and verify
+   \`auth.uid()\` inside the function body.
+7. Even though RLS acts as an implicit filter, still add the equivalent filter
+   to application queries (e.g. \`.eq('user_id', userId)\`) so Postgres can
+   build a better query plan.
+8. RLS only runs after schema and table \`grant\`s let a role reach the object
+   at all. If access looks blocked, confirm the required \`grant\`s exist before
+   assuming the policy logic is wrong.
+9. Write pgTAP tests for each policy (\`supabase test new\`, then
+   \`supabase test db\`), asserting the expected allow/deny outcome per role and
+   per operation, e.g. with \`policies_are()\`, \`results_eq()\`, and
+   \`tests.rls_enabled()\`.
+
+REFERENCE
+https://supabase.com/docs/guides/database/postgres/row-level-security.md#rls-performance-recommendations`,
   'ruby-on-rails': `Help me add Supabase to my Ruby on Rails project. Create a Supabase project at
 database.new. Then:
 1. Run \`rails new blog -d=postgresql\` to scaffold a new Rails project.

--- a/apps/docs/data/ai-prompts.data.ts
+++ b/apps/docs/data/ai-prompts.data.ts
@@ -218,10 +218,10 @@ Follow these rules:
    can build a better query plan. Mirror the branch of the policy you want, so
    a redundant filter does not drop rows the policy would allow.
 9. Test every policy with pgTAP — this is the recommended way to verify RLS.
-   Scaffold with \`supabase test new <name>\`, begin the file with
-   \`create extension if not exists pgtap with schema extensions;\`, wrap it in
-   \`begin;\`, \`select plan(<n>);\`, \`select * from finish();\`, \`rollback;\`, and
-   run it with \`supabase test db\`.
+   Scaffold with \`supabase test new <name>\`, then open with \`begin;\` followed
+   by \`create extension if not exists pgtap with schema extensions;\` and
+   \`select plan(<n>);\`, close with \`select * from finish();\` and \`rollback;\`,
+   and run it with \`supabase test db\`.
 10. In each test, switch roles with \`set local role authenticated;\` and
     \`set local request.jwt.claim.sub = '<user-uuid>';\`, and cover \`anon\` as
     well as \`authenticated\`. Assert both the allow and the deny case for every

--- a/apps/docs/data/ai-prompts.data.ts
+++ b/apps/docs/data/ai-prompts.data.ts
@@ -178,44 +178,68 @@ database.new and run the instruments table SQL. Then:
 REFERENCE
 https://supabase.com/docs/guides/getting-started/quickstarts/refine.md`,
   'row-level-security': `Help me write secure, performant Row Level Security (RLS) policies for my
-Supabase Postgres database. Follow these rules:
+Supabase Postgres database, plus pgTAP tests that prove each policy works.
+Follow these rules:
 1. Enable RLS on every table in an exposed schema (typically \`public\`) before
    writing any policies: \`alter table <table> enable row level security;\`.
-   Also run \`alter table <table> force row level security;\` if the table
-   should be protected even from its owning role, since table owners and
-   superusers otherwise bypass RLS entirely.
-2. Write one policy per operation (\`select\`, \`insert\`, \`update\`, \`delete\`)
-   and always scope it with \`to authenticated\` or \`to anon\` — never leave the
-   role unspecified. Remember \`insert\` only uses \`with check\`, \`delete\` only
-   uses \`using\`, and \`update\` needs both.
-3. Wrap row-invariant helper calls in \`select\` so Postgres computes them once
-   per statement instead of once per row, e.g. use
-   \`(select auth.uid()) = user_id\` instead of \`auth.uid() = user_id\`. This
-   only helps for \`stable\`/\`immutable\` functions — a \`volatile\` function can
-   still run per row regardless of the wrapper.
-4. Add a btree index on every column referenced in a policy's \`using\` or
-   \`with check\` expression, e.g.
-   \`create index on <table> using btree (<column>);\`.
-5. Avoid joins inside policies. Instead of joining the target table to the
-   source table's column, select the matching set from the target table
-   (filtered by \`(select auth.uid())\`) and use \`in\`/\`any\` against it.
-6. For checks that need to bypass RLS on a lookup table (e.g. team membership
-   or role checks), use a \`security definer\` function in a private,
-   non-exposed schema, with \`execute\` revoked from \`public\`, and verify
-   \`auth.uid()\` inside the function body.
-7. Even though RLS acts as an implicit filter, still add the equivalent filter
-   to application queries (e.g. \`.eq('user_id', userId)\`) so Postgres can
-   build a better query plan.
-8. RLS only runs after schema and table \`grant\`s let a role reach the object
-   at all. If access looks blocked, confirm the required \`grant\`s exist before
-   assuming the policy logic is wrong.
-9. Write pgTAP tests for each policy (\`supabase test new\`, then
-   \`supabase test db\`), asserting the expected allow/deny outcome per role and
-   per operation, e.g. with \`policies_are()\`, \`results_eq()\`, and
-   \`tests.rls_enabled()\`.
+   Add \`alter table <table> force row level security;\` only when a table must
+   also be protected from its owning role. \`force\` does not stop superusers or
+   roles with \`bypassrls\`, and it breaks \`security definer\` helpers that read
+   the table as its owner, so never force it on a lookup table a policy helper
+   reads.
+2. Grant each role only what it needs, for example
+   \`grant select on <table> to anon;\`, and revoke what it should not have. RLS
+   runs only after schema and table \`grant\`s let a role reach the object, so if
+   access looks blocked, confirm the grants before rewriting policy logic.
+3. Write one policy per operation (\`select\`, \`insert\`, \`update\`, \`delete\`) and
+   always scope it with \`to authenticated\` or \`to anon\` — never leave the role
+   unspecified. \`insert\` takes only \`with check\`, \`delete\` takes only \`using\`,
+   and \`update\` needs both. To deny an operation, grant nothing and write no
+   policy; adding another permissive policy only widens access, since policies
+   for the same operation are ORed together.
+4. Wrap row-invariant calls in \`select\` so Postgres caches the result per
+   statement instead of running the function per row: use
+   \`(select auth.uid()) = user_id\` instead of \`auth.uid() = user_id\`. Only do
+   this when the result does not change based on the row data.
+5. Add a btree index on every column a policy references in \`using\` or
+   \`with check\` that is not already indexed, for example
+   \`create index on <table> using btree (user_id);\`. A column that already
+   leads a primary key or unique index does not need another one.
+6. Avoid joins inside policies. Instead of joining the target table to the
+   source table, select the matching rows from the target table filtered by
+   \`(select auth.uid())\` and use \`in\` or \`any\` against that set.
+7. When a check needs to bypass RLS on a lookup table, such as team membership
+   or role checks, call a \`security definer\` function instead of joining.
+   Create it in a private, non-exposed schema, declare \`set search_path = ''\`
+   and schema-qualify every reference inside it, and verify \`auth.uid()\` in the
+   function body.
+8. Keep the equivalent filter in application queries even though policies act
+   as implicit where clauses, for example \`.eq('user_id', userId)\`, so Postgres
+   can build a better query plan. Mirror the branch of the policy you want, so
+   a redundant filter does not drop rows the policy would allow.
+9. Test every policy with pgTAP — this is the recommended way to verify RLS.
+   Scaffold with \`supabase test new <name>\`, begin the file with
+   \`create extension if not exists pgtap with schema extensions;\`, wrap it in
+   \`begin;\`, \`select plan(<n>);\`, \`select * from finish();\`, \`rollback;\`, and
+   run it with \`supabase test db\`.
+10. In each test, switch roles with \`set local role authenticated;\` and
+    \`set local request.jwt.claim.sub = '<user-uuid>';\`, and cover \`anon\` as
+    well as \`authenticated\`. Assert both the allow and the deny case for every
+    operation: \`results_eq()\` for visibility, \`lives_ok()\` for a permitted
+    write, and \`throws_ok(..., '42501', ...)\` where a \`with check\` or a missing
+    grant rejects the statement. A denied \`update\` or \`delete\` raises nothing,
+    because \`using\` filters the rows out, so assert that it changed no rows
+    instead. Use \`policies_are()\` to confirm the policy set.
+11. Plain pgTAP needs no extra packages. If you want helpers like
+    \`tests.create_supabase_user()\`, \`tests.authenticate_as()\`, and
+    \`tests.rls_enabled()\`, install \`basejump-supabase_test_helpers\` with dbdev
+    first in a \`000-setup-tests-hooks.sql\` file, since they are not part of
+    pgTAP itself.
 
 REFERENCE
-https://supabase.com/docs/guides/database/postgres/row-level-security.md#rls-performance-recommendations`,
+https://supabase.com/docs/guides/database/postgres/row-level-security.md
+https://supabase.com/docs/guides/database/functions.md
+https://supabase.com/docs/guides/local-development/testing/overview.md`,
   'ruby-on-rails': `Help me add Supabase to my Ruby on Rails project. Create a Supabase project at
 database.new. Then:
 1. Run \`rails new blog -d=postgresql\` to scaffold a new Rails project.


### PR DESCRIPTION
Closes DOCS-1258

<img width="1600" height="900" alt="image-1785864013861" src="https://github.com/user-attachments/assets/e40f9e7d-07b3-44ec-bf3c-aa30ecdde120" />

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## Problem

The [Row Level Security guide](https://supabase.com/docs/guides/database/postgres/row-level-security) documents solid RLS performance and security recommendations, but there's nothing on the page an AI coding agent can be handed directly to make it follow those recommendations when writing or reviewing policies. Framework quickstarts already solve this with a copy-pasteable `AiPrompt` component — the RLS guide didn't have one.

## Solution

Added an `<AiPrompt id="row-level-security" />` panel at the top of the RLS guide, using the same pattern as the framework quickstarts. It hands an agent a checklist covering three things:

- **Security** — enable RLS, grant least privilege, write one role-scoped policy per operation, and keep cross-table checks in a `security definer` function in a private schema
- **Performance** — wrap helper calls in `select`, index the columns policies reference, avoid joins inside policies, and mirror the filter in application queries
- **Testing** — write pgTAP tests that assert both allow and deny for every role and operation, and run them with `supabase test db`

Content was built from the doc's own performance section, the `security-rls-basics.md`/`security-rls-performance.md` references in `supabase/agent-skills`, and the RLS module of `supabase/supacademy`. Where those sources disagreed with the Supabase docs, the docs won.

Verified with evals rather than by inspection: the prompt's generated output was applied to a local stack and exercised with `supabase test db`. Several rules were corrected so that output runs cleanly, and the final run passes 31/31.

`REFERENCE` points at three page-level URLs instead of a single section anchor, matching every other entry in `ai-prompts.data.ts`.

**Files changed:**
- `apps/docs/data/ai-prompts.data.ts` — new `row-level-security` prompt entry
- `apps/docs/content/guides/database/postgres/row-level-security.mdx` — added `<AiPrompt id="row-level-security" />` after frontmatter

## Manual testing

1. Open `/guides/database/postgres/row-level-security` on Preview.
2. Confirm an "AI Prompt" panel appears at the top of the page, right below the subtitle, styled the same as the `AiPrompt` panel on e.g. `/guides/getting-started/quickstarts/nextjs`.
3. Click "Show more" and confirm the checklist expands and ends with a `REFERENCE` block listing three `.md` URLs.
4. Click the copy icon and paste somewhere to confirm the full prompt text copies correctly.
5. Run `pnpm typecheck --filter=docs` and `pnpm format` and confirm both pass.
6. Read the prompt and verify that the action it captures is what you would expect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AI assistance to the Row Level Security guide.
  * The prompt offers guidance on secure policy design, operation-specific policies, grants, performance optimization, indexing, security-definer functions, application-side filtering, and pgTAP testing.
  * Includes references to recommended Row Level Security, database functions, and testing practices to support safer, more effective database security implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
