### PR TITLE
fix(www): correct Brevo customer logo extension

### DIFF
--- a/apps/www/data/CustomerStories.ts
+++ b/apps/www/data/CustomerStories.ts
@@ -61,9 +61,9 @@ export const data: CustomerStoryType[] = [
     description:
       "Brevo's Revenue Operations team built three production AI workflows connecting their CRM to Dust's AI agents via Supabase MCP—without a single engineering ticket.",
     organization: 'Brevo',
-    imgUrl: 'images/customers/logos/brevo.svg',
-    logo: '/images/customers/logos/brevo.svg',
-    logo_inverse: '/images/customers/logos/light/brevo.svg',
+    imgUrl: 'images/customers/logos/brevo.png',
+    logo: '/images/customers/logos/brevo.png',
+    logo_inverse: '/images/customers/logos/light/brevo.png',
     url: '/customers/brevo',
     ctaText: 'View story',
   },


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix (missing customer logo).

## What is the current behavior?

The Brevo entry in `CustomerStories.ts` asks for `brevo.svg`, but the committed asset is `brevo.png`, in both the default and the `light/` directory. So the Brevo logo is a broken image wherever customer stories are rendered, including the home page section.

Confirmed against the live site:

```
404  /images/customers/logos/brevo.svg
200  /images/customers/logos/brevo.png
404  /images/customers/logos/light/brevo.svg
200  /images/customers/logos/light/brevo.png
```

Three references are affected: `imgUrl`, `logo` and `logo_inverse`.

## What is the new behavior?

All three point at `.png`, matching the files that are actually committed. No assets added or renamed.

## Additional context

File: `apps/www/data/CustomerStories.ts`, the Brevo entry.

How I found it: compared every `/images/...` reference in `apps/www` outside `_blog` against `apps/www/public`, then live-checked the candidates. Brevo was the only one where the correct asset is already committed under a different extension, so it is the only one I fixed here.

Two things I checked before touching it:

- Of the 54 customer logo references in that file, Brevo's three were the only ones that did not resolve. After the change, all 54 resolve.
- `imgUrl` has no leading slash on the Brevo entry, which looked wrong at first. It is the file's convention: all 28 `imgUrl` values omit it and none include it, so I left that alone and changed only the extension.

Gates run locally: `test:prettier` passes repo wide, `typecheck` passes 16/16, and the www vitest suite passes (6 files, 73 tests). I did not run `pnpm build`, which cannot complete in my environment because the docs `build:federated-content` step needs `DOCS_GITHUB_APP_PRIVATE_KEY`.

Freshman contributor, found this with a local asset scan and verified each status code myself, with Claude Code's help along the way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Brevo customer story imagery and logos for improved display consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
