### PR TITLE
fix(ui): remove extra spacing before custom reports section

### DIFF
--- a/apps/studio/components/layouts/ObservabilityLayout/ObservabilityMenu.tsx
+++ b/apps/studio/components/layouts/ObservabilityLayout/ObservabilityMenu.tsx
@@ -103,7 +103,7 @@ export const ObservabilityMenu = () => {
           <ShimmeringLoader className="w-1/2" />
         </div>
       ) : (
-        <div className="flex flex-col gap-y-6">
+        <div className="flex flex-col">
           <ProductMenu
             page={pageKey}
             menu={menuItems.map((item) => ({
@@ -115,7 +115,7 @@ export const ObservabilityMenu = () => {
           {IS_PLATFORM && (
             <>
               <div className="h-px w-full bg-border-overlay" />
-              <div className="mx-2">
+              <div className="mx-2 my-4">
                 <Menu type="pills">
                   <Menu.Group
                     title={


### PR DESCRIPTION
Fixes FE-4107.

## What is the current behavior?

The Observability sidebar had unnecessary spacing below the Product navigation. 

- Extra whitespace below the last Product menu item (`Realtime`).

## What is the new behavior?

Removes the global flex gap and applies spacing explicitly to the Custom Reports section. 

- Product navigation ends cleanly at the divider.
- Spacing before the Custom Reports section is intentional and consistent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing and alignment in the observability menu.
  * Added vertical separation around the custom reports section for a cleaner layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->