### PR TITLE
fix(studio): add accessible names to storage file picker header controls

### DIFF
--- a/apps/studio/components/interfaces/Storage/BucketFilePickerDialog/BucketFilePickerHeader.tsx
+++ b/apps/studio/components/interfaces/Storage/BucketFilePickerDialog/BucketFilePickerHeader.tsx
@@ -217,6 +217,7 @@ export const BucketFilePickerHeader = () => {
             {breadcrumbs.length > 0 && (
               <>
                 <Button
+                  aria-label="Go to parent folder"
                   icon={<ArrowLeft size={16} strokeWidth={2} />}
                   size="tiny"
                   variant="text"
@@ -314,7 +315,13 @@ export const BucketFilePickerHeader = () => {
             <div className="h-6 shrink-0 border-r border-control" />
             <div className="flex shrink-0 items-center space-x-1 px-2">
               <div className="hidden">
-                <input ref={uploadButtonRef} type="file" multiple onChange={handleFilesUpload} />
+                <input
+                  ref={uploadButtonRef}
+                  aria-label="Upload files"
+                  type="file"
+                  multiple
+                  onChange={handleFilesUpload}
+                />
               </div>
               <ButtonTooltip
                 icon={<Upload size={16} strokeWidth={2} />}
@@ -346,6 +353,7 @@ export const BucketFilePickerHeader = () => {
                   actions={[
                     <Button
                       key="cancel"
+                      aria-label="Clear search"
                       size="tiny"
                       variant="text"
                       icon={<X />}
@@ -360,6 +368,7 @@ export const BucketFilePickerHeader = () => {
                 />
               ) : (
                 <Button
+                  aria-label="Search for a file or folder"
                   icon={<Search />}
                   size="tiny"
                   variant="text"


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix (accessibility).

## What is the current behavior?

Three icon-only controls in the bucket file picker header have no accessible name.
A screen reader announces each one as just "button", with nothing to tell them apart:
the back button, the clear search button, and the button that opens search. The
hidden file input used for uploads is also unlabeled.

To reproduce: open a project, go to Storage, open a bucket, open the file picker
dialog, and read the header with VoiceOver or NVDA.

This fails WCAG 4.1.2 Name, Role, Value (Level A). ESLint already flags it:
`jsx-a11y/control-has-associated-label` reports 4 warnings on this file.

## What is the new behavior?

Each control gets an `aria-label`:

| Control | Label |
| ------- | ----- |
| `ArrowLeft` | `Go to parent folder` |
| `X` | `Clear search` |
| `Search` | `Search for a file or folder` |
| hidden file input | `Upload files` |

Warnings on this file go from 4 to 0. Across Studio,
`jsx-a11y/control-has-associated-label` goes from 228 to 224 against a baseline
of 248.

No visual change. Only `aria-label` attributes were added.

## Additional context

No new test. The rule is already in `apps/studio/scripts/ratchet-rules.json`, so CI
fails if these regress.

Two things worth a reviewer's opinion:

- The label on the hidden file input is inert. That input sits inside a `display: none`
  wrapper, so it never reaches the accessibility tree, and the visible upload button
  next to it already has a name. It is there to satisfy the lint rule. Happy to drop it
  and leave that one warning if you would rather not carry a no-op attribute.
- `Search for a file or folder` describes the field the button opens, not the button.
  Plain `Search` may read better. I matched the search input's placeholder for
  consistency, but I do not feel strongly.
