### PR TITLE
Initialize notebook editor page

### DIFF
--- a/apps/studio/components/interfaces/Explorer/ExplorerHome.tsx
+++ b/apps/studio/components/interfaces/Explorer/ExplorerHome.tsx
@@ -1,16 +1,18 @@
 import { MessageCirclePlus, NotebookText, SquareCode } from 'lucide-react'
 import { useState } from 'react'
 
+import { useCreateNotebook } from './hooks'
 import { ActionCard } from '@/components/layouts/Tabs/ActionCard'
 import { AssistantChatForm } from '@/components/ui/AIAssistantPanel/AssistantChatForm'
 import { AssistantModel } from '@/state/ai-assistant-state'
 
 export const ExplorerHome = () => {
+  const { createNotebook } = useCreateNotebook()
+
   const [value, setValue] = useState<string>('')
   const [selectedModel, setSelectedModal] = useState<AssistantModel>('gpt-5.4-nano')
 
   const onCreateNotebook = () => {}
-
   const onCreateChat = () => {}
 
   return (
@@ -41,7 +43,7 @@ export const ExplorerHome = () => {
               title="Create a notebook"
               description="Combine notes, queries, and results"
               bgColor="bg-blue-500"
-              onClick={onCreateNotebook}
+              onClick={createNotebook}
             />
             <ActionCard
               icon={<SquareCode className="h-4 w-4 text-foreground" strokeWidth={1.5} />}

--- a/apps/studio/components/interfaces/Explorer/NotebookEditor.tsx
+++ b/apps/studio/components/interfaces/Explorer/NotebookEditor.tsx
@@ -1,6 +1,11 @@
 import { useParams } from 'common'
-import { useEffect, useEffectEvent } from 'react'
+import { Edit, Notebook, NotebookText, Play, Save } from 'lucide-react'
+import { useEffect, useEffectEvent, useState } from 'react'
+import { AiIconAnimation, Button } from 'ui'
+import { Input } from 'ui-patterns/DataInputs/Input'
+import { EmptyStatePresentational } from 'ui-patterns/EmptyStatePresentational'
 
+import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import { useNotebooksStateSnapshot } from '@/state/notebooks/notebooks-state'
 import { createTabId, useTabsStateSnapshot } from '@/state/tabs'
 
@@ -10,17 +15,108 @@ export const NotebookEditor = () => {
   const snap = useNotebooksStateSnapshot()
   const stateNotebook = id ? snap.notebooks[id] : undefined
 
+  const { name, content } = stateNotebook?.notebook ?? {}
+
+  const [titleValue, setTitleValue] = useState<string>(name ?? '')
+  const [isEditingTitle, setIsEditingTitle] = useState(false)
+
+  const handleSaveTitle = () => {
+    const trimmedName = titleValue.trim()
+    if (id && trimmedName && trimmedName !== name) {
+      snap.renameNotebook({ id, name: trimmedName })
+      tabs.updateTab(createTabId('notebook', { id }), { label: trimmedName })
+    }
+
+    setIsEditingTitle(false)
+  }
+
   const registerTab = useEffectEvent(() => {
     if (!id) return
     tabs.addTab({
       id: createTabId('notebook', { id }),
       type: 'notebook',
-      label: stateNotebook?.notebook.name ?? 'New Notebook',
+      label: name ?? 'New Notebook',
       metadata: { notebookId: id },
+      isPreview: false,
     })
   })
 
   useEffect(() => registerTab(), [id])
 
-  return <div>This is a notebook</div>
+  return (
+    <div className="flex flex-col h-full bg-surface-100">
+      <div className="border-b min-h-10 flex items-center justify-between px-4">
+        <div className="flex items-center gap-x-2">
+          <NotebookText size={14} className="text-foreground-light" />
+          {isEditingTitle ? (
+            <Input
+              autoFocus
+              size="tiny"
+              value={titleValue}
+              onChange={(e) => setTitleValue(e.target.value)}
+              onBlur={() => {
+                if (isEditingTitle) handleSaveTitle()
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Escape') {
+                  e.preventDefault()
+                  e.stopPropagation()
+                  setIsEditingTitle(false)
+                  setTitleValue(name ?? '')
+                } else if (e.key === 'Enter') {
+                  e.preventDefault()
+                  e.stopPropagation()
+                  handleSaveTitle()
+                }
+              }}
+            />
+          ) : (
+            <Button
+              variant="text"
+              className="group"
+              onClick={() => setIsEditingTitle(true)}
+              iconRight={<Edit className="opacity-0 group-hover:opacity-100" />}
+            >
+              {name}
+            </Button>
+          )}
+        </div>
+        <div className="flex items-center gap-x-2">
+          <Button variant="outline" icon={<AiIconAnimation size={16} />}>
+            Analyze
+          </Button>
+          <ButtonTooltip
+            variant="outline"
+            icon={<Play />}
+            className="px-1"
+            tooltip={{ content: { side: 'bottom', text: 'Run notebook' } }}
+          />
+          <ButtonTooltip
+            variant="outline"
+            icon={<Save />}
+            className="px-1"
+            tooltip={{ content: { side: 'bottom', text: 'Save changes' } }}
+          />
+        </div>
+      </div>
+
+      <div className="w-full mx-auto flex-grow min-h-0 overflow-y-auto">
+        <div className="p-4">
+          {content?.cells.length === 0 && (
+            <EmptyStatePresentational
+              icon={<Notebook className="text-foreground-lighter" />}
+              title="This notebook is empty"
+              description="Add a query cell to run SQL against your database or logs."
+              contentClassName="[&>h3]:text-sm [&>p]:text-xs"
+            >
+              <div className="flex items-center gap-x-2">
+                <Button variant="default">Add query cell</Button>
+                <Button variant="default">Add markdown cell</Button>
+              </div>
+            </EmptyStatePresentational>
+          )}
+        </div>
+      </div>
+    </div>
+  )
 }

--- a/apps/studio/components/interfaces/Explorer/NotebookEditor.tsx
+++ b/apps/studio/components/interfaces/Explorer/NotebookEditor.tsx
@@ -74,7 +74,10 @@ export const NotebookEditor = () => {
             <Button
               variant="text"
               className="group"
-              onClick={() => setIsEditingTitle(true)}
+              onClick={() => {
+                setTitleValue(name ?? '')
+                setIsEditingTitle(true)
+              }}
               iconRight={<Edit className="opacity-0 group-hover:opacity-100" />}
             >
               {name}

--- a/apps/studio/components/interfaces/Explorer/__tests__/NotebookEditor.test.tsx
+++ b/apps/studio/components/interfaces/Explorer/__tests__/NotebookEditor.test.tsx
@@ -1,18 +1,22 @@
-import { render } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { NotebookEditor } from '../NotebookEditor'
 import { notebooksState } from '@/state/notebooks/notebooks-state'
 import type { Notebook } from '@/state/notebooks/types'
+import { customRender } from '@/tests/lib/custom-render'
 
 const { mockUseParams, mockAddTab } = vi.hoisted(() => ({
   mockUseParams: vi.fn(),
   mockAddTab: vi.fn(),
 }))
 
-vi.mock('common', () => ({
-  useParams: () => mockUseParams(),
-}))
+vi.mock('common', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('common')>()
+  return {
+    ...actual,
+    useParams: () => mockUseParams(),
+  }
+})
 
 vi.mock('@/state/tabs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/state/tabs')>()
@@ -55,7 +59,7 @@ describe('NotebookEditor tab registration', () => {
       notebook: makeNotebook('notebook-1', { name: 'My Notebook' }),
     })
 
-    render(<NotebookEditor />)
+    customRender(<NotebookEditor />)
 
     expect(mockAddTab).toHaveBeenCalledTimes(1)
     expect(mockAddTab).toHaveBeenCalledWith({
@@ -63,24 +67,26 @@ describe('NotebookEditor tab registration', () => {
       type: 'notebook',
       label: 'My Notebook',
       metadata: { notebookId: 'notebook-1' },
+      isPreview: false,
     })
   })
 
   it('falls back to "New Notebook" as the label when the notebook has not loaded yet', () => {
-    render(<NotebookEditor />)
+    customRender(<NotebookEditor />)
 
     expect(mockAddTab).toHaveBeenCalledWith({
       id: 'notebook-notebook-1',
       type: 'notebook',
       label: 'New Notebook',
       metadata: { notebookId: 'notebook-1' },
+      isPreview: false,
     })
   })
 
   it('does not register a tab when there is no id in the route', () => {
     mockUseParams.mockReturnValue({ ref: 'default', id: undefined })
 
-    render(<NotebookEditor />)
+    customRender(<NotebookEditor />)
 
     expect(mockAddTab).not.toHaveBeenCalled()
   })

--- a/apps/studio/components/layouts/ExplorerLayout/ExplorerLayout.constants.tsx
+++ b/apps/studio/components/layouts/ExplorerLayout/ExplorerLayout.constants.tsx
@@ -1,8 +1,11 @@
 import { motion } from 'framer-motion'
-import { ChevronLeft, MessageSquare, NotebookText } from 'lucide-react'
+import { ChevronLeft, MessageSquare, NotebookText, Plus } from 'lucide-react'
 import { type ComponentType, type PropsWithChildren } from 'react'
 import { Button, cn } from 'ui'
 import { InnerSideBarFilters, InnerSideBarFilterSearchInput } from 'ui-patterns/InnerSideMenu'
+
+import { useCreateNotebook } from '@/components/interfaces/Explorer/hooks'
+import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 
 export type ExplorerResourceType = 'notebook' | 'chat'
 
@@ -48,6 +51,7 @@ export const ExplorerNavResourceWrapper = ({
   setSearch: (value: string) => void
   onBack: () => void
 }>) => {
+  const { createNotebook } = useCreateNotebook()
   const searchPlaceholder = EXPLORER_SECTIONS.find((x) => x.type === type)?.searchPlaceholder
 
   return (
@@ -60,14 +64,14 @@ export const ExplorerNavResourceWrapper = ({
       transition={LEVEL_TRANSITION}
       className={cn('absolute inset-0 flex flex-col', className)}
     >
-      <div className="flex items-center gap-1 p-3 pb-2">
+      <div className="flex items-center gap-2 p-3 pb-2">
         <Button
-          variant="outline"
           size="tiny"
-          aria-label="Back to all resources"
+          variant="outline"
+          aria-label="Back"
           onClick={onBack}
           className="size-7 shrink-0 px-0"
-          icon={<ChevronLeft size={16} />}
+          icon={<ChevronLeft />}
         />
         <span id="explorer-sidebar-search-label" className="sr-only">
           {searchPlaceholder}
@@ -81,6 +85,17 @@ export const ExplorerNavResourceWrapper = ({
             onChange={(event) => setSearch(event.target.value)}
           />
         </InnerSideBarFilters>
+        <ButtonTooltip
+          size="tiny"
+          variant="outline"
+          aria-label={`New ${type}`}
+          className="size-7 shrink-0 px-0"
+          icon={<Plus />}
+          tooltip={{ content: { side: 'bottom', text: `New ${type}` } }}
+          onClick={() => {
+            if (type === 'notebook') createNotebook()
+          }}
+        />
       </div>
       {children}
     </motion.div>

--- a/apps/studio/components/layouts/ExplorerLayout/ExplorerLayout.tsx
+++ b/apps/studio/components/layouts/ExplorerLayout/ExplorerLayout.tsx
@@ -57,7 +57,7 @@ export const ExplorerLayout = ({ browserTitle, children, title }: ExplorerLayout
             newTabButton={<NewTabButton />}
           />
         </div>
-        <div className="h-full">{children}</div>
+        <div className="flex-grow min-h-0">{children}</div>
       </div>
     </ProjectLayoutWithAuth>
   )

--- a/apps/studio/state/tabs.tsx
+++ b/apps/studio/state/tabs.tsx
@@ -388,6 +388,9 @@ export function createTabsState(projectRef: string) {
           const schema = (router.query.schema as string) || 'public'
           router.push(`/project/${router.query.ref}/sql/${tab.metadata?.sqlId}?schema=${schema}`)
           break
+        case 'notebook':
+          router.push(`/project/${router.query.ref}/explorer/notebook/${tab.metadata?.notebookId}`)
+          break
         case 'r':
         case 'v':
         case 'm':


### PR DESCRIPTION
## Context

More groundwork for the Explorer - this PR initializes the Notebook editor page which you can access with the "New notebook" CTA

As usual nothing functional just yet, but this PR also addresses some UI functionality
- Creating more than 1 notebook will open multiple tabs (it wasn't previously)
- Swapping between notebooks will update the URL (wasn't previously as well)

Will probably start looking into the cells next, starting with MarkdownCell followed by QueryCell

<img width="1390" height="894" alt="image" src="https://github.com/user-attachments/assets/a467cdb4-f99f-43db-8106-c15c26c1bfbf" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added notebook creation actions from the Explorer home and navigation areas.
  * Introduced a full notebook editor with title editing, rename support, and Analyze, Run, and Save controls.
  * Added options to create query or Markdown cells in empty notebooks.
  * Notebook tabs now open the corresponding notebook in the project Explorer.

* **Bug Fixes**
  * Improved Explorer layout sizing and notebook tab navigation behavior.
  * Improved notebook tab labels and editing behavior, including cancellation with Escape and submission with Enter or blur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->