### PR TITLE
Enhance troubleshooting guide for pgrst.db_schemas error

### DIFF
--- a/apps/docs/content/troubleshooting/pgrst106-the-schema-must-be-one-of-the-following-error-when-querying-an-exposed-schema.mdx
+++ b/apps/docs/content/troubleshooting/pgrst106-the-schema-must-be-one-of-the-following-error-when-querying-an-exposed-schema.mdx
@@ -15,12 +15,33 @@ You may encounter a `PGRST106` error, stating `{"code":"PGRST106","message":"The
 This error occurs because the `authenticator` role's `pgrst.db_schemas` setting does not include the desired schema. This creates a conflict, as PostgREST relies on this setting to know which schemas it should expose.
 
 **How to Resolve This:**
-To fix this, you need to update the `pgrst.db_schemas` setting for the `authenticator` role. Connect to your database and execute one of the following SQL commands:
+Check if the setting exists for "all databases" or for a specific database using the below SQL query by connecting to your database:
+```
+SELECT
+    setrole::regrole,
+    COALESCE(d.datname, '<all databases>') AS database_name,
+    setconfig
+FROM pg_db_role_setting s
+LEFT JOIN pg_database d ON d.oid = s.setdatabase
+WHERE setrole = 'authenticator'::regrole;
+```
+
+To fix this, you need to update the `pgrst.db_schemas` setting for the `authenticator` role by executing one of the following SQL commands:
 
 - **To explicitly add your schema:**
   If you want to add your specific schema (e.g., `your_schema_name`) alongside existing schemas (like `public`), use the following command. Remember to replace `your_schema_name` with your actual schema name and include all other necessary schemas already defined.
+
+For all databases:
   `ALTER ROLE authenticator SET pgrst.db_schemas = 'public, your_schema_name';`
+
+For a specific database(example: postgres)
+  `ALTER ROLE authenticator IN DATABASE postgres SET pgrst.db_schemas = 'public, your_schema_name';`
 
 - **To reset to [dashboard configuration](/dashboard/project/_/settings/api):**
   Alternatively, you can reset this setting to allow the Supabase dashboard's configuration to take effect automatically.
+
+For all databases:
   `ALTER ROLE authenticator RESET pgrst.db_schemas;`
+
+For a specific database(example: postgres)
+  `ALTER ROLE authenticator IN DATABASE postgres RESET pgrst.db_schemas;`

--- a/apps/docs/content/troubleshooting/pgrst106-the-schema-must-be-one-of-the-following-error-when-querying-an-exposed-schema.mdx
+++ b/apps/docs/content/troubleshooting/pgrst106-the-schema-must-be-one-of-the-following-error-when-querying-an-exposed-schema.mdx
@@ -15,7 +15,7 @@ You may encounter a `PGRST106` error, stating `{"code":"PGRST106","message":"The
 This error occurs because the `authenticator` role's `pgrst.db_schemas` setting does not include the desired schema. This creates a conflict, as PostgREST relies on this setting to know which schemas it should expose.
 
 **How to Resolve This:**
-Check if the setting exists for "all databases" or for a specific database using the below SQL query by connecting to your database:
+The `authenticator` settings can be role-wide or database-specific. You can check using the below SQL query by connecting to your database:
 ```
 SELECT
     setrole::regrole,
@@ -31,7 +31,7 @@ To fix this, you need to update the `pgrst.db_schemas` setting for the `authenti
 - **To explicitly add your schema:**
   If you want to add your specific schema (e.g., `your_schema_name`) alongside existing schemas (like `public`), use the following command. Remember to replace `your_schema_name` with your actual schema name and include all other necessary schemas already defined.
 
-For all databases:
+For all databases(role-wide):
   `ALTER ROLE authenticator SET pgrst.db_schemas = 'public, your_schema_name';`
 
 For a specific database(example: postgres)
@@ -40,7 +40,7 @@ For a specific database(example: postgres)
 - **To reset to [dashboard configuration](/dashboard/project/_/settings/api):**
   Alternatively, you can reset this setting to allow the Supabase dashboard's configuration to take effect automatically.
 
-For all databases:
+For all databases(role-wide):
   `ALTER ROLE authenticator RESET pgrst.db_schemas;`
 
 For a specific database(example: postgres)


### PR DESCRIPTION
Added SQL queries to check and update the pgrst.db_schemas setting for the authenticator role in troubleshooting documentation.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Address only if the setting is for all databases

## What is the new behavior?

Also includes the solution if the setting is for a specific database

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded troubleshooting guidance for schema configuration errors.
  * Added commands to inspect `authenticator` role settings across all or specific databases.
  * Documented database-wide and database-specific commands for setting or resetting exposed schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->