### PR TITLE
docs(auth): handle incoming deep link URLs on Swift

### DIFF
--- a/apps/docs/content/guides/auth/native-mobile-deep-linking.mdx
+++ b/apps/docs/content/guides/auth/native-mobile-deep-linking.mdx
@@ -345,11 +345,13 @@ With Deep Linking, you can configure this redirect to open a specific page. This
       </plist>
     ```
 
-    ### Handling the incoming URL
+### Handling the incoming URL
 
     Once the OS opens your app via the redirect URL, pass that URL to `supabase.auth.handle(_:)` to complete the sign-in.
 
-    For a SwiftUI app, use the `onOpenURL` view modifier on your root view:
+    #### SwiftUI
+
+    Use the `onOpenURL` view modifier on your root view:
 
     ```swift
     SomeView()
@@ -358,7 +360,9 @@ With Deep Linking, you can configure this redirect to open a specific page. This
       }
     ```
 
-    For a UIKit app using the app delegate lifecycle, forward the URL from `application(_:open:options:)` (and from `didFinishLaunchingWithOptions` if the app was launched cold via the link):
+    #### UIKit: App delegate
+
+    Forward the URL from `application(_:open:options:)`, and from `didFinishLaunchingWithOptions` if the app was launched cold via the link:
 
     ```swift
     func application(
@@ -382,9 +386,21 @@ With Deep Linking, you can configure this redirect to open a specific page. This
     }
     ```
 
-    For a UIKit app using the scene delegate lifecycle, forward the URL from `SceneDelegate.swift`:
+    #### UIKit: Scene delegate
+
+    Forward the URL from `SceneDelegate.swift`, handling both a cold launch (via `scene(_:willConnectTo:options:)`) and a URL received while the scene is already running (via `scene(_:openURLContexts:)`):
 
     ```swift
+    func scene(
+      _ scene: UIScene,
+      willConnectTo session: UISceneSession,
+      options connectionOptions: UIScene.ConnectionOptions
+    ) {
+      for context in connectionOptions.urlContexts {
+        supabase.auth.handle(context.url)
+      }
+    }
+
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
       guard let url = URLContexts.first?.url else { return }
       supabase.auth.handle(url)

--- a/apps/docs/content/guides/auth/native-mobile-deep-linking.mdx
+++ b/apps/docs/content/guides/auth/native-mobile-deep-linking.mdx
@@ -345,6 +345,54 @@ With Deep Linking, you can configure this redirect to open a specific page. This
       </plist>
     ```
 
+    ### Handling the incoming URL
+
+    Once the OS opens your app via the redirect URL, pass that URL to `supabase.auth.handle(_:)` to complete the sign-in.
+
+    For a SwiftUI app, use the `onOpenURL` view modifier on your root view:
+
+    ```swift
+    SomeView()
+      .onOpenURL { url in
+        supabase.auth.handle(url)
+      }
+    ```
+
+    For a UIKit app using the app delegate lifecycle, forward the URL from `application(_:open:options:)` (and from `didFinishLaunchingWithOptions` if the app was launched cold via the link):
+
+    ```swift
+    func application(
+      _ application: UIApplication,
+      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+    ) -> Bool {
+      if let url = launchOptions?[.url] as? URL {
+        supabase.auth.handle(url)
+      }
+
+      return true
+    }
+
+    func application(
+      _ app: UIApplication,
+      open url: URL,
+      options: [UIApplication.OpenURLOptionsKey: Any]
+    ) -> Bool {
+      supabase.auth.handle(url)
+      return true
+    }
+    ```
+
+    For a UIKit app using the scene delegate lifecycle, forward the URL from `SceneDelegate.swift`:
+
+    ```swift
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+      guard let url = URLContexts.first?.url else { return }
+      supabase.auth.handle(url)
+    }
+    ```
+
+    `handle(_:)` is a convenience wrapper that calls `session(from:)` and logs any error. See the [Auth API reference](/docs/reference/swift/auth-api) for details, or call `session(from:)` directly if you need the returned `Session` or want control over error handling.
+
     <$Partial path="universal_links_apple.mdx" />
 
   </TabPanel>

--- a/apps/docs/content/guides/getting-started/tutorials/with-swift.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-swift.mdx
@@ -93,7 +93,13 @@ struct AuthView: View {
       }
     }
     .onOpenURL(perform: { url in
-      supabase.auth.handle(url)
+      Task {
+        do {
+          try await supabase.auth.session(from: url)
+        } catch {
+          self.result = .failure(error)
+        }
+      }
     })
   }
 

--- a/apps/docs/content/guides/getting-started/tutorials/with-swift.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-swift.mdx
@@ -93,13 +93,7 @@ struct AuthView: View {
       }
     }
     .onOpenURL(perform: { url in
-      Task {
-        do {
-          try await supabase.auth.session(from: url)
-        } catch {
-          self.result = .failure(error)
-        }
-      }
+      supabase.auth.handle(url)
     })
   }
 

--- a/supa-mdx-lint/Rule003Spelling.toml
+++ b/supa-mdx-lint/Rule003Spelling.toml
@@ -419,6 +419,7 @@ allow_list = [
     "Transformers.js",
     "tsquery",
     "Twilio",
+    "UIKit",
     "Undici",
     "UnionPay",
     "Unsplash",


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update.

## What is the current behavior?

The Swift tab in the [Native Mobile Deep Linking guide](https://supabase.com/docs/guides/auth/native-mobile-deep-linking?platform=swift) only covers registering a custom URL scheme (Info.plist config). Unlike the React Native, Flutter, and Kotlin tabs, it never shows the runtime code that actually consumes the incoming URL and completes the sign-in, so a Swift developer following the guide is left without a working implementation.

Linear: [SDK-83](https://linear.app/supabase/issue/SDK-83/swift-improve-docs-on-how-to-handle-deep-link-url)

## What is the new behavior?

Added a "Handling the incoming URL" section to the Swift tab with:
- SwiftUI: `onOpenURL` calling `supabase.auth.handle(url)`
- UIKit app delegate lifecycle: `application(_:didFinishLaunchingWithOptions:)` and `application(_:open:options:)`
- UIKit scene delegate lifecycle: `scene(_:openURLContexts:)`
- A note pointing to `session(from:)` for callers that need the returned `Session` or custom error handling

`handle(url)` and its usage patterns match the current `supabase-swift` reference spec (`supabase_swift_v2.yml`) and source.

Also added `UIKit` to the docs spelling allowlist (`supa-mdx-lint/Rule003Spelling.toml`) since it isn't in the dictionary.

## Additional context

`pnpm lint:mdx` passes on the changed file. `pnpm build:guides-markdown` fails, but on a pre-existing unrelated issue (missing generated `database-advisors.json`), not on this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Swift guidance for handling authentication deep links in SwiftUI and UIKit apps.
  * Documented deep-link delivery during cold launches and through scene delegates.
  * Clarified when to use authentication link handling versus direct session retrieval.
* **Chores**
  * Updated spelling validation to recognize UIKit terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->