### PR TITLE
feat(www): update Partner Day at Select 2026 go page copy

### DIFF
--- a/apps/www/_go/events/select-2026/partner-day.tsx
+++ b/apps/www/_go/events/select-2026/partner-day.tsx
@@ -61,10 +61,13 @@ const page: GoPageInput = {
         <div className="flex flex-col items-center gap-2 text-foreground-light">
           <p className="text-lg font-medium text-foreground">Date</p>
           <p>October 1, 2026</p>
+          <p className="text-sm text-foreground-lighter italic">
+            The day before Supabase Select 2026
+          </p>
           <p className="mt-4 text-lg font-medium text-foreground">Location</p>
           <p>San Francisco, CA</p>
           <p className="text-sm text-foreground-lighter italic">
-            venue details will be shared soon
+            Venue details will be shared soon
           </p>
           <p className="mt-4 text-lg font-medium text-foreground">Time</p>
           <p>Doors open at 2:30 PM</p>
@@ -150,7 +153,8 @@ const page: GoPageInput = {
         {
           type: 'select',
           name: 'attending',
-          label: 'Are you attending Select 2026?',
+          label:
+            'Are you attending Supabase Select on October 2? (your Partner Day invite covers it)',
           placeholder: 'Select an option',
           required: true,
           options: [


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Content update (marketing copy) for the `www` app.

## What is the current behavior?

`/go/select-2026/partner-day` copy is a couple of revisions behind the latest Notion draft (see #48771 and #48773 for prior rounds).

## What is the new behavior?

Updates the page copy to match the newest draft.

## Additional context

- Verified locally in the browser against the Notion copy doc, word-for-word.
- `prettier --check` passes on the changed file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Clarified Partner Day event details, including the day-before-Select note.
  * Improved venue information messaging.
  * Updated the RSVP question to reference Select on October 2 and the Partner Day invitation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->