### PR TITLE
chore: sync ssl enforcement and temporary access

### DIFF
--- a/apps/studio/components/interfaces/Settings/Database/JitDatabaseAccess/JitDbAccessConfiguration.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/JitDatabaseAccess/JitDbAccessConfiguration.tsx
@@ -128,7 +128,7 @@ export const JitDbAccessConfiguration = () => {
       onError: () => {},
     })
 
-  const { mutate: enableSSLEnforcement, isPending: isEnablingSSLEnforcement } =
+  const { mutateAsync: enableSSLEnforcement, isPending: isEnablingSSLEnforcement } =
     useSSLEnforcementUpdateMutation({
       onSuccess: () => {
         toast.success('Successfully enabled SSL enforcement')
@@ -138,9 +138,9 @@ export const JitDbAccessConfiguration = () => {
       },
     })
 
-  const handleEnableSSLEnforcement = () => {
+  const handleEnableSSLEnforcement = async () => {
     if (!ref) return console.error('Project ref is required')
-    enableSSLEnforcement({ projectRef: ref, requestedConfig: { database: true } })
+    await enableSSLEnforcement({ projectRef: ref, requestedConfig: { database: true } })
   }
 
   const { mutateAsync: revokeUserAccess, isPending: isRevokingAccess } =

--- a/apps/studio/components/interfaces/Settings/Database/JitDatabaseAccess/JitDbAccessConfiguration.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/JitDatabaseAccess/JitDbAccessConfiguration.tsx
@@ -42,6 +42,7 @@ import {
 import { JitDbAccessDeleteDialog } from './JitDbAccessDeleteDialog'
 import { JitDbAccessRuleSheet } from './JitDbAccessRuleSheet'
 import { JitDbAccessRulesTable } from './JitDbAccessRulesTable'
+import { SSLEnforcementConfirmDialog } from '@/components/interfaces/Settings/Database/SSLEnforcementConfirmDialog'
 import { getServiceVersionsPath } from '@/components/interfaces/Settings/General/ServiceVersions/ServiceVersions.utils'
 import { SupportLink } from '@/components/interfaces/Support/SupportLink'
 import { AlertError } from '@/components/ui/AlertError'
@@ -55,6 +56,7 @@ import { useJitDbAccessRevokeMutation } from '@/data/jit-db-access/jit-db-access
 import { useJitDbAccessUpdateMutation } from '@/data/jit-db-access/jit-db-access-update-mutation'
 import { useOrganizationMembersQuery } from '@/data/organizations/organization-members-query'
 import { useProjectMembersQuery } from '@/data/projects/project-members-query'
+import { useSSLEnforcementUpdateMutation } from '@/data/ssl-enforcement/ssl-enforcement-update-mutation'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
@@ -125,6 +127,21 @@ export const JitDbAccessConfiguration = () => {
       },
       onError: () => {},
     })
+
+  const { mutate: enableSSLEnforcement, isPending: isEnablingSSLEnforcement } =
+    useSSLEnforcementUpdateMutation({
+      onSuccess: () => {
+        toast.success('Successfully enabled SSL enforcement')
+      },
+      onError: (error) => {
+        toast.error(`Failed to enable SSL enforcement: ${error.message}`)
+      },
+    })
+
+  const handleEnableSSLEnforcement = () => {
+    if (!ref) return console.error('Project ref is required')
+    enableSSLEnforcement({ projectRef: ref, requestedConfig: { database: true } })
+  }
 
   const { mutateAsync: revokeUserAccess, isPending: isRevokingAccess } =
     useJitDbAccessRevokeMutation({
@@ -383,11 +400,15 @@ export const JitDbAccessConfiguration = () => {
                     <Link href={getServiceVersionsPath(ref)}>Upgrade Postgres</Link>
                   </Button>
                 ) : unavailableReason === 'ssl_enforcement_required' && ref ? (
-                  <Button variant="default" asChild>
-                    <Link href={`/project/${ref}/settings/database#ssl-configuration`}>
+                  <SSLEnforcementConfirmDialog
+                    targetEnforced
+                    isSubmitting={isEnablingSSLEnforcement}
+                    onConfirm={handleEnableSSLEnforcement}
+                  >
+                    <Button variant="default" loading={isEnablingSSLEnforcement}>
                       Enable SSL enforcement
-                    </Link>
-                  </Button>
+                    </Button>
+                  </SSLEnforcementConfirmDialog>
                 ) : (
                   <Button variant="default" asChild>
                     <SupportLink

--- a/apps/studio/components/interfaces/Settings/Database/JitDatabaseAccess/JitDbAccessConfiguration.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/JitDatabaseAccess/JitDbAccessConfiguration.tsx
@@ -401,7 +401,7 @@ export const JitDbAccessConfiguration = () => {
                   </Button>
                 ) : unavailableReason === 'ssl_enforcement_required' && ref ? (
                   <SSLEnforcementConfirmDialog
-                    targetEnforced
+                    isTargetEnforced
                     isSubmitting={isEnablingSSLEnforcement}
                     onConfirm={handleEnableSSLEnforcement}
                   >

--- a/apps/studio/components/interfaces/Settings/Database/SSLConfiguration.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/SSLConfiguration.tsx
@@ -2,26 +2,9 @@ import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useParams } from 'common'
 import { template } from 'lodash'
 import { Download, Loader2 } from 'lucide-react'
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import { toast } from 'sonner'
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-  Button,
-  Card,
-  CardContent,
-  Switch,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from 'ui'
+import { Button, Card, CardContent, Switch, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 import { Admonition } from 'ui-patterns/Admonition'
 import { FormLayout } from 'ui-patterns/form/Layout/FormLayout'
 import {
@@ -32,11 +15,13 @@ import {
   PageSectionTitle,
 } from 'ui-patterns/PageSection'
 
+import { SSLEnforcementConfirmDialog } from './SSLEnforcementConfirmDialog'
 import { SupportLink } from '@/components/interfaces/Support/SupportLink'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import { DocsButton } from '@/components/ui/DocsButton'
 import { InlineLinkClassName } from '@/components/ui/InlineLink'
 import { useProjectSettingsV2Query } from '@/data/config/project-settings-v2-query'
+import { useJitDbAccessQuery } from '@/data/jit-db-access/jit-db-access-query'
 import { useSSLEnforcementQuery } from '@/data/ssl-enforcement/ssl-enforcement-query'
 import { useSSLEnforcementUpdateMutation } from '@/data/ssl-enforcement/ssl-enforcement-update-mutation'
 import { useCustomContent } from '@/hooks/custom-content/useCustomContent'
@@ -47,7 +32,6 @@ import { DOCS_URL } from '@/lib/constants'
 export const SSLConfiguration = () => {
   const { ref } = useParams()
   const { data: project } = useSelectedProjectQuery()
-  const [isEnforced, setIsEnforced] = useState(false)
 
   const { data: settings } = useProjectSettingsV2Query({ projectRef: ref })
   const {
@@ -57,13 +41,13 @@ export const SSLConfiguration = () => {
   } = useSSLEnforcementQuery({
     projectRef: ref,
   })
+  const { data: jitDbAccessConfiguration } = useJitDbAccessQuery({ projectRef: ref })
   const { mutate: updateSSLEnforcement, isPending: isSubmitting } = useSSLEnforcementUpdateMutation(
     {
       onSuccess: () => {
         toast.success('Successfully updated SSL configuration')
       },
       onError: (error) => {
-        setIsEnforced(initialIsEnforced)
         toast.error(`Failed to update SSL enforcement: ${error.message}`)
       },
     }
@@ -78,16 +62,42 @@ export const SSLConfiguration = () => {
       },
     }
   )
-  const initialIsEnforced = isSuccess
-    ? sslEnforcementConfiguration.appliedSuccessfully &&
-      sslEnforcementConfiguration.currentConfig.database
-    : false
+
+  // Derived directly from the query so a refetch triggered elsewhere (e.g.
+  // enabling SSL enforcement from the JIT DB access unavailable banner) is
+  // reflected here too, instead of relying on a mirrored local state that
+  // would only resync on the initial load.
+  const isEnforced =
+    isSuccess &&
+    sslEnforcementConfiguration.appliedSuccessfully &&
+    sslEnforcementConfiguration.currentConfig.database
 
   const hasAccessToSSLEnforcement = !(
     sslEnforcementConfiguration !== undefined &&
     'isNotAllowed' in sslEnforcementConfiguration &&
     sslEnforcementConfiguration.isNotAllowed
   )
+
+  // Temporary access requires SSL enforcement to be enabled, so SSL enforcement
+  // can't be turned off again while temporary access is still enabled.
+  const isTemporaryAccessEnabled =
+    jitDbAccessConfiguration?.state === 'enabled' && jitDbAccessConfiguration.appliedSuccessfully
+
+  const isSwitchDisabled =
+    isLoading ||
+    isSubmitting ||
+    !canUpdateSSLEnforcement ||
+    !hasAccessToSSLEnforcement ||
+    isTemporaryAccessEnabled
+
+  const switchTooltipMessage = !canUpdateSSLEnforcement
+    ? 'You need additional permissions to update SSL enforcement for your project'
+    : !hasAccessToSSLEnforcement
+      ? 'Your project does not have access to SSL enforcement'
+      : isTemporaryAccessEnabled
+        ? 'Temporary access must first be disabled before SSL enforcement can be disabled'
+        : undefined
+
   const env = process.env.NEXT_PUBLIC_ENVIRONMENT === 'prod' ? 'prod' : 'staging'
   const hasSSLCertificate =
     settings?.inserted_at !== undefined && new Date(settings.inserted_at) >= new Date('2021-04-30')
@@ -98,15 +108,8 @@ export const SSLConfiguration = () => {
     [sslCertificateUrlTemplate, env]
   )
 
-  useEffect(() => {
-    if (!isLoading && sslEnforcementConfiguration) {
-      setIsEnforced(initialIsEnforced)
-    }
-  }, [isLoading])
-
   const toggleSSLEnforcement = async () => {
     if (!ref) return console.error('Project ref is required')
-    setIsEnforced(!isEnforced)
     updateSSLEnforcement({ projectRef: ref, requestedConfig: { database: !isEnforced } })
   }
 
@@ -126,64 +129,32 @@ export const SSLConfiguration = () => {
               label="Enforce SSL on incoming connections"
               description="Reject non-SSL connections to your database"
             >
-              <AlertDialog>
-                <AlertDialogTrigger asChild>
-                  <div className="flex items-center justify-end mt-2.5 space-x-2">
-                    {(isLoading || isSubmitting) && (
-                      <Loader2 className="animate-spin" strokeWidth={1.5} size={16} />
-                    )}
-                    {isSuccess && (
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          {/* [Joshen] Added div as tooltip is messing with data state property of toggle */}
-                          <div>
-                            <Switch
-                              size="large"
-                              checked={isEnforced}
-                              disabled={
-                                isLoading ||
-                                isSubmitting ||
-                                !canUpdateSSLEnforcement ||
-                                !hasAccessToSSLEnforcement
-                              }
-                            />
-                          </div>
-                        </TooltipTrigger>
-                        {(!canUpdateSSLEnforcement || !hasAccessToSSLEnforcement) && (
-                          <TooltipContent side="bottom" className="w-64 text-center">
-                            {!canUpdateSSLEnforcement
-                              ? 'You need additional permissions to update SSL enforcement for your project'
-                              : !hasAccessToSSLEnforcement
-                                ? 'Your project does not have access to SSL enforcement'
-                                : undefined}
-                          </TooltipContent>
-                        )}
-                      </Tooltip>
-                    )}
-                  </div>
-                </AlertDialogTrigger>
-                <AlertDialogContent size="medium">
-                  <AlertDialogHeader>
-                    <AlertDialogTitle>
-                      Updating SSL enforcement involves a brief downtime
-                    </AlertDialogTitle>
-                    <AlertDialogDescription>
-                      A database restart is required for SSL enforcement changes to take place, and
-                      this involves a few minutes of downtime. Confirm to proceed now?
-                    </AlertDialogDescription>
-                  </AlertDialogHeader>
-                  <AlertDialogFooter>
-                    <AlertDialogCancel disabled={isSubmitting}>Cancel</AlertDialogCancel>
-                    <AlertDialogAction
-                      variant="warning"
-                      disabled={isSubmitting}
-                      onClick={toggleSSLEnforcement}
-                    >
-                      {!isEnforced ? 'Enable SSL' : 'Disable SSL'}
-                    </AlertDialogAction>
-                  </AlertDialogFooter>
-                </AlertDialogContent>
-              </AlertDialog>
+              <SSLEnforcementConfirmDialog
+                targetEnforced={!isEnforced}
+                isSubmitting={isSubmitting}
+                onConfirm={toggleSSLEnforcement}
+              >
+                <div className="flex items-center justify-end mt-2.5 space-x-2">
+                  {(isLoading || isSubmitting) && (
+                    <Loader2 className="animate-spin" strokeWidth={1.5} size={16} />
+                  )}
+                  {isSuccess && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        {/* [Joshen] Added div as tooltip is messing with data state property of toggle */}
+                        <div>
+                          <Switch size="large" checked={isEnforced} disabled={isSwitchDisabled} />
+                        </div>
+                      </TooltipTrigger>
+                      {switchTooltipMessage && (
+                        <TooltipContent side="bottom" className="w-64 text-center">
+                          {switchTooltipMessage}
+                        </TooltipContent>
+                      )}
+                    </Tooltip>
+                  )}
+                </div>
+              </SSLEnforcementConfirmDialog>
             </FormLayout>
             {isSuccess && !sslEnforcementConfiguration?.appliedSuccessfully && (
               <Admonition

--- a/apps/studio/components/interfaces/Settings/Database/SSLConfiguration.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/SSLConfiguration.tsx
@@ -89,13 +89,16 @@ export const SSLConfiguration = () => {
     !hasAccessToSSLEnforcement ||
     isTemporaryAccessEnabled
 
-  const switchTooltipMessage = !canUpdateSSLEnforcement
-    ? 'You need additional permissions to update SSL enforcement for your project'
-    : !hasAccessToSSLEnforcement
-      ? 'Your project does not have access to SSL enforcement'
-      : isTemporaryAccessEnabled
-        ? 'Temporary access must first be disabled before SSL enforcement can be disabled'
-        : undefined
+  let switchTooltipMessage: string | undefined
+  if (!canUpdateSSLEnforcement) {
+    switchTooltipMessage =
+      'You need additional permissions to update SSL enforcement for your project'
+  } else if (!hasAccessToSSLEnforcement) {
+    switchTooltipMessage = 'Your project does not have access to SSL enforcement'
+  } else if (isTemporaryAccessEnabled) {
+    switchTooltipMessage =
+      'Temporary access must first be disabled before SSL enforcement can be disabled'
+  }
 
   const env = process.env.NEXT_PUBLIC_ENVIRONMENT === 'prod' ? 'prod' : 'staging'
   const hasSSLCertificate =
@@ -129,7 +132,7 @@ export const SSLConfiguration = () => {
               description="Reject non-SSL connections to your database"
             >
               <SSLEnforcementConfirmDialog
-                targetEnforced={!isEnforced}
+                isTargetEnforced={!isEnforced}
                 isSubmitting={isSubmitting}
                 onConfirm={toggleSSLEnforcement}
               >

--- a/apps/studio/components/interfaces/Settings/Database/SSLConfiguration.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/SSLConfiguration.tsx
@@ -42,16 +42,15 @@ export const SSLConfiguration = () => {
     projectRef: ref,
   })
   const { data: jitDbAccessConfiguration } = useJitDbAccessQuery({ projectRef: ref })
-  const { mutate: updateSSLEnforcement, isPending: isSubmitting } = useSSLEnforcementUpdateMutation(
-    {
+  const { mutateAsync: updateSSLEnforcement, isPending: isSubmitting } =
+    useSSLEnforcementUpdateMutation({
       onSuccess: () => {
         toast.success('Successfully updated SSL configuration')
       },
       onError: (error) => {
         toast.error(`Failed to update SSL enforcement: ${error.message}`)
       },
-    }
-  )
+    })
 
   const { can: canUpdateSSLEnforcement } = useAsyncCheckPermissions(
     PermissionAction.UPDATE,
@@ -110,7 +109,7 @@ export const SSLConfiguration = () => {
 
   const toggleSSLEnforcement = async () => {
     if (!ref) return console.error('Project ref is required')
-    updateSSLEnforcement({ projectRef: ref, requestedConfig: { database: !isEnforced } })
+    await updateSSLEnforcement({ projectRef: ref, requestedConfig: { database: !isEnforced } })
   }
 
   return (

--- a/apps/studio/components/interfaces/Settings/Database/SSLEnforcementConfirmDialog.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/SSLEnforcementConfirmDialog.tsx
@@ -12,13 +12,13 @@ import {
 } from 'ui'
 
 interface SSLEnforcementConfirmDialogProps {
-  targetEnforced: boolean
+  isTargetEnforced: boolean
   isSubmitting: boolean
   onConfirm: () => Promise<void>
 }
 
 export const SSLEnforcementConfirmDialog = ({
-  targetEnforced,
+  isTargetEnforced,
   isSubmitting,
   onConfirm,
   children,
@@ -37,7 +37,7 @@ export const SSLEnforcementConfirmDialog = ({
         <AlertDialogFooter>
           <AlertDialogCancel disabled={isSubmitting}>Cancel</AlertDialogCancel>
           <AlertDialogAction variant="warning" disabled={isSubmitting} onClick={onConfirm}>
-            {targetEnforced ? 'Enable SSL' : 'Disable SSL'}
+            {isTargetEnforced ? 'Enable SSL' : 'Disable SSL'}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/apps/studio/components/interfaces/Settings/Database/SSLEnforcementConfirmDialog.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/SSLEnforcementConfirmDialog.tsx
@@ -1,0 +1,46 @@
+import { type PropsWithChildren } from 'react'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from 'ui'
+
+interface SSLEnforcementConfirmDialogProps {
+  targetEnforced: boolean
+  isSubmitting: boolean
+  onConfirm: () => void
+}
+
+export const SSLEnforcementConfirmDialog = ({
+  targetEnforced,
+  isSubmitting,
+  onConfirm,
+  children,
+}: PropsWithChildren<SSLEnforcementConfirmDialogProps>) => {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>{children}</AlertDialogTrigger>
+      <AlertDialogContent size="medium">
+        <AlertDialogHeader>
+          <AlertDialogTitle>Updating SSL enforcement involves a brief downtime</AlertDialogTitle>
+          <AlertDialogDescription>
+            A database restart is required for SSL enforcement changes to take place, and this
+            involves a few minutes of downtime. Confirm to proceed now?
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isSubmitting}>Cancel</AlertDialogCancel>
+          <AlertDialogAction variant="warning" disabled={isSubmitting} onClick={onConfirm}>
+            {targetEnforced ? 'Enable SSL' : 'Disable SSL'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/apps/studio/components/interfaces/Settings/Database/SSLEnforcementConfirmDialog.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/SSLEnforcementConfirmDialog.tsx
@@ -14,7 +14,7 @@ import {
 interface SSLEnforcementConfirmDialogProps {
   targetEnforced: boolean
   isSubmitting: boolean
-  onConfirm: () => void
+  onConfirm: () => Promise<void>
 }
 
 export const SSLEnforcementConfirmDialog = ({

--- a/apps/studio/data/ssl-enforcement/ssl-enforcement-update-mutation.ts
+++ b/apps/studio/data/ssl-enforcement/ssl-enforcement-update-mutation.ts
@@ -3,6 +3,7 @@ import { toast } from 'sonner'
 
 import { sslEnforcementKeys } from './keys'
 import { handleError, put } from '@/data/fetchers'
+import { jitDbAccessKeys } from '@/data/jit-db-access/keys'
 import type { ResponseError, UseCustomMutationOptions } from '@/types'
 
 export type SSLEnforcementUpdateVariables = {
@@ -48,6 +49,9 @@ export const useSSLEnforcementUpdateMutation = ({
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
       await queryClient.invalidateQueries({ queryKey: sslEnforcementKeys.list(projectRef) })
+      // JIT DB access can report `unavailableReason: 'ssl_enforcement_required'`,
+      // so its status needs to be refetched whenever SSL enforcement changes.
+      await queryClient.invalidateQueries({ queryKey: jitDbAccessKeys.list(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {


### PR DESCRIPTION


## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Chore - fix-up

## What is the current behavior?

Temporary access depends on ssl enforcement. The frontend doesn't enforce this very well or keep state between the two configs. 

## What is the new behavior?

This updates the two configs to be interdependent and updates to each one triggers a frontend state change on the other.

## Additional context

Before:


https://github.com/user-attachments/assets/8f040b62-587c-4268-9e27-27dd09b052a3



After:


https://github.com/user-attachments/assets/c62e006e-6147-4c94-b6cf-375ca300b890



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added confirmation dialogs and downtime warnings before changing database SSL enforcement.
  - Added loading states and success or failure notifications for SSL updates.
  - Enabled SSL enforcement directly from temporary database access settings.

- **Bug Fixes**
  - Prevented SSL enforcement from being disabled while temporary database access is enabled.
  - Improved settings refresh after SSL enforcement changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->