### PR TITLE
docs: fix DEFFERED and indentity typos in database guides

### DIFF
--- a/apps/docs/content/guides/database/json.mdx
+++ b/apps/docs/content/guides/database/json.mdx
@@ -52,7 +52,7 @@ create table books (
 
 - Name: `id`
   - Type: `int8`
-  - Default value: `Automatically generate as indentity`
+  - Default value: `Automatically generate as identity`
 - **title** column
   - Name: `title`
   - Type: `text`

--- a/apps/docs/content/guides/database/postgres/cascade-deletes.mdx
+++ b/apps/docs/content/guides/database/postgres/cascade-deletes.mdx
@@ -149,7 +149,7 @@ add constraint child_father_fkey foreign key (father) references parent (id)
   on delete no action initially deferred;
 ```
 
-Here you will see that `INITIALLY DEFFERED` seems to operate like `NO ACTION` or `RESTRICT`. When we run a delete, it seems to make no difference:
+Here you will see that `INITIALLY DEFERRED` seems to operate like `NO ACTION` or `RESTRICT`. When we run a delete, it seems to make no difference:
 
 ```shell
 postgres=# delete from grandparent;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation fix - two spelling errors.

## What is the current behavior?

**1. `guides/database/postgres/cascade-deletes`** spells the Postgres keyword `DEFERRED` as `DEFFERED`:

> Here you will see that `INITIALLY DEFFERED` seems to operate like `NO ACTION` or `RESTRICT`.

The SQL block directly above it correctly uses `initially deferred`, and the paragraph before it correctly writes `NO ACTION INITIALLY DEFERRED` - so this line is inconsistent with its own surrounding text. Anyone copying the keyword out of that sentence gets a syntax error.

**2. `guides/database/json`** spells the dashboard option as `indentity`:

> Default value: `Automatically generate as indentity`

The actual Dashboard label is "Automatically generate as identity", so the docs did not match the UI being described.

## What is the new behavior?

Both spellings corrected. Two words changed, no other edits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the Dashboard setup label from “indentity” to “identity.”
  * Fixed the PostgreSQL constraint terminology from “DEFFERED” to “DEFERRED” in the cascade deletes guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->