### PR TITLE
fix(ui): opaque default button hover fills

### DIFF
--- a/packages/ui-patterns/src/CommandMenu/api/CommandMenu.tsx
+++ b/packages/ui-patterns/src/CommandMenu/api/CommandMenu.tsx
@@ -188,9 +188,9 @@ function CommandMenuTriggerInput({
           'grow md:min-w-44 xl:min-w-56 h-[30px] rounded-md',
           'pl-1.5 md:pl-2 pr-1',
           'flex items-center justify-between',
-          // Match Button default (Connect): selection hover fill, stronger border.
+          // Match Button default (Connect): opaque popover hover fill, stronger border.
           'bg-transparent text-foreground-lighter border border-strong',
-          'hover:bg-selection hover:border-stronger',
+          'hover:bg-popover hover:border-stronger',
           'focus-ring',
           'transition-colors',
           className

--- a/packages/ui-patterns/src/SkipToContent/SkipToContent.test.tsx
+++ b/packages/ui-patterns/src/SkipToContent/SkipToContent.test.tsx
@@ -26,7 +26,6 @@ describe('SkipToContent', () => {
     const wrapper = container.firstElementChild as HTMLElement
     expect(wrapper.className).toContain('-translate-y-full')
     expect(wrapper.className).toContain('focus-within:translate-y-[10px]')
-    expect(wrapper.className).toContain('bg-background')
     expect(wrapper.className).toContain('w-fit')
     expect(wrapper.className).toContain('left-[10px]')
   })
@@ -35,6 +34,7 @@ describe('SkipToContent', () => {
     render(<SkipToContent href="#main" />)
 
     const link = screen.getByRole('link', { name: 'Skip to content' })
+    expect(link.className).toContain('hover:bg-popover')
     expect(link.className).not.toContain('bg-surface-300')
     expect(link.className).not.toContain('hover:bg-secondary')
   })

--- a/packages/ui-patterns/src/SkipToContent/SkipToContent.tsx
+++ b/packages/ui-patterns/src/SkipToContent/SkipToContent.tsx
@@ -19,9 +19,8 @@ function SkipToContent({ href, children = 'Skip to content', className }: SkipTo
   return (
     <div
       className={cn(
-        // Opaque plate so default Button muted/selection fills composite like any other control.
-        // w-fit: plate is a block div by default and would otherwise span the full content column.
-        'fixed top-0 left-[10px] z-[100] w-fit rounded-md bg-background',
+        // w-fit: wrapper is a block div by default and would otherwise span the full content column.
+        'fixed top-0 left-[10px] z-[100] w-fit',
         '-translate-y-full focus-within:translate-y-[10px]',
         'transition-transform duration-200 ease-out',
         className

--- a/packages/ui-patterns/src/multi-select/multi-select.tsx
+++ b/packages/ui-patterns/src/multi-select/multi-select.tsx
@@ -294,12 +294,12 @@ const MultiSelectorTrigger = React.forwardRef<HTMLButtonElement, MultiSelectorTr
           role="combobox"
           className={cn(
             'flex w-full min-w-[200px] min-h-[34px] items-center justify-between rounded-md border',
-            'border-strong bg-alternative dark:bg-muted px-3 py-1.5 text-sm',
+            'border-strong bg-background dark:bg-card px-3 py-1.5 text-sm',
             'placeholder:text-muted-foreground',
             'ring-border-control focus-ring',
             'disabled:cursor-not-allowed disabled:opacity-50',
-            'hover:border-stronger hover:bg-selection transition-colors duration-200',
-            open && 'bg-selection border-stronger',
+            'hover:border-stronger hover:bg-popover transition-colors duration-200',
+            open && 'bg-popover border-stronger',
             className
           )}
           {...props}

--- a/packages/ui/build/css/source/compat.css
+++ b/packages/ui/build/css/source/compat.css
@@ -18,21 +18,31 @@
   --foreground-muted: var(--tertiary-foreground);
   /* --foreground-contrast lives in semantic.css — do not remap to --primary-foreground */
 
-  /* Legacy background aliases */
+  /* Legacy background aliases.
+   *
+   * Pre-color-system, these were opaque greys. Do not map fill tokens used by
+   * controls / overlapping surfaces onto the translucent overlay ramp
+   * (--muted / --accent / --tertiary): alpha fills punch through stacked
+   * content (buttons over table cells, sticky columns, skip links, etc.).
+   *
+   * Solid elevation twins: muted≈card (e1), accent/selection≈popover (e2),
+   * tertiary≈secondary (e3). Overlay-hover stays on --accent so menu item
+   * washes still composite on opaque bg-overlay panels.
+   */
   --background-default: var(--background);
   --background-200: var(--card);
   --background-alternative-default: var(--background);
   --background-alternative-200: var(--card);
-  --background-selection: var(--accent);
-  --background-control: var(--accent);
+  --background-selection: var(--popover);
+  --background-control: var(--card);
   --background-surface-75: var(--card);
   --background-surface-100: var(--card);
-  --background-surface-200: var(--muted);
+  --background-surface-200: var(--card);
   --background-surface-300: var(--secondary);
-  --background-surface-400: var(--tertiary);
+  --background-surface-400: var(--secondary);
   --background-overlay-default: var(--secondary);
   --background-overlay-hover: var(--accent);
-  --background-muted: var(--muted);
+  --background-muted: var(--card);
   --background-button-default: var(--secondary);
   --background-dialog-default: var(--popover);
   --background-dash-sidebar: var(--background);

--- a/packages/ui/build/css/source/compat.css
+++ b/packages/ui/build/css/source/compat.css
@@ -18,31 +18,21 @@
   --foreground-muted: var(--tertiary-foreground);
   /* --foreground-contrast lives in semantic.css — do not remap to --primary-foreground */
 
-  /* Legacy background aliases.
-   *
-   * Pre-color-system, these were opaque greys. Do not map fill tokens used by
-   * controls / overlapping surfaces onto the translucent overlay ramp
-   * (--muted / --accent / --tertiary): alpha fills punch through stacked
-   * content (buttons over table cells, sticky columns, skip links, etc.).
-   *
-   * Solid elevation twins: muted≈card (e1), accent/selection≈popover (e2),
-   * tertiary≈secondary (e3). Overlay-hover stays on --accent so menu item
-   * washes still composite on opaque bg-overlay panels.
-   */
+  /* Legacy background aliases */
   --background-default: var(--background);
   --background-200: var(--card);
   --background-alternative-default: var(--background);
   --background-alternative-200: var(--card);
-  --background-selection: var(--popover);
-  --background-control: var(--card);
+  --background-selection: var(--accent);
+  --background-control: var(--accent);
   --background-surface-75: var(--card);
   --background-surface-100: var(--card);
-  --background-surface-200: var(--card);
+  --background-surface-200: var(--muted);
   --background-surface-300: var(--secondary);
-  --background-surface-400: var(--secondary);
+  --background-surface-400: var(--tertiary);
   --background-overlay-default: var(--secondary);
   --background-overlay-hover: var(--accent);
-  --background-muted: var(--card);
+  --background-muted: var(--muted);
   --background-button-default: var(--secondary);
   --background-dialog-default: var(--popover);
   --background-dash-sidebar: var(--background);

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -37,9 +37,9 @@ const buttonVariants = cva(
           `,
         default: `
           text-foreground
-          bg-alternative dark:bg-muted  hover:bg-selection
+          bg-background dark:bg-card hover:bg-popover
           border-strong hover:border-stronger
-          data-[state=open]:bg-selection
+          data-[state=open]:bg-popover
           data-[state=open]:border-button-hover
           `,
         secondary: `

--- a/packages/ui/src/components/shadcn/ui/select.tsx
+++ b/packages/ui/src/components/shadcn/ui/select.tsx
@@ -47,8 +47,8 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      'flex w-full items-center justify-between rounded-md border border-strong hover:border-stronger bg-alternative dark:bg-muted hover:bg-selection text-xs data-[placeholder]:text-foreground-lighter ring-border-control focus-ring disabled:cursor-not-allowed disabled:opacity-50 transition-colors duration-200',
-      'data-[state=open]:bg-selection data-[state=open]:border-stronger',
+      'flex w-full items-center justify-between rounded-md border border-strong hover:border-stronger bg-background dark:bg-card hover:bg-popover text-xs data-[placeholder]:text-foreground-lighter ring-border-control focus-ring disabled:cursor-not-allowed disabled:opacity-50 transition-colors duration-200',
+      'data-[state=open]:bg-popover data-[state=open]:border-stronger',
       'gap-2',
       '[&>span]:truncate text-left', // [kemal] This is to prevent double lines rendering when a string is particularly long.
       SelectTriggerVariants({ size }),


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for translucent default Button (and related control) fills that show through stacked content on hover.

Resolves [DEPR-636](https://linear.app/supabase/issue/DEPR-636/report-snippet-cell-expand-button-becomes-transparent-on-hover).

## What is the current behavior?

Default `Button` hover uses `bg-selection`, and dark-mode rest uses `bg-muted`. After the colour system migration those legacy aliases point at translucent `--accent` / `--muted`, so hover punches through whatever sits behind the button (SQL Editor / Reports cell expand, sticky columns, skip-to-content, etc.).

| Before: Light | Before: Dark |
| --- | --- |
| <img width="491" height="75" alt="CleanShot 2026-08-03 at 09 12 26@2x" src="https://github.com/user-attachments/assets/20e33ba9-74c5-47eb-aced-ac932a0059fa" /> | <img width="205" height="54" alt="21257" src="https://github.com/user-attachments/assets/a2c9f092-18a7-4a4d-a49b-6e019e50895f" /> |

## What is the new behavior?

Default Button, Select, MultiSelect, and the CommandMenu trigger use opaque elevation tokens (`bg-background dark:bg-card`, `hover:bg-popover`). SkipToContent drops its opaque-plate workaround. No global `compat.css` alias remaps.

| After: Light | After: Dark |
| --- | --- |
| <img width="466" height="110" alt="CleanShot 2026-08-07 at 16 09 59@2x" src="https://github.com/user-attachments/assets/6410cb58-b37c-427f-a0ff-7b223a7f3f51" /> | <img width="474" height="132" alt="CleanShot 2026-08-07 at 16 08 53@2x" src="https://github.com/user-attachments/assets/575c56d1-8ee5-4eb5-8f08-e4b5af8520f0" /> |

## Additional context

- Overlay tokens (`--muted` / `--accent` / `--tertiary`) stay intentional for washes on solid surfaces. Controls that can sit over content should use solid elevation tokens (`card` / `popover`) instead.
- Same root cause as the workarounds in #47996 and #48314.
- The “View full cell content” control lives in SQL Editor results / Report `QueryBlock` (`ResultCell`), not Table Editor. It only renders when the value is an object/array, contains a newline, or is longer than 60 characters, and it stays `opacity-0` until you hover the cell.

## To test

Short path in Studio (light and dark):

1. **Expand button over cell text (clearest repro)** – SQL Editor, run:
   ```sql
   select repeat('x', 80) as name;
   ```
   Hover the result cell. The expand control should appear over the text; hover the button itself and confirm the fill is solid (no `x`s showing through). Same control is what Report snippets use.
2. **Any default Button** – Top nav **Connect** (or any bordered default button). Hover: solid fill.
3. **Select** – Project picker or a Settings form select. Trigger hover / open fill stays opaque.
4. **Command menu trigger** – Hover the header search / Cmd-K control; match default Button.
5. **Skip to content** – Tab once on Studio. Skip link hover stays solid over the page behind it.
6. **Editor tabs regression** – SQL / Table Editor tab strip should still look grey in light mode (not washed white).