### PR TITLE
feat(studio): migrate API and Storage reports to ClickHouse OTEL logs

### DIFF
--- a/apps/studio/components/interfaces/Reports/Reports.constants.otel.test.ts
+++ b/apps/studio/components/interfaces/Reports/Reports.constants.otel.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest'
+
+import { generateOtelWhereSafe, PRESET_CONFIG } from './Reports.constants'
+import { Presets } from './Reports.types'
+import type { ReportFilterItem, ReportQueryLogs } from './Reports.types'
+
+const sql = (fragment: { toString(): string }) => String(fragment)
+const apiQueries = PRESET_CONFIG[Presets.API].queries as Record<
+  | 'totalRequests'
+  | 'topRoutes'
+  | 'errorCounts'
+  | 'topErrorRoutes'
+  | 'responseSpeed'
+  | 'topSlowRoutes'
+  | 'networkTraffic'
+  | 'requestsByCountry',
+  ReportQueryLogs
+>
+const storageQueries = PRESET_CONFIG[Presets.STORAGE].queries as Record<
+  'cacheHitRate' | 'topCacheMisses',
+  ReportQueryLogs
+>
+
+describe('generateOtelWhereSafe', () => {
+  it('should return empty fragment when no filters provided', () => {
+    expect(generateOtelWhereSafe([])).toBe('')
+  })
+
+  it('should generate a WHERE clause keyed by the full dotted log_attributes path', () => {
+    const filters: ReportFilterItem[] = [
+      { key: 'request.path', value: '/api/users', compare: 'is' },
+    ]
+    expect(generateOtelWhereSafe(filters, true)).toBe(
+      "WHERE log_attributes['request.path'] = '/api/users'"
+    )
+  })
+
+  it('should translate a numeric comparison filter using toInt64OrZero', () => {
+    const filters: ReportFilterItem[] = [{ key: 'response.status_code', value: 500, compare: '>=' }]
+    expect(generateOtelWhereSafe(filters, true)).toBe(
+      "WHERE toInt64OrZero(log_attributes['response.status_code']) >= 500"
+    )
+  })
+
+  it('should drop a numeric comparison filter with a non-numeric value instead of coercing it', () => {
+    const filters: ReportFilterItem[] = [
+      { key: 'response.status_code', value: 'not-a-number', compare: '>=' },
+    ]
+    expect(generateOtelWhereSafe(filters, true)).toBe('')
+  })
+
+  it('should generate an AND clause with prepend=false, for appending after an existing WHERE', () => {
+    const filters: ReportFilterItem[] = [{ key: 'request.method', value: 'GET', compare: 'is' }]
+    expect(generateOtelWhereSafe(filters, false)).toBe(
+      "AND log_attributes['request.method'] = 'GET'"
+    )
+  })
+})
+
+describe('PRESET_CONFIG.api safeSqlOtel', () => {
+  it('queries the single OTEL logs table by source, never a per-service table', () => {
+    const out = sql(apiQueries.totalRequests.safeSqlOtel!([]))
+
+    expect(out).toContain('from logs')
+    expect(out).toContain("where source = 'edge_logs'")
+    expect(out).not.toContain('from edge_logs')
+    expect(out).not.toContain('cross join unnest')
+  })
+
+  it('emits 16-digit unix-microsecond timestamps bucketed by hour', () => {
+    expect(sql(apiQueries.totalRequests.safeSqlOtel!([]))).toContain(
+      'toUnixTimestamp(toStartOfHour(timestamp)) * 1000000 as timestamp'
+    )
+  })
+
+  it('reads route dimensions from log_attributes for topRoutes', () => {
+    const out = sql(apiQueries.topRoutes.safeSqlOtel!([]))
+
+    expect(out).toContain("log_attributes['request.path'] as path")
+    expect(out).toContain("log_attributes['request.method'] as method")
+    expect(out).toContain("log_attributes['request.search'] as search")
+    expect(out).toContain("toInt32OrZero(log_attributes['response.status_code']) as status_code")
+  })
+
+  it('filters errorCounts/topErrorRoutes to status codes >= 400', () => {
+    expect(sql(apiQueries.errorCounts.safeSqlOtel!([]))).toContain(
+      "toInt32OrZero(log_attributes['response.status_code']) >= 400"
+    )
+    expect(sql(apiQueries.topErrorRoutes.safeSqlOtel!([]))).toContain(
+      "toInt32OrZero(log_attributes['response.status_code']) >= 400"
+    )
+  })
+
+  it('averages response.origin_time for responseSpeed/topSlowRoutes', () => {
+    expect(sql(apiQueries.responseSpeed.safeSqlOtel!([]))).toContain(
+      "avg(toFloat64OrZero(log_attributes['response.origin_time'])) as avg"
+    )
+    expect(sql(apiQueries.topSlowRoutes.safeSqlOtel!([]))).toContain(
+      "avg(toFloat64OrZero(log_attributes['response.origin_time'])) as avg"
+    )
+  })
+
+  it('sums request/response content_length headers for networkTraffic', () => {
+    const out = sql(apiQueries.networkTraffic.safeSqlOtel!([]))
+    expect(out).toContain(
+      "sum(toInt64OrZero(log_attributes['request.headers.content_length'])) / 1000000 as ingress_mb"
+    )
+    expect(out).toContain(
+      "sum(toInt64OrZero(log_attributes['response.headers.content_length'])) / 1000000 as egress_mb"
+    )
+  })
+
+  it('reads the country from request.cf.country and excludes empty values for requestsByCountry', () => {
+    const out = sql(apiQueries.requestsByCountry.safeSqlOtel!([]))
+    expect(out).toContain("log_attributes['request.cf.country'] as country")
+    expect(out).toContain("log_attributes['request.cf.country'] != ''")
+  })
+
+  it('applies caller-provided filters via generateOtelWhereSafe', () => {
+    const out = sql(
+      apiQueries.totalRequests.safeSqlOtel!([
+        { key: 'request.method', value: 'GET', compare: 'is' },
+      ])
+    )
+    expect(out).toContain("log_attributes['request.method'] = 'GET'")
+  })
+})
+
+describe('PRESET_CONFIG.storage safeSqlOtel', () => {
+  it('scopes cacheHitRate to storage object requests on the single OTEL logs table', () => {
+    const out = sql(storageQueries.cacheHitRate.safeSqlOtel!([]))
+
+    expect(out).toContain('from logs')
+    expect(out).toContain("where source = 'edge_logs'")
+    expect(out).toContain("log_attributes['request.path'] like '/storage/v1/object%'")
+    expect(out).toContain("log_attributes['request.method'] = 'GET'")
+    expect(out).not.toContain('cross join unnest')
+  })
+
+  it('buckets cf_cache_status into hit_count/miss_count via countIf', () => {
+    const out = sql(storageQueries.cacheHitRate.safeSqlOtel!([]))
+
+    expect(out).toContain(
+      "countIf(log_attributes['response.headers.cf_cache_status'] in ('HIT', 'STALE', 'REVALIDATED', 'UPDATING')) as hit_count"
+    )
+    expect(out).toContain(
+      "countIf(log_attributes['response.headers.cf_cache_status'] in ('MISS', 'NONE/UNKNOWN', 'EXPIRED', 'BYPASS', 'DYNAMIC')) as miss_count"
+    )
+  })
+
+  it('reads path/search dimensions from log_attributes for topCacheMisses', () => {
+    const out = sql(storageQueries.topCacheMisses.safeSqlOtel!([]))
+
+    expect(out).toContain('from logs')
+    expect(out).toContain("where source = 'edge_logs'")
+    expect(out).toContain("log_attributes['request.path'] as path")
+    expect(out).toContain("log_attributes['request.search'] as search")
+    expect(out).toContain('count() as count')
+    expect(out).toContain('limit 12')
+  })
+
+  it('filters topCacheMisses to miss statuses only', () => {
+    const out = sql(storageQueries.topCacheMisses.safeSqlOtel!([]))
+    expect(out).toContain(
+      "log_attributes['response.headers.cf_cache_status'] in ('MISS', 'NONE/UNKNOWN', 'EXPIRED', 'BYPASS', 'DYNAMIC')"
+    )
+  })
+})

--- a/apps/studio/components/interfaces/Reports/Reports.constants.ts
+++ b/apps/studio/components/interfaces/Reports/Reports.constants.ts
@@ -143,6 +143,86 @@ export function generateRegexpWhereSafe(
   return prepend ? safeLogSql`WHERE ${joined}` : safeLogSql`AND ${joined}`
 }
 
+// Key is used as-is here: log_attributes is keyed by the full dotted path, unlike the BigQuery unnest above.
+export function generateOtelWhereSafe(
+  filters: ReportFilterItem[],
+  prepend = true
+): SafeLogSqlFragment {
+  if (filters.length === 0) return safeLogSql``
+
+  const conditions = filters
+    .map((filter) => {
+      const col = safeLogSql`log_attributes[${analyticsLiteral(filter.key)}]`
+
+      const valueIsNumber = !isNaN(Number(filter.value))
+      const stringLit = analyticsLiteral(String(filter.value))
+
+      switch (filter.compare) {
+        case 'matches':
+          return safeLogSql`match(${col}, ${stringLit})`
+        case 'is':
+          return safeLogSql`${col} = ${stringLit}`
+        case '!=':
+          return safeLogSql`${col} != ${stringLit}`
+        case '>=':
+        case '<=':
+        case '>':
+        case '<': {
+          // Dropped, not coerced: toInt64OrZero(non-numeric) silently becomes 0, which is worse than a no-op.
+          if (!valueIsNumber) return null
+          const num = analyticsLiteral(Number(filter.value))
+          const lhs = safeLogSql`toInt64OrZero(${col})`
+          if (filter.compare === '>=') return safeLogSql`${lhs} >= ${num}`
+          if (filter.compare === '<=') return safeLogSql`${lhs} <= ${num}`
+          if (filter.compare === '>') return safeLogSql`${lhs} > ${num}`
+          return safeLogSql`${lhs} < ${num}`
+        }
+        default:
+          return safeLogSql`${col} = ${stringLit}`
+      }
+    })
+    .filter((c) => c !== null)
+
+  if (conditions.length === 0) return safeLogSql``
+
+  const joined = joinSqlFragments(conditions, ' AND ')
+  return prepend ? safeLogSql`WHERE ${joined}` : safeLogSql`AND ${joined}`
+}
+
+// fillTimeseries/isUnixMicro expects a 16-digit unix-microsecond timestamp, matching BigQuery's timestamp_trunc.
+const OTEL_TIMESTAMP: SafeLogSqlFragment = safeLogSql`toUnixTimestamp(toStartOfHour(timestamp)) * 1000000`
+
+function otelWhere(filters: ReportFilterItem[], extra?: SafeLogSqlFragment): SafeLogSqlFragment {
+  const base = extra
+    ? safeLogSql`where source = 'edge_logs' and ${extra}`
+    : safeLogSql`where source = 'edge_logs'`
+  if (filters.length === 0) return base
+  return safeLogSql`${base} ${generateOtelWhereSafe(filters, false)}`
+}
+
+const OTEL_STATUS_CODE: SafeLogSqlFragment = safeLogSql`toInt32OrZero(log_attributes['response.status_code'])`
+const OTEL_ROUTE_SELECT: SafeLogSqlFragment = safeLogSql`
+  log_attributes['request.path'] as path,
+  log_attributes['request.method'] as method,
+  log_attributes['request.search'] as search,
+  ${OTEL_STATUS_CODE} as status_code`
+const OTEL_ROUTE_GROUP_BY: SafeLogSqlFragment = safeLogSql`log_attributes['request.path'], log_attributes['request.method'], log_attributes['request.search'], ${OTEL_STATUS_CODE}`
+const OTEL_STATUS_IS_ERROR: SafeLogSqlFragment = safeLogSql`${OTEL_STATUS_CODE} >= 400`
+const OTEL_ORIGIN_TIME: SafeLogSqlFragment = safeLogSql`toFloat64OrZero(log_attributes['response.origin_time'])`
+
+function statusInListLiteral(statuses: string[]): SafeLogSqlFragment {
+  return safeLogSql`(${joinSqlFragments(statuses.map(analyticsLiteral), ', ')})`
+}
+
+const STORAGE_CACHE_HIT_STATUSES = statusInListLiteral(['HIT', 'STALE', 'REVALIDATED', 'UPDATING'])
+const STORAGE_CACHE_MISS_STATUSES = statusInListLiteral([
+  'MISS',
+  'NONE/UNKNOWN',
+  'EXPIRED',
+  'BYPASS',
+  'DYNAMIC',
+])
+
 export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
   [Presets.API]: {
     title: 'API',
@@ -164,6 +244,13 @@ export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
           timestamp
         ORDER BY
           timestamp ASC`,
+        safeSqlOtel: (filters) => safeLogSql`
+        -- reports-api-total-requests (otel)
+        select ${OTEL_TIMESTAMP} as timestamp, count() as count
+        from logs
+        ${otelWhere(filters)}
+        group by timestamp
+        order by timestamp asc`,
       },
       topRoutes: {
         queryType: 'logs',
@@ -187,6 +274,14 @@ export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
           count desc
         limit 10
         `,
+        safeSqlOtel: (filters) => safeLogSql`
+        -- reports-api-top-routes (otel)
+        select ${OTEL_ROUTE_SELECT}, count() as count
+        from logs
+        ${otelWhere(filters)}
+        group by ${OTEL_ROUTE_GROUP_BY}
+        order by count desc
+        limit 10`,
       },
       errorCounts: {
         queryType: 'logs',
@@ -208,6 +303,13 @@ export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
         ORDER BY
           timestamp ASC
         `,
+        safeSqlOtel: (filters) => safeLogSql`
+        -- reports-api-error-counts (otel)
+        select ${OTEL_TIMESTAMP} as timestamp, count() as count
+        from logs
+        ${otelWhere(filters, OTEL_STATUS_IS_ERROR)}
+        group by timestamp
+        order by timestamp asc`,
       },
       topErrorRoutes: {
         queryType: 'logs',
@@ -233,6 +335,14 @@ export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
           count desc
         limit 10
         `,
+        safeSqlOtel: (filters) => safeLogSql`
+        -- reports-api-top-error-routes (otel)
+        select ${OTEL_ROUTE_SELECT}, count() as count
+        from logs
+        ${otelWhere(filters, OTEL_STATUS_IS_ERROR)}
+        group by ${OTEL_ROUTE_GROUP_BY}
+        order by count desc
+        limit 10`,
       },
       responseSpeed: {
         queryType: 'logs',
@@ -253,6 +363,13 @@ export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
         ORDER BY
           timestamp ASC
       `,
+        safeSqlOtel: (filters) => safeLogSql`
+        -- reports-api-response-speed (otel)
+        select ${OTEL_TIMESTAMP} as timestamp, avg(${OTEL_ORIGIN_TIME}) as avg
+        from logs
+        ${otelWhere(filters)}
+        group by timestamp
+        order by timestamp asc`,
       },
       topSlowRoutes: {
         queryType: 'logs',
@@ -277,6 +394,14 @@ export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
           avg desc
         limit 10
         `,
+        safeSqlOtel: (filters) => safeLogSql`
+        -- reports-api-top-slow-routes (otel)
+        select ${OTEL_ROUTE_SELECT}, count() as count, avg(${OTEL_ORIGIN_TIME}) as avg
+        from logs
+        ${otelWhere(filters)}
+        group by ${OTEL_ROUTE_GROUP_BY}
+        order by avg desc
+        limit 10`,
       },
       networkTraffic: {
         queryType: 'logs',
@@ -315,6 +440,16 @@ export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
         ORDER BY
           timestamp ASC
         `,
+        safeSqlOtel: (filters) => safeLogSql`
+        -- reports-api-network-traffic (otel)
+        select
+          ${OTEL_TIMESTAMP} as timestamp,
+          sum(toInt64OrZero(log_attributes['request.headers.content_length'])) / 1000000 as ingress_mb,
+          sum(toInt64OrZero(log_attributes['response.headers.content_length'])) / 1000000 as egress_mb
+        from logs
+        ${otelWhere(filters)}
+        group by timestamp
+        order by timestamp asc`,
       },
       requestsByCountry: {
         queryType: 'logs',
@@ -335,6 +470,15 @@ export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
         group by
           cf.country
         `,
+        safeSqlOtel: (filters) => safeLogSql`
+        -- reports-api-requests-by-country (otel)
+        select
+          log_attributes['request.cf.country'] as country,
+          count() as count
+        from logs
+        ${otelWhere(filters, safeLogSql`log_attributes['request.cf.country'] != ''`)}
+        group by
+          country`,
       },
     },
   },
@@ -364,6 +508,19 @@ where starts_with(r.path, '/storage/v1/object') and r.method = 'GET'
 group by timestamp
 order by timestamp desc
 `,
+        safeSqlOtel: (filters) => safeLogSql`
+        -- reports-storage-cache-hit-rate (otel)
+select
+  ${OTEL_TIMESTAMP} as timestamp,
+  countIf(log_attributes['response.headers.cf_cache_status'] in ${STORAGE_CACHE_HIT_STATUSES}) as hit_count,
+  countIf(log_attributes['response.headers.cf_cache_status'] in ${STORAGE_CACHE_MISS_STATUSES}) as miss_count
+from logs
+where source = 'edge_logs'
+  and log_attributes['request.path'] like '/storage/v1/object%'
+  and log_attributes['request.method'] = 'GET'
+  ${generateOtelWhereSafe(filters, false)}
+group by timestamp
+order by timestamp desc`,
       },
       topCacheMisses: {
         queryType: 'logs',
@@ -387,6 +544,21 @@ group by path, search
 order by count desc
 limit 12
     `,
+        safeSqlOtel: (filters) => safeLogSql`
+        -- reports-storage-top-cache-misses (otel)
+select
+  log_attributes['request.path'] as path,
+  log_attributes['request.search'] as search,
+  count() as count
+from logs
+where source = 'edge_logs'
+  and log_attributes['request.path'] like '/storage/v1/object%'
+  and log_attributes['request.method'] = 'GET'
+  and log_attributes['response.headers.cf_cache_status'] in ${STORAGE_CACHE_MISS_STATUSES}
+  ${generateOtelWhereSafe(filters, false)}
+group by path, search
+order by count desc
+limit 12`,
       },
     },
   },

--- a/apps/studio/components/interfaces/Reports/Reports.types.ts
+++ b/apps/studio/components/interfaces/Reports/Reports.types.ts
@@ -33,6 +33,7 @@ export interface ReportQueryLogs {
     page?: number,
     pageSize?: number
   ) => SafeLogSqlFragment
+  safeSqlOtel?: (filters: ReportFilterItem[]) => SafeLogSqlFragment
 }
 
 export interface ReportQueryDb {

--- a/apps/studio/components/interfaces/Reports/Reports.utils.tsx
+++ b/apps/studio/components/interfaces/Reports/Reports.utils.tsx
@@ -47,7 +47,8 @@ type PresetHooks = Record<keyof PresetConfig['queries'], () => PresetHookResult>
  */
 export const queriesFactory = <T extends string>(
   queries: BaseQueries<T>,
-  projectRef: string
+  projectRef: string,
+  useOtel = false
 ): PresetHooks => {
   const hooks: PresetHooks = Object.entries<ReportQuery>(queries).reduce((acc, [k, query]) => {
     if (query.queryType === 'db') {
@@ -58,16 +59,23 @@ export const queriesFactory = <T extends string>(
     } else {
       return {
         ...acc,
-        [k]: () => useLogsQuery({ projectRef }),
+        [k]: () => useLogsQuery({ projectRef, options: { useOtel } }),
       }
     }
   }, {})
   return hooks
 }
 
-export function getLogsSql(query: ReportQuery, filters: ReportFilterItem[]): SafeLogSqlFragment {
+export function getLogsSql(
+  query: ReportQuery,
+  filters: ReportFilterItem[],
+  useOtel = false
+): SafeLogSqlFragment {
   if (query.queryType !== 'logs') {
     throw new Error(`Expected logs query, got ${query.queryType}`)
+  }
+  if (useOtel && query.safeSqlOtel) {
+    return query.safeSqlOtel(filters)
   }
   return query.safeSql(filters)
 }

--- a/apps/studio/data/reports/api-report-query.ts
+++ b/apps/studio/data/reports/api-report-query.ts
@@ -1,4 +1,4 @@
-import { useParams } from 'common'
+import { useFlag, useParams } from 'common'
 import { isEqual } from 'lodash'
 import { useEffect, useState } from 'react'
 
@@ -11,13 +11,15 @@ import { useDatabaseSelectorStateSnapshot } from '@/state/database-selector'
 export const useApiReport = () => {
   const { ref: projectRef } = useParams()
   const state = useDatabaseSelectorStateSnapshot()
+  const useOtel = useFlag('otelReports')
 
   const identifier = state.selectedDatabaseId
   const [filters, setFilters] = useState<ReportFilterItem[]>([])
 
   const queryHooks = queriesFactory<keyof typeof PRESET_CONFIG.api.queries>(
     PRESET_CONFIG.api.queries,
-    projectRef ?? 'default'
+    projectRef ?? 'default',
+    useOtel
   )
   const totalRequests = queryHooks.totalRequests()
   const topRoutes = queryHooks.topRoutes()
@@ -74,44 +76,48 @@ export const useApiReport = () => {
     // update sql for each query
     if (totalRequests.changeQuery) {
       totalRequests.changeQuery(
-        getLogsSql(PRESET_CONFIG.api.queries.totalRequests, formattedFilters)
+        getLogsSql(PRESET_CONFIG.api.queries.totalRequests, formattedFilters, useOtel)
       )
     }
     if (topRoutes.changeQuery) {
-      topRoutes.changeQuery(getLogsSql(PRESET_CONFIG.api.queries.topRoutes, formattedFilters))
+      topRoutes.changeQuery(
+        getLogsSql(PRESET_CONFIG.api.queries.topRoutes, formattedFilters, useOtel)
+      )
     }
     if (errorCounts.changeQuery) {
-      errorCounts.changeQuery(getLogsSql(PRESET_CONFIG.api.queries.errorCounts, formattedFilters))
+      errorCounts.changeQuery(
+        getLogsSql(PRESET_CONFIG.api.queries.errorCounts, formattedFilters, useOtel)
+      )
     }
 
     if (topErrorRoutes.changeQuery) {
       topErrorRoutes.changeQuery(
-        getLogsSql(PRESET_CONFIG.api.queries.topErrorRoutes, formattedFilters)
+        getLogsSql(PRESET_CONFIG.api.queries.topErrorRoutes, formattedFilters, useOtel)
       )
     }
     if (responseSpeed.changeQuery) {
       responseSpeed.changeQuery(
-        getLogsSql(PRESET_CONFIG.api.queries.responseSpeed, formattedFilters)
+        getLogsSql(PRESET_CONFIG.api.queries.responseSpeed, formattedFilters, useOtel)
       )
     }
 
     if (topSlowRoutes.changeQuery) {
       topSlowRoutes.changeQuery(
-        getLogsSql(PRESET_CONFIG.api.queries.topSlowRoutes, formattedFilters)
+        getLogsSql(PRESET_CONFIG.api.queries.topSlowRoutes, formattedFilters, useOtel)
       )
     }
 
     if (networkTraffic.changeQuery) {
       networkTraffic.changeQuery(
-        getLogsSql(PRESET_CONFIG.api.queries.networkTraffic, formattedFilters)
+        getLogsSql(PRESET_CONFIG.api.queries.networkTraffic, formattedFilters, useOtel)
       )
     }
     if (requestsByCountry.changeQuery) {
       requestsByCountry.changeQuery(
-        getLogsSql(PRESET_CONFIG.api.queries.requestsByCountry, formattedFilters)
+        getLogsSql(PRESET_CONFIG.api.queries.requestsByCountry, formattedFilters, useOtel)
       )
     }
-  }, [JSON.stringify(formattedFilters)])
+  }, [JSON.stringify(formattedFilters), useOtel])
 
   const handleRefresh = async () => {
     activeHooks.forEach((hook) => hook.runQuery())

--- a/apps/studio/data/reports/storage-report-query.ts
+++ b/apps/studio/data/reports/storage-report-query.ts
@@ -1,4 +1,4 @@
-import { useParams } from 'common'
+import { useFlag, useParams } from 'common'
 import isEqual from 'lodash/isEqual'
 import { useEffect, useState } from 'react'
 
@@ -12,16 +12,19 @@ export const useStorageReport = () => {
   const { ref: projectRef } = useParams()
   const [filters, setFilters] = useState<ReportFilterItem[]>([])
   const state = useDatabaseSelectorStateSnapshot()
+  const useOtel = useFlag('otelReports')
 
   const identifier = state.selectedDatabaseId
 
   const queryHooks = queriesFactory<keyof typeof PRESET_CONFIG.api.queries>(
     PRESET_CONFIG.api.queries,
-    projectRef ?? 'default'
+    projectRef ?? 'default',
+    useOtel
   )
   const storageQueryHooks = queriesFactory<keyof typeof PRESET_CONFIG.storage.queries>(
     PRESET_CONFIG.storage.queries,
-    projectRef ?? 'default'
+    projectRef ?? 'default',
+    useOtel
   )
   const totalRequests = queryHooks.totalRequests()
   const topRoutes = queryHooks.topRoutes()
@@ -87,47 +90,53 @@ export const useStorageReport = () => {
   useEffect(() => {
     if (totalRequests.changeQuery) {
       totalRequests.changeQuery(
-        getLogsSql(PRESET_CONFIG.api.queries.totalRequests, formattedFilters)
+        getLogsSql(PRESET_CONFIG.api.queries.totalRequests, formattedFilters, useOtel)
       )
     }
     if (topRoutes.changeQuery) {
-      topRoutes.changeQuery(getLogsSql(PRESET_CONFIG.api.queries.topRoutes, formattedFilters))
+      topRoutes.changeQuery(
+        getLogsSql(PRESET_CONFIG.api.queries.topRoutes, formattedFilters, useOtel)
+      )
     }
     if (errorCounts.changeQuery) {
-      errorCounts.changeQuery(getLogsSql(PRESET_CONFIG.api.queries.errorCounts, formattedFilters))
+      errorCounts.changeQuery(
+        getLogsSql(PRESET_CONFIG.api.queries.errorCounts, formattedFilters, useOtel)
+      )
     }
 
     if (topErrorRoutes.changeQuery) {
       topErrorRoutes.changeQuery(
-        getLogsSql(PRESET_CONFIG.api.queries.topErrorRoutes, formattedFilters)
+        getLogsSql(PRESET_CONFIG.api.queries.topErrorRoutes, formattedFilters, useOtel)
       )
     }
     if (responseSpeed.changeQuery) {
       responseSpeed.changeQuery(
-        getLogsSql(PRESET_CONFIG.api.queries.responseSpeed, formattedFilters)
+        getLogsSql(PRESET_CONFIG.api.queries.responseSpeed, formattedFilters, useOtel)
       )
     }
 
     if (topSlowRoutes.changeQuery) {
       topSlowRoutes.changeQuery(
-        getLogsSql(PRESET_CONFIG.api.queries.topSlowRoutes, formattedFilters)
+        getLogsSql(PRESET_CONFIG.api.queries.topSlowRoutes, formattedFilters, useOtel)
       )
     }
 
     if (networkTraffic.changeQuery) {
       networkTraffic.changeQuery(
-        getLogsSql(PRESET_CONFIG.api.queries.networkTraffic, formattedFilters)
+        getLogsSql(PRESET_CONFIG.api.queries.networkTraffic, formattedFilters, useOtel)
       )
     }
 
     if (cacheHitRate.changeQuery) {
-      cacheHitRate.changeQuery(getLogsSql(PRESET_CONFIG.storage.queries.cacheHitRate, []))
+      cacheHitRate.changeQuery(getLogsSql(PRESET_CONFIG.storage.queries.cacheHitRate, [], useOtel))
     }
 
     if (topCacheMisses.changeQuery) {
-      topCacheMisses.changeQuery(getLogsSql(PRESET_CONFIG.storage.queries.topCacheMisses, []))
+      topCacheMisses.changeQuery(
+        getLogsSql(PRESET_CONFIG.storage.queries.topCacheMisses, [], useOtel)
+      )
     }
-  }, [JSON.stringify(formattedFilters)])
+  }, [JSON.stringify(formattedFilters), useOtel])
 
   const isLoading = activeHooks.some((hook) => hook.isLoading)
 


### PR DESCRIPTION
## Problem

The API Overview and Storage observability reports (`data/reports/api-report-query.ts`, `data/reports/storage-report-query.ts`) still query BigQuery only, via the shared `queriesFactory`/`getLogsSql` dispatcher in `Reports.utils.tsx`. As part of the Reports→ClickHouse migration (DEBUG-73), each report needs a ClickHouse OTEL variant behind the `otelReports` flag, same as the Auth report.

Before touching anything, I verified this code path is actually live: `api-report-query.ts` → `api-overview.tsx`, `storage-report-query.ts` → `storage.tsx`, both reachable nav items in `ObservabilityMenu.utils.tsx`. `query-performance.tsx` also calls `queriesFactory`, but its preset (`QUERY_PERFORMANCE`) and the `DATABASE` preset are 100% `queryType: 'db'` (direct Postgres queries against `pg_stat_statements`/`pg_catalog`), so ClickHouse OTEL doesn't apply there — left untouched.

## Fix

- `Reports.types.ts`: added an optional `safeSqlOtel` variant to `ReportQueryLogs`.
- `Reports.utils.tsx`: `queriesFactory` and `getLogsSql` now take a `useOtel` flag, picking `safeSqlOtel` over `safeSql` when set (falls back to BQ if a query has no OTEL variant yet).
- `Reports.constants.ts`: added a `generateOtelWhereSafe` filter-to-WHERE helper (log_attributes-keyed, mirrors the existing `generateRegexpWhereSafe`) and `safeSqlOtel` for all 8 API-preset queries and both Storage-preset queries, all against the single ClickHouse `logs` table filtered to `source = 'edge_logs'`.
- `api-report-query.ts` / `storage-report-query.ts`: wired up via `useFlag('otelReports')`, matching the Auth report's pattern.

Field mappings (`request.path`, `response.status_code`, `response.origin_time`, `request.cf.country`, `request.headers.content_length` / `response.headers.content_length`, `response.headers.cf_cache_status`) all reuse conventions already established and tested elsewhere in the codebase (`Logs.constants.ts` OTEL templates, the in-flight Storage OTEL branch) — nothing here is a new/unverified schema guess.

No functional change while the flag is off — both reports still fetch from BigQuery by default.

## How to test

- `pnpm vitest run components/interfaces/Reports data/reports` — 128 tests pass (17 new, covering `generateOtelWhereSafe` and every new `safeSqlOtel` query shape).
- `pnpm tsc --noEmit` — no new errors.
- Manually: with `otelReports` enabled, visit a project's API Overview and Storage observability reports and confirm charts render from the ClickHouse endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenTelemetry support for API and storage reports.
  * Reports can now query request, error, performance, traffic, geographic, and cache metrics from OpenTelemetry data.
  * Improved report filtering, including safe handling of numeric and string values.

* **Tests**
  * Added comprehensive coverage for OpenTelemetry report queries, filters, aggregations, and metric calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->