### PR TITLE
docs: fix broken Swift example in joins-and-nesting guide

### DIFF
--- a/apps/docs/content/guides/database/joins-and-nesting.mdx
+++ b/apps/docs/content/guides/database/joins-and-nesting.mdx
@@ -920,7 +920,8 @@ struct Shift: Codable {
   let userId: Int
   let attendanceStatus: String?
 
-  let scans: [Scan]
+  let startScan: Scan
+  let endScan: Scan
 
   struct Scan: Codable {
     let id: Int
@@ -938,6 +939,8 @@ struct Shift: Codable {
     case id
     case userId = "user_id"
     case attendanceStatus = "attendance_status"
+    case startScan = "start_scan"
+    case endScan = "end_scan"
   }
 }
 
@@ -951,11 +954,11 @@ let shifts: [Shift] = try await supabase
         user_id,
         badge_scan_time
       ),
-     scans: scan_id_end (
+      end_scan:scans!scan_id_end (
         id,
         user_id,
         badge_scan_time
-     )
+      )
     """
   )
   .execute()


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs fix.

## What is the current behavior?

Fixes [SDK-958](https://linear.app/supabase/issue/SDK-958/docs-incomplete-documentation), reported via the docs feedback widget on [joins-and-nesting](https://supabase.com/docs/guides/database/joins-and-nesting).

In the "Specifying the `ON` clause for joins with multiple foreign keys" section, the Swift example was broken relative to the other language tabs (JS, Dart, Kotlin, Python, C#):

- The query string aliased the second embed as `scans: scan_id_end`, which isn't valid PostgREST embed syntax (should be `end_scan:scans!scan_id_end`).
- The `Shift` struct only declared a single `scans: [Scan]` property with no `CodingKeys` entry for `start_scan` or `end_scan` — so it never actually decoded either aliased relation, which is why the reporter couldn't tell where `start_scan` was supposed to come from.

## What is the new behavior?

- Query now aliases both relations consistently: `start_scan:scans!scan_id_start (...)` and `end_scan:scans!scan_id_end (...)`, matching the other language examples.
- `Shift` struct now declares `startScan: Scan` and `endScan: Scan`, mapped via `CodingKeys` to `start_scan` and `end_scan`.

## Additional context

Docs-only change to a code sample inside `apps/docs/content/guides/database/joins-and-nesting.mdx`. Verified with `prettier --check` (mdx lint tool failed locally due to an unrelated missing native module, `node-pty`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Swift join example to represent separate start and end scan relationships.
  * Revised response field selections and coding keys to match the updated relationship names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->