### PR TITLE
fix(examples): restore imports and default export in react-user-management App.jsx

### DIFF
--- a/examples/user-management/react-user-management/src/App.jsx
+++ b/examples/user-management/react-user-management/src/App.jsx
@@ -1,3 +1,9 @@
+import { useState, useEffect } from 'react'
+import './App.css'
+import { supabase } from './supabaseClient'
+import Auth from './Auth'
+import Account from './Account'
+
 function App() {
   const [claims, setClaims] = useState(null)
 
@@ -26,3 +32,5 @@ function App() {
     </div>
   )
 }
+
+export default App


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`examples/user-management/react-user-management/src/App.jsx` lost its import block and its `export default App` line in #45539, so the file no longer compiles. Running the example fails in the browser with:

```
Uncaught SyntaxError: The requested module '/src/App.jsx' does not provide an export named 'default' (at main.jsx:4:8)
```

The React tutorial and the example README both embed this file, so the published snippet is broken too.

Fixes #48829

## What is the new behavior?

The imports and the default export are back. The `getClaims()` logic added in #45539 is untouched.

## Additional context

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the main application entry point for the user management example.
  * Integrated authentication, account management, styling, and backend connectivity components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->