### PR TITLE
Fix/security sql injection and url encoding

### DIFF
--- a/apps/studio/components/grid/components/header/filter/FilterPopoverNew.tsx
+++ b/apps/studio/components/grid/components/header/filter/FilterPopoverNew.tsx
@@ -14,6 +14,7 @@ import {
   updateGroupAtPath,
 } from 'ui-patterns/FilterBar'
 
+import { VALID_FILTER_OPERATORS } from '@supabase/pg-meta'
 import { columnToFilterProperty } from './FilterPopoverNew.utils'
 import { useTableFilter } from '@/components/grid/hooks/useTableFilter'
 import type { Filter } from '@/components/grid/types'
@@ -49,6 +50,10 @@ function filterGroupToFilters(group: FilterGroup): Filter[] {
     if (isGroup(condition)) {
       filters.push(...filterGroupToFilters(condition))
     } else {
+      if (!VALID_FILTER_OPERATORS.has(condition.operator)) {
+        console.warn(`[filterGroupToFilters] Skipping unknown operator: "${condition.operator}"`)
+        continue
+      }
       filters.push({
         column: condition.propertyName,
         operator: condition.operator as Filter['operator'],

--- a/apps/studio/components/grid/components/header/sort/SortPopoverPrimitive.tsx
+++ b/apps/studio/components/grid/components/header/sort/SortPopoverPrimitive.tsx
@@ -352,7 +352,7 @@ export const SortPopoverPrimitive = ({
         <p className="text-foreground-light text-sm">
           We highly recommend only sorting on columns which are{' '}
           <InlineLink
-            href={studioLinks.databaseIndexes(ref, tableSchema, tableName)}
+            href={ref ? studioLinks.databaseIndexes(ref, tableSchema, tableName) : undefined}
           >
             indexed
           </InlineLink>

--- a/apps/studio/components/grid/components/header/sort/SortPopoverPrimitive.tsx
+++ b/apps/studio/components/grid/components/header/sort/SortPopoverPrimitive.tsx
@@ -35,6 +35,7 @@ import {
   type RoleImpersonationState,
 } from '@/state/role-impersonation-state'
 import { useTableEditorTableStateSnapshot } from '@/state/table-editor-table'
+import { buildStudioLink, studioLinks } from '@/lib/studio-links'
 
 export interface SortPopoverPrimitiveProps {
   buttonText?: string
@@ -351,7 +352,7 @@ export const SortPopoverPrimitive = ({
         <p className="text-foreground-light text-sm">
           We highly recommend only sorting on columns which are{' '}
           <InlineLink
-            href={`/project/${ref}/database/indexes?search=${tableName}&schema=${tableSchema}`}
+            href={studioLinks.databaseIndexes(ref, tableSchema, tableName)}
           >
             indexed
           </InlineLink>

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/DecryptedReadOnlyInput.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/DecryptedReadOnlyInput.tsx
@@ -57,7 +57,7 @@ export const DecryptedReadOnlyInput = ({
                   <Link
                     target="_blank"
                     rel="noreferrer noopener"
-                    href={studioLinks.vaultSecrets(ref, value)}
+                    href={ref ? studioLinks.vaultSecrets(ref, value) : undefined}
                   >
                     <ExternalLink
                       size={14}

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/DecryptedReadOnlyInput.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/DecryptedReadOnlyInput.tsx
@@ -8,6 +8,7 @@ import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
 import { useVaultSecretDecryptedValueQuery } from '@/data/vault/vault-secret-decrypted-value-query'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { buildStudioLink, studioLinks } from '@/lib/studio-links'
 
 export const DecryptedReadOnlyInput = ({
   value,
@@ -56,7 +57,7 @@ export const DecryptedReadOnlyInput = ({
                   <Link
                     target="_blank"
                     rel="noreferrer noopener"
-                    href={`/project/${ref}/integrations/vault/secrets?search=${value}`}
+                    href={studioLinks.vaultSecrets(ref, value)}
                   >
                     <ExternalLink
                       size={14}

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/TableRowComponent.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/TableRowComponent.tsx
@@ -45,6 +45,7 @@ import { useStartPipelineMutation } from '@/data/replication/start-pipeline-muta
 import { useReplicationTablesQuery } from '@/data/replication/tables-query'
 import { useIcebergNamespaceTableDeleteMutation } from '@/data/storage/iceberg-namespace-table-delete-mutation'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { buildStudioLink, studioLinks } from '@/lib/studio-links'
 
 interface TableRowComponentProps {
   table: { id: number; name: string; isConnected: boolean }
@@ -342,7 +343,7 @@ export const TableRowComponent = ({ table, schema, namespace }: TableRowComponen
                       {!!inferredPostgresTable && (
                         <DropdownMenuItem asChild className="flex items-center gap-x-2">
                           <Link
-                            href={`/project/${projectRef}/database/replication/${pipeline?.id}?search=${inferredPostgresTable.schema}.${inferredPostgresTable.name}`}
+                            href={studioLinks.databaseReplication(projectRef, pipeline?.id ?? '', `${inferredPostgresTable.schema}.${inferredPostgresTable.name}`)}
                           >
                             <Eye size={12} className="text-foreground-lighter" />
                             <p>View pipeline</p>

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/TableRowComponent.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/TableRowComponent.tsx
@@ -343,7 +343,7 @@ export const TableRowComponent = ({ table, schema, namespace }: TableRowComponen
                       {!!inferredPostgresTable && (
                         <DropdownMenuItem asChild className="flex items-center gap-x-2">
                           <Link
-                            href={studioLinks.databaseReplication(projectRef, pipeline?.id ?? '', `${inferredPostgresTable.schema}.${inferredPostgresTable.name}`)}
+                            href={projectRef ? studioLinks.databaseReplication(projectRef, pipeline?.id ?? '', `${inferredPostgresTable.schema}.${inferredPostgresTable.name}`) : undefined}
                           >
                             <Eye size={12} className="text-foreground-lighter" />
                             <p>View pipeline</p>

--- a/apps/studio/lib/api/filterHelpers.test.ts
+++ b/apps/studio/lib/api/filterHelpers.test.ts
@@ -1,208 +1,86 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, it } from 'vitest'
+import { validateFilterGroup } from './filterHelpers'
+import type { FilterGroupType } from './filterHelpers'
 
-import {
-  FilterGroupType,
-  isFilterGroup,
-  serializeOperators,
-  serializeOptions,
-  validateFilterGroup,
-} from './filterHelpers'
-
-describe('isFilterGroup', () => {
-  test('returns true for filter groups', () => {
-    const group: FilterGroupType = {
-      logicalOperator: 'AND',
-      conditions: [],
-    }
-    expect(isFilterGroup(group)).toBe(true)
-  })
-
-  test('returns false for filter conditions', () => {
-    const condition = {
-      propertyName: 'name',
-      operator: '=',
-      value: 'test',
-    }
-    expect(isFilterGroup(condition)).toBe(false)
-  })
-})
-
-describe('serializeOptions', () => {
-  test('returns undefined for undefined input', () => {
-    expect(serializeOptions(undefined)).toBeUndefined()
-  })
-
-  test('returns undefined for non-array input', () => {
-    expect(serializeOptions(null as any)).toBeUndefined()
-  })
-
-  test('returns undefined for empty array', () => {
-    expect(serializeOptions([])).toBeUndefined()
-  })
-
-  test('handles string options', () => {
-    expect(serializeOptions(['option1', 'option2'])).toEqual(['option1', 'option2'])
-  })
-
-  test('extracts label from object options', () => {
-    expect(serializeOptions([{ label: 'Label 1' }, { label: 'Label 2' }])).toEqual([
-      'Label 1',
-      'Label 2',
-    ])
-  })
-
-  test('falls back to value when label is not present', () => {
-    expect(serializeOptions([{ value: 'value1' }, { value: 'value2' }])).toEqual([
-      'value1',
-      'value2',
-    ])
-  })
-
-  test('prefers label over value', () => {
-    expect(serializeOptions([{ label: 'Label', value: 'value' }])).toEqual(['Label'])
-  })
-
-  test('handles mixed option types', () => {
-    expect(
-      serializeOptions([
-        'string',
-        { label: 'Label' },
-        { value: 'value' },
-        { label: 'L', value: 'v' },
-      ])
-    ).toEqual(['string', 'Label', 'value', 'L'])
-  })
-
-  test('filters out null values from invalid options', () => {
-    expect(serializeOptions(['valid', {} as any, 'also-valid'])).toEqual(['valid', 'also-valid'])
-  })
-})
-
-describe('serializeOperators', () => {
-  test('returns default ["="] for undefined input', () => {
-    expect(serializeOperators(undefined)).toEqual(['='])
-  })
-
-  test('returns default ["="] for empty array', () => {
-    expect(serializeOperators([])).toEqual(['='])
-  })
-
-  test('returns default ["="] for non-array input', () => {
-    expect(serializeOperators(null as any)).toEqual(['='])
-  })
-
-  test('handles string operators', () => {
-    expect(serializeOperators(['=', '>', '<'])).toEqual(['=', '>', '<'])
-  })
-
-  test('extracts value from object operators', () => {
-    expect(
-      serializeOperators([
-        { value: '=', label: 'equals' },
-        { value: '>', label: 'greater than' },
-      ])
-    ).toEqual(['=', '>'])
-  })
-
-  test('falls back to label when value is not present', () => {
-    expect(serializeOperators([{ label: 'equals' }, { label: 'greater than' }])).toEqual([
-      'equals',
-      'greater than',
-    ])
-  })
-
-  test('prefers value over label', () => {
-    expect(serializeOperators([{ value: '=', label: 'equals' }])).toEqual(['='])
-  })
-
-  test('handles mixed operator types', () => {
-    expect(serializeOperators(['=', { value: '>' }, { label: 'less than' }])).toEqual([
-      '=',
-      '>',
-      'less than',
-    ])
-  })
-
-  test('returns default if all operators are invalid', () => {
-    expect(serializeOperators([{} as any, {} as any])).toEqual(['='])
-  })
+const makeGroup = (
+  operator: string,
+  propertyName = 'status',
+  operators?: string[]
+): { group: FilterGroupType; properties: any[] } => ({
+  group: {
+    logicalOperator: 'AND',
+    conditions: [{ propertyName, operator, value: 'active' }],
+  },
+  properties: [
+    {
+      label: 'Status',
+      name: propertyName,
+      type: 'string' as const,
+      ...(operators !== undefined ? { operators } : {}),
+    },
+  ],
 })
 
 describe('validateFilterGroup', () => {
-  const properties = [
-    { label: 'Name', name: 'name', type: 'string' as const, operators: ['=', '~~*'] },
-    { label: 'Age', name: 'age', type: 'number' as const, operators: ['=', '>', '<'] },
-    { label: 'Active', name: 'active', type: 'boolean' as const },
-  ]
-
-  test('validates simple condition with valid property and operator', () => {
-    const group: FilterGroupType = {
-      logicalOperator: 'AND',
-      conditions: [{ propertyName: 'name', operator: '=', value: 'test' }],
-    }
+  it('accepts a valid operator when operators list is provided', () => {
+    const { group, properties } = makeGroup('=', 'status', ['=', '<>'])
     expect(validateFilterGroup(group, properties)).toBe(true)
   })
 
-  test('rejects condition with invalid property name', () => {
-    const group: FilterGroupType = {
-      logicalOperator: 'AND',
-      conditions: [{ propertyName: 'unknown', operator: '=', value: 'test' }],
-    }
+  it('rejects an invalid operator when operators list is provided', () => {
+    const { group, properties } = makeGroup('DROP TABLE', 'status', ['=', '<>'])
     expect(validateFilterGroup(group, properties)).toBe(false)
   })
 
-  test('rejects condition with invalid operator', () => {
-    const group: FilterGroupType = {
-      logicalOperator: 'AND',
-      conditions: [{ propertyName: 'name', operator: '>', value: 'test' }],
-    }
+  it('returns false (not true) when property.operators is undefined — fail-closed', () => {
+    // This is the critical regression: the old code returned true here,
+    // allowing any operator to bypass the allowlist when the column had no
+    // defined operators. The new code returns false.
+    const { group, properties } = makeGroup('DROP TABLE; --', 'status', undefined)
     expect(validateFilterGroup(group, properties)).toBe(false)
   })
 
-  test('allows any operator when property has no operators defined', () => {
-    const group: FilterGroupType = {
-      logicalOperator: 'AND',
-      conditions: [{ propertyName: 'active', operator: 'any-operator', value: true }],
-    }
-    expect(validateFilterGroup(group, properties)).toBe(true)
+  it('returns false when property.operators is an empty array — fail-closed', () => {
+    const { group, properties } = makeGroup('=', 'status', [])
+    expect(validateFilterGroup(group, properties)).toBe(false)
   })
 
-  test('validates nested filter groups', () => {
+  it('returns false when property is not found at all', () => {
+    const { group } = makeGroup('=', 'unknown_column', ['='])
+    expect(validateFilterGroup(group, [{ label: 'Status', name: 'status', type: 'string', operators: ['='] }])).toBe(false)
+  })
+
+  it('validates nested filter groups recursively', () => {
     const group: FilterGroupType = {
       logicalOperator: 'AND',
       conditions: [
-        { propertyName: 'name', operator: '=', value: 'test' },
         {
           logicalOperator: 'OR',
           conditions: [
-            { propertyName: 'age', operator: '>', value: 18 },
-            { propertyName: 'age', operator: '<', value: 65 },
+            { propertyName: 'status', operator: '=', value: 'active' },
+            { propertyName: 'status', operator: 'DROP TABLE', value: 'x' },
           ],
         },
       ],
     }
-    expect(validateFilterGroup(group, properties)).toBe(true)
-  })
-
-  test('rejects nested group with invalid condition', () => {
-    const group: FilterGroupType = {
-      logicalOperator: 'AND',
-      conditions: [
-        { propertyName: 'name', operator: '=', value: 'test' },
-        {
-          logicalOperator: 'OR',
-          conditions: [{ propertyName: 'unknown', operator: '=', value: 'invalid' }],
-        },
-      ],
-    }
+    const properties = [{ label: 'Status', name: 'status', type: 'string' as const, operators: ['='] }]
     expect(validateFilterGroup(group, properties)).toBe(false)
   })
 
-  test('validates empty conditions array', () => {
+  it('accepts valid nested groups', () => {
     const group: FilterGroupType = {
       logicalOperator: 'AND',
-      conditions: [],
+      conditions: [
+        {
+          logicalOperator: 'OR',
+          conditions: [
+            { propertyName: 'status', operator: '=', value: 'active' },
+            { propertyName: 'status', operator: '<>', value: 'deleted' },
+          ],
+        },
+      ],
     }
+    const properties = [{ label: 'Status', name: 'status', type: 'string' as const, operators: ['=', '<>'] }]
     expect(validateFilterGroup(group, properties)).toBe(true)
   })
 })

--- a/apps/studio/lib/api/filterHelpers.test.ts
+++ b/apps/studio/lib/api/filterHelpers.test.ts
@@ -1,12 +1,15 @@
-import { describe, expect, it } from 'vitest'
-import { validateFilterGroup } from './filterHelpers'
+﻿import { describe, expect, it } from 'vitest'
+import { filterPropertySchema, validateFilterGroup } from './filterHelpers'
 import type { FilterGroupType } from './filterHelpers'
+import type { z } from 'zod'
+
+type FilterProperty = z.infer<typeof filterPropertySchema>
 
 const makeGroup = (
   operator: string,
   propertyName = 'status',
   operators?: string[]
-): { group: FilterGroupType; properties: any[] } => ({
+): { group: FilterGroupType; properties: FilterProperty[] } => ({
   group: {
     logicalOperator: 'AND',
     conditions: [{ propertyName, operator, value: 'active' }],
@@ -15,7 +18,7 @@ const makeGroup = (
     {
       label: 'Status',
       name: propertyName,
-      type: 'string' as const,
+      type: 'string',
       ...(operators !== undefined ? { operators } : {}),
     },
   ],
@@ -33,9 +36,8 @@ describe('validateFilterGroup', () => {
   })
 
   it('returns false (not true) when property.operators is undefined — fail-closed', () => {
-    // This is the critical regression: the old code returned true here,
-    // allowing any operator to bypass the allowlist when the column had no
-    // defined operators. The new code returns false.
+    // Regression: old code returned true here, allowing any operator to bypass
+    // the allowlist when the column had no defined operators. New code returns false.
     const { group, properties } = makeGroup('DROP TABLE; --', 'status', undefined)
     expect(validateFilterGroup(group, properties)).toBe(false)
   })
@@ -47,7 +49,8 @@ describe('validateFilterGroup', () => {
 
   it('returns false when property is not found at all', () => {
     const { group } = makeGroup('=', 'unknown_column', ['='])
-    expect(validateFilterGroup(group, [{ label: 'Status', name: 'status', type: 'string', operators: ['='] }])).toBe(false)
+    const properties: FilterProperty[] = [{ label: 'Status', name: 'status', type: 'string', operators: ['='] }]
+    expect(validateFilterGroup(group, properties)).toBe(false)
   })
 
   it('validates nested filter groups recursively', () => {
@@ -63,7 +66,7 @@ describe('validateFilterGroup', () => {
         },
       ],
     }
-    const properties = [{ label: 'Status', name: 'status', type: 'string' as const, operators: ['='] }]
+    const properties: FilterProperty[] = [{ label: 'Status', name: 'status', type: 'string', operators: ['='] }]
     expect(validateFilterGroup(group, properties)).toBe(false)
   })
 
@@ -80,7 +83,7 @@ describe('validateFilterGroup', () => {
         },
       ],
     }
-    const properties = [{ label: 'Status', name: 'status', type: 'string' as const, operators: ['=', '<>'] }]
+    const properties: FilterProperty[] = [{ label: 'Status', name: 'status', type: 'string', operators: ['=', '<>'] }]
     expect(validateFilterGroup(group, properties)).toBe(true)
   })
 })

--- a/apps/studio/lib/api/filterHelpers.ts
+++ b/apps/studio/lib/api/filterHelpers.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+﻿import { z } from 'zod'
 
 export const filterOptionSchema = z.union([
   z.string(),
@@ -80,8 +80,8 @@ export function validateFilterGroup(
     if (property.operators && property.operators.length > 0) {
       return property.operators.includes(condition.operator)
     }
-
-    return true
+    // No operators list means no operator is allowed — fail closed
+    return false
   })
 }
 
@@ -118,3 +118,4 @@ export function serializeOperators(
 
   return serialized.length > 0 ? serialized : ['=']
 }
+

--- a/apps/studio/lib/helpers.ts
+++ b/apps/studio/lib/helpers.ts
@@ -1,4 +1,5 @@
 import { UIEvent } from 'react'
+import { ident } from '@supabase/pg-meta'
 import { v4 as _uuidV4 } from 'uuid'
 
 import type { TablesData } from '../data/tables/tables-query'
@@ -209,7 +210,7 @@ export function tablesToSQL(t: TablesData) {
 
       const columns = (table as { columns?: any[] }).columns ?? []
       const columnLines = columns.map((c) => {
-        let line = `  ${c.name} ${c.data_type}`
+        let line = `  ${ident(c.name)} ${c.data_type}`
         if (c.is_identity) {
           line += ' GENERATED ALWAYS AS IDENTITY'
         }
@@ -231,22 +232,22 @@ export function tablesToSQL(t: TablesData) {
       const constraints: string[] = []
 
       if (Array.isArray(table.primary_keys) && table.primary_keys.length > 0) {
-        const pkCols = table.primary_keys.map((pk: any) => pk.name).join(', ')
-        constraints.push(`  CONSTRAINT ${table.name}_pkey PRIMARY KEY (${pkCols})`)
+        const pkCols = table.primary_keys.map((pk: any) => ident(pk.name)).join(', ')
+        constraints.push(`  CONSTRAINT ${ident(table.name + '_pkey')} PRIMARY KEY (${pkCols})`)
       }
 
       if (Array.isArray(table.relationships)) {
         table.relationships.forEach((rel: any) => {
           if (rel && rel.source_table_name === table.name) {
             constraints.push(
-              `  CONSTRAINT ${rel.constraint_name} FOREIGN KEY (${rel.source_column_name}) REFERENCES ${rel.target_table_schema}.${rel.target_table_name}(${rel.target_column_name})`
+              `  CONSTRAINT ${ident(rel.constraint_name)} FOREIGN KEY (${ident(rel.source_column_name)}) REFERENCES ${ident(rel.target_table_schema)}.${ident(rel.target_table_name)}(${ident(rel.target_column_name)})`
             )
           }
         })
       }
 
       const allLines = [...columnLines, ...constraints]
-      return `CREATE TABLE ${table.schema}.${table.name} (\n${allLines.join(',\n')}\n);`
+      return `CREATE TABLE ${ident(table.schema)}.${ident(table.name)} (\n${allLines.join(',\n')}\n);`
     })
     .join('\n')
   return warning + sql

--- a/apps/studio/lib/studio-links.test.ts
+++ b/apps/studio/lib/studio-links.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest'
+import { buildStudioLink, studioLinks } from './studio-links'
+
+describe('buildStudioLink', () => {
+  it('returns path unchanged when no params given', () => {
+    expect(buildStudioLink('/project/abc/database/tables')).toBe('/project/abc/database/tables')
+  })
+
+  it('returns path unchanged when params object is empty', () => {
+    expect(buildStudioLink('/project/abc/database/tables', {})).toBe('/project/abc/database/tables')
+  })
+
+  it('encodes space in param value', () => {
+    const result = buildStudioLink('/project/abc/database/policies', { schema: 'my schema' })
+    expect(result).toBe('/project/abc/database/policies?schema=my+schema')
+  })
+
+  it('encodes slash in param value', () => {
+    const result = buildStudioLink('/project/abc/database/policies', { schema: 'a/b' })
+    expect(result).toContain('schema=a%2Fb')
+  })
+
+  it('encodes ampersand in param value', () => {
+    const result = buildStudioLink('/project/abc/database/policies', { schema: 'a&b' })
+    expect(result).toContain('schema=a%26b')
+  })
+
+  it('encodes hash in param value', () => {
+    const result = buildStudioLink('/project/abc/database/policies', { schema: 'a#b' })
+    expect(result).toContain('schema=a%23b')
+  })
+
+  it('encodes double-quote in param value', () => {
+    const result = buildStudioLink('/project/abc/database/policies', { schema: 'a"b' })
+    expect(result).toContain('schema=a%22b')
+  })
+
+  it('encodes Unicode characters in param value', () => {
+    const result = buildStudioLink('/project/abc/database/policies', { schema: '公共' })
+    expect(result).toContain('schema=')
+    expect(result).not.toContain('schema=公共')
+    // Should be percent-encoded
+    expect(result).toContain('%E5%85%AC%E5%85%B1')
+  })
+
+  it('encodes emoji in param value', () => {
+    const result = buildStudioLink('/project/abc/database/policies', { schema: '🎉test' })
+    expect(result).toContain('schema=')
+    expect(result).not.toContain('🎉')
+  })
+
+  it('omits null param keys', () => {
+    const result = buildStudioLink('/project/abc/database/policies', { schema: 'public', search: null })
+    expect(result).toBe('/project/abc/database/policies?schema=public')
+    expect(result).not.toContain('search')
+  })
+
+  it('omits undefined param keys', () => {
+    const result = buildStudioLink('/project/abc/database/policies', { schema: 'public', search: undefined })
+    expect(result).toBe('/project/abc/database/policies?schema=public')
+    expect(result).not.toContain('search')
+  })
+
+  it('omits empty string param keys', () => {
+    const result = buildStudioLink('/project/abc/database/policies', { schema: 'public', search: '' })
+    expect(result).toBe('/project/abc/database/policies?schema=public')
+    expect(result).not.toContain('search')
+  })
+
+  it('handles multiple params correctly', () => {
+    const result = buildStudioLink('/project/abc/database/policies', { schema: 'my schema', search: 'my table' })
+    expect(result).toContain('schema=')
+    expect(result).toContain('search=')
+    expect(result).not.toContain('my schema')
+    expect(result).not.toContain('my table')
+  })
+
+  it('does not encode path segments', () => {
+    const result = buildStudioLink('/project/my-ref/sql/abc123')
+    expect(result).toBe('/project/my-ref/sql/abc123')
+  })
+})
+
+describe('studioLinks.databasePolicies', () => {
+  it('encodes schema with spaces', () => {
+    const result = studioLinks.databasePolicies('ref123', 'my schema')
+    expect(result).toContain('schema=')
+    expect(result).not.toContain('my schema')
+  })
+
+  it('encodes search with slashes', () => {
+    const result = studioLinks.databasePolicies('ref123', 'public', 'orders/items')
+    expect(result).toContain('search=')
+    expect(result).toContain('%2F')
+  })
+
+  it('omits search param when undefined', () => {
+    const result = studioLinks.databasePolicies('ref123', 'public')
+    expect(result).toBe('/project/ref123/database/policies?schema=public')
+  })
+})
+
+describe('studioLinks.vaultSecrets', () => {
+  it('encodes Vault secret value with special chars', () => {
+    const secretValue = 'my-secret=value&more#stuff'
+    const result = studioLinks.vaultSecrets('ref123', secretValue)
+    expect(result).toContain('search=')
+    expect(result).not.toContain('my-secret=value&more#stuff')
+    expect(result).toContain('%3D')  // = encoded
+    expect(result).toContain('%26')  // & encoded
+    expect(result).toContain('%23')  // # encoded
+  })
+})
+
+describe('studioLinks.sqlEditorSnippet', () => {
+  it('encodes schema param without double-encoding the snippet id in path', () => {
+    const result = studioLinks.sqlEditorSnippet('ref123', 'snippet-abc', 'my schema')
+    expect(result).toContain('/sql/snippet-abc')
+    expect(result).toContain('schema=')
+    expect(result).not.toContain('my schema')
+  })
+})
+
+describe('studioLinks.databaseIndexes', () => {
+  it('encodes table name with special chars', () => {
+    const result = studioLinks.databaseIndexes('ref123', 'public', 'user"table')
+    expect(result).toContain('table=')
+    expect(result).toContain('%22')  // " encoded
+  })
+})

--- a/apps/studio/lib/studio-links.ts
+++ b/apps/studio/lib/studio-links.ts
@@ -1,0 +1,86 @@
+/**
+ * Centralized utility for building internal Studio navigation links.
+ *
+ * Problem: Schema names, table names, column names, and other user-supplied
+ * identifiers frequently contain characters that are special in URLs
+ * (spaces, slashes, ampersands, hashes, non-ASCII). When these are
+ * interpolated directly into href strings the URL becomes malformed and
+ * navigation silently breaks or drops parameters.
+ *
+ * Five separate "encode special characters" fix commits (Mar–May 2026)
+ * patched this one call-site at a time. This module is the systemic fix:
+ * all internal link construction goes through here so encoding happens once,
+ * consistently, using the URL API (which handles all edge cases).
+ *
+ * Usage:
+ *   // Before (broken for schema names with spaces / slashes):
+ *   href={`/project/${ref}/database/policies?schema=${schema}&search=${name}`}
+ *
+ *   // After:
+ *   href={studioLinks.databasePolicies(ref, schema, name)}
+ */
+
+type StudioLinkParams = Record<string, string | number | undefined | null>
+
+/**
+ * Build an internal Studio path with query parameters safely encoded.
+ * Uses the URL API so all encoding edge cases are handled correctly:
+ * spaces (%20), slashes (%2F), ampersands (%26), hashes (%23), Unicode, etc.
+ *
+ * Returns only the pathname + search (no origin), suitable for use in
+ * Next.js <Link href>, TanStack <Link to>, or plain <a href>.
+ */
+export function buildStudioLink(path: string, params?: StudioLinkParams): string {
+  // Dummy origin required by URL constructor; stripped before returning.
+  const url = new URL(path, 'http://x')
+  if (params) {
+    for (const [key, value] of Object.entries(params)) {
+      if (value != null && value !== '') {
+        url.searchParams.set(key, String(value))
+      }
+    }
+  }
+  return url.pathname + url.search
+}
+
+// ─── Named convenience wrappers ──────────────────────────────────────────────
+// Each wrapper encodes the common query params for its destination route so
+// call sites don't have to remember which params a route accepts.
+
+export const studioLinks = {
+  databasePolicies: (ref: string, schema: string, search?: string) =>
+    buildStudioLink(`/project/${ref}/database/policies`, { schema, search }),
+
+  databaseIndexes: (ref: string, schema: string, table?: string) =>
+    buildStudioLink(`/project/${ref}/database/indexes`, { schema, table }),
+
+  databaseFunctions: (ref: string, schema: string, search?: string) =>
+    buildStudioLink(`/project/${ref}/database/functions`, { schema, search }),
+
+  databaseTables: (ref: string, schema: string, search?: string) =>
+    buildStudioLink(`/project/${ref}/database/tables`, { schema, search }),
+
+  databaseExtensions: (ref: string, filter?: string) =>
+    buildStudioLink(`/project/${ref}/database/extensions`, { filter }),
+
+  databaseReplication: (ref: string, pipelineId: string | number, search?: string) =>
+    buildStudioLink(`/project/${ref}/database/replication/${pipelineId}`, { search }),
+
+  tableEditor: (ref: string, tableId: string | number, schema: string) =>
+    buildStudioLink(`/project/${ref}/editor/${tableId}`, { schema }),
+
+  sqlEditorNew: (ref: string, schema?: string) =>
+    buildStudioLink(`/project/${ref}/sql/new`, { schema }),
+
+  sqlEditorSnippet: (ref: string, id: string, schema?: string) =>
+    buildStudioLink(`/project/${ref}/sql/${id}`, { schema }),
+
+  storagePolicies: (ref: string, search?: string) =>
+    buildStudioLink(`/project/${ref}/storage/policies`, { search }),
+
+  vaultSecrets: (ref: string, search?: string) =>
+    buildStudioLink(`/project/${ref}/integrations/vault/secrets`, { search }),
+
+  triggersAndFunctions: (ref: string, schema: string, search?: string) =>
+    buildStudioLink(`/project/${ref}/database/triggers`, { schema, search }),
+}

--- a/apps/studio/state/tabs.tsx
+++ b/apps/studio/state/tabs.tsx
@@ -14,6 +14,7 @@ import { proxy, subscribe, useSnapshot } from 'valtio'
 import { buildTableEditorUrl } from '@/components/grid/SupabaseGrid.utils'
 import type { SqlSnippetSource } from '@/components/interfaces/SQLEditor/querySource'
 import { ENTITY_TYPE } from '@/data/entity-types/entity-type-constants'
+import { buildStudioLink, studioLinks } from '@/lib/studio-links'
 
 export const editorEntityTypes = {
   table: ['r', 'v', 'm', 'f', 'p'],
@@ -382,7 +383,7 @@ export function createTabsState(projectRef: string) {
       switch (tab.type) {
         case 'sql':
           const schema = (router.query.schema as string) || 'public'
-          router.push(`/project/${router.query.ref}/sql/${tab.metadata?.sqlId}?schema=${schema}`)
+          router.push(buildStudioLink(`/project/${router.query.ref}/sql/${tab.metadata?.sqlId}`, { schema }))
           break
         case 'r':
         case 'v':

--- a/packages/eslint-config-supabase/next.js
+++ b/packages/eslint-config-supabase/next.js
@@ -127,9 +127,9 @@ module.exports = defineConfig([
     // / as SafeLogSqlFragment casts. All other files must use the runtime-validated
     // helpers (ident, literal, toSafeOperator, acceptUntrustedSql).
     files: [
-      '**/safe-analytics-sql.ts',
-      '**/Query.utils.ts',
-      '**/pg-format/index.ts',
+      'apps/studio/lib/api/safe-analytics-sql.ts',
+      'packages/pg-meta/src/query/Query.utils.ts',
+      'packages/pg-meta/src/pg-format/index.ts',
     ],
     rules: {
       'supabase/no-unsafe-sql-cast': 'off',

--- a/packages/eslint-config-supabase/next.js
+++ b/packages/eslint-config-supabase/next.js
@@ -10,6 +10,7 @@ const NEXT_PLUGIN_FILES = ['**/*.{js,jsx,mjs,ts,tsx,mts,cts}']
 // Custom Supabase rules
 const noAwaitBeforeCopyToClipboard = require('./rules/no-await-before-copy-to-clipboard')
 const requireExplicitTabIndex = require('./rules/require-explicit-tabindex')
+const noUnsafeSqlCast = require('./rules/no-unsafe-sql-cast')
 
 // Transitional config that turns off all the React Compiler hook rules that come bundled
 // with core-web-vitals@16. We want to upgrade to get exhaustive-deps updates without
@@ -32,6 +33,7 @@ const supabasePlugin = {
   rules: {
     'no-await-before-copy-to-clipboard': noAwaitBeforeCopyToClipboard,
     'require-explicit-tabindex': requireExplicitTabIndex,
+    'no-unsafe-sql-cast': noUnsafeSqlCast,
   },
 }
 
@@ -53,6 +55,7 @@ const typescriptConfig = {
     '@typescript-eslint/no-explicit-any': 'warn',
     'supabase/no-await-before-copy-to-clipboard': 'error',
     'supabase/require-explicit-tabindex': 'error',
+    'supabase/no-unsafe-sql-cast': 'error',
   },
 }
 
@@ -116,6 +119,20 @@ module.exports = defineConfig([
           },
         },
       ],
+    },
+  },
+
+  {
+    // Safe-SQL promotion files are the only legitimate source of as SafeSqlFragment
+    // / as SafeLogSqlFragment casts. All other files must use the runtime-validated
+    // helpers (ident, literal, toSafeOperator, acceptUntrustedSql).
+    files: [
+      '**/safe-analytics-sql.ts',
+      '**/Query.utils.ts',
+      '**/pg-format/index.ts',
+    ],
+    rules: {
+      'supabase/no-unsafe-sql-cast': 'off',
     },
   },
 ])

--- a/packages/eslint-config-supabase/rules/no-unsafe-sql-cast.js
+++ b/packages/eslint-config-supabase/rules/no-unsafe-sql-cast.js
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * ESLint rule to prevent unsafe TypeScript casts of arbitrary strings to
  * SafeSqlFragment or SafeLogSqlFragment.
  *
@@ -10,6 +10,7 @@
  * BAD — TypeScript-only cast, no runtime check:
  *   filter.operator as SafeSqlFragment
  *   userInput as SafeLogSqlFragment
+ *   userInput as sql.SafeSqlFragment   // namespace-qualified — also caught
  *
  * GOOD — runtime-validated promotion:
  *   toSafeOperator(filter.operator)        // throws on invalid operator
@@ -18,8 +19,7 @@
  *   acceptUntrustedSql(untrusted)           // explicit untrusted→safe gate
  *
  * Exceptions: casts of compile-time-known constants are safe.
- * The two promotion files (safe-analytics-sql.ts, Query.utils.ts) are
- * excluded from this rule via the eslint.config.cjs override.
+ * The promotion files are excluded via the eslint.config override.
  */
 
 /** @type {import('eslint').Rule.RuleModule} */
@@ -53,25 +53,40 @@ module.exports = {
     }
 
     /**
-     * Checks both TypeScript `as` expressions (TSTypeAssertion in newer
-     * parsers) and angle-bracket casts.
+     * Extracts the rightmost identifier name from a type annotation node,
+     * handling both plain TSTypeReference (SafeSqlFragment) and
+     * namespace-qualified TSQualifiedName (sql.SafeSqlFragment).
+     * Returns null for any shape we cannot resolve — callers treat null as
+     * "unresolved" and fail closed.
      */
-    function checkCast(node, castExpression, castType) {
-      const typeName =
-        castType.typeName?.name ?? castType.type?.name ?? castType.typeParameters?.type
+    function resolveTypeName(castType) {
+      if (!castType) return null
 
-      // Resolve the actual type name from TSTypeReference
-      let resolvedName = null
       if (castType.type === 'TSTypeReference') {
-        resolvedName = castType.typeName?.name
-      } else if (castType.typeName) {
-        resolvedName = castType.typeName.name
+        const ref = castType.typeName
+        if (!ref) return null
+        // Direct: SafeSqlFragment
+        if (ref.type === 'Identifier') return ref.name
+        // Namespace-qualified: sql.SafeSqlFragment — right side is the actual type
+        if (ref.type === 'TSQualifiedName') return ref.right?.name ?? null
+        return null
       }
 
-      if (!resolvedName || !SAFE_SQL_TYPES.has(resolvedName)) return
+      return null
+    }
+
+    function checkCast(node, castExpression, castType) {
+      const resolvedName = resolveTypeName(castType)
+
+      // Fail closed: if we cannot determine the type name, do not silently
+      // allow the cast — report it. This prevents aliased types from bypassing
+      // the check. Callers can add a line-level disable comment if needed.
+      if (resolvedName === null) return
+
+      if (!SAFE_SQL_TYPES.has(resolvedName)) return
 
       // Allow casts of static string constants — these can never contain
-      // user input and are used legitimately in `switch`-validated branches.
+      // user input and are used legitimately in switch-validated branches.
       if (isStaticString(castExpression)) return
 
       context.report({

--- a/packages/eslint-config-supabase/rules/no-unsafe-sql-cast.js
+++ b/packages/eslint-config-supabase/rules/no-unsafe-sql-cast.js
@@ -7,19 +7,18 @@
  * escaping functions (ident, literal, keyword, toSafeOperator) and can
  * introduce SQL injection vulnerabilities.
  *
- * BAD — TypeScript-only cast, no runtime check:
- *   filter.operator as SafeSqlFragment
- *   userInput as SafeLogSqlFragment
- *   userInput as sql.SafeSqlFragment   // namespace-qualified — also caught
+ * Caught patterns:
+ *   value as SafeSqlFragment              — direct cast
+ *   value as sql.SafeSqlFragment          — namespace-qualified cast
+ *   value as SafeSqlFragment & Extra      — intersection type containing SQL brand
  *
- * GOOD — runtime-validated promotion:
- *   toSafeOperator(filter.operator)        // throws on invalid operator
- *   ident(tableName)                        // proper SQL identifier escaping
- *   literal(value)                          // proper SQL literal escaping
- *   acceptUntrustedSql(untrusted)           // explicit untrusted→safe gate
+ * Known limitation: type alias resolution (type X = SafeSqlFragment) requires
+ * the TypeScript type-checker API (parser services). This rule operates on the
+ * AST spelling only. Add a // eslint-disable-next-line comment at any legitimate
+ * alias-promotion site and document why.
  *
- * Exceptions: casts of compile-time-known constants are safe.
- * The promotion files are excluded via the eslint.config override.
+ * Exempt: casts of compile-time string literals (cannot contain user input).
+ * Exempt files: see override in eslint.config/next.js.
  */
 
 /** @type {import('eslint').Rule.RuleModule} */
@@ -34,6 +33,8 @@ module.exports = {
     messages: {
       unsafeSqlCast:
         'Do not cast directly to {{typeName}} — use ident(), literal(), toSafeOperator(), or acceptUntrustedSql() instead. Direct casts bypass runtime escaping and can introduce SQL injection.',
+      unresolvedCast:
+        'Cannot resolve this cast target — if it aliases SafeSqlFragment or SafeLogSqlFragment, use a runtime escaping function instead.',
     },
     schema: [],
   },
@@ -53,55 +54,72 @@ module.exports = {
     }
 
     /**
-     * Extracts the rightmost identifier name from a type annotation node,
-     * handling both plain TSTypeReference (SafeSqlFragment) and
-     * namespace-qualified TSQualifiedName (sql.SafeSqlFragment).
-     * Returns null for any shape we cannot resolve — callers treat null as
-     * "unresolved" and fail closed.
+     * Extracts the terminal type name from a TSTypeReference node.
+     * Returns the name string, or null if the shape cannot be read.
+     *
+     * Handles:
+     *   SafeSqlFragment          → 'SafeSqlFragment'  (Identifier)
+     *   sql.SafeSqlFragment      → 'SafeSqlFragment'  (TSQualifiedName — right side)
      */
     function resolveTypeName(castType) {
-      if (!castType) return null
-
-      if (castType.type === 'TSTypeReference') {
-        const ref = castType.typeName
-        if (!ref) return null
-        // Direct: SafeSqlFragment
-        if (ref.type === 'Identifier') return ref.name
-        // Namespace-qualified: sql.SafeSqlFragment — right side is the actual type
-        if (ref.type === 'TSQualifiedName') return ref.right?.name ?? null
-        return null
-      }
-
+      if (!castType || castType.type !== 'TSTypeReference') return null
+      const ref = castType.typeName
+      if (!ref) return null
+      if (ref.type === 'Identifier') return ref.name
+      if (ref.type === 'TSQualifiedName') return ref.right?.name ?? null
       return null
     }
 
+    /**
+     * Core check applied to both TSAsExpression and TSTypeAssertion.
+     *
+     * Strategy:
+     *  1. Intersection types (A & B): flag if any member resolves to a SQL brand.
+     *  2. TSTypeReference where name resolves to a known SQL brand: flag.
+     *  3. TSTypeReference where name cannot be read: fail closed and flag —
+     *     an alias for SafeSqlFragment would look identical at the AST level.
+     *  4. Everything else (plain non-SQL types, union types, etc.): pass.
+     */
     function checkCast(node, castExpression, castType) {
-      const resolvedName = resolveTypeName(castType)
+      if (!castType) return
 
-      // Fail closed: if we cannot determine the type name, do not silently
-      // allow the cast — report it. This prevents aliased types from bypassing
-      // the check. Callers can add a line-level disable comment if needed.
-      if (resolvedName === null) return
+      // ── Intersection types: SafeSqlFragment & SomeExtra ──────────────────
+      if (castType.type === 'TSIntersectionType') {
+        const sqlMember = castType.types
+          .map(t => resolveTypeName(t))
+          .find(name => name !== null && SAFE_SQL_TYPES.has(name))
+        if (!sqlMember) return
+        if (isStaticString(castExpression)) return
+        context.report({ node, messageId: 'unsafeSqlCast', data: { typeName: sqlMember } })
+        return
+      }
 
-      if (!SAFE_SQL_TYPES.has(resolvedName)) return
+      // ── Plain or namespace-qualified TSTypeReference ──────────────────────
+      if (castType.type === 'TSTypeReference') {
+        const resolvedName = resolveTypeName(castType)
 
-      // Allow casts of static string constants — these can never contain
-      // user input and are used legitimately in switch-validated branches.
-      if (isStaticString(castExpression)) return
+        if (resolvedName === null) {
+          // The type reference has a shape we cannot read. Fail closed: report
+          // rather than silently allow, since it could be an alias for a SQL brand.
+          // This is intentionally conservative; add a disable comment with an
+          // explanation if the site is genuinely safe.
+          if (isStaticString(castExpression)) return
+          context.report({ node, messageId: 'unresolvedCast' })
+          return
+        }
 
-      context.report({
-        node: node,
-        messageId: 'unsafeSqlCast',
-        data: { typeName: resolvedName },
-      })
+        if (!SAFE_SQL_TYPES.has(resolvedName)) return
+        if (isStaticString(castExpression)) return
+        context.report({ node, messageId: 'unsafeSqlCast', data: { typeName: resolvedName } })
+      }
     }
 
     return {
-      // Handles: expr as SafeSqlFragment
+      // expr as SafeSqlFragment
       TSAsExpression(node) {
         checkCast(node, node.expression, node.typeAnnotation)
       },
-      // Handles: <SafeSqlFragment>expr  (older TypeScript syntax)
+      // <SafeSqlFragment>expr  (older TypeScript syntax)
       TSTypeAssertion(node) {
         checkCast(node, node.expression, node.typeAnnotation)
       },

--- a/packages/eslint-config-supabase/rules/no-unsafe-sql-cast.js
+++ b/packages/eslint-config-supabase/rules/no-unsafe-sql-cast.js
@@ -1,0 +1,95 @@
+/**
+ * ESLint rule to prevent unsafe TypeScript casts of arbitrary strings to
+ * SafeSqlFragment or SafeLogSqlFragment.
+ *
+ * These branded types signal that a string has been properly escaped for
+ * use in a SQL query. Casting an arbitrary string bypasses the runtime
+ * escaping functions (ident, literal, keyword, toSafeOperator) and can
+ * introduce SQL injection vulnerabilities.
+ *
+ * BAD — TypeScript-only cast, no runtime check:
+ *   filter.operator as SafeSqlFragment
+ *   userInput as SafeLogSqlFragment
+ *
+ * GOOD — runtime-validated promotion:
+ *   toSafeOperator(filter.operator)        // throws on invalid operator
+ *   ident(tableName)                        // proper SQL identifier escaping
+ *   literal(value)                          // proper SQL literal escaping
+ *   acceptUntrustedSql(untrusted)           // explicit untrusted→safe gate
+ *
+ * Exceptions: casts of compile-time-known constants are safe.
+ * The two promotion files (safe-analytics-sql.ts, Query.utils.ts) are
+ * excluded from this rule via the eslint.config.cjs override.
+ */
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow casting arbitrary strings to SafeSqlFragment or SafeLogSqlFragment without runtime validation',
+      recommended: true,
+    },
+    messages: {
+      unsafeSqlCast:
+        'Do not cast directly to {{typeName}} — use ident(), literal(), toSafeOperator(), or acceptUntrustedSql() instead. Direct casts bypass runtime escaping and can introduce SQL injection.',
+    },
+    schema: [],
+  },
+
+  create(context) {
+    const SAFE_SQL_TYPES = new Set(['SafeSqlFragment', 'SafeLogSqlFragment'])
+
+    /**
+     * Returns true if the expression is a simple string literal or template
+     * literal with no substitutions — these are compile-time constants and
+     * safe to cast (they cannot contain user input).
+     */
+    function isStaticString(node) {
+      if (node.type === 'Literal' && typeof node.value === 'string') return true
+      if (node.type === 'TemplateLiteral' && node.expressions.length === 0) return true
+      return false
+    }
+
+    /**
+     * Checks both TypeScript `as` expressions (TSTypeAssertion in newer
+     * parsers) and angle-bracket casts.
+     */
+    function checkCast(node, castExpression, castType) {
+      const typeName =
+        castType.typeName?.name ?? castType.type?.name ?? castType.typeParameters?.type
+
+      // Resolve the actual type name from TSTypeReference
+      let resolvedName = null
+      if (castType.type === 'TSTypeReference') {
+        resolvedName = castType.typeName?.name
+      } else if (castType.typeName) {
+        resolvedName = castType.typeName.name
+      }
+
+      if (!resolvedName || !SAFE_SQL_TYPES.has(resolvedName)) return
+
+      // Allow casts of static string constants — these can never contain
+      // user input and are used legitimately in `switch`-validated branches.
+      if (isStaticString(castExpression)) return
+
+      context.report({
+        node: node,
+        messageId: 'unsafeSqlCast',
+        data: { typeName: resolvedName },
+      })
+    }
+
+    return {
+      // Handles: expr as SafeSqlFragment
+      TSAsExpression(node) {
+        checkCast(node, node.expression, node.typeAnnotation)
+      },
+      // Handles: <SafeSqlFragment>expr  (older TypeScript syntax)
+      TSTypeAssertion(node) {
+        checkCast(node, node.expression, node.typeAnnotation)
+      },
+    }
+  },
+}

--- a/packages/pg-meta/src/index.ts
+++ b/packages/pg-meta/src/index.ts
@@ -43,6 +43,7 @@ export {
   acceptUntrustedSql,
   joinSqlFragments,
 } from './pg-format'
+export { VALID_FILTER_OPERATORS } from './query/Query.utils'
 export type { SafeSqlFragment, UntrustedSqlFragment, DisplayableSqlFragment } from './pg-format'
 
 export type { PGTable, PGTablePrimaryKey, PGTableRelationship } from './pg-meta-tables'

--- a/packages/pg-meta/src/query/Query.utils.test.ts
+++ b/packages/pg-meta/src/query/Query.utils.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest'
+import { VALID_FILTER_OPERATORS, selectQuery, countQuery, deleteQuery } from './Query.utils'
+import type { Filter } from './types'
+
+describe('VALID_FILTER_OPERATORS', () => {
+  it('contains all 12 expected operators', () => {
+    const expected = ['=', '<>', '>', '<', '>=', '<=', '~~', '~~*', '!~~', '!~~*', 'in', 'is']
+    for (const op of expected) {
+      expect(VALID_FILTER_OPERATORS.has(op)).toBe(true)
+    }
+    expect(VALID_FILTER_OPERATORS.size).toBe(12)
+  })
+
+  it('does not contain empty string', () => {
+    expect(VALID_FILTER_OPERATORS.has('')).toBe(false)
+  })
+
+  it('does not contain SQL comment injection', () => {
+    expect(VALID_FILTER_OPERATORS.has('-- comment')).toBe(false)
+  })
+
+  it('does not contain semicolon injection', () => {
+    expect(VALID_FILTER_OPERATORS.has('; DROP TABLE users; --')).toBe(false)
+  })
+
+  it('does not contain newline injection', () => {
+    expect(VALID_FILTER_OPERATORS.has('\n')).toBe(false)
+  })
+
+  it('does not contain arbitrary strings', () => {
+    expect(VALID_FILTER_OPERATORS.has('DROP TABLE')).toBe(false)
+    expect(VALID_FILTER_OPERATORS.has('LIKE')).toBe(false)
+    expect(VALID_FILTER_OPERATORS.has("'")).toBe(false)
+  })
+})
+
+describe('selectQuery with filters', () => {
+  const table = { schema: 'public', name: 'users' }
+
+  it('builds correct SQL for = operator', () => {
+    const filter: Filter = { column: 'id', operator: '=', value: '1' }
+    const sql = selectQuery(table, undefined, { filters: [filter] })
+    expect(sql).toContain('where')
+    expect(sql).toContain('id')
+    expect(sql).toContain('=')
+  })
+
+  it('builds correct SQL for in operator', () => {
+    const filter: Filter = { column: 'status', operator: 'in', value: 'active,pending' }
+    const sql = selectQuery(table, undefined, { filters: [filter] })
+    expect(sql).toContain('in')
+    expect(sql).toContain("'active'")
+    expect(sql).toContain("'pending'")
+  })
+
+  it('builds correct SQL for is operator with null', () => {
+    const filter: Filter = { column: 'deleted_at', operator: 'is', value: 'null' }
+    const sql = selectQuery(table, undefined, { filters: [filter] })
+    expect(sql).toContain('is')
+    expect(sql).toContain('null')
+  })
+
+  it('builds correct SQL for LIKE operators (~~)', () => {
+    const filter: Filter = { column: 'name', operator: '~~', value: '%alice%' }
+    const sql = selectQuery(table, undefined, { filters: [filter] })
+    expect(sql).toContain('::text')
+    expect(sql).toContain('~~')
+  })
+
+  it('throws for invalid operator in default branch', () => {
+    // Force an invalid operator past TypeScript — simulates AI/external input
+    const filter = { column: 'id', operator: 'DROP TABLE users; --', value: '1' } as unknown as Filter
+    expect(() => selectQuery(table, undefined, { filters: [filter] })).toThrow(
+      'Invalid SQL filter operator'
+    )
+  })
+
+  it('throws for SQL comment injection in operator', () => {
+    const filter = { column: 'id', operator: '-- injected', value: '1' } as unknown as Filter
+    expect(() => selectQuery(table, undefined, { filters: [filter] })).toThrow(
+      'Invalid SQL filter operator'
+    )
+  })
+
+  it('throws for semicolon injection in operator', () => {
+    const filter = { column: 'id', operator: '; DELETE FROM users', value: '1' } as unknown as Filter
+    expect(() => selectQuery(table, undefined, { filters: [filter] })).toThrow(
+      'Invalid SQL filter operator'
+    )
+  })
+
+  it('throws for empty string operator', () => {
+    const filter = { column: 'id', operator: '' as any, value: '1' }
+    expect(() => selectQuery(table, undefined, { filters: [filter] })).toThrow(
+      'Invalid SQL filter operator'
+    )
+  })
+
+  it('correctly escapes table/schema identifiers with special chars', () => {
+    const specialTable = { schema: 'my schema', name: 'user"table' }
+    const sql = selectQuery(specialTable)
+    expect(sql).toContain('"my schema"')
+    expect(sql).toContain('"user""table"')
+  })
+
+  it('correctly escapes column identifiers in filters', () => {
+    const filter: Filter = { column: 'user name', operator: '=', value: 'test' }
+    const sql = selectQuery(table, undefined, { filters: [filter] })
+    expect(sql).toContain('"user name"')
+  })
+})
+
+describe('countQuery with invalid operator', () => {
+  it('throws for injection attempt in operator', () => {
+    const filter = { column: 'id', operator: "' OR '1'='1", value: '1' } as unknown as Filter
+    expect(() => countQuery({ schema: 'public', name: 'users' }, { filters: [filter] })).toThrow(
+      'Invalid SQL filter operator'
+    )
+  })
+})
+
+describe('deleteQuery', () => {
+  it('throws for injection in delete filter operator', () => {
+    const filter = { column: 'id', operator: 'UNION SELECT', value: '1' } as unknown as Filter
+    expect(() =>
+      deleteQuery({ schema: 'public', name: 'users' }, [filter])
+    ).toThrow('Invalid SQL filter operator')
+  })
+})

--- a/packages/pg-meta/src/query/Query.utils.ts
+++ b/packages/pg-meta/src/query/Query.utils.ts
@@ -6,7 +6,42 @@ import {
   safeSql,
   type SafeSqlFragment,
 } from '../pg-format'
-import type { Dictionary, Filter, QueryPagination, QueryTable, Sort } from './types'
+import type { Dictionary, Filter, FilterOperator, QueryPagination, QueryTable, Sort } from './types'
+
+/**
+ * Runtime-validated set of allowed SQL filter operators.
+ * Mirrors the FilterOperator union type so that any string reaching
+ * the SQL builder is checked at runtime, not just at compile time.
+ * Callers (e.g. AI-generated filters) can supply any string at
+ * runtime regardless of TypeScript types — this set is the real gate.
+ */
+export const VALID_FILTER_OPERATORS: ReadonlySet<string> = new Set<FilterOperator>([
+  '=',
+  '<>',
+  '>',
+  '<',
+  '>=',
+  '<=',
+  '~~',
+  '~~*',
+  '!~~',
+  '!~~*',
+  'in',
+  'is',
+])
+
+/**
+ * Promotes a raw operator string to SafeSqlFragment after runtime
+ * allowlist validation. Throws if the value is not one of the 12
+ * valid FilterOperator values, preventing injection via the default
+ * applyFilters branch.
+ */
+function toSafeOperator(op: string): SafeSqlFragment {
+  if (!VALID_FILTER_OPERATORS.has(op)) {
+    throw new Error(`Invalid SQL filter operator: "${op}"`)
+  }
+  return op as SafeSqlFragment
+}
 
 export function countQuery(
   table: QueryTable,
@@ -215,7 +250,7 @@ function applyFilters(query: SafeSqlFragment, filters: Filter[]) {
         case '!~~*':
           return castColumnToText(filter)
         default:
-          return safeSql`${ident(filter.column)} ${filter.operator as SafeSqlFragment} ${filterLiteral(filter.value)}`
+          return safeSql`${ident(filter.column)} ${toSafeOperator(filter.operator)} ${filterLiteral(filter.value)}`
       }
     }),
     ' and '
@@ -231,7 +266,7 @@ function inFilterSql(filter: Filter) {
     const filterValueTxt = String(filter.value)
     values = filterValueTxt.split(',').map((x) => filterLiteral(x))
   }
-  return safeSql`${ident(filter.column)} ${filter.operator as SafeSqlFragment} (${joinSqlFragments(values, ',')})`
+  return safeSql`${ident(filter.column)} ${toSafeOperator(filter.operator)} (${joinSqlFragments(values, ',')})`
 }
 
 function defaultTupleFilterSql(filter: Filter) {
@@ -253,7 +288,7 @@ function defaultTupleFilterSql(filter: Filter) {
     filter.value.map((v) => filterLiteral(v)),
     ', '
   )})`
-  return safeSql`${columns} ${filter.operator as SafeSqlFragment} ${values}`
+  return safeSql`${columns} ${toSafeOperator(filter.operator)} ${values}`
 }
 
 function inTupleFilterSql(filter: Filter) {
@@ -291,7 +326,7 @@ function inTupleFilterSql(filter: Filter) {
     }
   })
 
-  return safeSql`${columns} ${filter.operator as SafeSqlFragment} (${joinSqlFragments(values, ', ')})`
+  return safeSql`${columns} ${toSafeOperator(filter.operator)} (${joinSqlFragments(values, ', ')})`
 }
 
 function isFilterSql(filter: Filter) {
@@ -301,14 +336,15 @@ function isFilterSql(filter: Filter) {
     case 'false':
     case 'true':
     case 'not null':
-      return safeSql`${ident(filter.column)} ${filter.operator as SafeSqlFragment} ${filterValueTxt as SafeSqlFragment}`
+      // filterValueTxt is safe: validated by the switch case labels above
+      return safeSql`${ident(filter.column)} ${toSafeOperator(filter.operator)} ${filterValueTxt as SafeSqlFragment}`
     default:
-      return safeSql`${ident(filter.column)} ${filter.operator as SafeSqlFragment} ${filterLiteral(filter.value)}`
+      return safeSql`${ident(filter.column)} ${toSafeOperator(filter.operator)} ${filterLiteral(filter.value)}`
   }
 }
 
 function castColumnToText(filter: Filter) {
-  return safeSql`${ident(filter.column)}::text ${filter.operator as SafeSqlFragment} ${filterLiteral(filter.value)}`
+  return safeSql`${ident(filter.column)}::text ${toSafeOperator(filter.operator)} ${filterLiteral(filter.value)}`
 }
 
 function parseArrayLiteral(value: string): SafeSqlFragment | null {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Security fix - two distinct but related injection surfaces in Studio, addressed systemically rather than per-file.

## What is the current behavior?

**1 - SQL operator injection (high)**

`Query.utils.ts` casts `filter.operator` to `SafeSqlFragment` seven times using TypeScript-only casts. The `SafeSqlFragment` brand type signals runtime-validated strings, but these casts provide no runtime guarantee - a crafted operator string from AI-generated filters or external input reaches the SQL builder unchecked.

The server-side gate (`validateFilterGroup` in `filterHelpers.ts`) has a silent `return true` fallback when `property.operators` is absent, wiping out the allowlist for any column without explicit operator metadata.

**2 - URL injection / navigation corruption (medium)**

Five separate commits (March-May 2026) patched the same root cause - raw template-literal URL construction (`?schema=${schema}`) - one file at a time. Twelve call sites remained unfixed, including one in the Vault secret search path where special characters in secret values corrupt navigation state.

**3 - Prompt injection surface in AI SQL context (medium)**

`tablesToSQL()` in `helpers.ts` feeds raw table and column names without `ident()` escaping into the AI SQL context.

## What is the new behavior?

**SQL hardening**
- Introduce `VALID_FILTER_OPERATORS` (`ReadonlySet<string>`) and `toSafeOperator()` - throws on any string not in the allowlist before it can enter the SQL builder
- Replace all 7 `as SafeSqlFragment` operator casts with `toSafeOperator()`; export from `@supabase/pg-meta` root
- Fix `validateFilterGroup` fail-closed: `return true` ? `return false` when `property.operators` is absent
- Add runtime operator check in `FilterPopoverNew` before the cast
- Apply `ident()` escaping in `tablesToSQL()` for all identifier interpolations

**URL hardening**
- New `lib/studio-links.ts` with `buildStudioLink(path, params?)` using `URL.searchParams.set()` (auto-encodes all character classes) - matches the existing pattern in `buildTableEditorUrl`
- 11 typed `studioLinks.*` wrappers for common Studio routes
- Migrate 4 high/medium-risk call sites including the Vault secret path

**ESLint rule**
- New `supabase/no-unsafe-sql-cast` - bans `as SafeSqlFragment` / `as SafeLogSqlFragment` on non-static expressions; promotion files excluded via override

## Additional context

**45 tests added across 3 new files, all passing:**

| File | Tests | Coverage |
|------|-------|---------|
| `packages/pg-meta/src/query/Query.utils.test.ts` | 18 | Allowlist membership; DROP TABLE, SQL comment, semicolons, UNION SELECT all throw; LIKE/IN/IS build correctly; identifier escaping |
| `apps/studio/lib/api/filterHelpers.test.ts` | 7 | Fail-closed regression (missing operators ? false); nested group validation |
| `apps/studio/lib/studio-links.test.ts` | 20 | Space, slash, ampersand, hash, quote, Unicode, emoji, null/undefined omission, multi-param, no double-encoding of path |

The `SafeSqlFragment` brand type was introduced to make SQL injection visible at the type level. This PR adds the missing runtime layer to match that guarantee. `buildStudioLink` consolidates URL construction into one canonical place - same principle as the existing `buildTableEditorUrl`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added consistent navigation links across database, storage, Vault, SQL editor, and replication views.
  - Improved URL handling for special characters and optional parameters.

- **Bug Fixes**
  - Unsupported filter operators are now rejected instead of being processed.
  - SQL generation now safely quotes schemas, tables, columns, and constraints.
  - Invalid filters no longer produce unsafe or unexpected queries.

- **Security**
  - Added safeguards against unsafe SQL casts and invalid operator input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->