### PR TITLE
fix(studio): use publishable key env var in Flask connect snippet

### DIFF
--- a/apps/studio/components/interfaces/ConnectSheet/content/flask/supabasepy/content.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/content/flask/supabasepy/content.tsx
@@ -7,10 +7,13 @@ const ContentFile = ({ projectKeys }: StepContentProps) => {
     {
       name: '.env',
       language: 'bash',
-      code: `
-SUPABASE_URL=${projectKeys.apiUrl ?? 'your-project-url'}
-SUPABASE_KEY=${projectKeys.publishableKey ?? projectKeys.anonKey ?? 'your-anon-key'}
-        `,
+      code: [
+        `SUPABASE_URL=${projectKeys.apiUrl ?? 'your-project-url'}`,
+        projectKeys?.publishableKey
+          ? `SUPABASE_PUBLISHABLE_KEY=${projectKeys.publishableKey}`
+          : `SUPABASE_ANON_KEY=${projectKeys.anonKey ?? 'your-anon-key'}`,
+        '',
+      ].join('\n'),
     },
     {
       name: 'app.py',
@@ -27,7 +30,7 @@ app = Flask(__name__)
 
 supabase: Client = create_client(
     os.environ.get("SUPABASE_URL"),
-    os.environ.get("SUPABASE_KEY")
+    os.environ.get("${projectKeys.publishableKey ? 'SUPABASE_PUBLISHABLE_KEY' : 'SUPABASE_ANON_KEY'}")
 )
 
 @app.route('/')


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

The Flask entry in the Connect panel tells you to put the key in `SUPABASE_KEY`, while the [Flask quickstart](https://supabase.com/docs/guides/getting-started/quickstarts/flask) uses `SUPABASE_PUBLISHABLE_KEY`. Anyone who copies the `.env` from one page and `app.py` from the other ends up with an empty key and `SupabaseException: supabase_key is required`.

Fixes #48826

## What is the new behavior?

The Flask snippet now names the variable after the key it actually prints, `SUPABASE_PUBLISHABLE_KEY` or `SUPABASE_ANON_KEY`, the same way the Next.js, Vue, SolidJS and other framework snippets already do, and `app.py` reads the matching name.

## Additional context

Only the Flask content file changed. Other frameworks that still say `SUPABASE_KEY` (Astro, Nuxt, TanStack, Refine, Expo, Ionic) are left alone here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Flask connection instructions to use the publishable key when available.
  * Added fallback support for the legacy anonymous key.
  * Updated Python examples to reference the appropriate environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->