### PR TITLE
[MUL-1203] fix(studio): hide HA toggle for free plan orgs

### DIFF
--- a/apps/studio/components/interfaces/ProjectCreation/HighAvailabilityInput.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/HighAvailabilityInput.tsx
@@ -7,6 +7,7 @@ import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { CreateProjectForm } from './ProjectCreation.schema'
 import Panel from '@/components/ui/Panel'
 import { useCheckEntitlements } from '@/hooks/misc/useCheckEntitlements'
+import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 
 interface HighAvailabilityInputProps {
   form: UseFormReturn<CreateProjectForm>
@@ -21,6 +22,8 @@ export const HighAvailabilityInput = ({
 }: HighAvailabilityInputProps) => {
   const { getValues, setValue } = form
   const { hasAccess } = useCheckEntitlements('instances.high_availability')
+  const { data: organization } = useSelectedOrganizationQuery()
+  const isFreePlan = organization?.plan?.id === 'free'
   const highAvailability = useWatch({ control: form.control, name: 'highAvailability' })
 
   // Fields to revert to when toggling off HA, so previously selected values aren't lost.
@@ -91,7 +94,7 @@ export const HighAvailabilityInput = ({
     setValue('dbRegion', highAvailabilityRegionName)
   }, [highAvailability, highAvailabilityRegionName, getValues, setValue])
 
-  if (!hasAccess) return null
+  if (!hasAccess || isFreePlan) return null
 
   return (
     <Panel.Content>

--- a/apps/studio/tests/pages/new/[slug].test.tsx
+++ b/apps/studio/tests/pages/new/[slug].test.tsx
@@ -733,6 +733,17 @@ describe('project creation wizard', () => {
       expect(screen.queryByText('High availability')).not.toBeInTheDocument()
     })
 
+    test('hides the high availability toggle when the org is on the free plan', async () => {
+      mockWizardEndpoints({
+        organizations: [mockOrg({ plan: { id: 'free', name: 'Free' } })],
+      })
+
+      await renderWizard()
+
+      await screen.findByPlaceholderText('Project name')
+      expect(screen.queryByText('High availability')).not.toBeInTheDocument()
+    })
+
     test('removes the custom Postgres version field while high availability is enabled', async () => {
       mockWizardEndpoints()
 


### PR DESCRIPTION
Hides the High Availability toggle on the create project page for free plan organizations — it now only shows for orgs on Pro or above (in addition to the existing `instances.high_availability` entitlement check).

The Oriole-related UI in the HA section was already hidden by #48375, so this covers the remaining scope of MUL-1203.

**Changed:**
- `HighAvailabilityInput` returns `null` when the selected org is on the free plan
- Added a component test: free plan org with the entitlement enabled no longer sees the toggle

## To test

- As a free plan org with the `instances.high_availability` entitlement, open the create project page — the High availability toggle should not appear
- As a Pro (or above) org with the entitlement, the toggle should still appear and behave as before
- `pnpm vitest run "tests/pages/new/[slug].test.tsx"` in `apps/studio` — 34/34 pass

https://linear.app/supabase/issue/MUL-1203/hide-oriole-related-ui-for-multigres

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * High-availability options are now hidden for organizations on free plans or without the required entitlement.
  * Eligible organizations retain the existing high-availability controls and form behavior.

* **Tests**
  * Added coverage verifying that free-plan organizations do not see the high-availability toggle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->