### PR TITLE
fix(blog): correct light-mode image extensions in supavisor 1M post

### DIFF
--- a/apps/www/_blog/2023-08-11-supavisor-1-million.mdx
+++ b/apps/www/_blog/2023-08-11-supavisor-1-million.mdx
@@ -110,7 +110,7 @@ We also monitored how the load was distributed over Supavisor instance's cores:
   <Img
     alt="cpu load vertical scaling light"
     src={{
-      light: '/images/blog/2023-08-11-supavisor-1-million/cpu-vertical-light.png',
+      light: '/images/blog/2023-08-11-supavisor-1-million/cpu-vertical-light.jpg',
       dark: '/images/blog/2023-08-11-supavisor-1-million/cpu-vertical-dark.png',
     }}
   />
@@ -153,7 +153,7 @@ Within the cluster:
   <Img
     alt="cpu load 1 million light"
     src={{
-      light: '/images/blog/2023-08-11-supavisor-1-million/cpu-1m-light.png',
+      light: '/images/blog/2023-08-11-supavisor-1-million/cpu-1m-light.jpg',
       dark: '/images/blog/2023-08-11-supavisor-1-million/cpu-1m-dark.png',
     }}
   />


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix (two broken images in a published blog post).

## What is the current behavior?

In "Supavisor: Scaling Postgres to 1 Million Connections", two charts are broken in light mode. The post asks for `.png` but the files on disk are `.jpg`:

| referenced | on disk |
| --- | --- |
| `cpu-vertical-light.png` | `cpu-vertical-light.jpg` |
| `cpu-1m-light.png` | `cpu-1m-light.jpg` |

Confirmed against the live site:

```
404  /images/blog/2023-08-11-supavisor-1-million/cpu-1m-light.png
200  /images/blog/2023-08-11-supavisor-1-million/cpu-1m-light.jpg
```

Both are used in a light and dark pair, and the dark halves are genuinely `.png` and load fine. So a reader in dark mode sees the charts and a reader in light mode gets two broken images.

## What is the new behavior?

The two `light` paths now use `.jpg`, matching the files that are actually committed. Two characters each, no other change, and no new assets added.

## Additional context

File: `apps/www/_blog/2023-08-11-supavisor-1-million.mdx`, the `light` entries around lines 113 and 156.

How I found and checked it: extracted every `/images/...` reference in `apps/www/_blog` (1463 distinct paths) and compared each against `apps/www/public`. Exactly two did not exist, both in this post. I confirmed the `.jpg` files are real images (`JPEG image data ... 2000x384` and `2000x589`), confirmed the `.png` variants 404 on production while the `.jpg` variants return 200, and re-ran the scan afterwards: zero missing blog image references remain.

I fixed the reference rather than renaming or re-adding files, since the committed assets are fine and it is only the extension in the post that drifted.

Gates run locally: `test:prettier` passes repo wide and the www vitest suite passes (6 files, 73 tests). I did not run `pnpm build`, which cannot complete in my environment because the docs `build:federated-content` step requires `DOCS_GITHUB_APP_PRIVATE_KEY` and fails before Next compiles.

Freshman contributor, found this with a local asset scan and verified the status codes myself, with Claude Code's help along the way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Supavisor CPU chart images in the blog post to use JPG format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->