### PR TITLE
fix(ui): add bottom padding to scroll container in RLS search

### DIFF
--- a/apps/studio/components/interfaces/App/CommandMenu/PolicySearchResults.tsx
+++ b/apps/studio/components/interfaces/App/CommandMenu/PolicySearchResults.tsx
@@ -134,7 +134,7 @@ export function PolicySearchResults({ query }: PolicySearchResultsProps) {
 
   return (
     <div className="relative h-full flex flex-col">
-      <div className="flex-1 min-h-0 overflow-hidden">
+      <div className="flex-1 min-h-0 overflow-y-auto pb-9">
         <ResultsList
           results={policyResults}
           icon={Auth}
@@ -150,7 +150,6 @@ export function PolicySearchResults({ query }: PolicySearchResultsProps) {
             }
             return `/project/${projectRef}/database/policies?${params.toString()}` as `/${string}`
           }}
-          className="pb-9"
         />
       </div>
       {renderFooter()}


### PR DESCRIPTION
Fixes FE-4075. 

## What kind of change does this PR introduce?

The footer displaying the total number of RLS policies overlaps the last search result in the RLS Policy Search dialog. As a result, the last policy entry is partially hidden and cannot be fully read when scrolling to the bottom.

## What is the current behavior?

The search results container now reserves space for the footer, preventing it from overlapping the last search result. All policy entries remain fully visible when scrolling to the bottom.

<img width="400" height="300" alt="image" src="https://github.com/user-attachments/assets/46529ca4-bdce-4fa2-b0ba-ea87e769cc24" />

## What is the new behavior?

<img width="400" height="300" alt="CleanShot 2026-08-05 at 18 19 27@2x" src="https://github.com/user-attachments/assets/093a3f9e-fd4c-4ff6-b483-2839f3916d13" />

## How to test

- Open a project in the Supabase Dashboard.
- Navigate to Database → RLS Policies.
- Open the policy search dialog.
- Search for a term that returns enough results to make the list scrollable 
- Scroll to the bottom of the results.

The [database.sql](https://gist.github.com/monicakh/49b5ff201893eb43aea329395b3f635b) to create the tables/policies to test. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scrolling in policy search results.
  * Added spacing at the bottom so results remain visible above the fixed footer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->