### PR TITLE
docs: CLI 'Transport error' caused by antivirus/proxy TLS interception

### DIFF
--- a/apps/docs/content/troubleshooting/supabase-cli-transport-error-antivirus-firewall-tls-interception.mdx
+++ b/apps/docs/content/troubleshooting/supabase-cli-transport-error-antivirus-firewall-tls-interception.mdx
@@ -20,7 +20,7 @@ failed to list projects: HttpClientError: Transport error (GET https://api.supab
 
 The CLI's HTTP client buckets any failure that happens before it receives an HTTP response — timeouts, connection resets, certificate rejections — under one generic `TransportError` label. The message alone doesn't tell you which of these occurred, which makes this error hard to diagnose from the output alone.
 
-One confirmed cause: antivirus software or corporate SSL-inspecting proxies that intercept HTTPS traffic to scan it. These install a local root certificate and re-sign connections so they can decrypt, inspect, and re-encrypt traffic in transit — a documented feature of products like Norton (under names like "Web and Mail Shield" or "Safe Web") and corporate proxies like Zscaler or Netskope. The CLI receives the substituted certificate instead of Supabase's real one and rejects it, surfacing as the generic transport error above rather than a certificate-specific one.
+One confirmed cause: antivirus software or corporate SSL-inspecting proxies that intercept HTTPS traffic to scan it. These install a local root certificate and re-sign connections so they can decrypt, inspect, and re-encrypt traffic in transit — a documented feature of products like Norton (under names like "Web and Mail Shield" or "Safe Web") and of enterprise network security proxies. The CLI receives the substituted certificate instead of Supabase's real one and rejects it, surfacing as the generic transport error above rather than a certificate-specific one.
 
 Other HTTP clients on the same machine can behave differently, which is a useful diagnostic signal. In one confirmed case (Norton 360 on Windows), `curl` connected successfully while the CLI failed, and Node's `fetch()` surfaced a more specific `UNABLE_TO_VERIFY_LEAF_SIGNATURE` error for the same request.
 
@@ -28,7 +28,7 @@ Other HTTP clients on the same machine can behave differently, which is a useful
 
 - Compare behavior across HTTP clients on the same machine. If `curl -v https://api.supabase.com` or a browser succeeds while the CLI fails, the network path itself is fine and something local to the machine is the difference.
 - Check the certificate being served for `api.supabase.com`. In a browser, click the padlock icon next to the address bar and check the certificate's **Issuer** field. It should be a public CA (e.g. Google Trust Services). If it's your antivirus vendor or a corporate proxy CA instead, that's what's intercepting the connection.
-- If you're on a corporate network, check whether your organization uses an SSL-inspecting proxy (Zscaler, Netskope, or similar) and whether its root CA is installed and trusted on your machine.
+- If you're on a corporate network, check whether your organization uses an SSL-inspecting proxy and whether its root CA is installed and trusted on your machine.
 
 ## How to resolve
 

--- a/apps/docs/content/troubleshooting/supabase-cli-transport-error-antivirus-firewall-tls-interception.mdx
+++ b/apps/docs/content/troubleshooting/supabase-cli-transport-error-antivirus-firewall-tls-interception.mdx
@@ -27,7 +27,7 @@ Other HTTP clients on the same machine can behave differently, which is a useful
 ## How to diagnose
 
 - Compare behavior across HTTP clients on the same machine. If `curl -v https://api.supabase.com` or a browser succeeds while the CLI fails, the network path itself is fine and something local to the machine is the difference.
-- Check the certificate actually being served for `api.supabase.com`. In a browser, click the padlock icon next to the address bar and check the certificate's **Issuer** field. It should be a public CA (e.g. Google Trust Services). If it's your antivirus vendor or a corporate proxy CA instead, that's what's intercepting the connection.
+- Check the certificate being served for `api.supabase.com`. In a browser, click the padlock icon next to the address bar and check the certificate's **Issuer** field. It should be a public CA (e.g. Google Trust Services). If it's your antivirus vendor or a corporate proxy CA instead, that's what's intercepting the connection.
 - If you're on a corporate network, check whether your organization uses an SSL-inspecting proxy (Zscaler, Netskope, or similar) and whether its root CA is installed and trusted on your machine.
 
 ## How to resolve

--- a/apps/docs/content/troubleshooting/supabase-cli-transport-error-antivirus-firewall-tls-interception.mdx
+++ b/apps/docs/content/troubleshooting/supabase-cli-transport-error-antivirus-firewall-tls-interception.mdx
@@ -32,7 +32,9 @@ Other HTTP clients on the same machine can behave differently, which is a useful
 
 ## How to resolve
 
-Identify and disable the specific feature doing HTTPS/TLS inspection. This is often a separate setting from the general firewall or "protection" toggle, so disabling the main antivirus switch alone may not be enough.
+Only disable HTTPS/TLS inspection after the diagnostic step above confirms it's the cause — a `Transport error` can also come from an unrelated timeout or connection reset, and disabling scanning you don't need reduces your protection unnecessarily.
+
+Once confirmed, identify and disable the specific feature doing the inspection. This is often a separate setting from the general firewall or "protection" toggle, so disabling the main antivirus switch alone may not be enough. Treat this as temporary while you resolve connectivity — prefer a narrower host-specific exclusion for `api.supabase.com` over disabling scanning outright, if your software supports one.
 
 For **Norton 360 on Windows**, the responsible feature is **Safe Web / Web & Mail Shield**, not Smart Firewall — disabling Smart Firewall alone does not stop the interception. After disabling it, confirm the certificate reverts to the expected issuer before retrying.
 

--- a/apps/docs/content/troubleshooting/supabase-cli-transport-error-antivirus-firewall-tls-interception.mdx
+++ b/apps/docs/content/troubleshooting/supabase-cli-transport-error-antivirus-firewall-tls-interception.mdx
@@ -1,0 +1,39 @@
+---
+title = "Supabase CLI fails with 'Transport error' (antivirus/proxy TLS interception)"
+topics = [ "cli", "platform" ]
+keywords = [ "windows", "norton", "tls interception", "certificate", "transport error", "ssl inspection", "firewall", "web and mail shield", "zscaler", "netskope" ]
+
+[[errors]]
+message = "Transport error"
+
+[[errors]]
+message = "UNABLE_TO_VERIFY_LEAF_SIGNATURE"
+---
+
+This typically affects CLI commands that call the Management API, such as `supabase projects list` and `supabase link`:
+
+```
+failed to list projects: HttpClientError: Transport error (GET https://api.supabase.com/v1/projects)
+```
+
+## Why this happens
+
+The CLI's HTTP client buckets any failure that happens before it receives an HTTP response — timeouts, connection resets, certificate rejections — under one generic `TransportError` label. The message alone doesn't tell you which of these occurred, which makes this error hard to diagnose from the output alone.
+
+One confirmed cause: antivirus software or corporate SSL-inspecting proxies that intercept HTTPS traffic to scan it. These install a local root certificate and re-sign connections so they can decrypt, inspect, and re-encrypt traffic in transit — a documented feature of products like Norton (under names like "Web and Mail Shield" or "Safe Web") and corporate proxies like Zscaler or Netskope. The CLI receives the substituted certificate instead of Supabase's real one and rejects it, surfacing as the generic transport error above rather than a certificate-specific one.
+
+Other HTTP clients on the same machine can behave differently, which is a useful diagnostic signal. In one confirmed case (Norton 360 on Windows), `curl` connected successfully while the CLI failed, and Node's `fetch()` surfaced a more specific `UNABLE_TO_VERIFY_LEAF_SIGNATURE` error for the same request.
+
+## How to diagnose
+
+- Compare behavior across HTTP clients on the same machine. If `curl -v https://api.supabase.com` or a browser succeeds while the CLI fails, the network path itself is fine and something local to the machine is the difference.
+- Check the certificate actually being served for `api.supabase.com`. In a browser, click the padlock icon next to the address bar and check the certificate's **Issuer** field. It should be a public CA (e.g. Google Trust Services). If it's your antivirus vendor or a corporate proxy CA instead, that's what's intercepting the connection.
+- If you're on a corporate network, check whether your organization uses an SSL-inspecting proxy (Zscaler, Netskope, or similar) and whether its root CA is installed and trusted on your machine.
+
+## How to resolve
+
+Identify and disable the specific feature doing HTTPS/TLS inspection. This is often a separate setting from the general firewall or "protection" toggle, so disabling the main antivirus switch alone may not be enough.
+
+For **Norton 360 on Windows**, the responsible feature is **Safe Web / Web & Mail Shield**, not Smart Firewall — disabling Smart Firewall alone does not stop the interception. After disabling it, confirm the certificate reverts to the expected issuer before retrying.
+
+If you're behind a corporate SSL-inspecting proxy, this is managed by your IT/security team rather than something you can change locally — they can add an exclusion for `api.supabase.com` on the proxy side if needed.


### PR DESCRIPTION
## Summary
- Adds a troubleshooting entry for the Supabase CLI's generic `HttpClientError: Transport error` when a Management API call (e.g. `projects list`, `link`) fails.
- Root cause documented: antivirus software or corporate SSL-inspecting proxies (e.g. Norton Safe Web/Web & Mail Shield, Zscaler, Netskope) substituting their own TLS certificate, which the CLI's HTTP client rejects and reports as a generic transport error rather than a certificate error.
- Includes a vendor-agnostic diagnostic method (compare `curl`/browser vs. CLI behavior, check the served certificate's Issuer field) plus the specific Norton fix confirmed via a support ticket (disabling Smart Firewall alone does not stop the interception; Safe Web/Web & Mail Shield does).

## Test plan
- [ ] `pnpm --filter docs lint:mdx` passes in CI
- [ ] Frontmatter renders correctly on the troubleshooting page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guidance for Supabase CLI transport errors caused by antivirus software or corporate TLS inspection.
  * Included diagnostic steps, common error messages, and resolution guidance for Norton 360 and SSL-inspecting proxies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->