### PR TITLE
fix(marketing): honour the documented checkbox group contract

### DIFF
--- a/packages/marketing/package.json
+++ b/packages/marketing/package.json
@@ -10,7 +10,9 @@
   },
   "scripts": {
     "preinstall": "npx only-allow pnpm",
-    "clean": "rimraf .turbo tsconfig.tsbuildinfo"
+    "clean": "rimraf .turbo tsconfig.tsbuildinfo",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@types/react": "catalog:",
@@ -26,7 +28,8 @@
     "tailwindcss": "^4.2.4",
     "tsconfig": "workspace:",
     "@typescript/native": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   },
   "license": "MIT"
 }

--- a/packages/marketing/src/forms/MarketingForm.tsx
+++ b/packages/marketing/src/forms/MarketingForm.tsx
@@ -17,6 +17,7 @@ import type { z } from 'zod'
 
 import { submitFormAction } from '../go/actions/submitForm'
 import { formFieldSchema, type GoFormFieldShowWhen } from '../go/schemas'
+import { validateCheckboxes } from './validateCheckboxes'
 
 /** Input-shape field type — fields with Zod defaults (`half`, `required`) are optional here. */
 export type MarketingFormField = z.input<typeof formFieldSchema>
@@ -214,36 +215,10 @@ export default function MarketingForm({
     e.preventDefault()
 
     // Required checkboxes aren't covered by HTML5 validation; check them manually.
-    const uncheckedRequired = visibleFields.filter(
-      (f) => f.type === 'checkbox' && f.required && !f.group && values[f.name] !== 'true'
-    )
-    if (uncheckedRequired.length > 0) {
+    const checkboxErrors = validateCheckboxes(visibleFields, values)
+    if (checkboxErrors.length > 0) {
       setSubmitState('error')
-      setErrorMessages(
-        uncheckedRequired.map((f) => `Please confirm: ${f.label.replace(/\*$/, '').trim()}`)
-      )
-      return
-    }
-
-    const requiredCheckboxGroups = new Map<string, MarketingFormField[]>()
-    visibleFields.forEach((field) => {
-      if (field.type !== 'checkbox' || !field.group || !field.groupRequired) return
-      const groupFields = requiredCheckboxGroups.get(field.group) ?? []
-      groupFields.push(field)
-      requiredCheckboxGroups.set(field.group, groupFields)
-    })
-
-    const missingRequiredGroups = Array.from(requiredCheckboxGroups.values()).filter((group) =>
-      group.every((field) => values[field.name] !== 'true')
-    )
-    if (missingRequiredGroups.length > 0) {
-      setSubmitState('error')
-      setErrorMessages(
-        missingRequiredGroups.map((group) => {
-          const labels = group.map((field) => field.label).join(', ')
-          return `Please select at least one option: ${labels}`
-        })
-      )
+      setErrorMessages(checkboxErrors)
       return
     }
     // Strip values for fields that are currently hidden so stale data doesn't leak.

--- a/packages/marketing/src/forms/validateCheckboxes.test.ts
+++ b/packages/marketing/src/forms/validateCheckboxes.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+
+import type { MarketingFormField } from './MarketingForm'
+import { validateCheckboxes } from './validateCheckboxes'
+
+const checkbox = (name: string, overrides: Partial<MarketingFormField> = {}): MarketingFormField =>
+  ({ type: 'checkbox', name, label: name, ...overrides }) as MarketingFormField
+
+describe('validateCheckboxes', () => {
+  it('passes when there is nothing to enforce', () => {
+    expect(validateCheckboxes([checkbox('newsletter')], {})).toEqual([])
+  })
+
+  describe('individually required checkboxes', () => {
+    it('reports an unchecked required checkbox', () => {
+      expect(validateCheckboxes([checkbox('terms', { required: true })], {})).toEqual([
+        'Please confirm: terms',
+      ])
+    })
+
+    it('accepts a checked required checkbox', () => {
+      expect(
+        validateCheckboxes([checkbox('terms', { required: true })], { terms: 'true' })
+      ).toEqual([])
+    })
+
+    it('strips the trailing asterisk from the label', () => {
+      expect(
+        validateCheckboxes([checkbox('terms', { label: 'I agree *', required: true })], {})
+      ).toEqual(['Please confirm: I agree'])
+    })
+
+    // Regression: `required` used to be skipped for any checkbox that also had a
+    // `group`, silently dropping its individual enforcement.
+    it('still enforces required on a checkbox that also belongs to a group', () => {
+      const fields = [checkbox('terms', { required: true, group: 'legal' })]
+      expect(validateCheckboxes(fields, {})).toEqual(['Please confirm: terms'])
+    })
+  })
+
+  describe('required groups', () => {
+    const group = [
+      checkbox('clickhouse', { group: 'destinations', groupRequired: true }),
+      checkbox('snowflake', { group: 'destinations', groupRequired: true }),
+    ]
+
+    it('reports a required group with nothing selected', () => {
+      expect(validateCheckboxes(group, {})).toEqual([
+        'Please select at least one option: clickhouse, snowflake',
+      ])
+    })
+
+    it('accepts a required group with one member selected', () => {
+      expect(validateCheckboxes(group, { snowflake: 'true' })).toEqual([])
+    })
+
+    it('ignores groups where no member sets groupRequired', () => {
+      const optional = [checkbox('a', { group: 'optional' }), checkbox('b', { group: 'optional' })]
+      expect(validateCheckboxes(optional, {})).toEqual([])
+    })
+
+    // Regression: the group map was built only from members that set
+    // `groupRequired`, so checking a member without the flag did not satisfy
+    // the group even though the schema documents that it should.
+    it('is satisfied by a member that does not itself set groupRequired', () => {
+      const mixed = [
+        checkbox('a', { group: 'mixed', groupRequired: true }),
+        checkbox('b', { group: 'mixed', groupRequired: true }),
+        checkbox('c', { group: 'mixed', groupRequired: false }),
+      ]
+      expect(validateCheckboxes(mixed, { c: 'true' })).toEqual([])
+    })
+
+    it('lists every group member in the error, not just the flagged ones', () => {
+      const mixed = [
+        checkbox('a', { group: 'mixed', groupRequired: true }),
+        checkbox('c', { group: 'mixed', groupRequired: false }),
+      ]
+      expect(validateCheckboxes(mixed, {})).toEqual(['Please select at least one option: a, c'])
+    })
+
+    it('reports each unsatisfied group separately', () => {
+      const two = [
+        checkbox('a', { group: 'one', groupRequired: true }),
+        checkbox('b', { group: 'two', groupRequired: true }),
+      ]
+      expect(validateCheckboxes(two, {})).toHaveLength(2)
+    })
+  })
+
+  it('reports individual failures before group failures', () => {
+    const fields = [
+      checkbox('terms', { required: true }),
+      checkbox('a', { group: 'destinations', groupRequired: true }),
+    ]
+    expect(validateCheckboxes(fields, {})).toEqual(['Please confirm: terms'])
+  })
+
+  it('only considers the fields it is given', () => {
+    // The caller passes visible fields only, so a hidden required checkbox
+    // never reaches validation.
+    expect(validateCheckboxes([], { terms: 'false' })).toEqual([])
+  })
+})

--- a/packages/marketing/src/forms/validateCheckboxes.ts
+++ b/packages/marketing/src/forms/validateCheckboxes.ts
@@ -1,0 +1,43 @@
+import type { MarketingFormField } from './MarketingForm'
+
+const isChecked = (field: MarketingFormField, values: Record<string, string>) =>
+  values[field.name] === 'true'
+
+/**
+ * Validate the checkbox rules HTML5 validation can't express: individually
+ * required checkboxes, and groups where at least one member must be selected.
+ *
+ * A group is required when *any* of its visible members sets
+ * `groupRequired: true`, and it is satisfied by *any* member of that group
+ * being checked — including members that don't set the flag themselves. This
+ * is the contract documented on `checkboxFieldSchema.group`.
+ *
+ * Returns the messages to surface, empty when the checkboxes pass. Individual
+ * `required` failures take precedence so the more specific message wins.
+ */
+export function validateCheckboxes(
+  visibleFields: MarketingFormField[],
+  values: Record<string, string>
+): string[] {
+  const uncheckedRequired = visibleFields.filter(
+    (f) => f.type === 'checkbox' && f.required && !isChecked(f, values)
+  )
+  if (uncheckedRequired.length > 0) {
+    return uncheckedRequired.map((f) => `Please confirm: ${f.label.replace(/\*$/, '').trim()}`)
+  }
+
+  const groups = new Map<string, { fields: MarketingFormField[]; required: boolean }>()
+  visibleFields.forEach((field) => {
+    if (field.type !== 'checkbox' || !field.group) return
+    const group = groups.get(field.group) ?? { fields: [], required: false }
+    group.fields.push(field)
+    group.required ||= Boolean(field.groupRequired)
+    groups.set(field.group, group)
+  })
+
+  return Array.from(groups.values())
+    .filter((group) => group.required && !group.fields.some((f) => isChecked(f, values)))
+    .map(
+      (group) => `Please select at least one option: ${group.fields.map((f) => f.label).join(', ')}`
+    )
+}

--- a/packages/marketing/vitest.config.ts
+++ b/packages/marketing/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+})


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix, plus the first test setup for `packages/marketing`.

## What is the current behavior?

Closes #48071.

`checkboxFieldSchema.group` in `packages/marketing/src/go/schemas.ts` documents the contract as: "When any visible checkbox in a group has `groupRequired: true`, at least one checkbox in that group must be selected." `MarketingForm`'s `handleSubmit` diverges from that in two ways.

The group map was built only from checkboxes that set `groupRequired` themselves, and the group was then satisfied only if one of *those* was checked. In a group mixing flagged and unflagged members, a user who checked an unflagged member was still rejected with "Please select at least one option", and the error listed only the flagged labels rather than the whole group.

Separately, the individual required check filtered on `f.required && !f.group`, so a checkbox setting both `required` and `group` lost its own enforcement entirely and could be submitted unchecked.

No live form is affected. The only current caller, `apps/www/_go/pre-release/supabase-pipelines-new-destinations.tsx`, sets `groupRequired: true` on all three members of its group and `required: true` on no checkbox, so both paths behave exactly as before for it. This is latent until a schema mixes the flags.

## What is the new behavior?

A group is collected from every visible checkbox carrying that `group`, is required when any member sets `groupRequired`, and is satisfied when any member is checked. The error message lists all members. Removing `!f.group` restores individual `required` enforcement for grouped checkboxes.

Both rules moved into a pure `validateCheckboxes(visibleFields, values)` so they can be tested without rendering the form. `handleSubmit` now calls it and surfaces whatever it returns; the precedence of individual errors over group errors is preserved.

## Additional context

`packages/marketing` had no test setup, so this adds `vitest` and a node-environment config matching `packages/ai-commands`, plus 13 tests covering both regressions and the existing behaviour around them.

Verified locally on Windows against `upstream/master` at 2a3025df25:

- `vitest run` in `packages/marketing` — 13 passed.
- I reconstructed the pre-fix logic verbatim in a scratch file and ran the two regression tests against it. Both fail there (the mixed-group case returns `["Please select at least one option: a"]` instead of `[]`; the grouped-`required` case returns `[]` instead of an error) while a control test for plain `required` passes, confirming the tests actually pin the reported bugs and my reconstruction was faithful. Scratch file removed before committing.
- `tsc --noEmit -p packages/marketing/tsconfig.json` — no errors in the changed files. Two pre-existing errors remain in `packages/ui` for missing CSS-module declarations; they are present on a clean checkout of `upstream/master` too.
- `prettier --check` on the five changed files is clean. I could not use the repo-wide `test:prettier` as a signal because this checkout has `core.autocrlf=true`, which flags all 52 files in the package; the committed blobs contain no CR bytes.

I did not run the full monorepo `lint`/`build`, so CI is the authority on those.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved marketing form checkbox validation for required individual checkboxes and checkbox groups.
  * Forms now consistently display the appropriate validation message when required selections are missing.
  * Individual checkbox errors are prioritized, while grouped requirements correctly accept any selected option.

* **Tests**
  * Added comprehensive automated coverage for checkbox validation scenarios, including field scoping, label formatting, ordering, and grouped checkbox regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->