### PR TITLE
fix(docs e2e): say when a broken link is a redirect

### DIFF
--- a/e2e/docs/features/docs-pages.spec.ts
+++ b/e2e/docs/features/docs-pages.spec.ts
@@ -5,6 +5,7 @@ import {
   articleSelectorForPagePath,
   browserLikeUserAgent,
   collectDocsOwnedLinks,
+  formatLinkFailure,
   parseDocsE2EPagePaths,
 } from '../utils/docs-links.js'
 
@@ -48,13 +49,16 @@ test.describe('Docs owned pages', () => {
         try {
           const linkResponse = await page.request.get(url, { headers: { 'user-agent': userAgent } })
           expect
-            .soft(linkResponse.ok(), `${url} should resolve (status ${linkResponse.status()})`)
+            .soft(linkResponse.ok(), formatLinkFailure({ url, status: linkResponse.status() }))
             .toBeTruthy()
         } catch (error) {
           expect
             .soft(
               null,
-              `${url} should be reachable (${error instanceof Error ? error.message : error})`
+              formatLinkFailure({
+                url,
+                status: error instanceof Error ? error.message : String(error),
+              })
             )
             .toBeTruthy()
         }

--- a/e2e/docs/package.json
+++ b/e2e/docs/package.json
@@ -9,13 +9,15 @@
     "e2e:docs:a11y": "node --experimental-strip-types scripts/run-e2e-docs.ts --grep @a11y",
     "e2e:ui": "node --experimental-strip-types scripts/run-e2e-docs.ts --ui",
     "e2e:docs:local-smoke": "playwright test --config=playwright.local-smoke.config.ts",
-    "resolve-docs-scope": "node --experimental-strip-types scripts/resolve-docs-scope.ts"
+    "resolve-docs-scope": "node --experimental-strip-types scripts/resolve-docs-scope.ts",
+    "test": "node --experimental-strip-types --test utils/**/*.test.ts"
   },
   "dependencies": {
     "@playwright/test": "^1.59.1"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.12.1",
-    "@types/node": "catalog:"
+    "@types/node": "catalog:",
+    "path-to-regexp": "^6.3.0"
   }
 }

--- a/e2e/docs/utils/docs-links.test.ts
+++ b/e2e/docs/utils/docs-links.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { formatLinkFailure } from './docs-links.ts'
+
+test('formatLinkFailure names the redirect and the destination to link to', () => {
+  const message = formatLinkFailure({
+    url: 'https://docs-preview.vercel.app/docs/guides/database/data-api',
+    status: 404,
+    lookupRedirect: () => ({
+      source: '/docs/guides/database/data-api',
+      destination: '/docs/guides/api/securing-your-api',
+      permanent: true,
+    }),
+  })
+
+  assert.match(message, /should resolve \(status 404\)/)
+  assert.match(
+    message,
+    /This link is a redirect: \/docs\/guides\/database\/data-api → \/docs\/guides\/api\/securing-your-api/
+  )
+  assert.match(message, /Fix: change the link to \/docs\/guides\/api\/securing-your-api\./)
+})
+
+test('formatLinkFailure adds nothing when no redirect covers the path', () => {
+  const message = formatLinkFailure({
+    url: 'https://docs-preview.vercel.app/docs/guides/typo-ed-link',
+    status: 404,
+    lookupRedirect: () => null,
+  })
+
+  assert.equal(
+    message,
+    'https://docs-preview.vercel.app/docs/guides/typo-ed-link should resolve (status 404)'
+  )
+})
+
+test('formatLinkFailure reports a network error in place of a status', () => {
+  const message = formatLinkFailure({
+    url: 'https://docs-preview.vercel.app/docs/guides/unreachable',
+    status: 'socket hang up',
+    lookupRedirect: () => null,
+  })
+
+  assert.match(message, /should resolve \(status socket hang up\)/)
+})

--- a/e2e/docs/utils/docs-links.ts
+++ b/e2e/docs/utils/docs-links.ts
@@ -1,5 +1,7 @@
 import type { Page } from '@playwright/test'
 
+import { findRedirect } from './www-redirects.ts'
+
 export const GUIDE_ARTICLE_SELECTOR = '[data-testid="sb-docs-guide-main-article"]'
 export const TROUBLESHOOTING_ARTICLE_SELECTOR =
   '[data-testid="sb-docs-troubleshooting-main-article"]'
@@ -63,6 +65,38 @@ export async function collectDocsOwnedLinks(
   }
 
   return [...links].sort()
+}
+
+/**
+ * Explains a failed docs-owned link, adding redirect detail when one applies.
+ *
+ * A docs preview never serves apps/www/lib/redirects.js. That table belongs to
+ * the www project, which production requests pass through first. So a
+ * redirect-backed link fails on a preview even though it works on
+ * supabase.com, which is worth saying. A link with no redirect is just broken.
+ */
+export function formatLinkFailure({
+  url,
+  status,
+  lookupRedirect = findRedirect,
+}: {
+  url: string
+  status: number | string
+  lookupRedirect?: typeof findRedirect
+}): string {
+  const message = `${url} should resolve (status ${status})`
+  const redirect = lookupRedirect(new URL(url).pathname)
+  if (!redirect) return message
+
+  return [
+    message,
+    '',
+    `This link is a redirect: ${redirect.source} → ${redirect.destination}`,
+    'Docs previews do not serve apps/www/lib/redirects.js, so it fails here even',
+    'though it works on supabase.com.',
+    '',
+    `Fix: change the link to ${redirect.destination}.`,
+  ].join('\n')
 }
 
 /**

--- a/e2e/docs/utils/www-redirects.test.ts
+++ b/e2e/docs/utils/www-redirects.test.ts
@@ -1,0 +1,131 @@
+import assert from 'node:assert/strict'
+import { dirname, join } from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+import { compileRedirectRules, loadWwwRedirects, type RedirectRule } from './www-redirects.ts'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = join(__dirname, '../../..')
+
+test('loadWwwRedirects reads the real redirects.js and contains a known entry', () => {
+  const rules = loadWwwRedirects(REPO_ROOT)
+
+  assert.ok(rules.length > 400, `expected hundreds of redirects, got ${rules.length}`)
+
+  // If this ever fails, it's telling you something real changed in
+  // apps/www/lib/redirects.js — update the fixture below, don't just delete it.
+  const match = rules.find((rule) => rule.source === '/docs/careers')
+  assert.ok(match, 'expected /docs/careers to still be a redirect source')
+  assert.equal(match?.destination, 'https://about.supabase.com/careers')
+  assert.equal(match?.permanent, false)
+})
+
+test('loadWwwRedirects skips conditional (`has`) entries', () => {
+  const rules = loadWwwRedirects(REPO_ROOT)
+  // This source is host-conditional in the real file; a literal path match
+  // would be wrong here since it applies only on a different host.
+  assert.ok(
+    !rules.some((rule) => rule.source === '/:path*' && rule.destination.includes('design-system')),
+    'expected the host-conditional design-system catch-all to be filtered out'
+  )
+})
+
+test('compileRedirectRules matches an exact literal source', () => {
+  const rules: RedirectRule[] = [
+    {
+      source: '/docs/guides/database/data-api',
+      destination: '/docs/guides/api/data-api',
+      permanent: true,
+    },
+  ]
+  const findRedirect = compileRedirectRules(rules)
+
+  assert.deepEqual(findRedirect('/docs/guides/database/data-api'), {
+    source: '/docs/guides/database/data-api',
+    destination: '/docs/guides/api/data-api',
+    permanent: true,
+  })
+  assert.equal(findRedirect('/docs/guides/database/data-api-extra'), null)
+})
+
+test('compileRedirectRules substitutes a `:name*` wildcard into the destination', () => {
+  const rules: RedirectRule[] = [
+    {
+      source: '/docs/guides/reports/:match*',
+      destination: '/docs/guides/observability/:match*',
+      permanent: true,
+    },
+  ]
+  const findRedirect = compileRedirectRules(rules)
+
+  assert.deepEqual(findRedirect('/docs/guides/reports/foo/bar'), {
+    source: '/docs/guides/reports/:match*',
+    destination: '/docs/guides/observability/foo/bar',
+    permanent: true,
+  })
+})
+
+test('compileRedirectRules matches a literal destination containing a query string, when the source has no params', () => {
+  const rules: RedirectRule[] = [
+    {
+      source: '/docs/guides/auth/server-side/nextjs',
+      destination:
+        '/docs/guides/auth/server-side/creating-a-client?queryGroups=framework&framework=nextjs',
+      permanent: false,
+    },
+  ]
+  const findRedirect = compileRedirectRules(rules)
+
+  // path-to-regexp's compile() cannot parse a `?query=string` destination as
+  // a template. Since the source captured no params, no substitution is
+  // needed, and the literal destination is returned as-is rather than
+  // crashing the whole matcher over an unrelated rule.
+  const match = findRedirect('/docs/guides/auth/server-side/nextjs')
+  assert.deepEqual(match, {
+    source: '/docs/guides/auth/server-side/nextjs',
+    destination:
+      '/docs/guides/auth/server-side/creating-a-client?queryGroups=framework&framework=nextjs',
+    permanent: false,
+  })
+})
+
+test('compileRedirectRules treats a dynamic source with an uncompilable destination as no match', () => {
+  const rules: RedirectRule[] = [
+    {
+      source: '/docs/careers/:match*',
+      destination: 'https://about.supabase.com/careers//:match*',
+      permanent: true,
+    },
+  ]
+  const findRedirect = compileRedirectRules(rules)
+
+  // The source captured params, so a substitution IS needed, but the
+  // destination is an absolute URL path-to-regexp can't compile. Must not throw.
+  assert.equal(findRedirect('/docs/careers/foo'), null)
+})
+
+test('compileRedirectRules applies the first matching rule, same order Vercel would', () => {
+  const rules: RedirectRule[] = [
+    { source: '/docs/guides/a', destination: '/docs/guides/first', permanent: true },
+    { source: '/docs/guides/a', destination: '/docs/guides/second', permanent: true },
+  ]
+  const findRedirect = compileRedirectRules(rules)
+
+  assert.equal(findRedirect('/docs/guides/a')?.destination, '/docs/guides/first')
+})
+
+test('compileRedirectRules never throws across every real rule in redirects.js', () => {
+  const rules = loadWwwRedirects(REPO_ROOT)
+  const findRedirect = compileRedirectRules(rules)
+
+  for (const rule of rules) {
+    // Replace any `:param*`/`:param` placeholder with a literal segment so
+    // dynamic sources are exercised too, not just literal ones.
+    const probe = rule.source.replace(/:[^/]+\*?/g, 'probe-value')
+    assert.doesNotThrow(
+      () => findRedirect(probe),
+      `threw while matching against source ${rule.source}`
+    )
+  }
+})

--- a/e2e/docs/utils/www-redirects.ts
+++ b/e2e/docs/utils/www-redirects.ts
@@ -1,0 +1,116 @@
+import { createRequire } from 'node:module'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { compile, match } from 'path-to-regexp'
+
+export type RedirectRule = {
+  source: string
+  destination: string
+  permanent: boolean
+}
+
+export type RedirectMatch = {
+  source: string
+  destination: string
+  permanent: boolean
+}
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const DEFAULT_REPO_ROOT = join(__dirname, '../../..')
+const WWW_REDIRECTS_PATH = 'apps/www/lib/redirects.js'
+
+const requireFromHere = createRequire(import.meta.url)
+
+/**
+ * Loads apps/www/lib/redirects.js as data. It's a plain CommonJS array
+ * (`module.exports = [{ source, destination, permanent }, ...]`), so this
+ * executes no www app code — it's the same mechanism as requiring a JSON file.
+ *
+ * A docs preview deployment is the `docs` Vercel project; it never serves
+ * these, only `zone-www-dot-com` does. That's the whole reason a redirect
+ * looks broken on a preview and works on production.
+ *
+ * Skips conditional entries (a `has` clause keyed on host/query/cookie):
+ * without full request context they can't be evaluated, and none of the
+ * ~660 unconditional entries collide with a path they would otherwise match.
+ */
+export function loadWwwRedirects(repoRoot: string = DEFAULT_REPO_ROOT): RedirectRule[] {
+  const redirectsPath = join(repoRoot, WWW_REDIRECTS_PATH)
+  const raw = requireFromHere(redirectsPath) as Array<{
+    source: string
+    destination: string
+    permanent?: boolean
+    has?: unknown
+  }>
+
+  return raw
+    .filter((entry) => !entry.has)
+    .map((entry) => ({
+      source: entry.source,
+      destination: entry.destination,
+      permanent: entry.permanent ?? false,
+    }))
+}
+
+type CompiledRule = {
+  rule: RedirectRule
+  test: ReturnType<typeof match> | null
+}
+
+function compileRule(rule: RedirectRule): CompiledRule {
+  try {
+    return { rule, test: match(rule.source, { decode: decodeURIComponent }) }
+  } catch {
+    // A source path-to-regexp can't parse just means this rule is invisible to
+    // the matcher — safe, since an unrecognized redirect falls through to
+    // production corroboration rather than a false positive.
+    return { rule, test: null }
+  }
+}
+
+/**
+ * Compiles rules once; call the returned matcher repeatedly against many
+ * pathnames. First match wins, same order Vercel applies `redirects()` in.
+ */
+export function compileRedirectRules(
+  rules: RedirectRule[]
+): (pathname: string) => RedirectMatch | null {
+  const compiled = rules.map(compileRule)
+
+  return (pathname: string) => {
+    for (const { rule, test } of compiled) {
+      if (!test) continue
+      const result = test(pathname)
+      if (!result) continue
+
+      const params = result.params as Record<string, string | string[]>
+      const hasParams = Object.keys(params).length > 0
+      if (!hasParams) {
+        return { source: rule.source, destination: rule.destination, permanent: rule.permanent }
+      }
+
+      // Only reached for a dynamic source (e.g. `:match*`) that captured
+      // segments to substitute into the destination. Most destinations in
+      // this file are plain paths, so `compile()` accepts them — but a few
+      // are absolute URLs or contain a literal query string, which
+      // path-to-regexp can't parse as a template. Treat those as no match
+      // rather than guess at a substitution.
+      try {
+        const destination = compile(rule.destination, { encode: encodeURIComponent })(params)
+        return { source: rule.source, destination, permanent: rule.permanent }
+      } catch {
+        continue
+      }
+    }
+    return null
+  }
+}
+
+let defaultMatcher: ((pathname: string) => RedirectMatch | null) | null = null
+
+/** Looks a path up in the real apps/www/lib/redirects.js, compiling it once. */
+export function findRedirect(pathname: string): RedirectMatch | null {
+  if (!defaultMatcher) defaultMatcher = compileRedirectRules(loadWwwRedirects())
+  return defaultMatcher(pathname)
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2027,6 +2027,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 22.13.14
+      path-to-regexp:
+        specifier: ^6.3.0
+        version: 6.3.0
 
   e2e/studio:
     dependencies:
@@ -10253,6 +10256,7 @@ packages:
   cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
     engines: {node: '>=12.0.0'}
+    deprecated: v4 is no longer maintained, upgrade to v5
 
   croner@10.0.1:
     resolution: {integrity: sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==}


### PR DESCRIPTION
Fixes [DOCS-1271](https://linear.app/supabase/issue/DOCS-1271/make-docs-e2e-link-failures-redirect-aware-and-actionable).

## Problem

A docs preview never serves `apps/www/lib/redirects.js`. Production does. So a link that resolves through a redirect fails on a preview and passes on supabase.com.

The failure said only `should resolve (status 404)`. That leaves the author to work out whether the target moved or the link is simply wrong.

## Solution

On failure, look the path up in `apps/www/lib/redirects.js`. When a redirect covers it, add the redirect and the destination to link to instead:

```
/docs/guides/database/data-api should resolve (status 404)

This link is a redirect: /docs/guides/database/data-api → /docs/guides/api/securing-your-api
Docs previews do not serve apps/www/lib/redirects.js, so it fails here even
though it works on supabase.com.

Fix: change the link to /docs/guides/api/securing-your-api.
```

A link with no redirect is just broken, so its message is unchanged. The link still fails either way.

## Manual Testing

1. Run `pnpm -C e2e/docs test`. Expect `11 pass`.
2. Run the command below. `/docs/guides/database/data-api` is a real entry in `apps/www/lib/redirects.js`. Expect the message above.

   ```bash
   cd e2e/docs
   node --experimental-strip-types -e "
   import { formatLinkFailure } from './utils/docs-links.ts'
   console.log(formatLinkFailure({
     url: 'https://docs-preview.vercel.app/docs/guides/database/data-api',
     status: 404,
   }))
   "
   ```

3. Run the same command with the path changed to `/docs/guides/does-not-exist`. Expect one line, with no redirect section.
4. Run `PLAYWRIGHT_BASE_URL=https://supabase.com DOCS_E2E_PAGE_PATHS=/docs/guides/cli pnpm -C e2e/docs exec playwright test --grep-invert @a11y --reporter=list`. Expect `2 passed`.

`Docs E2E` skips on this pull request. It only maps content changes to pages, and this pull request changes none.
