### PR TITLE
docs: clarify PAT wording in temporary access and API intro

### DIFF
--- a/apps/docs/content/guides/platform/temporary-access.mdx
+++ b/apps/docs/content/guides/platform/temporary-access.mdx
@@ -51,7 +51,7 @@ curl -X PUT "https://api.supabase.com/v1/projects/$PROJECT_REF/database/jit-acce
 
 Once temporary access has been enabled, project users must be authorized and mapped to Postgres roles they are allowed to access. Each user can be authorized to "assume" one or more Postgres roles using temporary access.
 
-When a user is authorized to assume a Postgres role, the user's access token (Personal Access Token (PAT) or Scoped PAT) will be used as the password for the Postgres role.
+When a user is authorized to assume a Postgres role, the user's Personal Access Token (PAT) will be used as the password for the Postgres role.
 
 <Admonition type="note">
 

--- a/apps/docs/docs/ref/api/introduction.mdx
+++ b/apps/docs/docs/ref/api/introduction.mdx
@@ -22,7 +22,7 @@ hideTitle: true
       There are two ways to generate an access token:
 
       1. **Personal access token (PAT):**
-      PATs are long-lived tokens that you manually generate to access the Management API. They are useful for automating workflows or developing against the Management API. PATs carry the same privileges as your user account, so be sure to keep it secret.
+      PATs are tokens with a custom expiry that you manually generate to access the Management API. They are useful for automating workflows or developing against the Management API. PATs carry the same privileges as your user account, so be sure to keep it secret.
 
           To generate or manage your personal access tokens, visit your [account](/dashboard/account/tokens) page.
 


### PR DESCRIPTION
Two small copy fixes to keep PAT descriptions accurate:

- temporary-access: drop the "(PAT or Scoped PAT)" parenthetical — the token used as the Postgres role password is simply the user's Personal Access Token, and calling out scoped variants here was confusing
- api/introduction: describe PATs as tokens with a custom expiry rather than "long-lived", since expiry is now user-configurable