### PR TITLE
fix(studio): update Flask ConnectSheet env var to SUPABASE_PUBLISHABLE_KEY (#48826)

### DIFF
--- a/apps/studio/components/interfaces/ConnectSheet/content/flask/supabasepy/content.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/content/flask/supabasepy/content.tsx
@@ -9,7 +9,7 @@ const ContentFile = ({ projectKeys }: StepContentProps) => {
       language: 'bash',
       code: `
 SUPABASE_URL=${projectKeys.apiUrl ?? 'your-project-url'}
-SUPABASE_KEY=${projectKeys.publishableKey ?? projectKeys.anonKey ?? 'your-anon-key'}
+SUPABASE_PUBLISHABLE_KEY=${projectKeys.publishableKey ?? projectKeys.anonKey ?? 'your-anon-key'}
         `,
     },
     {
@@ -27,7 +27,7 @@ app = Flask(__name__)
 
 supabase: Client = create_client(
     os.environ.get("SUPABASE_URL"),
-    os.environ.get("SUPABASE_KEY")
+    os.environ.get("SUPABASE_PUBLISHABLE_KEY")
 )
 
 @app.route('/')


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

In the Connect Sheet modal for Flask (`apps/studio/components/interfaces/ConnectSheet/content/flask/supabasepy/content.tsx`), the example code snippet uses `SUPABASE_KEY` for `.env` and `os.environ.get("SUPABASE_KEY")` in `app.py`. When users follow the Flask Quickstart guide (which specifies `SUPABASE_PUBLISHABLE_KEY`), running `app.py` raises `SupabaseException: supabase_key is required`.

## What is the new behavior?

Updated the `.env` code snippet to `SUPABASE_PUBLISHABLE_KEY` and `app.py` to `os.environ.get("SUPABASE_PUBLISHABLE_KEY")` matching the standard Quickstart convention.

## Additional context

Fixes #48826