### PR TITLE
docs(www): point anchor fragments at their current heading ids

### DIFF
--- a/apps/www/_blog/2023-02-08-supabase-beta-january-2023.mdx
+++ b/apps/www/_blog/2023-02-08-supabase-beta-january-2023.mdx
@@ -56,7 +56,7 @@ Views, Materialized Views, and Foreign Tables are three database objects that pr
 
 WebP is a modern image format that provides superior lossless and lossy compression for images on the web. We are enabling format conversion by default for anyone who has Image Transformations. You can opt out by including format: origin in the transformation parameters.
 
-[Read the docs](https://supabase.com/docs/guides/storage/serving/image-transformations#automatic-image-optimisation-webp)
+[Read the docs](https://supabase.com/docs/guides/storage/serving/image-transformations#automatic-image-optimization-webp)
 
 ## Quick product updates
 

--- a/apps/www/_blog/2025-03-07-dedicated-poolers.mdx
+++ b/apps/www/_blog/2025-03-07-dedicated-poolers.mdx
@@ -17,7 +17,7 @@ Today we're announcing **Dedicated Poolers** - a Postgres connection pooler that
 
 <Admonition type="info">
 
-Don't know what a Pooler is? Check out our [docs](/docs/guides/database/connecting-to-postgres#serverside-poolers).
+Don't know what a Pooler is? Check out our [docs](/docs/guides/database/connecting-to-postgres#server-side-poolers).
 
 </Admonition>
 

--- a/apps/www/data/features.tsx
+++ b/apps/www/data/features.tsx
@@ -600,7 +600,7 @@ Dedicated Poolers provide an alternative to Supavisor for specific use cases, gi
     icon: Database,
     products: [PRODUCT_SHORTNAMES.DATABASE],
     heroImage: '',
-    docsUrl: 'https://supabase.com/docs/guides/database/connecting-to-postgres#serverside-poolers',
+    docsUrl: 'https://supabase.com/docs/guides/database/connecting-to-postgres#server-side-poolers',
     slug: 'dedicated-poolers',
     status: {
       stage: PRODUCT_STAGES.GA,
@@ -952,7 +952,7 @@ Broadcast from Database provides a powerful way to trigger real-time events dire
     icon: DatabaseZap,
     products: [PRODUCT_SHORTNAMES.REALTIME],
     heroImage: '',
-    docsUrl: 'https://supabase.com/docs/guides/realtime/broadcast#broadcast-from-database',
+    docsUrl: 'https://supabase.com/docs/guides/realtime/broadcast#broadcast-from-the-database',
     slug: 'realtime-broadcast-from-database',
     status: {
       stage: PRODUCT_STAGES.PUBLIC_BETA,


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs fix (broken anchor links).

## What is the current behavior?

Four links on the marketing site point at heading ids that do not exist on the destination page, so they land the reader at the top instead of the section. The pages themselves load fine, which is why these are easy to miss.

| fragment used | id actually on the page |
| --- | --- |
| `image-transformations#automatic-image-optimisation-webp` | `automatic-image-optimization-webp` |
| `realtime/broadcast#broadcast-from-database` | `broadcast-from-the-database` |
| `connecting-to-postgres#serverside-poolers` (x2) | `server-side-poolers` |

Three small drifts: British spelling where the heading uses U.S. English, a missing "the", and a missing hyphen.

## What is the new behavior?

Each fragment matches the id that is actually rendered. Fragments only, no paths, prose or link text changed.

## Additional context

Files:

- `apps/www/data/features.tsx` (2, the docs links on the features page)
- `apps/www/_blog/2023-02-08-supabase-beta-january-2023.mdx` (1)
- `apps/www/_blog/2025-03-07-dedicated-poolers.mdx` (1)

How I verified: extracted every anchor bearing `supabase.com/docs` link in `apps/www` (57 distinct), fetched each destination once, and compared the fragment against the `id="..."` values actually present. Then confirmed each replacement id is on the page.

I kept this to the cases where the intended target is unambiguous. The same scan flagged others I left alone because picking a successor would be guesswork rather than a rename, for example `connecting-to-postgres#connection-pool` and `#how-connection-pooling-works`, where the page now has `poolers`, `more-about-connection-pooling` and `dedicated-pooler` and I cannot tell which was meant, and `functions/quickstart#create-an-edge-function`, where that page has been restructured into numbered steps. I also skipped two `reference/*/initializing` pages whose headings are not in the server HTML, so my check cannot judge them either way.

Two notes on overlap with my own open PRs, so nothing here is a surprise:

- `apps/www/data/features.tsx` is also touched by #48682, but on different lines (that one fixes `reference/<lib>/start` links, this one fixes fragments), so they should merge independently.
- The scan also flagged `connecting-to-postgres#direct-connections` in `apps/www/_blog/2024-01-16-ipv6.mdx`, which I left out because #48629 already fixes exactly that line.

Gates run locally: `test:prettier` passes repo wide and the www vitest suite passes (6 files, 73 tests). `typecheck` failed once in a full parallel run with a `TS2589` in studio and passed 9 of 9 on `typecheck --filter=studio --force`, which is a load flake unrelated to this change (this PR touches no studio code). I did not run `pnpm build`, which cannot complete here because the docs `build:federated-content` step needs `DOCS_GITHUB_APP_PRIVATE_KEY`.

Freshman contributor, checked every id and URL myself with Claude Code's help along the way. Glad to adjust or drop any of these.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Image Transformation documentation links to the correct URL anchor.
  - Corrected the Dedicated Poolers documentation link.
  - Updated Dedicated Poolers and Realtime Broadcast documentation URLs to their current locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->