### PR TITLE
feat: migrate Edge Functions report to ClickHouse OTEL logs

### DIFF
--- a/apps/studio/data/reports/report.utils.ts
+++ b/apps/studio/data/reports/report.utils.ts
@@ -1,7 +1,7 @@
 import { type ComparisonOperator } from '@/components/interfaces/Reports/v2/ReportsNumericFilter'
 import { AnalyticsInterval } from '@/data/analytics/constants'
-import { useEdgeFunctionsQuery } from '@/data/edge-functions/edge-functions-query'
 import { executeAnalyticsSql } from '@/data/logs/execute-analytics-sql'
+import { logsAllEndpointUrl } from '@/data/logs/logs-endpoint'
 import { safeSql, type SafeLogSqlFragment } from '@/data/logs/safe-analytics-sql'
 
 export type Granularity = 'minute' | 'hour' | 'day'
@@ -66,49 +66,19 @@ export const REPORT_STATUS_CODE_COLORS: { [key: string]: { light: string; dark: 
   default: { light: '#757575', dark: '#9E9E9E' },
 }
 
-export const useEdgeFnIdToName = ({ projectRef }: { projectRef: string }) => {
-  const { data: edgeFunctions, isPending: isLoading } = useEdgeFunctionsQuery({
-    projectRef,
-  })
-
-  function edgeFnIdToName(id: string) {
-    return edgeFunctions?.find((fn) => fn.id === id)?.name
-  }
-
-  return {
-    edgeFnIdToName,
-    isLoading,
-  }
-}
-
 export async function fetchLogs(
   projectRef: string,
   sql: SafeLogSqlFragment,
   startDate: string,
-  endDate: string
+  endDate: string,
+  useOtel = false
 ) {
   return await executeAnalyticsSql({
     projectRef,
-    endpoint: '/platform/projects/{ref}/analytics/endpoints/logs.all',
+    endpoint: logsAllEndpointUrl(useOtel),
     sql,
     iso_timestamp_start: startDate,
     iso_timestamp_end: endDate,
     method: 'get',
   })
-}
-
-export const STATUS_CODE_COLORS: { [key: string]: { light: string; dark: string } } = {
-  '400': { light: '#FFD54F', dark: '#FFF176' },
-  '401': { light: '#FF8A65', dark: '#FFAB91' },
-  '403': { light: '#FFB74D', dark: '#FFCC80' },
-  '404': { light: '#90A4AE', dark: '#B0BEC5' },
-  '409': { light: '#BA68C8', dark: '#CE93D8' },
-  '410': { light: '#A1887F', dark: '#BCAAA4' },
-  '422': { light: '#FF9800', dark: '#FFB74D' },
-  '429': { light: '#E65100', dark: '#F57C00' },
-  '500': { light: '#B71C1C', dark: '#D32F2F' },
-  '502': { light: '#9575CD', dark: '#B39DDB' },
-  '503': { light: '#0097A7', dark: '#4DD0E1' },
-  '504': { light: '#C0CA33', dark: '#D4E157' },
-  default: { light: '#757575', dark: '#9E9E9E' },
 }

--- a/apps/studio/data/reports/v2/edge-functions.config.otel.test.ts
+++ b/apps/studio/data/reports/v2/edge-functions.config.otel.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+
+import { METRIC_SQL_OTEL } from './edge-functions.config'
+
+const sql = (fragment: { toString(): string }) => String(fragment)
+
+describe('METRIC_SQL_OTEL', () => {
+  it('queries the single OTEL logs table by source, never a per-service table', () => {
+    const out = sql(METRIC_SQL_OTEL.TotalInvocations('1h'))
+
+    expect(out).toContain('from logs')
+    expect(out).toContain("source = 'function_edge_logs'")
+    expect(out).not.toContain('from function_edge_logs')
+    expect(out).not.toContain('cross join unnest')
+  })
+
+  it('emits 16-digit unix-microsecond timestamps bucketed by granularity', () => {
+    expect(sql(METRIC_SQL_OTEL.TotalInvocations('1h'))).toContain(
+      'toUnixTimestamp(toStartOfHour(timestamp)) * 1000000 as timestamp'
+    )
+    expect(sql(METRIC_SQL_OTEL.TotalInvocations('1d'))).toContain(
+      'toUnixTimestamp(toStartOfDay(timestamp)) * 1000000 as timestamp'
+    )
+    expect(sql(METRIC_SQL_OTEL.TotalInvocations('5m'))).toContain(
+      'toUnixTimestamp(toStartOfMinute(timestamp)) * 1000000 as timestamp'
+    )
+  })
+
+  it('reads function_id from log_attributes for total invocations', () => {
+    const out = sql(METRIC_SQL_OTEL.TotalInvocations('1h'))
+    expect(out).toContain("log_attributes['function_id'] as function_id")
+    expect(out).toContain('count() as count')
+  })
+
+  it('reads response status code from log_attributes, coerced to a number', () => {
+    const out = sql(METRIC_SQL_OTEL.ExecutionStatusCodes('1h'))
+    expect(out).toContain("toInt32OrZero(log_attributes['response.status_code']) as status_code")
+  })
+
+  it('reads region from the response headers attribute and drops empty values', () => {
+    const out = sql(METRIC_SQL_OTEL.InvocationsByRegion('1h'))
+    expect(out).toContain("log_attributes['response.headers.x_sb_edge_region'] as region")
+    expect(out).toContain("log_attributes['response.headers.x_sb_edge_region'] != ''")
+  })
+
+  it('averages execution_time_ms from log_attributes, coerced to a float', () => {
+    const out = sql(METRIC_SQL_OTEL.ExecutionTime('1h'))
+    expect(out).toContain(
+      "avg(toFloat64OrZero(log_attributes['execution_time_ms'])) as avg_execution_time"
+    )
+  })
+
+  it('filters by function_id list when functions filter is set', () => {
+    const out = sql(METRIC_SQL_OTEL.TotalInvocations('1h', { functions: ['fn-1', 'fn-2'] } as any))
+    expect(out).toContain("log_attributes['function_id'] IN ('fn-1','fn-2')")
+  })
+
+  it('applies the numeric status_code filter using toInt32OrZero', () => {
+    const out = sql(
+      METRIC_SQL_OTEL.ExecutionStatusCodes('1h', {
+        status_code: { operator: '>=', value: 500 },
+      } as any)
+    )
+    expect(out).toContain("AND toInt32OrZero(log_attributes['response.status_code']) >= 500")
+  })
+
+  it('applies the numeric execution_time filter using toFloat64OrZero', () => {
+    const out = sql(
+      METRIC_SQL_OTEL.ExecutionTime('1h', {
+        execution_time: { operator: '>=', value: 100 },
+      } as any)
+    )
+    expect(out).toContain("AND toFloat64OrZero(log_attributes['execution_time_ms']) >= 100")
+  })
+})

--- a/apps/studio/data/reports/v2/edge-functions.config.ts
+++ b/apps/studio/data/reports/v2/edge-functions.config.ts
@@ -25,6 +25,7 @@ import {
   fetchLogs,
   SAFE_COMPARISON_OPERATOR_SQL,
   SAFE_GRANULARITY_SQL,
+  type Granularity,
 } from '@/data/reports/report.utils'
 
 type EdgeFunctionReportFilters = {
@@ -168,6 +169,122 @@ order by
   },
 }
 
+// fillTimeseries/isUnixMicro expects a 16-digit unix-microsecond timestamp, matching BigQuery's timestamp_trunc.
+const OTEL_TIMESTAMP: Record<Granularity, SafeLogSqlFragment> = {
+  minute: safeSql`toUnixTimestamp(toStartOfMinute(timestamp)) * 1000000`,
+  hour: safeSql`toUnixTimestamp(toStartOfHour(timestamp)) * 1000000`,
+  day: safeSql`toUnixTimestamp(toStartOfDay(timestamp)) * 1000000`,
+}
+
+function filterToWhereClauseOtel(filters?: EdgeFunctionReportFilters): SafeLogSqlFragment {
+  const whereClauses: SafeLogSqlFragment[] = [safeSql`source = 'function_edge_logs'`]
+
+  if (filters?.functions && filters.functions.length > 0) {
+    const ids = joinSqlFragments(filters.functions.map(analyticsLiteral), ',')
+    whereClauses.push(safeSql`log_attributes['function_id'] IN (${ids})`)
+  }
+
+  if (filters?.status_code) {
+    const op = SAFE_COMPARISON_OPERATOR_SQL[filters.status_code.operator]
+    whereClauses.push(
+      safeSql`toInt32OrZero(log_attributes['response.status_code']) ${op} ${analyticsLiteral(filters.status_code.value)}`
+    )
+  }
+
+  if (filters?.region && filters.region.length > 0) {
+    const regions = joinSqlFragments(filters.region.map(analyticsLiteral), ',')
+    whereClauses.push(safeSql`log_attributes['response.headers.x_sb_edge_region'] IN (${regions})`)
+  }
+
+  if (filters?.execution_time) {
+    const op = SAFE_COMPARISON_OPERATOR_SQL[filters.execution_time.operator]
+    whereClauses.push(
+      safeSql`toFloat64OrZero(log_attributes['execution_time_ms']) ${op} ${analyticsLiteral(filters.execution_time.value)}`
+    )
+  }
+
+  return safeSql`WHERE ${joinSqlFragments(whereClauses, ' AND ')}`
+}
+
+export const METRIC_SQL_OTEL: Record<
+  string,
+  (interval: AnalyticsInterval, filters?: EdgeFunctionReportFilters) => SafeLogSqlFragment
+> = {
+  TotalInvocations: (interval, filters) => {
+    const ts = OTEL_TIMESTAMP[analyticsIntervalToGranularity(interval)]
+    const whereClause = filterToWhereClauseOtel(filters)
+    return safeSql`
+--edgefn-report-invocations (otel)
+select
+  ${ts} as timestamp,
+  log_attributes['function_id'] as function_id,
+  count() as count
+from logs
+${whereClause}
+group by
+  timestamp,
+  function_id
+order by
+  timestamp desc
+`
+  },
+  ExecutionStatusCodes: (interval, filters) => {
+    const ts = OTEL_TIMESTAMP[analyticsIntervalToGranularity(interval)]
+    const whereClause = filterToWhereClauseOtel(filters)
+    return safeSql`
+--edgefn-report-execution-status-codes (otel)
+select
+  ${ts} as timestamp,
+  toInt32OrZero(log_attributes['response.status_code']) as status_code,
+  count() as count
+from logs
+${whereClause}
+group by
+  timestamp,
+  status_code
+order by
+  timestamp desc
+`
+  },
+  InvocationsByRegion: (interval, filters) => {
+    const ts = OTEL_TIMESTAMP[analyticsIntervalToGranularity(interval)]
+    const whereClause = filterToWhereClauseOtel(filters)
+    return safeSql`
+--edgefn-report-invocations-by-region (otel)
+select
+  ${ts} as timestamp,
+  log_attributes['response.headers.x_sb_edge_region'] as region,
+  count() as count
+from logs
+${whereClause}
+  AND log_attributes['response.headers.x_sb_edge_region'] != ''
+group by
+  timestamp,
+  region
+order by
+  timestamp desc
+`
+  },
+  ExecutionTime: (interval, filters) => {
+    const ts = OTEL_TIMESTAMP[analyticsIntervalToGranularity(interval)]
+    const whereClause = filterToWhereClauseOtel(filters)
+    return safeSql`
+--edgefn-report-execution-time (otel)
+select
+  ${ts} as timestamp,
+  log_attributes['function_id'] as function_id,
+  avg(toFloat64OrZero(log_attributes['execution_time_ms'])) as avg_execution_time
+from logs
+${whereClause}
+group by
+  timestamp,
+  function_id
+order by
+  timestamp desc
+`
+  },
+}
+
 /**
  * Transforms raw invocation data by normalizing timestamps and adding function names
  * @param data - Raw data from the database
@@ -209,6 +326,7 @@ export const edgeFunctionReports = ({
   endDate,
   interval,
   filters,
+  useOtel = false,
 }: {
   projectRef: string
   functions: { id: string; name: string }[]
@@ -216,6 +334,7 @@ export const edgeFunctionReports = ({
   endDate: string
   interval: AnalyticsInterval
   filters: EdgeFunctionReportFilters
+  useOtel?: boolean
 }): ReportConfig<EdgeFunctionReportFilters>[] => [
   {
     id: 'total-invocations',
@@ -229,8 +348,8 @@ export const edgeFunctionReports = ({
     defaultChartStyle: 'line',
     titleTooltip: 'The total number of edge function invocations over time.',
     dataProvider: async () => {
-      const sql = METRIC_SQL.TotalInvocations(interval, filters)
-      const response = await fetchLogs(projectRef, sql, startDate, endDate)
+      const sql = (useOtel ? METRIC_SQL_OTEL : METRIC_SQL).TotalInvocations(interval, filters)
+      const response = await fetchLogs(projectRef, sql, startDate, endDate, useOtel)
 
       if (!response?.result) return { data: [] }
 
@@ -260,8 +379,8 @@ export const edgeFunctionReports = ({
     defaultChartStyle: 'line',
     titleTooltip: 'The total number of edge function executions by status code.',
     dataProvider: async () => {
-      const sql = METRIC_SQL.ExecutionStatusCodes(interval, filters)
-      const rawData = await fetchLogs(projectRef, sql, startDate, endDate)
+      const sql = (useOtel ? METRIC_SQL_OTEL : METRIC_SQL).ExecutionStatusCodes(interval, filters)
+      const rawData = await fetchLogs(projectRef, sql, startDate, endDate, useOtel)
 
       if (!rawData?.result) return { data: [] }
 
@@ -296,8 +415,8 @@ export const edgeFunctionReports = ({
     },
     format: (value: unknown) => millisecondFormatter(Number(value)),
     dataProvider: async () => {
-      const sql = METRIC_SQL.ExecutionTime(interval, filters)
-      const rawData = await fetchLogs(projectRef, sql, startDate, endDate)
+      const sql = (useOtel ? METRIC_SQL_OTEL : METRIC_SQL).ExecutionTime(interval, filters)
+      const rawData = await fetchLogs(projectRef, sql, startDate, endDate, useOtel)
 
       if (!rawData?.result) return { data: [] }
 
@@ -354,8 +473,8 @@ export const edgeFunctionReports = ({
     entitlement: 'edge_functions',
     requiredPlan: 'Pro',
     dataProvider: async () => {
-      const sql = METRIC_SQL.InvocationsByRegion(interval, filters)
-      const rawData = await fetchLogs(projectRef, sql, startDate, endDate)
+      const sql = (useOtel ? METRIC_SQL_OTEL : METRIC_SQL).InvocationsByRegion(interval, filters)
+      const rawData = await fetchLogs(projectRef, sql, startDate, endDate, useOtel)
       const data = rawData.result?.map((point: any) => ({
         ...point,
         timestamp: isUnixMicro(point.timestamp)

--- a/apps/studio/pages/project/[ref]/observability/edge-functions.tsx
+++ b/apps/studio/pages/project/[ref]/observability/edge-functions.tsx
@@ -1,5 +1,5 @@
 import { useQueryClient } from '@tanstack/react-query'
-import { useParams } from 'common'
+import { useFlag, useParams } from 'common'
 import dayjs from 'dayjs'
 import { ArrowRight, RefreshCw } from 'lucide-react'
 import { parseAsJson, useQueryState } from 'nuqs'
@@ -60,6 +60,7 @@ const REPORT_TITLE = 'Edge Functions'
 
 const EdgeFunctionsUsage = () => {
   const { ref } = useParams()
+  const useOtel = useFlag('otelReports')
   const { data: functions } = useEdgeFunctionsQuery({
     projectRef: ref,
   })
@@ -114,6 +115,7 @@ const EdgeFunctionsUsage = () => {
         region: regionFilter ?? [],
         execution_time: executionTimeFilter,
       },
+      useOtel,
     })
   }, [
     ref,
@@ -123,6 +125,7 @@ const EdgeFunctionsUsage = () => {
     statusCodeFilter,
     regionFilter,
     executionTimeFilter,
+    useOtel,
   ])
 
   const onRefreshReport = useRefreshHandler(


### PR DESCRIPTION
## Problem

The Edge Functions report (`observability/edge-functions`) only queries BigQuery. As part of the broader Reports→ClickHouse OTEL migration (DEBUG-73), we need each report migrated one at a time behind the `otelReports` flag.

## Fix

Adds a ClickHouse OTEL SQL variant (`METRIC_SQL_OTEL`) for the 4 Edge Functions metrics (TotalInvocations, ExecutionStatusCodes, InvocationsByRegion, ExecutionTime), querying the unified `logs` table filtered to `source = 'function_edge_logs'`, with fields read from `log_attributes` (`function_id`, `response.status_code`, `response.headers.x_sb_edge_region`, `execution_time_ms`) — the same mapping already used by `edge-functions-last-hour-stats-query.ts`.

`edgeFunctionReports()` now takes a `useOtel` flag that picks between the BQ and OTEL query sets and forwards it to `fetchLogs`. The page wires this up via `useFlag('otelReports')`, matching the pattern used for the Auth report. No behavior change while the flag is off — report still fetches from BigQuery.

Also removed two pieces of dead code spotted in `report.utils.ts` while touching it: the unused `useEdgeFnIdToName` hook and a `STATUS_CODE_COLORS` map that was an exact duplicate of `REPORT_STATUS_CODE_COLORS` (the one actually imported elsewhere).

This PR is standalone — no dependency on the in-flight Auth report OTEL stack.

## How to test

- `pnpm vitest run data/reports/v2/edge-functions.config.otel.test.ts` — 9 new tests covering the OTEL SQL shape (single logs table, unix-microsecond timestamp bucketing, field mapping, filters).
- `pnpm vitest run data/reports` and `pnpm vitest run data/edge-functions components/interfaces/Reports` — existing suites (46 + 54 tests) still pass, confirming no regression to the BQ path.
- Manually: with `otelReports` flag enabled, visit a project's Edge Functions observability report and confirm charts render from the ClickHouse endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenTelemetry support for Edge Functions observability metrics, including invocations, status codes, regional activity, and execution time.
  * Reports can now dynamically use either the standard or OpenTelemetry logs source.

* **Bug Fixes**
  * Improved filtering and timestamp handling for OpenTelemetry-based Edge Functions metrics.
  * Added coverage for status, execution time, function, and region filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->