### PR TITLE
fix(studio): validate edge-function test URL after normalization, closing prefix-collapse SSRF

### DIFF
--- a/apps/studio/lib/api/edgeFunctions.test.ts
+++ b/apps/studio/lib/api/edgeFunctions.test.ts
@@ -152,4 +152,21 @@ describe('isValidEdgeFunctionURL', () => {
       expect(isValidEdgeFunctionURL(url, false), `Expected ${url} to be invalid`).toBe(false)
     }
   })
+
+  it('should reject path-normalization escapes that pass a raw-string check', () => {
+    // '/functions/v1/../../x' passes a raw regex but fetch normalizes to '/x'
+    const traversalUrls = [
+      'http://kong:8000/functions/v1/../',
+      'http://169.254.169.254/functions/v1/../../latest/meta-data/',
+      'https://uniquetwentychararef.supabase.co/functions/v1/../rest/v1/',
+    ]
+    for (const url of traversalUrls) {
+      expect(isValidEdgeFunctionURL(url, false), `Expected ${url} to be invalid off platform`).toBe(
+        false
+      )
+      expect(isValidEdgeFunctionURL(url, true), `Expected ${url} to be invalid on platform`).toBe(
+        false
+      )
+    }
+  })
 })

--- a/apps/studio/lib/api/edgeFunctions.ts
+++ b/apps/studio/lib/api/edgeFunctions.ts
@@ -35,24 +35,33 @@ export const isEdgeFunctionUrl = (
   )
 }
 
+const FUNCTIONS_PATH_PREFIX = /^\/functions\/v[0-9]{1}\//
+
 export const isValidEdgeFunctionURL = (url: string, isPlatform: boolean) => {
+  // Validate the parsed URL, not the raw string. A raw-string regex can be
+  // passed by '/functions/v1/../../<path>' while fetch normalizes the dots
+  // away before sending, so the request escapes the functions prefix to any
+  // path on any host (SSRF; e.g. cloud metadata endpoints on self-hosted).
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return false
+  }
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return false
+  if (!FUNCTIONS_PATH_PREFIX.test(parsed.pathname)) return false
+
   if (NIMBUS_PROD_PROJECTS_URL !== undefined) {
     const apexDomain = NIMBUS_PROD_PROJECTS_URL.replace('https://*.', '').replace(/\./g, '\\.')
-    const nimbusRegex = new RegExp('^https://[a-z]*\\.' + apexDomain + '/functions/v[0-9]{1}/.*$')
-    return nimbusRegex.test(url)
+    const nimbusHostRegex = new RegExp('^[a-z]*\\.' + apexDomain + '$')
+    return parsed.protocol === 'https:' && nimbusHostRegex.test(parsed.host)
   }
 
   if (!isPlatform) {
-    const regexValidLocalEdgeFunctionURL = new RegExp(
-      /^https?:\/\/[^\s/?#]+\/functions\/v[0-9]{1}\/.*$/
-    )
-
-    return regexValidLocalEdgeFunctionURL.test(url)
+    // Self-hosted may serve edge functions on a custom domain, so any host is
+    // allowed; the normalized path prefix above is the security invariant.
+    return true
   }
 
-  const regexValidEdgeFunctionURL = new RegExp(
-    /^https:\/\/[a-z]{20}\.supabase\.(red|co)\/functions\/v[0-9]{1}\/.*$/
-  )
-
-  return regexValidEdgeFunctionURL.test(url)
+  return parsed.protocol === 'https:' && /^[a-z]{20}\.supabase\.(red|co)$/.test(parsed.host)
 }


### PR DESCRIPTION
## Summary

`POST /api/edge-functions/test` fetches a caller-supplied URL server-side and returns the full response (status, headers, body). Before fetching, the URL is checked by `isValidEdgeFunctionURL`, which regex-tested the **raw** string.

`fetch` normalizes dot segments **after** that check, so:

```
http://169.254.169.254/functions/v1/../../latest/meta-data/
```

passes the raw regex, then `new URL(...)` collapses it to `/latest/meta-data/` and the request escapes the `/functions/v1/` prefix entirely.

**Impact (self-hosted, `IS_PLATFORM=false`):** the self-hosted branch intentionally allows any host, so this is a full unauthenticated SSRF relay (the route has no `apiWrapper` auth): attacker-chosen internal host + path, method, and headers, with the response body returned. Reaches cloud instance metadata (IMDSv1), the `kong` admin API, or any internal HTTP service. On platform (`IS_PLATFORM=true`) the host regex is tight, but the same collapse escapes the functions prefix to any same-host path (e.g. `/rest/v1/`).

## Fix

Validate the **parsed** URL instead of the raw string: `parsed.pathname` must start with `/functions/vN/` *after* normalization; the platform branch additionally pins the host with the same regex as before. Self-hosted keeps its intended any-host flexibility — the normalized path prefix is the security invariant.

## Test plan

- All pre-existing `isValidEdgeFunctionURL` expectations (valid platform URLs, valid self-hosted custom-domain URLs, invalid cross-cases) verified preserved.
- Added regression tests asserting `/functions/v1/../../latest/meta-data/`, `/functions/v1/../`, and platform `/functions/v1/../rest/v1/` are now rejected on both branches.
- Note: could not run the studio vitest suite in a sparse clone (workspace deps not installed); the logic was verified standalone against the exact new code path (11/11 cases, including every pre-existing expectation).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved edge-function URL validation to block path traversal and invalid path formats.
  * Restricted edge-function URLs to secure HTTP(S) protocols.
  * Added stricter host validation for platform and Nimbus configurations while preserving support for self-hosted deployments.
  * Added coverage for URLs that attempt to escape the expected functions path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->