### PR TITLE
feat(docs): scoped pat update

### DIFF
--- a/apps/docs/content/guides/platform/temporary-access.mdx
+++ b/apps/docs/content/guides/platform/temporary-access.mdx
@@ -51,7 +51,7 @@ curl -X PUT "https://api.supabase.com/v1/projects/$PROJECT_REF/database/jit-acce
 
 Once temporary access has been enabled, project users must be authorized and mapped to Postgres roles they are allowed to access. Each user can be authorized to "assume" one or more Postgres roles using temporary access.
 
-When a user is authorized to assume a Postgres role, the user's access token (Personal Access Token (PAT) or Scoped PAT) will be used as the password for the Postgres role.
+When a user is authorized to assume a Postgres role, the user's Personal Access Token (PAT) will be used as the password for the Postgres role.
 
 <Admonition type="note">
 

--- a/apps/docs/docs/ref/api/introduction.mdx
+++ b/apps/docs/docs/ref/api/introduction.mdx
@@ -22,7 +22,7 @@ hideTitle: true
       There are two ways to generate an access token:
 
       1. **Personal access token (PAT):**
-      PATs are long-lived tokens that you manually generate to access the Management API. They are useful for automating workflows or developing against the Management API. PATs carry the same privileges as your user account, so be sure to keep it secret.
+      PATs are tokens with a custom expiry that you manually generate to access the Management API. They are useful for automating workflows or developing against the Management API. PATs carry the same privileges as your user account, so be sure to keep it secret.
 
           To generate or manage your personal access tokens, visit your [account](/dashboard/account/tokens) page.
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Updates docs around scoped PAT's. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that temporary database access uses a Personal Access Token as the Postgres role password.
  * Updated API documentation to explain that Personal Access Tokens support custom expiration rather than being described as long-lived.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->