### PR TITLE
docs(blog): point dead Edge Functions guide links at their current pages

### DIFF
--- a/apps/www/_blog/2023-12-12-edge-functions-node-npm.mdx
+++ b/apps/www/_blog/2023-12-12-edge-functions-node-npm.mdx
@@ -97,7 +97,7 @@ These changes help you spot any issues with your Edge Functions and act on them.
 
 <div className="bg-gray-300 rounded-lg px-6 py-2 bold">
 
-ℹ️ See the [logging and metrics guide](https://supabase.com/docs/guides/functions/debugging) for Edge Functions to learn more.
+ℹ️ See the [logging and metrics guide](https://supabase.com/docs/guides/functions/logging) for Edge Functions to learn more.
 
 </div>
 

--- a/apps/www/_blog/2024-04-25-exploring-support-tooling.mdx
+++ b/apps/www/_blog/2024-04-25-exploring-support-tooling.mdx
@@ -276,6 +276,6 @@ And we're not done with SLA Buddy. It'll grow and evolve as Supabase grows, and 
 
 - [GitHub Repo: SLA Buddy](https://github.com/mansueli/slabuddy)
 - [Docs Edge Functions: slack mention reply](https://supabase.com/docs/guides/functions/examples/slack-bot-mention)
-- [Docs Edge Functions: geting started](https://supabase.com/docs/guides/functions/getting-started)
-- [Docs Edge Functions: debugging](https://supabase.com/docs/guides/functions/debugging)
+- [Docs Edge Functions: geting started](https://supabase.com/docs/guides/functions/quickstart)
+- [Docs Edge Functions: debugging](https://supabase.com/docs/guides/functions/debugging-tools)
 - [Slack Consolidate: a slackbot build with Python & Supabase](https://supabase.com/blog/slack-consolidate-slackbot-to-consolidate-messages)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs fix (broken links in blog posts).

## What is the current behavior?

Three links in two blog posts point at Edge Functions guide pages that no longer exist:

| dead link | post |
| --- | --- |
| `guides/functions/getting-started` | `2024-04-25-exploring-support-tooling` |
| `guides/functions/debugging` | `2024-04-25-exploring-support-tooling` |
| `guides/functions/debugging` | `2023-12-12-edge-functions-node-npm` |

## What is the new behavior?

The two `debugging` links go to different places, because the link text is describing two different pages:

| post | link text | new target |
| --- | --- | --- |
| exploring-support-tooling | "Docs Edge Functions: geting started" | `guides/functions/quickstart` |
| exploring-support-tooling | "Docs Edge Functions: debugging" | `guides/functions/debugging-tools` |
| edge-functions-node-npm | "logging and metrics guide" | `guides/functions/logging` |

All three destinations return 200 and are in the sitemap.

The split is worth calling out. `guides/functions/debugging` has been replaced by two separate pages, `debugging-tools` (local debugging with Chrome DevTools) and `logging`. A blanket rename would have sent the "logging and metrics guide" link to the wrong one. The docs already treat these as distinct: `troubleshooting/edge-function-546-error-response.mdx` links "log" to `functions/logging`, while the 500, 503 and 504 troubleshooting entries link local debugging to `functions/debugging-tools`. I followed that same split.

## Additional context

Files:

- `apps/www/_blog/2024-04-25-exploring-support-tooling.mdx` (2)
- `apps/www/_blog/2023-12-12-edge-functions-node-npm.mdx` (1)

Link targets only. I left the "geting started" typo in the link text alone, since fixing prose in a published post is a separate call from fixing a dead link, but happy to correct it if you want.

I did not touch `apps/www/app/api-v2/md/content.generated.ts`, which mirrors this content and regenerates from the posts.

Verification: both old paths confirmed 404 and absent from the sitemap; `quickstart`, `debugging-tools` and `logging` all confirmed 200 and present. I matched on the exact dead path rather than the prefix, because most in-repo references already point at `debugging-tools` and a loose grep makes them look broken when they are fine.

Gates run locally: `test:prettier` passes repo wide and the www vitest suite passes (6 files, 73 tests). I did not run `pnpm build`, which cannot complete here because the docs `build:federated-content` step needs `DOCS_GITHUB_APP_PRIVATE_KEY`.

Freshman contributor, put this together with Claude Code's help and checked each URL and link sentence myself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Edge Functions metrics guidance to link to the logging documentation.
  * Refreshed Slack and Edge Functions resource links, including quickstart and debugging documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
