### PR TITLE
docs(blog): point renamed JS reference links at their current pages

### DIFF
--- a/apps/www/_blog/2021-11-05-supabase-beta-october-2021.mdx
+++ b/apps/www/_blog/2021-11-05-supabase-beta-october-2021.mdx
@@ -106,7 +106,7 @@ Learn more about the power of PostgREST for RESTful APIs. [Docs](https://supabas
 
 - Redwood Quickstart: [https://supabase.com/docs/guides/with-redwoodjs](https://supabase.com/docs/guides/with-redwoodjs)
 - Expanded Self-hosting: [https://supabase.com/docs/guides/hosting/overview](https://supabase.com/docs/guides/hosting/overview)
-- Expanded Auth Reference docs with [serverside functions](https://supabase.com/docs/reference/javascript/auth-api-deleteuser).
+- Expanded Auth Reference docs with [serverside functions](https://supabase.com/docs/reference/javascript/auth-admin-deleteuser).
 - "Before you launch" checklist: [https://supabase.com/docs/going-into-prod](https://supabase.com/docs/going-into-prod)
 
 !["Before you launch" checklist](/images/blog/2021-oct/launch-ckecklist.png)

--- a/apps/www/_blog/2022-08-18-supabase-realtime-multiplayer-general-availability.mdx
+++ b/apps/www/_blog/2022-08-18-supabase-realtime-multiplayer-general-availability.mdx
@@ -23,7 +23,7 @@ Today, we're excited to announce the general availability of Realtime's multipla
 
 Here are the key takeaways:
 
-- We've added [Broadcast](https://supabase.com/docs/guides/realtime/broadcast) and [Presence](https://supabase.com/docs/guides/realtime/presence) to our Realtime server. You can use these features with the new [supabase-js](https://supabase.com/docs/reference/javascript/next) release.
+- We've added [Broadcast](https://supabase.com/docs/guides/realtime/broadcast) and [Presence](https://supabase.com/docs/guides/realtime/presence) to our Realtime server. You can use these features with the new [supabase-js](https://supabase.com/docs/reference/javascript/introduction) release.
 - All active Supabase projects on the Free Plan have access to the these features.
 - All new Supabase projects created from August 18th have access to these features.
 - We will work with all other projects to migrate to the new Realtime over the next few weeks. If you want immediate access, [reach out](https://supabase.com/dashboard/support/new).

--- a/apps/www/_blog/2022-12-16-postgrest-11-prerelease.mdx
+++ b/apps/www/_blog/2022-12-16-postgrest-11-prerelease.mdx
@@ -216,7 +216,7 @@ const { data, error } = await supabase
 ```
 
 This was already possible with the `!inner` modifier([introduced on PostgREST 9](https://supabase.com/blog/postgrest-9#resource-embedding-with-inner-joins))
-but the `not null` filter is more flexible and can be used with an [or filter](https://supabase.com/docs/reference/javascript/or) to combine related tables' conditions.
+but the `not null` filter is more flexible and can be used with an [or filter](https://supabase.com/docs/reference/javascript/using-filters-or) to combine related tables' conditions.
 
 ## Try it out
 

--- a/apps/www/_blog/2023-03-09-supabase-beta-update-february-2023.mdx
+++ b/apps/www/_blog/2023-03-09-supabase-beta-update-february-2023.mdx
@@ -70,7 +70,7 @@ API docs got a light touchup and were moved to the table editor. You can now loo
 
 - **Auth**: Added full OpenAPI 3.0 spec which provides a comprehensive overview of the API with documentation on each request. [PR](https://github.com/supabase/gotrue/pull/918)
 
-- **Database**: supabase-js now infers the response type from your query. If the inferred type is incorrect, you can use `.returns<MyType>()` to override it. [Doc](https://supabase.com/docs/reference/javascript/db-returns)
+- **Database**: supabase-js now infers the response type from your query. If the inferred type is incorrect, you can use `.returns<MyType>()` to override it. [Doc](https://supabase.com/docs/reference/javascript/using-modifiers-returns)
 
 - **Dashboard**: Improved database roles management, you can now create, update and delete database roles through the dashboard. [Dashboard](https://supabase.com/dashboard/project/_/database/roles)
 

--- a/apps/www/_blog/2023-04-04-infinite-scroll-with-nextjs-framer-motion.mdx
+++ b/apps/www/_blog/2023-04-04-infinite-scroll-with-nextjs-framer-motion.mdx
@@ -135,7 +135,7 @@ return <div ref={containerRef}>{/* List of loaded tickets */}</div>
 
 ## Step 3. Load tickets based on the offset
 
-Now we can load more tickets based on the current offset. We'll use the [range](https://supabase.com/docs/reference/javascript/range) method from the supabase-js library to easily work with the pagination logic.
+Now we can load more tickets based on the current offset. We'll use the [range](https://supabase.com/docs/reference/javascript/using-modifiers-range) method from the supabase-js library to easily work with the pagination logic.
 
 ```jsx
 export default function TicketsPage() {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs fix (broken links in blog posts).

## What is the current behavior?

Five blog posts link to JavaScript reference pages that return 404. The PostgREST filter and modifier methods were renamed to `using-filters-*` and `using-modifiers-*`, and a couple of others moved as well.

| dead link | post |
| --- | --- |
| `reference/javascript/or` | `2022-12-16-postgrest-11-prerelease` |
| `reference/javascript/range` | `2023-04-04-infinite-scroll-with-nextjs-framer-motion` |
| `reference/javascript/db-returns` | `2023-03-09-supabase-beta-update-february-2023` |
| `reference/javascript/auth-api-deleteuser` | `2021-11-05-supabase-beta-october-2021` |
| `reference/javascript/next` | `2022-08-18-supabase-realtime-multiplayer-general-availability` |

## What is the new behavior?

| old | new | why |
| --- | --- | --- |
| `or` | `using-filters-or` | the sentence says "can be used with an or filter" |
| `range` | `using-modifiers-range` | "the range method ... to easily work with the pagination logic" |
| `db-returns` | `using-modifiers-returns` | the sentence is "you can use `.returns<MyType>()` to override it" |
| `auth-api-deleteuser` | `auth-admin-deleteuser` | link text is "serverside functions", and this is the admin auth API |
| `next` | `introduction` | see the note below |

All five destinations return 200 and are in the sitemap.

The one I am least sure about is `next`. That path was the pre-release channel for supabase-js v2 and no longer exists in any form, so there is no direct equivalent. The sentence is "You can use these features with the new [supabase-js](...) release", so I pointed it at the current JavaScript reference introduction, which is where a reader following that link now wants to end up. If you would rather it point at the v2 release blog post, the changelog, or just lose the link, say which and I will change it.

## Additional context

Five links across five files, all under `apps/www/_blog`. Link targets only, no prose changed.

I did not touch `apps/www/app/api-v2/md/content.generated.ts`, which mirrors this content, since it is generated and regenerates from the posts.

Verification: each old URL confirmed 404 and absent from the sitemap, each replacement confirmed 200 and present. I checked the surrounding sentence in every case rather than pattern matching on the slug, which is how the `db-returns` and `or` mappings got pinned down.

Gates run locally: `test:prettier` passes repo wide and the www vitest suite passes (6 files, 73 tests). I did not run `pnpm build`, which cannot complete in my environment because the docs `build:federated-content` step requires `DOCS_GITHUB_APP_PRIVATE_KEY`.

This is part of a sweep over every `supabase.com/docs` link referenced from `apps/www` and `apps/docs`. Thanks for the review on #48655, that was helpful confirmation I was reading these renames the right way. There are a few sibling PRs open from the same sweep (#48560, #48562, #48563, #48568, #48629, #48634, #48656, #48682, #48683). I kept them separate because they touch different areas, but I am glad to squash them into one if a single review is easier.

Freshman contributor, worked through this with Claude Code's help and checked every URL and sentence myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated outdated links across blog posts to point to the current Auth, JavaScript, PostgREST filtering, database modifier, and range documentation.
  * Improved navigation for readers following implementation guidance and API references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->