### PR TITLE
feat(www): tweak Partner Day RSVP field wording

### DIFF
--- a/apps/www/_go/events/select-2026/partner-day.tsx
+++ b/apps/www/_go/events/select-2026/partner-day.tsx
@@ -154,7 +154,7 @@ const page: GoPageInput = {
           type: 'select',
           name: 'attending',
           label:
-            'Are you attending Supabase Select on October 2? (your Partner Day invite covers it)',
+            'Would you like to attend Supabase Select on October 2? (your Partner Day invite covers it)',
           placeholder: 'Select an option',
           required: true,
           options: [


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Content update (marketing copy) for the `www` app.

## What is the current behavior?

`/go/select-2026/partner-day`'s RSVP "attending" field label reads "Are you attending Supabase Select on October 2? (your Partner Day invite covers it)".

## What is the new behavior?

Updates the label to "Would you like to attend Supabase Select on October 2? (your Partner Day invite covers it)"

## Additional context

- Verified locally in the browser against the Notion copy doc.
- `prettier --check` passes on the changed file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Clarified the RSVP attendance question to ask whether attendees would like to attend Supabase Select.
  * RSVP options and form behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->