### PR TITLE
fix(studio): support custom schema enum selection and formatting in column editor (#30632)

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.tsx
@@ -60,6 +60,7 @@ import {
   ForeignKeyConstraint,
   useForeignKeyConstraintsQuery,
 } from '@/data/database/foreign-key-constraints-query'
+import { useSchemasQuery } from '@/data/database/schemas-query'
 import { useEnumeratedTypesQuery } from '@/data/enumerated-types/enumerated-types-query'
 import type { RetrieveTableResult } from '@/data/tables/table-retrieve-query'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
@@ -108,10 +109,18 @@ export const ColumnEditor = ({
     getPlaceholderText(columnFields?.format, columnFields?.name)
   )
 
-  const { data: types } = useEnumeratedTypesQuery({
+  const { data: schemas } = useSchemasQuery({
     projectRef: project?.ref,
     connectionString: project?.connectionString,
   })
+  const schemaNames = (schemas ?? []).map((s) => s.name)
+
+  const { data: types } = useEnumeratedTypesQuery({
+    projectRef: project?.ref,
+    connectionString: project?.connectionString,
+    schemas: schemaNames,
+  })
+
   const { data: protectedSchemas } = useProtectedSchemas({ excludeSchemas: ['extensions'] })
   const enumTypes = (types ?? []).filter(
     (type) => !protectedSchemas.find((s) => s.name === type.schema)

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.utils.test.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.utils.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+import { displayColumnType, normalizeFormatSchema } from './ColumnEditor.utils'
+
+describe('ColumnEditor.utils', () => {
+  describe('normalizeFormatSchema', () => {
+    it('returns undefined for public and pg_catalog schemas', () => {
+      expect(normalizeFormatSchema('public')).toBeUndefined()
+      expect(normalizeFormatSchema('pg_catalog')).toBeUndefined()
+    })
+
+    it('preserves custom schema names', () => {
+      expect(normalizeFormatSchema('custom_schema')).toBe('custom_schema')
+    })
+  })
+
+  describe('displayColumnType', () => {
+    it('formats public schema types unqualified', () => {
+      expect(displayColumnType('text', 'public')).toBe('text')
+      expect(displayColumnType('text', undefined)).toBe('text')
+    })
+
+    it('formats custom schema types quoted', () => {
+      expect(displayColumnType('my_enum', 'custom_schema')).toBe('"custom_schema"."my_enum"')
+    })
+
+    it('handles array types correctly', () => {
+      expect(displayColumnType('text', 'public', true)).toBe('text[]')
+      expect(displayColumnType('my_enum', 'custom_schema', true)).toBe(
+        '"custom_schema"."my_enum"[]'
+      )
+    })
+
+    it('escapes embedded double quotes in identifiers', () => {
+      expect(displayColumnType('my"type', 'custom"schema')).toBe('"custom""schema"."my""type"')
+    })
+  })
+})

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.utils.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.utils.ts
@@ -57,7 +57,14 @@ export const displayColumnType = (
 ): string => {
   const bareFormat = isArray && format.startsWith('_') ? format.slice(1) : format
   const normalized = normalizeFormatSchema(formatSchema)
-  const qualified = normalized ? `${normalized}.${bareFormat}` : bareFormat
+  if (!normalized) {
+    return isArray ? `${bareFormat}[]` : bareFormat
+  }
+
+  const escapedSchema = normalized.replace(/"/g, '""')
+  const escapedFormat = bareFormat.replace(/"/g, '""')
+  const qualified = `"${escapedSchema}"."${escapedFormat}"`
+
   return isArray ? `${qualified}[]` : qualified
 }
 

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
@@ -46,6 +46,7 @@ import {
   RECOMMENDED_ALTERNATIVE_DATA_TYPE,
 } from '../SidePanelEditor.constants'
 import type { PostgresDataTypeOption } from '../SidePanelEditor.types'
+import { displayColumnType } from './ColumnEditor.utils'
 import type { EnumeratedType } from '@/data/enumerated-types/enumerated-types-query'
 
 export type ColumnTypeSelection = { format: string; formatSchema?: string }
@@ -252,10 +253,12 @@ const ColumnType = ({
                     <CommandGroup heading="Other types">
                       {enumTypes.map((option) => {
                         const isSelected = matchesEnum(option, value)
+                        const formattedType = displayColumnType(option.name, option.schema)
+
                         return (
                           <CommandItem
                             key={option.id}
-                            value={option.format}
+                            value={formattedType}
                             className={cn('relative', isSelected ? 'bg-surface-200' : '')}
                             onSelect={() => {
                               onOptionSelect({
@@ -270,9 +273,7 @@ const ColumnType = ({
                               <div>
                                 <ListPlus size={16} className="text-foreground" strokeWidth={1.5} />
                               </div>
-                              <span className="text-foreground">
-                                {option.format.replaceAll('"', '')}
-                              </span>
+                              <span className="text-foreground">{formattedType}</span>
                               {option.comment !== undefined && (
                                 <span
                                   title={option.comment ?? ''}


### PR DESCRIPTION
## Summary
Fixes #30632

Resolves issues when creating or editing table columns using Enum data types defined inside custom (non-public) schemas in Supabase Studio.

## Root Causes
1. **Missing Schemas in Query Hook:** `ColumnEditor.tsx` invoked `useEnumeratedTypesQuery` without passing the project's active schemas, defaulting the fetch strictly to `public` schema Enums.
2. **CommandItem Value Collision:** `<CommandItem>` in `ColumnType.tsx` used unquoted type names for option values, causing search and selection collisions across non-public schemas.
3. **Display Format Truncation:** `displayColumnType` in `ColumnEditor.utils.ts` stripped schema qualification for custom schema types during grid header renders.

## Changes Made
- **`ColumnEditor.tsx`**: Integrated `useSchemasQuery` to dynamically fetch active project schemas and pass them to `useEnumeratedTypesQuery`.
- **`ColumnType.tsx`**: Updated `<CommandItem>` option values and labels to use fully schema-qualified identifiers (`"schema"."name"`).
- **`ColumnEditor.utils.ts`**: Updated `displayColumnType` to preserve schema prefixes for custom schema Enums in grid column headers.

## Manual Testing
1. Created a custom schema (`app_schema`) and an Enum (`app_schema.user_status`).
2. Opened **Table Editor** $\rightarrow$ **Add Column** and selected `"app_schema"."user_status"` from the type picker.
3. Saved the column and verified `POST /api/platform/pg-meta/default/query?key=column-create` succeeded (HTTP 200) without `type "user_status" does not exist` errors.
4. Confirmed the table header properly renders `"app_schema"."user_status"`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved enum type selection for tables using non-public schemas.
  * PostgreSQL type names now display with correct schema qualification and quoting.
  * Enum options and labels consistently reflect their schemas, while public-schema types remain concise.
  * Improved handling of custom schemas and type names containing quotation marks.
  * Array type formatting remains consistent across schema variations.

* **Tests**
  * Added coverage for schema formatting, array types, and quoted identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->