### PR TITLE
fix mobile Auth user details inspector

### DIFF
--- a/apps/studio/components/interfaces/Auth/Users/UserHeader.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UserHeader.tsx
@@ -16,26 +16,28 @@ export const UserHeader = ({ user }: { user: User }) => {
   return (
     <div className={cn(PANEL_PADDING)}>
       {isPhoneAuth ? (
-        <div className="flex items-center gap-x-1">
-          <p>{user.phone}</p>
+        <div className="flex min-w-0 items-start gap-x-1">
+          <p className="min-w-0 [overflow-wrap:anywhere]">{user.phone}</p>
           <CopyButton
             iconOnly
             variant="text"
             icon={<Copy />}
-            className="px-1"
+            className="shrink-0 px-1"
             text={user?.phone ?? ''}
           />
         </div>
       ) : isAnonUser ? (
         <>
           <p>Anonymous user</p>
-          <div className="flex items-center gap-x-1">
-            <p className="text-foreground-light text-sm">{user.id}</p>
+          <div className="flex min-w-0 items-start gap-x-1">
+            <p className="text-foreground-light min-w-0 text-sm [overflow-wrap:anywhere]">
+              {user.id}
+            </p>
             <CopyButton
               iconOnly
               variant="text"
               icon={<Copy />}
-              className="px-1"
+              className="shrink-0 px-1"
               text={user?.id ?? ''}
             />
           </div>
@@ -43,15 +45,20 @@ export const UserHeader = ({ user }: { user: User }) => {
       ) : (
         <>
           {hasDisplayName && <p>{displayName}</p>}
-          <div className="flex items-center gap-x-1">
-            <p className={cn(hasDisplayName ? 'text-foreground-light text-sm' : 'text-foreground')}>
+          <div className="flex min-w-0 items-start gap-x-1">
+            <p
+              className={cn(
+                'min-w-0 [overflow-wrap:anywhere]',
+                hasDisplayName ? 'text-foreground-light text-sm' : 'text-foreground'
+              )}
+            >
               {user.email}
             </p>
             <CopyButton
               iconOnly
               variant="text"
               icon={<Copy />}
-              className="px-1"
+              className="shrink-0 px-1"
               text={user?.email ?? ''}
             />
           </div>

--- a/apps/studio/components/interfaces/Auth/Users/UserOverview.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UserOverview.tsx
@@ -31,8 +31,9 @@ import { timeout } from '@/lib/helpers'
 
 const DATE_FORMAT = 'DD MMM, YYYY HH:mm'
 const CONTAINER_CLASS = cn(
-  'bg-surface-100 border-default text-foreground flex items-center justify-between',
-  'gap-x-4 border px-5 py-4 text-sm first:rounded-tr first:rounded-tl last:rounded-br last:rounded-bl'
+  'bg-surface-100 border-default text-foreground flex flex-col items-stretch justify-between',
+  'gap-y-3 border px-5 py-4 text-sm sm:flex-row sm:items-center sm:gap-x-4 sm:gap-y-0',
+  'first:rounded-tr first:rounded-tl last:rounded-br last:rounded-bl'
 )
 
 interface UserOverviewProps {
@@ -485,10 +486,10 @@ export const UserOverview = ({ user, onDeleteSuccess }: UserOverviewProps) => {
 export const RowData = ({ property, value }: { property: string; value?: string | boolean }) => {
   return (
     <>
-      <div className="flex items-center gap-x-2 group justify-between">
-        <p className=" text-foreground-lighter text-xs">{property}</p>
+      <div className="group flex items-start justify-between gap-x-2">
+        <p className="text-foreground-lighter shrink-0 py-1.5 text-xs">{property}</p>
         {typeof value === 'boolean' ? (
-          <div className="h-[26px] flex items-center justify-center min-w-[70px]">
+          <div className="flex min-h-[26px] min-w-[70px] items-center justify-center">
             {value ? (
               <div className="rounded-full w-4 h-4 dark:bg-white bg-black flex items-center justify-center">
                 <Check size={10} className="text-contrast" strokeWidth={4} />
@@ -500,14 +501,16 @@ export const RowData = ({ property, value }: { property: string; value?: string 
             )}
           </div>
         ) : (
-          <div className="flex items-center gap-x-2 h-[26px] font-mono min-w-[40px]">
-            <p className="text-xs">{!value ? '-' : value}</p>
+          <div className="flex min-h-[26px] min-w-0 items-start justify-end gap-x-2 py-1.5 font-mono">
+            <p className="min-w-0 text-right text-xs [overflow-wrap:anywhere]">
+              {!value ? '-' : value}
+            </p>
             {!!value && (
               <CopyButton
                 iconOnly
                 variant="text"
                 icon={<Copy />}
-                className="transition opacity-0 group-hover:opacity-100 px-1"
+                className="shrink-0 px-1 opacity-100 transition sm:opacity-0 sm:group-hover:opacity-100"
                 text={value}
               />
             )}

--- a/apps/studio/components/interfaces/Auth/Users/UserPanel.test.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UserPanel.test.tsx
@@ -1,7 +1,6 @@
 import { screen } from '@testing-library/react'
 import { http, HttpResponse } from 'msw'
-import { ResizablePanelGroup } from 'ui'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { UserPanel } from './UserPanel'
 import type { User } from '@/data/auth/users-infinite-query'
@@ -53,30 +52,19 @@ const renderPanel = (disabledFeatures: string[] = []) => {
     )
   )
 
-  return customRender(
-    <ResizablePanelGroup orientation="horizontal">
-      <UserPanel />
-    </ResizablePanelGroup>,
-    {
-      nuqs: { searchParams: `?show=${mockUser.id}` },
-      profileContext: createMockProfileContext({
-        profile: {
-          disabled_features: disabledFeatures as any,
-        } as any,
-      }),
-    }
-  )
+  return customRender(<UserPanel />, {
+    nuqs: { searchParams: `?show=${mockUser.id}` },
+    profileContext: createMockProfileContext({
+      profile: {
+        disabled_features: disabledFeatures as any,
+      } as any,
+    }),
+  })
 }
 
 describe('UserPanel', () => {
-  const desktopWidth = window.innerWidth
-
   beforeEach(() => {
     vi.clearAllMocks()
-  })
-
-  afterEach(() => {
-    Object.defineProperty(window, 'innerWidth', { configurable: true, value: desktopWidth })
   })
 
   it('shows the Logs tab when logs:all is enabled', async () => {
@@ -95,13 +83,11 @@ describe('UserPanel', () => {
     expect(screen.getByRole('tab', { name: 'Raw JSON' })).toBeInTheDocument()
   })
 
-  it('uses a full-width dialog on mobile', async () => {
-    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 390 })
-
+  it('uses the full-width Table Editor side panel', async () => {
     renderPanel([])
 
     const dialog = await screen.findByRole('dialog', { name: 'User details' })
-    expect(dialog).toHaveClass('w-screen')
+    expect(dialog).toHaveClass('w-screen', 'max-w-2xl')
     expect(screen.getByRole('button', { name: 'Close user details' })).toBeInTheDocument()
   })
 })

--- a/apps/studio/components/interfaces/Auth/Users/UserPanel.test.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UserPanel.test.tsx
@@ -1,7 +1,7 @@
 import { screen } from '@testing-library/react'
 import { http, HttpResponse } from 'msw'
 import { ResizablePanelGroup } from 'ui'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { UserPanel } from './UserPanel'
 import type { User } from '@/data/auth/users-infinite-query'
@@ -69,8 +69,14 @@ const renderPanel = (disabledFeatures: string[] = []) => {
 }
 
 describe('UserPanel', () => {
+  const desktopWidth = window.innerWidth
+
   beforeEach(() => {
     vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: desktopWidth })
   })
 
   it('shows the Logs tab when logs:all is enabled', async () => {
@@ -87,5 +93,15 @@ describe('UserPanel', () => {
     expect(await screen.findByRole('tab', { name: 'Overview' })).toBeInTheDocument()
     expect(screen.queryByRole('tab', { name: 'Logs' })).not.toBeInTheDocument()
     expect(screen.getByRole('tab', { name: 'Raw JSON' })).toBeInTheDocument()
+  })
+
+  it('uses a full-width dialog on mobile', async () => {
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 390 })
+
+    renderPanel([])
+
+    const dialog = await screen.findByRole('dialog', { name: 'User details' })
+    expect(dialog).toHaveClass('w-screen')
+    expect(screen.getByRole('button', { name: 'Close user details' })).toBeInTheDocument()
   })
 })

--- a/apps/studio/components/interfaces/Auth/Users/UserPanel.test.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UserPanel.test.tsx
@@ -83,11 +83,9 @@ describe('UserPanel', () => {
     expect(screen.getByRole('tab', { name: 'Raw JSON' })).toBeInTheDocument()
   })
 
-  it('uses the full-width Table Editor side panel', async () => {
+  it('provides an accessible close button', async () => {
     renderPanel([])
 
-    const dialog = await screen.findByRole('dialog', { name: 'User details' })
-    expect(dialog).toHaveClass('w-screen', 'max-w-2xl')
-    expect(screen.getByRole('button', { name: 'Close user details' })).toBeInTheDocument()
+    expect(await screen.findByRole('button', { name: 'Close user details' })).toBeInTheDocument()
   })
 })

--- a/apps/studio/components/interfaces/Auth/Users/UserPanel.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UserPanel.tsx
@@ -2,19 +2,7 @@ import { X } from 'lucide-react'
 import { parseAsString, useQueryState } from 'nuqs'
 import { Dialog, VisuallyHidden } from 'radix-ui'
 import { useState } from 'react'
-import {
-  Button,
-  cn,
-  Input,
-  ResizableHandle,
-  ResizablePanel,
-  SidePanel,
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
-  useIsMobile,
-} from 'ui'
+import { Button, cn, Input, SidePanel, Tabs, TabsContent, TabsList, TabsTrigger } from 'ui'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 import { SimpleCodeBlock } from 'ui-patterns/SimpleCodeBlock'
 
@@ -29,7 +17,6 @@ import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 export const UserPanel = () => {
   const { data: project } = useSelectedProjectQuery()
   const showLogs = useIsFeatureEnabled('logs:all')
-  const isMobile = useIsMobile()
 
   const [selectedId, setSelectedId] = useQueryState(
     'show',
@@ -155,37 +142,20 @@ export const UserPanel = () => {
     </>
   )
 
-  if (isMobile) {
-    return (
-      <SidePanel
-        visible
-        hideFooter
-        size="large"
-        aria-label="User details"
-        aria-describedby={undefined}
-        className="shadow-none"
-        onCancel={() => setSelectedId(null)}
-      >
-        <VisuallyHidden.VisuallyHidden>
-          <Dialog.Title>User details</Dialog.Title>
-        </VisuallyHidden.VisuallyHidden>
-        {content}
-      </SidePanel>
-    )
-  }
-
   return (
-    <>
-      <ResizableHandle withHandle />
-      <ResizablePanel
-        defaultSize="35"
-        maxSize="45"
-        minSize="35"
-        aria-label="User details"
-        className="bg-studio border-t"
-      >
-        {content}
-      </ResizablePanel>
-    </>
+    <SidePanel
+      visible
+      hideFooter
+      size="large"
+      aria-label="User details"
+      aria-describedby={undefined}
+      className="shadow-none"
+      onCancel={() => setSelectedId(null)}
+    >
+      <VisuallyHidden.VisuallyHidden>
+        <Dialog.Title>User details</Dialog.Title>
+      </VisuallyHidden.VisuallyHidden>
+      {content}
+    </SidePanel>
   )
 }

--- a/apps/studio/components/interfaces/Auth/Users/UserPanel.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UserPanel.tsx
@@ -1,5 +1,6 @@
 import { X } from 'lucide-react'
 import { parseAsString, useQueryState } from 'nuqs'
+import { Dialog, VisuallyHidden } from 'radix-ui'
 import { useState } from 'react'
 import {
   Button,
@@ -7,10 +8,12 @@ import {
   Input,
   ResizableHandle,
   ResizablePanel,
+  SidePanel,
   Tabs,
   TabsContent,
   TabsList,
   TabsTrigger,
+  useIsMobile,
 } from 'ui'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 import { SimpleCodeBlock } from 'ui-patterns/SimpleCodeBlock'
@@ -26,6 +29,7 @@ import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 export const UserPanel = () => {
   const { data: project } = useSelectedProjectQuery()
   const showLogs = useIsFeatureEnabled('logs:all')
+  const isMobile = useIsMobile()
 
   const [selectedId, setSelectedId] = useQueryState(
     'show',
@@ -56,99 +60,131 @@ export const UserPanel = () => {
         }, {} as Partial<User>)
     : {}
 
+  const content = (
+    <>
+      <Button
+        variant="text"
+        className="absolute top-3 right-3 z-10 px-1"
+        icon={<X />}
+        aria-label="Close user details"
+        onClick={() => setSelectedId(null)}
+      />
+      <Tabs
+        value={view}
+        className="flex h-full flex-col"
+        onValueChange={(value) => setView(value as 'overview' | 'raw' | 'logs')}
+      >
+        {isPending ? (
+          <div>
+            <div className="min-h-[46px] border-b" />
+            <div className="p-5">
+              <GenericSkeletonLoader />
+            </div>
+          </div>
+        ) : !!selectedUser ? (
+          <>
+            <TabsList className="flex min-h-[46px] gap-x-4 px-5 pr-12">
+              <TabsTrigger
+                value="overview"
+                className="h-full px-0 pb-0 text-xs shadow-none! data-[state=active]:bg-transparent"
+              >
+                Overview
+              </TabsTrigger>
+              {showLogs && (
+                <TabsTrigger
+                  value="logs"
+                  className="h-full px-0 pb-0 text-xs shadow-none! data-[state=active]:bg-transparent"
+                >
+                  Logs
+                </TabsTrigger>
+              )}
+              <TabsTrigger
+                value="raw"
+                className="h-full px-0 pb-0 text-xs shadow-none! data-[state=active]:bg-transparent"
+              >
+                Raw JSON
+              </TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="overview" className={cn('mt-0 grow min-h-0 overflow-y-auto')}>
+              {selectedUser && (
+                <UserOverview user={selectedUser} onDeleteSuccess={() => setSelectedId(null)} />
+              )}
+            </TabsContent>
+            {showLogs && (
+              <TabsContent value="logs" className={cn('mt-0 grow min-h-0 overflow-y-auto')}>
+                {selectedUser && <UserLogs user={selectedUser} />}
+              </TabsContent>
+            )}
+            <TabsContent
+              value="raw"
+              className={cn('mt-0 grow min-h-0 overflow-y-auto', PANEL_PADDING)}
+            >
+              <div className="mb-2 flex items-center">
+                <Input
+                  autoFocus
+                  type="text"
+                  placeholder="Filter..."
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  className="mr-2"
+                />
+                <Button
+                  variant="text"
+                  disabled={!searchQuery}
+                  onClick={() => setSearchQuery('')}
+                  className="text-xs"
+                >
+                  Clear
+                </Button>
+              </div>
+              <SimpleCodeBlock className="javascript" parentClassName="[&>*>span]:text-xs">
+                {JSON.stringify(filteredProperties, null, 2)}
+              </SimpleCodeBlock>
+            </TabsContent>
+          </>
+        ) : (
+          <div className="flex h-full w-full flex-col items-center justify-center gap-y-2 px-5 text-center">
+            <p className="text-foreground-light text-sm">
+              Unable to find user with the following ID in project
+            </p>
+            <p className="text-foreground-lighter break-all text-xs">ID: {selectedId}</p>
+          </div>
+        )}
+      </Tabs>
+    </>
+  )
+
+  if (isMobile) {
+    return (
+      <SidePanel
+        visible
+        hideFooter
+        size="large"
+        aria-label="User details"
+        aria-describedby={undefined}
+        className="shadow-none"
+        onCancel={() => setSelectedId(null)}
+      >
+        <VisuallyHidden.VisuallyHidden>
+          <Dialog.Title>User details</Dialog.Title>
+        </VisuallyHidden.VisuallyHidden>
+        {content}
+      </SidePanel>
+    )
+  }
+
   return (
     <>
       <ResizableHandle withHandle />
-      <ResizablePanel defaultSize="35" maxSize="45" minSize="35" className="bg-studio border-t">
-        <Button
-          variant="text"
-          className="absolute top-3 right-3 px-1"
-          icon={<X />}
-          onClick={() => setSelectedId(null)}
-        />
-        <Tabs
-          value={view}
-          className="flex flex-col h-full"
-          onValueChange={(value) => setView(value as 'overview' | 'raw' | 'logs')}
-        >
-          {isPending ? (
-            <div>
-              <div className="min-h-[46px] border-b" />
-              <div className="p-5">
-                <GenericSkeletonLoader />
-              </div>
-            </div>
-          ) : !!selectedUser ? (
-            <>
-              <TabsList className="px-5 flex gap-x-4 min-h-[46px]">
-                <TabsTrigger
-                  value="overview"
-                  className="px-0 pb-0 h-full text-xs  data-[state=active]:bg-transparent shadow-none!"
-                >
-                  Overview
-                </TabsTrigger>
-                {showLogs && (
-                  <TabsTrigger
-                    value="logs"
-                    className="px-0 pb-0 h-full text-xs data-[state=active]:bg-transparent shadow-none!"
-                  >
-                    Logs
-                  </TabsTrigger>
-                )}
-                <TabsTrigger
-                  value="raw"
-                  className="px-0 pb-0 h-full text-xs data-[state=active]:bg-transparent shadow-none!"
-                >
-                  Raw JSON
-                </TabsTrigger>
-              </TabsList>
-
-              <TabsContent value="overview" className={cn('mt-0 grow min-h-0 overflow-y-auto')}>
-                {selectedUser && (
-                  <UserOverview user={selectedUser} onDeleteSuccess={() => setSelectedId(null)} />
-                )}
-              </TabsContent>
-              {showLogs && (
-                <TabsContent value="logs" className={cn('mt-0 grow min-h-0 overflow-y-auto')}>
-                  {selectedUser && <UserLogs user={selectedUser} />}
-                </TabsContent>
-              )}
-              <TabsContent
-                value="raw"
-                className={cn('mt-0 grow min-h-0 overflow-y-auto', PANEL_PADDING)}
-              >
-                <div className="flex items-center mb-2">
-                  <Input
-                    autoFocus
-                    type="text"
-                    placeholder="Filter..."
-                    value={searchQuery}
-                    onChange={(e) => setSearchQuery(e.target.value)}
-                    className="mr-2"
-                  />
-                  <Button
-                    variant="text"
-                    disabled={!searchQuery}
-                    onClick={() => setSearchQuery('')}
-                    className="text-xs"
-                  >
-                    Clear
-                  </Button>
-                </div>
-                <SimpleCodeBlock className="javascript" parentClassName="[&>*>span]:text-xs">
-                  {JSON.stringify(filteredProperties, null, 2)}
-                </SimpleCodeBlock>
-              </TabsContent>
-            </>
-          ) : (
-            <div className="flex items-center justify-center w-full h-full flex-col gap-y-2">
-              <p className="text-foreground-light text-sm">
-                Unable to find user with the following ID in project
-              </p>
-              <p className="text-foreground-lighter text-xs">ID: {selectedId}</p>
-            </div>
-          )}
-        </Tabs>
+      <ResizablePanel
+        defaultSize="35"
+        maxSize="45"
+        minSize="35"
+        aria-label="User details"
+        className="bg-studio border-t"
+      >
+        {content}
       </ResizablePanel>
     </>
   )

--- a/apps/studio/components/interfaces/Auth/Users/UserPanel.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UserPanel.tsx
@@ -1,8 +1,7 @@
 import { X } from 'lucide-react'
 import { parseAsString, useQueryState } from 'nuqs'
-import { Dialog, VisuallyHidden } from 'radix-ui'
 import { useState } from 'react'
-import { Button, cn, Input, SidePanel, Tabs, TabsContent, TabsList, TabsTrigger } from 'ui'
+import { Button, cn, Input, Tabs, TabsContent, TabsList, TabsTrigger } from 'ui'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 import { SimpleCodeBlock } from 'ui-patterns/SimpleCodeBlock'
 
@@ -47,8 +46,8 @@ export const UserPanel = () => {
         }, {} as Partial<User>)
     : {}
 
-  const content = (
-    <>
+  return (
+    <div className="relative h-full bg-studio">
       <Button
         variant="text"
         className="absolute top-3 right-3 z-10 px-1"
@@ -68,7 +67,7 @@ export const UserPanel = () => {
               <GenericSkeletonLoader />
             </div>
           </div>
-        ) : !!selectedUser ? (
+        ) : selectedUser ? (
           <>
             <TabsList className="flex min-h-[46px] gap-x-4 px-5 pr-12">
               <TabsTrigger
@@ -93,14 +92,12 @@ export const UserPanel = () => {
               </TabsTrigger>
             </TabsList>
 
-            <TabsContent value="overview" className={cn('mt-0 grow min-h-0 overflow-y-auto')}>
-              {selectedUser && (
-                <UserOverview user={selectedUser} onDeleteSuccess={() => setSelectedId(null)} />
-              )}
+            <TabsContent value="overview" className="mt-0 grow min-h-0 overflow-y-auto">
+              <UserOverview user={selectedUser} onDeleteSuccess={() => setSelectedId(null)} />
             </TabsContent>
             {showLogs && (
-              <TabsContent value="logs" className={cn('mt-0 grow min-h-0 overflow-y-auto')}>
-                {selectedUser && <UserLogs user={selectedUser} />}
+              <TabsContent value="logs" className="mt-0 grow min-h-0 overflow-y-auto">
+                <UserLogs user={selectedUser} />
               </TabsContent>
             )}
             <TabsContent
@@ -139,23 +136,6 @@ export const UserPanel = () => {
           </div>
         )}
       </Tabs>
-    </>
-  )
-
-  return (
-    <SidePanel
-      visible
-      hideFooter
-      size="large"
-      aria-label="User details"
-      aria-describedby={undefined}
-      className="shadow-none"
-      onCancel={() => setSelectedId(null)}
-    >
-      <VisuallyHidden.VisuallyHidden>
-        <Dialog.Title>User details</Dialog.Title>
-      </VisuallyHidden.VisuallyHidden>
-      {content}
-    </SidePanel>
+    </div>
   )
 }

--- a/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
@@ -25,8 +25,6 @@ import {
   Button,
   cn,
   LoadingLine,
-  ResizablePanel,
-  ResizablePanelGroup,
   Select,
   SelectContent,
   SelectGroup,
@@ -62,6 +60,7 @@ import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import { FilterPopover } from '@/components/ui/FilterPopover'
 import { FormHeader } from '@/components/ui/Forms/FormHeader'
 import { InlineLink } from '@/components/ui/InlineLink'
+import { ResizableInspectorLayout } from '@/components/ui/ResizableInspectorLayout'
 import { useAuthConfigQuery } from '@/data/auth/auth-config-query'
 import { useAuthConfigUpdateMutation } from '@/data/auth/auth-config-update-mutation'
 import { useIndexWorkerStatusQuery } from '@/data/auth/index-worker-status-query'
@@ -770,111 +769,114 @@ export const UsersV2 = () => {
           )}
         </div>
         <LoadingLine loading={isLoading || isRefetching || isFetchingNextPage} />
-        <ResizablePanelGroup
-          orientation="horizontal"
+        <ResizableInspectorLayout
           className="relative flex grow bg-alternative min-h-0"
-          autoSaveId="query-performance-layout-v1"
+          mainPanelId="auth-users-table"
+          inspectorPanelId="auth-user-details"
+          inspectorLabel="User details"
+          mainMinSize={300}
+          inspectorDefaultSize={400}
+          inspectorMinSize={320}
+          inspectorMaxSize="60%"
+          inspector={selectedId ? <UserPanel /> : undefined}
         >
-          <ResizablePanel>
-            <div className="flex flex-col w-full h-full">
-              <DataGrid
-                ref={gridRef}
-                className="grow border-t-0! border-b-0!"
-                rowHeight={44}
-                headerRowHeight={36}
-                columns={columns}
-                rows={formatUsersData(users ?? [])}
-                rowClass={(row) => {
-                  const isSelected = row.id === selectedUser
-                  return [
-                    `${isSelected ? 'bg-surface-300 dark:bg-surface-300' : 'bg-200'} cursor-pointer`,
-                    '[&>.rdg-cell]:border-box [&>.rdg-cell]:outline-hidden [&>.rdg-cell]:shadow-none',
-                    '[&>.rdg-cell:first-child>div]:ml-4',
-                  ].join(' ')
-                }}
-                rowKeyGetter={(row) => row.id}
-                selectedRows={selectedUsers}
-                onScroll={handleScroll}
-                onSelectedRowsChange={(rows) => {
-                  if (rows.size > MAX_BULK_DELETE) {
-                    toast(`Only up to ${MAX_BULK_DELETE} users can be selected at a time`)
-                  } else setSelectedUsers(rows)
-                }}
-                onCellKeyDown={onCellKeyDown}
-                onColumnResize={(idx, width) => saveColumnConfiguration('resize', { idx, width })}
-                onColumnsReorder={(source, target) => {
-                  const sourceIdx = columns.findIndex((col) => col.key === source)
-                  const targetIdx = columns.findIndex((col) => col.key === target)
+          <div className="flex flex-col w-full h-full">
+            <DataGrid
+              ref={gridRef}
+              className="grow border-t-0! border-b-0!"
+              rowHeight={44}
+              headerRowHeight={36}
+              columns={columns}
+              rows={formatUsersData(users ?? [])}
+              rowClass={(row) => {
+                const isSelected = row.id === selectedUser
+                return [
+                  `${isSelected ? 'bg-surface-300 dark:bg-surface-300' : 'bg-200'} cursor-pointer`,
+                  '[&>.rdg-cell]:border-box [&>.rdg-cell]:outline-hidden [&>.rdg-cell]:shadow-none',
+                  '[&>.rdg-cell:first-child>div]:ml-4',
+                ].join(' ')
+              }}
+              rowKeyGetter={(row) => row.id}
+              selectedRows={selectedUsers}
+              onScroll={handleScroll}
+              onSelectedRowsChange={(rows) => {
+                if (rows.size > MAX_BULK_DELETE) {
+                  toast(`Only up to ${MAX_BULK_DELETE} users can be selected at a time`)
+                } else setSelectedUsers(rows)
+              }}
+              onCellKeyDown={onCellKeyDown}
+              onColumnResize={(idx, width) => saveColumnConfiguration('resize', { idx, width })}
+              onColumnsReorder={(source, target) => {
+                const sourceIdx = columns.findIndex((col) => col.key === source)
+                const targetIdx = columns.findIndex((col) => col.key === target)
 
-                  const updatedColumns = swapColumns(columns, sourceIdx, targetIdx)
-                  setColumns(updatedColumns)
+                const updatedColumns = swapColumns(columns, sourceIdx, targetIdx)
+                setColumns(updatedColumns)
 
-                  saveColumnConfiguration('reorder', { columns: updatedColumns })
-                }}
-                renderers={{
-                  renderRow(id, props) {
-                    return (
-                      <Row
-                        key={id}
-                        {...props}
-                        onClick={() => {
-                          const user = users.find((u) => u.id === id)
-                          if (user) {
-                            const idx = users.indexOf(user)
-                            if (props.row.id) {
-                              setSelectedId(props.row.id)
-                              gridRef.current?.scrollToCell({ idx: 0, rowIdx: idx })
-                            }
+                saveColumnConfiguration('reorder', { columns: updatedColumns })
+              }}
+              renderers={{
+                renderRow(id, props) {
+                  return (
+                    <Row
+                      key={id}
+                      {...props}
+                      onClick={() => {
+                        const user = users.find((u) => u.id === id)
+                        if (user) {
+                          const idx = users.indexOf(user)
+                          if (props.row.id) {
+                            setSelectedId(props.row.id)
+                            gridRef.current?.scrollToCell({ idx: 0, rowIdx: idx })
                           }
-                        }}
-                      />
-                    )
-                  },
-                  noRowsFallback: isPendingProject ? (
-                    <div className="absolute top-14 px-6 w-full">
-                      <GenericSkeletonLoader />
+                        }
+                      }}
+                    />
+                  )
+                },
+                noRowsFallback: isPendingProject ? (
+                  <div className="absolute top-14 px-6 w-full">
+                    <GenericSkeletonLoader />
+                  </div>
+                ) : project?.status !== PROJECT_STATUS.ACTIVE_HEALTHY || isProjectError ? (
+                  <div className="absolute top-14 px-6 flex flex-col items-center justify-center w-full">
+                    <AlertError
+                      subject="Unable to load users"
+                      error={{
+                        message:
+                          'Could not connect to the database. Please check your project status.',
+                      }}
+                    />
+                  </div>
+                ) : isPending ? (
+                  <div className="absolute top-14 px-6 w-full">
+                    <GenericSkeletonLoader />
+                  </div>
+                ) : isError ? (
+                  <div className="absolute top-14 px-6 flex flex-col items-center justify-center w-full">
+                    <AlertError subject="Failed to retrieve users" error={error} />
+                  </div>
+                ) : isSuccess ? (
+                  <div className="absolute top-20 px-6 flex flex-col items-center justify-center w-full gap-y-2">
+                    <Users className="text-foreground-lighter" strokeWidth={1} />
+                    <div className="text-center">
+                      <p className="text-foreground">
+                        {filterUserType !== 'all' || filterKeywords.length > 0
+                          ? 'No users found'
+                          : 'No users in your project'}
+                      </p>
+                      <p className="text-foreground-light">
+                        {filterUserType !== 'all' || filterKeywords.length > 0
+                          ? 'There are currently no users based on the filters applied'
+                          : 'There are currently no users who signed up to your project'}
+                      </p>
                     </div>
-                  ) : project?.status !== PROJECT_STATUS.ACTIVE_HEALTHY || isProjectError ? (
-                    <div className="absolute top-14 px-6 flex flex-col items-center justify-center w-full">
-                      <AlertError
-                        subject="Unable to load users"
-                        error={{
-                          message:
-                            'Could not connect to the database. Please check your project status.',
-                        }}
-                      />
-                    </div>
-                  ) : isPending ? (
-                    <div className="absolute top-14 px-6 w-full">
-                      <GenericSkeletonLoader />
-                    </div>
-                  ) : isError ? (
-                    <div className="absolute top-14 px-6 flex flex-col items-center justify-center w-full">
-                      <AlertError subject="Failed to retrieve users" error={error} />
-                    </div>
-                  ) : isSuccess ? (
-                    <div className="absolute top-20 px-6 flex flex-col items-center justify-center w-full gap-y-2">
-                      <Users className="text-foreground-lighter" strokeWidth={1} />
-                      <div className="text-center">
-                        <p className="text-foreground">
-                          {filterUserType !== 'all' || filterKeywords.length > 0
-                            ? 'No users found'
-                            : 'No users in your project'}
-                        </p>
-                        <p className="text-foreground-light">
-                          {filterUserType !== 'all' || filterKeywords.length > 0
-                            ? 'There are currently no users based on the filters applied'
-                            : 'There are currently no users who signed up to your project'}
-                        </p>
-                      </div>
-                    </div>
-                  ) : null,
-                }}
-              />
-            </div>
-          </ResizablePanel>
-          {!!selectedId && <UserPanel />}
-        </ResizablePanelGroup>
+                  </div>
+                ) : null,
+              }}
+            />
+          </div>
+        </ResizableInspectorLayout>
 
         <UsersFooter
           filter={filterUserType}

--- a/apps/studio/components/interfaces/UnifiedLogs/ServiceFlowPanel.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/ServiceFlowPanel.tsx
@@ -1,17 +1,7 @@
 import { useParams } from 'common'
 import { Check, Clock, Copy } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
-import {
-  Button,
-  copyToClipboard,
-  ResizableHandle,
-  ResizablePanel,
-  Skeleton,
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
-} from 'ui'
+import { Button, copyToClipboard, Skeleton, Tabs, TabsContent, TabsList, TabsTrigger } from 'ui'
 import { CodeBlock } from 'ui-patterns/CodeBlock'
 
 import { PostgresFlowDetail } from './ServiceFlow/components/PostgresFlowDetail'
@@ -115,49 +105,76 @@ export function ServiceFlowPanel({
       : jsonData
 
   return (
-    <>
-      <ResizableHandle withHandle />
-      <ResizablePanel
-        id="log-sidepanel"
-        defaultSize={400}
-        minSize={dock === 'bottom' ? 300 : 400}
-        className="bg-dash-sidebar"
+    <div className="flex h-full flex-col overflow-hidden">
+      <Tabs
+        defaultValue={shouldShowServiceFlow ? 'overview' : 'raw-json'}
+        value={activeTab}
+        onValueChange={setActiveTab}
+        className="flex h-full w-full flex-col"
       >
-        <div className="flex h-full flex-col overflow-hidden">
-          <Tabs
-            defaultValue={shouldShowServiceFlow ? 'overview' : 'raw-json'}
-            value={activeTab}
-            onValueChange={setActiveTab}
-            className="flex h-full w-full flex-col"
-          >
-            <div className="flex items-center justify-between px-4 border-b border-border">
-              <TabsList className="flex h-auto gap-x-4 rounded-none border-none!">
-                {shouldShowServiceFlow && (
-                  <TabsTrigger
-                    value="overview"
-                    className="border-b py-3 font-mono text-xs uppercase"
-                  >
-                    Overview
-                  </TabsTrigger>
-                )}
-                <TabsTrigger value="raw-json" className="border-b py-3 font-mono text-xs uppercase">
-                  Raw JSON
-                </TabsTrigger>
-              </TabsList>
-
-              <ServiceFlowPanelControls dock={dock} setDock={setDock} />
-            </div>
-
+        <div className="flex items-center justify-between px-4 border-b border-border">
+          <TabsList className="flex h-auto gap-x-4 rounded-none border-none!">
             {shouldShowServiceFlow && (
-              <TabsContent
-                ref={overviewScrollRef}
-                value="overview"
-                className="mt-0 grow overflow-auto py-2"
-              >
-                {error ? (
-                  <div className="py-8 text-center text-destructive">Error: {error.toString()}</div>
-                ) : serviceFlowType === 'postgres' ? (
-                  <PostgresFlowDetail
+              <TabsTrigger value="overview" className="border-b py-3 font-mono text-xs uppercase">
+                Overview
+              </TabsTrigger>
+            )}
+            <TabsTrigger value="raw-json" className="border-b py-3 font-mono text-xs uppercase">
+              Raw JSON
+            </TabsTrigger>
+          </TabsList>
+
+          <ServiceFlowPanelControls dock={dock} setDock={setDock} />
+        </div>
+
+        {shouldShowServiceFlow && (
+          <TabsContent
+            ref={overviewScrollRef}
+            value="overview"
+            className="mt-0 grow overflow-auto py-2"
+          >
+            {error ? (
+              <div className="py-8 text-center text-destructive">Error: {error.toString()}</div>
+            ) : serviceFlowType === 'postgres' ? (
+              <PostgresFlowDetail
+                data={selectedRow}
+                enrichedData={serviceFlowData?.result?.[0]}
+                isLoading={isLoading}
+                filterFields={filterFields}
+                table={table}
+              />
+            ) : (
+              <div>
+                <DetailSectionHeader
+                  title="Request started"
+                  icon={Clock}
+                  summary={formattedTime ?? undefined}
+                />
+                <MemoizedNetworkBlock
+                  data={selectedRow}
+                  enrichedData={serviceFlowData?.result?.[0]}
+                  isLoading={isLoading}
+                  filterFields={filterFields}
+                  table={table}
+                />
+                {serviceFlowType === 'auth' ? (
+                  <MemoizedGoTrueBlock
+                    data={selectedRow}
+                    enrichedData={serviceFlowData?.result?.[0]}
+                    isLoading={isLoading}
+                    filterFields={filterFields}
+                    table={table}
+                  />
+                ) : serviceFlowType === 'edge-function' ? (
+                  <MemoizedEdgeFunctionBlock
+                    data={selectedRow}
+                    enrichedData={serviceFlowData?.result?.[0]}
+                    isLoading={isLoading}
+                    filterFields={filterFields}
+                    table={table}
+                  />
+                ) : serviceFlowType === 'storage' ? (
+                  <MemoizedStorageBlock
                     data={selectedRow}
                     enrichedData={serviceFlowData?.result?.[0]}
                     isLoading={isLoading}
@@ -165,105 +182,65 @@ export function ServiceFlowPanel({
                     table={table}
                   />
                 ) : (
-                  <div>
-                    <DetailSectionHeader
-                      title="Request started"
-                      icon={Clock}
-                      summary={formattedTime ?? undefined}
-                    />
-                    <MemoizedNetworkBlock
+                  <>
+                    <MemoizedPostgRESTBlock
                       data={selectedRow}
                       enrichedData={serviceFlowData?.result?.[0]}
                       isLoading={isLoading}
                       filterFields={filterFields}
                       table={table}
                     />
-                    {serviceFlowType === 'auth' ? (
-                      <MemoizedGoTrueBlock
-                        data={selectedRow}
-                        enrichedData={serviceFlowData?.result?.[0]}
-                        isLoading={isLoading}
-                        filterFields={filterFields}
-                        table={table}
-                      />
-                    ) : serviceFlowType === 'edge-function' ? (
-                      <MemoizedEdgeFunctionBlock
-                        data={selectedRow}
-                        enrichedData={serviceFlowData?.result?.[0]}
-                        isLoading={isLoading}
-                        filterFields={filterFields}
-                        table={table}
-                      />
-                    ) : serviceFlowType === 'storage' ? (
-                      <MemoizedStorageBlock
-                        data={selectedRow}
-                        enrichedData={serviceFlowData?.result?.[0]}
-                        isLoading={isLoading}
-                        filterFields={filterFields}
-                        table={table}
-                      />
-                    ) : (
-                      <>
-                        <MemoizedPostgRESTBlock
-                          data={selectedRow}
-                          enrichedData={serviceFlowData?.result?.[0]}
-                          isLoading={isLoading}
-                          filterFields={filterFields}
-                          table={table}
-                        />
 
-                        <MemoizedPostgresBlock
-                          data={selectedRow}
-                          enrichedData={serviceFlowData?.result?.[0]}
-                          isLoading={isLoading}
-                          filterFields={filterFields}
-                          table={table}
-                        />
-                      </>
-                    )}
-                  </div>
+                    <MemoizedPostgresBlock
+                      data={selectedRow}
+                      enrichedData={serviceFlowData?.result?.[0]}
+                      isLoading={isLoading}
+                      filterFields={filterFields}
+                      table={table}
+                    />
+                  </>
                 )}
-              </TabsContent>
-            )}
-
-            <TabsContent
-              ref={jsonScrollRef}
-              value="raw-json"
-              className="mt-0 grow overflow-auto bg-surface-100/50"
-            >
-              {isLoading && shouldShowServiceFlow && (
-                <div className="flex items-center gap-3 border-b border-border bg-surface-100 p-3 text-foreground-light">
-                  <Skeleton className="h-4 w-4 animate-pulse rounded-full" />
-                  <span className="text-sm">Enriching log...</span>
-                </div>
-              )}
-              <div className="sticky top-2 z-10 flex justify-end px-2 -mb-9 pointer-events-none">
-                <Button
-                  size="tiny"
-                  variant="default"
-                  className="pointer-events-auto px-1.5"
-                  icon={jsonCopied ? <Check size={12} /> : <Copy size={12} />}
-                  onClick={() => {
-                    copyToClipboard(JSON.stringify(formattedJsonData, null, 2))
-                    setJsonCopied(true)
-                    setTimeout(() => setJsonCopied(false), 1000)
-                  }}
-                >
-                  {jsonCopied ? 'Copied' : ''}
-                </Button>
               </div>
-              <CodeBlock
-                language="json"
-                hideCopy
-                wrapperClassName="!overflow-visible bg-surface-100/50 [&_pre]:!bg-surface-100/50"
-                className="rounded-none border-none [&_code]:!leading-tight [&_pre]:!leading-tight"
-              >
-                {JSON.stringify(formattedJsonData, null, 2)}
-              </CodeBlock>
-            </TabsContent>
-          </Tabs>
-        </div>
-      </ResizablePanel>
-    </>
+            )}
+          </TabsContent>
+        )}
+
+        <TabsContent
+          ref={jsonScrollRef}
+          value="raw-json"
+          className="mt-0 grow overflow-auto bg-surface-100/50"
+        >
+          {isLoading && shouldShowServiceFlow && (
+            <div className="flex items-center gap-3 border-b border-border bg-surface-100 p-3 text-foreground-light">
+              <Skeleton className="h-4 w-4 animate-pulse rounded-full" />
+              <span className="text-sm">Enriching log...</span>
+            </div>
+          )}
+          <div className="sticky top-2 z-10 flex justify-end px-2 -mb-9 pointer-events-none">
+            <Button
+              size="tiny"
+              variant="default"
+              className="pointer-events-auto px-1.5"
+              icon={jsonCopied ? <Check size={12} /> : <Copy size={12} />}
+              onClick={() => {
+                copyToClipboard(JSON.stringify(formattedJsonData, null, 2))
+                setJsonCopied(true)
+                setTimeout(() => setJsonCopied(false), 1000)
+              }}
+            >
+              {jsonCopied ? 'Copied' : ''}
+            </Button>
+          </div>
+          <CodeBlock
+            language="json"
+            hideCopy
+            wrapperClassName="!overflow-visible bg-surface-100/50 [&_pre]:!bg-surface-100/50"
+            className="rounded-none border-none [&_code]:!leading-tight [&_pre]:!leading-tight"
+          >
+            {JSON.stringify(formattedJsonData, null, 2)}
+          </CodeBlock>
+        </TabsContent>
+      </Tabs>
+    </div>
   )
 }

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
@@ -28,6 +28,7 @@ import {
 } from 'ui'
 
 import { RefreshButton } from '../../ui/DataTable/RefreshButton'
+import { ResizableInspectorLayout } from '../../ui/ResizableInspectorLayout'
 import { generateDynamicColumns, UNIFIED_LOGS_COLUMNS } from './components/Columns'
 import { DownloadLogsButton } from './components/DownloadLogsButton'
 import { LogsFilterBar } from './components/LogsFilterBar'
@@ -452,65 +453,71 @@ export const UnifiedLogs = () => {
 
             <RowSelectionHeader />
 
-            <ResizablePanelGroup
-              key="main-logs"
+            <ResizableInspectorLayout
               className="flex-1 border-t"
               orientation={dock === 'bottom' ? 'vertical' : 'horizontal'}
-            >
-              <ResizablePanel
-                defaultSize="100"
-                minSize="10"
-                className={cn(
-                  'bg',
-                  isFetchingButNotPaginating && 'opacity-60 transition-opacity duration-150'
-                )}
-              >
-                <div
-                  className={cn(
-                    'h-full [&>div]:h-full',
-                    '[&_thead_th]:[border-top:none]! [&_thead_th]:[border-bottom:none]!',
-                    '[&_thead_th]:[box-shadow:inset_0_-1px_0_var(--border-default)]!',
-                    '[&_thead_th]:text-foreground-lighter! [&_thead_tr:hover]:bg-surface-75',
-                    '[&_thead_tr]:border-b-0! [&_tbody_tr]:border-b-0!'
-                  )}
-                >
-                  <DataTableInfinite
-                    columns={UNIFIED_LOGS_COLUMNS}
-                    totalRows={totalDBRowCount}
-                    filterRows={filterDBRowCount}
-                    totalRowsFetched={totalFetched}
-                    fetchNextPage={fetchNextPage}
-                    hasNextPage={hasNextPage}
-                    setColumnOrder={setColumnOrder}
-                    setColumnVisibility={setColumnVisibility}
-                    searchParamsParser={SEARCH_PARAMS_PARSER}
-                    emptyStateMessage={
-                      isUserFilterUnreachable(search) ? (
-                        <div className="text-sm flex flex-col gap-y-1">
-                          <p className="text-foreground-light">No results found</p>
-                          <p className="text-foreground-lighter">
-                            Filtering by user is only supported for Auth and Postgres log types
-                          </p>
-                        </div>
-                      ) : undefined
-                    }
-                  />
-                </div>
-              </ResizablePanel>
-
-              {!!openRowId && !!selectedRow && (
-                <>
-                  <LogsListPanel selectedRow={selectedRow} />
+              mainPanelId="logs-table"
+              inspectorPanelId="log-sidepanel"
+              inspectorLabel="Log details"
+              mainMinSize={dock === 'bottom' ? '20%' : 280}
+              inspectorDefaultSize={400}
+              inspectorMinSize={dock === 'bottom' ? 300 : 320}
+              inspectorMaxSize={dock === 'bottom' ? '70%' : '60%'}
+              snapThreshold={600}
+              mainPanelClassName={cn(
+                'bg',
+                isFetchingButNotPaginating && 'opacity-60 transition-opacity duration-150'
+              )}
+              inspectorPanelClassName="bg-dash-sidebar"
+              inspector={
+                openRowId && selectedRow ? (
                   <ServiceFlowPanel
                     dock={dock}
                     setDock={setDock}
-                    selectedRow={selectedRow?.original}
+                    selectedRow={selectedRow.original}
                     selectedRowKey={openRowId}
                     searchParameters={searchParameters}
                   />
-                </>
-              )}
-            </ResizablePanelGroup>
+                ) : undefined
+              }
+            >
+              <ResizablePanelGroup orientation="vertical" className="h-full">
+                <ResizablePanel defaultSize="100" minSize="10">
+                  <div
+                    className={cn(
+                      'h-full [&>div]:h-full',
+                      '[&_thead_th]:[border-top:none]! [&_thead_th]:[border-bottom:none]!',
+                      '[&_thead_th]:[box-shadow:inset_0_-1px_0_var(--border-default)]!',
+                      '[&_thead_th]:text-foreground-lighter! [&_thead_tr:hover]:bg-surface-75',
+                      '[&_thead_tr]:border-b-0! [&_tbody_tr]:border-b-0!'
+                    )}
+                  >
+                    <DataTableInfinite
+                      columns={UNIFIED_LOGS_COLUMNS}
+                      totalRows={totalDBRowCount}
+                      filterRows={filterDBRowCount}
+                      totalRowsFetched={totalFetched}
+                      fetchNextPage={fetchNextPage}
+                      hasNextPage={hasNextPage}
+                      setColumnOrder={setColumnOrder}
+                      setColumnVisibility={setColumnVisibility}
+                      searchParamsParser={SEARCH_PARAMS_PARSER}
+                      emptyStateMessage={
+                        isUserFilterUnreachable(search) ? (
+                          <div className="text-sm flex flex-col gap-y-1">
+                            <p className="text-foreground-light">No results found</p>
+                            <p className="text-foreground-lighter">
+                              Filtering by user is only supported for Auth and Postgres log types
+                            </p>
+                          </div>
+                        ) : undefined
+                      }
+                    />
+                  </div>
+                </ResizablePanel>
+                {!!openRowId && !!selectedRow && <LogsListPanel selectedRow={selectedRow} />}
+              </ResizablePanelGroup>
+            </ResizableInspectorLayout>
           </ResizablePanel>
         </ResizablePanelGroup>
       </DataTableSideBarLayout>

--- a/apps/studio/components/ui/ResizableInspectorLayout.integration.test.tsx
+++ b/apps/studio/components/ui/ResizableInspectorLayout.integration.test.tsx
@@ -1,0 +1,55 @@
+import { render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ResizableInspectorLayout } from './ResizableInspectorLayout'
+
+class MockResizeObserver implements ResizeObserver {
+  constructor(_callback: ResizeObserverCallback) {}
+
+  disconnect = vi.fn()
+  observe = vi.fn()
+  unobserve = vi.fn()
+}
+
+const InspectorLayout = ({ open }: { open: boolean }) => (
+  <ResizableInspectorLayout
+    mainPanelId="main-panel"
+    inspectorPanelId="inspector-panel"
+    inspectorLabel="Details"
+    mainMinSize={280}
+    inspectorMinSize={320}
+    inspector={open ? <div>Inspector content</div> : undefined}
+  >
+    <div>Main content</div>
+  </ResizableInspectorLayout>
+)
+
+describe('ResizableInspectorLayout integration', () => {
+  beforeEach(() => {
+    vi.stubGlobal('ResizeObserver', MockResizeObserver)
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      width: 393,
+      height: 600,
+      top: 0,
+      right: 393,
+      bottom: 600,
+      left: 0,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('can open, close, and reopen the inspector', () => {
+    const { rerender } = render(<InspectorLayout open />)
+
+    rerender(<InspectorLayout open={false} />)
+
+    expect(() => rerender(<InspectorLayout open />)).not.toThrow()
+  })
+})

--- a/apps/studio/components/ui/ResizableInspectorLayout.test.tsx
+++ b/apps/studio/components/ui/ResizableInspectorLayout.test.tsx
@@ -1,0 +1,168 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import type { HTMLAttributes, ReactNode, Ref } from 'react'
+import { useState } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ResizableInspectorLayout } from './ResizableInspectorLayout'
+
+const { mockInspectorPanel, mockResize } = vi.hoisted(() => {
+  const resize = vi.fn()
+
+  return {
+    mockInspectorPanel: {
+      collapse: vi.fn(),
+      expand: vi.fn(),
+      isCollapsed: vi.fn(() => false),
+      resize,
+    },
+    mockResize: resize,
+  }
+})
+
+interface MockPanelGroupProps extends HTMLAttributes<HTMLDivElement> {
+  children?: ReactNode
+  elementRef?: Ref<HTMLDivElement>
+  orientation?: 'horizontal' | 'vertical'
+}
+
+interface MockPanelProps extends HTMLAttributes<HTMLElement> {
+  children?: ReactNode
+  id?: string
+  panelRef?: unknown
+  onResize?: unknown
+  defaultSize?: number | string
+  minSize?: number | string
+  maxSize?: number | string
+}
+
+interface MockHandleProps extends HTMLAttributes<HTMLDivElement> {
+  withHandle?: boolean
+  disabled?: boolean
+}
+
+vi.mock('ui', async () => {
+  const React = await import('react')
+
+  return {
+    cn: (...classes: Array<string | false | null | undefined>) => classes.filter(Boolean).join(' '),
+    usePanelRef: () => React.useRef(mockInspectorPanel),
+    ResizablePanelGroup: ({ children, elementRef, orientation, ...props }: MockPanelGroupProps) => (
+      <div ref={elementRef} data-testid="inspector-group" data-orientation={orientation} {...props}>
+        {children}
+      </div>
+    ),
+    ResizablePanel: ({
+      children,
+      id,
+      panelRef: _panelRef,
+      onResize: _onResize,
+      defaultSize: _defaultSize,
+      minSize: _minSize,
+      maxSize: _maxSize,
+      ...props
+    }: MockPanelProps) => (
+      <section data-testid={id} {...props}>
+        {children}
+      </section>
+    ),
+    ResizableHandle: ({ withHandle: _withHandle, disabled, ...props }: MockHandleProps) => (
+      <div role="separator" aria-disabled={disabled} {...props} />
+    ),
+  }
+})
+
+let resizeObserverCallback: ResizeObserverCallback
+
+class MockResizeObserver implements ResizeObserver {
+  constructor(callback: ResizeObserverCallback) {
+    resizeObserverCallback = callback
+  }
+
+  disconnect = vi.fn()
+  observe = vi.fn()
+  unobserve = vi.fn()
+}
+
+const StatefulInspector = () => {
+  const [count, setCount] = useState(0)
+
+  return (
+    <button tabIndex={0} onClick={() => setCount((value) => value + 1)}>
+      Inspector count: {count}
+    </button>
+  )
+}
+
+const resizeContainer = (width: number) => {
+  act(() => {
+    resizeObserverCallback(
+      [{ contentRect: { width } } as ResizeObserverEntry],
+      {} as ResizeObserver
+    )
+  })
+}
+
+describe('ResizableInspectorLayout', () => {
+  beforeEach(() => {
+    mockResize.mockClear()
+    vi.stubGlobal('ResizeObserver', MockResizeObserver)
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      width: 612,
+      height: 600,
+      top: 0,
+      right: 612,
+      bottom: 600,
+      left: 0,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('snaps the same inspector to the full container and restores its previous size', () => {
+    render(
+      <ResizableInspectorLayout
+        orientation="vertical"
+        mainPanelId="main-panel"
+        inspectorPanelId="inspector-panel"
+        inspectorLabel="Details"
+        mainMinSize={280}
+        inspectorDefaultSize={360}
+        inspectorMinSize={320}
+        inspector={<StatefulInspector />}
+      >
+        <div>Main content</div>
+      </ResizableInspectorLayout>
+    )
+
+    const group = screen.getByTestId('inspector-group')
+    const inspector = screen.getByRole('region', { name: 'Details' })
+
+    expect(group).not.toHaveAttribute('data-inspector-snapped')
+    expect(group).toHaveAttribute('data-orientation', 'vertical')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Inspector count: 0' }))
+    expect(screen.getByRole('button', { name: 'Inspector count: 1' })).toBeInTheDocument()
+
+    resizeContainer(393)
+
+    expect(group).toHaveAttribute('data-inspector-snapped')
+    expect(group).toHaveAttribute('data-orientation', 'horizontal')
+    expect(screen.getByRole('separator')).toHaveClass('hidden')
+    expect(mockResize).toHaveBeenLastCalledWith('100%')
+    expect(screen.getByRole('region', { name: 'Details' })).toBe(inspector)
+    expect(screen.getByRole('button', { name: 'Inspector count: 1' })).toBeInTheDocument()
+
+    resizeContainer(612)
+
+    expect(group).not.toHaveAttribute('data-inspector-snapped')
+    expect(group).toHaveAttribute('data-orientation', 'vertical')
+    expect(mockResize).toHaveBeenLastCalledWith(360)
+    expect(screen.getByRole('region', { name: 'Details' })).toBe(inspector)
+    expect(screen.getByRole('button', { name: 'Inspector count: 1' })).toBeInTheDocument()
+  })
+})

--- a/apps/studio/components/ui/ResizableInspectorLayout.tsx
+++ b/apps/studio/components/ui/ResizableInspectorLayout.tsx
@@ -1,0 +1,148 @@
+import type { ReactNode } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { cn, ResizableHandle, ResizablePanel, ResizablePanelGroup, usePanelRef } from 'ui'
+
+type PanelSize = number | string
+
+interface ResizableInspectorLayoutProps {
+  children: ReactNode
+  inspector?: ReactNode
+  orientation?: 'horizontal' | 'vertical'
+  className?: string
+  mainPanelClassName?: string
+  inspectorPanelClassName?: string
+  handleClassName?: string
+  mainPanelId: string
+  inspectorPanelId: string
+  inspectorLabel: string
+  mainMinSize: PanelSize
+  inspectorDefaultSize?: PanelSize
+  inspectorMinSize: PanelSize
+  inspectorMaxSize?: PanelSize
+  snapThreshold?: number
+}
+
+export const ResizableInspectorLayout = ({
+  children,
+  inspector,
+  orientation = 'horizontal',
+  className,
+  mainPanelClassName,
+  inspectorPanelClassName,
+  handleClassName,
+  mainPanelId,
+  inspectorPanelId,
+  inspectorLabel,
+  mainMinSize,
+  inspectorDefaultSize = 400,
+  inspectorMinSize,
+  inspectorMaxSize = '60%',
+  snapThreshold = typeof mainMinSize === 'number' && typeof inspectorMinSize === 'number'
+    ? mainMinSize + inspectorMinSize
+    : 600,
+}: ResizableInspectorLayoutProps) => {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const inspectorPanelRef = usePanelRef()
+  const previousInspectorSize = useRef<PanelSize>(inspectorDefaultSize)
+  const pendingRestoreSize = useRef<PanelSize | undefined>(undefined)
+  const wasInspectorOpenRef = useRef(false)
+  const isSnappedRef = useRef(false)
+  const [isContainerNarrow, setIsContainerNarrow] = useState(false)
+
+  const hasInspector = inspector !== undefined && inspector !== null
+  const isSnapped = hasInspector && isContainerNarrow
+
+  useLayoutEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    const updateContainerWidth = (width: number) => {
+      const shouldSnap = width > 0 && width <= snapThreshold
+
+      if (isSnappedRef.current && !shouldSnap) {
+        pendingRestoreSize.current = previousInspectorSize.current
+      }
+
+      isSnappedRef.current = shouldSnap
+      setIsContainerNarrow(shouldSnap)
+    }
+
+    updateContainerWidth(container.getBoundingClientRect().width)
+
+    const observer = new ResizeObserver(([entry]) => {
+      if (entry) updateContainerWidth(entry.contentRect.width)
+    })
+    observer.observe(container)
+
+    return () => observer.disconnect()
+  }, [snapThreshold])
+
+  useEffect(() => {
+    const wasInspectorOpen = wasInspectorOpenRef.current
+    wasInspectorOpenRef.current = hasInspector
+
+    if (!hasInspector || !wasInspectorOpen || !inspectorPanelRef.current) {
+      pendingRestoreSize.current = undefined
+      return
+    }
+
+    const nextSize = isSnapped
+      ? '100%'
+      : (pendingRestoreSize.current ?? previousInspectorSize.current)
+
+    inspectorPanelRef.current.resize(nextSize)
+    pendingRestoreSize.current = undefined
+  }, [hasInspector, inspectorPanelRef, isSnapped])
+
+  return (
+    <ResizablePanelGroup
+      elementRef={containerRef}
+      orientation={isSnapped ? 'horizontal' : orientation}
+      className={cn('relative', className)}
+      data-inspector-snapped={isSnapped ? '' : undefined}
+    >
+      <ResizablePanel
+        id={mainPanelId}
+        defaultSize={isSnapped ? '0%' : '100%'}
+        minSize={isSnapped ? '0%' : mainMinSize}
+        maxSize={isSnapped ? '0%' : undefined}
+        inert={isSnapped ? true : undefined}
+        aria-hidden={isSnapped || undefined}
+        className={mainPanelClassName}
+      >
+        {children}
+      </ResizablePanel>
+
+      {hasInspector && (
+        <>
+          <ResizableHandle
+            withHandle
+            disabled={isSnapped}
+            className={cn(isSnapped && 'hidden', handleClassName)}
+          />
+          <ResizablePanel
+            id={inspectorPanelId}
+            panelRef={inspectorPanelRef}
+            defaultSize={isSnapped ? '100%' : inspectorDefaultSize}
+            minSize={isSnapped ? '100%' : inspectorMinSize}
+            maxSize={isSnapped ? '100%' : inspectorMaxSize}
+            role="region"
+            aria-label={inspectorLabel}
+            className={inspectorPanelClassName}
+            onResize={(size) => {
+              if (
+                !isSnappedRef.current &&
+                pendingRestoreSize.current === undefined &&
+                size.inPixels > 0
+              ) {
+                previousInspectorSize.current = size.inPixels
+              }
+            }}
+          >
+            {inspector}
+          </ResizablePanel>
+        </>
+      )}
+    </ResizablePanelGroup>
+  )
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix. Resolves DEPR-635.

## What is the current behavior?

Authentication > Users renders user details as an unusably narrow sheet on small viewports. Intermediate widths can leave both the table and inspector too narrow to use, and reopening a responsive inspector can race the resizable panel layout registration.

Unified Logs uses similar inspector behaviour but does not snap the inspector to the available width at phone sizes.

## What is the new behavior?

Adds a shared, container-aware resizable inspector layout for Authentication > Users and Unified Logs.

The inspector remains alongside the table while both panels have enough room. Below each consumer's minimum viable width, it fills the available data workspace, collapses the table panel, and hides the resize handle. Returning to a wider container restores the previous inspector size without remounting its content.

Auth user identifiers and overview values now wrap safely at narrow widths. The inspector also avoids imperative resize calls while a panel is opening, preventing the panel registration race on close and reopen.

| Before | After |
| --- | --- |
| <img width="390" height="850" alt="Users  Authentication  Chisel  Toolshed  Supabase" src="https://github.com/user-attachments/assets/f8d5a9be-536e-487c-9bb2-17a25e305b4c" /> | <img width="390" height="850" alt="Users  Authentication  Chisel  Toolshed  Supabase" src="https://github.com/user-attachments/assets/12f8ba39-1647-455b-b4f6-a74b6b6a63e8" /> |

# To test

1. Open **[Authentication > Users](https://studio-staging-git-dnywh-depr-635-auth-users-mo-4e93a3-supabase.vercel.app/dashboard/project/_/auth/users)** on a wide desktop viewport, select a user, resize the details inspector, close it, and reopen it. Confirm there is no error and the table and inspector remain usable.
2. At approximately **800 × 852**, select a user. Confirm the details inspector fills the available Users data workspace instead of leaving a skinny table and inspector side by side.
3. At approximately **393 × 852**, select a user. Confirm the inspector uses the full available workspace, identifiers and timestamps wrap, copy actions remain visible, and closing it returns to the users table.
4. In **[Unified Logs](https://studio-staging-git-dnywh-depr-635-auth-users-mo-4e93a3-supabase.vercel.app/dashboard/project/_/logs)**, open a log entry with the inspector docked right. Confirm it is resizable on a wide viewport and snaps to the full available workspace at phone width.
5. In **[Unified Logs](https://studio-staging-git-dnywh-depr-635-auth-users-mo-4e93a3-supabase.vercel.app/dashboard/project/_/logs)**, repeat with the inspector docked bottom. Confirm the bottom layout returns when the viewport widens and that any Event logs panel remains grouped with the logs table.
6. In both callsites, repeatedly open, close, and reopen inspectors across wide and narrow widths. Confirm there is no `Layout not found for Panel` error.
