### PR TITLE
docs(auth): note that resetPasswordForEmail doesn't send email for un…

### DIFF
--- a/apps/docs/content/guides/auth/passwords.mdx
+++ b/apps/docs/content/guides/auth/passwords.mdx
@@ -611,7 +611,9 @@ var session = await supabase.Auth.SignIn("valid.email@supabase.io", "example-pas
 
 <Admonition type="note">
 
-To prevent user enumeration, `resetPasswordForEmail()` doesn't reveal whether an account exists for the given email address. If no user is associated with the address, Supabase Auth doesn't send an email, but the method still returns without an error.
+To prevent user enumeration, `resetPasswordForEmail()` doesn't reveal whether an account exists for the given email address.
+
+When no user is associated with the address, Supabase Auth won't send an email, though the method still returns without an error.
 
 </Admonition>
 

--- a/apps/docs/content/guides/auth/passwords.mdx
+++ b/apps/docs/content/guides/auth/passwords.mdx
@@ -609,6 +609,12 @@ var session = await supabase.Auth.SignIn("valid.email@supabase.io", "example-pas
 
 ### Resetting a password
 
+<Admonition type="note">
+
+To prevent user enumeration, `resetPasswordForEmail()` doesn't reveal whether an account exists for the given email address. If no user is associated with the address, Supabase Auth doesn't send an email, but the method still returns without an error.
+
+</Admonition>
+
 <Tabs
   scrollable
   size="small"


### PR DESCRIPTION
add note on `resetPasswordForEmail` doesn't send email for unregistered emails

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that password reset requests do not reveal whether an email address is associated with an account.
  * Documented that requests for unrecognized email addresses complete without an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->