### PR TITLE
docs(auth): clarify audit logs storage options and configuration

### DIFF
--- a/apps/docs/content/guides/auth/audit-logs.mdx
+++ b/apps/docs/content/guides/auth/audit-logs.mdx
@@ -18,25 +18,24 @@ Supabase auth audit logs automatically capture all authentication events includi
 
 ## Storage options
 
-By default, audit logs are stored in two places:
+By default, audit logs are stored in:
 
-1. **Your project's Postgres database** - Stored in the `auth.audit_log_entries` table, searchable via SQL but uses database storage
-2. **External log storage** - Cost-efficient storage accessible through the dashboard
+- **External log storage** - Cost-efficient storage accessible through the dashboard
 
-You can disable Postgres storage to reduce database storage costs while keeping the external log storage.
+You can optionally enable audit log storage in your project’s Postgres database, where the audit trail is stored in the `auth.audit_log_entries` table and is searchable via SQL. However, this uses additional database storage.
+
+<Admonition type="note">
+
+Enabling Postgres storage increases your database storage costs. Disable this option to reduce storage usage while keeping audit logs available through the dashboard.
+
+</Admonition>
 
 ### Configuring audit log storage
 
 1. Navigate to your project’s dashboard
 2. Go to **Authentication**
 3. Find the **Audit Logs** under **Configuration** section
-4. Toggle on "Disable writing auth audit logs to project database" to disable database storage
-
-<Admonition type="note">
-
-Disabling Postgres storage reduces your database storage costs. Audit logs will still be available through the dashboard.
-
-</Admonition>
+4. Toggle "Write audit logs to the database" on to enable or off to disable database storage
 
 ## Log format
 

--- a/apps/docs/content/guides/auth/audit-logs.mdx
+++ b/apps/docs/content/guides/auth/audit-logs.mdx
@@ -18,23 +18,18 @@ Supabase auth audit logs automatically capture all authentication events includi
 
 ## Storage options
 
-By default, audit logs are stored in:
+Audit logs are stored in:
 
 - **External log storage** - Cost-efficient storage accessible through the dashboard
+- **Postgres database** (optional) - Stored in the `auth.audit_log_entries` table, searchable via SQL, but uses additional database storage
 
-You can optionally enable audit log storage in your project’s Postgres database, where the audit trail is stored in the `auth.audit_log_entries` table and is searchable via SQL. However, this uses additional database storage.
-
-<Admonition type="note">
-
-Enabling Postgres storage increases your database storage costs. Disable this option to reduce storage usage while keeping audit logs available through the dashboard.
-
-</Admonition>
+You can enable or disable Postgres database storage to optimize your costs.
 
 ### Configuring audit log storage
 
 1. Navigate to your project’s dashboard
 2. Go to **Authentication**
-3. Find the **Audit Logs** under **Configuration** section
+3. Find the **Audit Logs** under the **Configuration** section
 4. Toggle "Write audit logs to the database" on to enable or off to disable database storage
 
 ## Log format


### PR DESCRIPTION
## Summary

- Clarify that external log storage is the default
- Explain that Postgres database storage is optional
- Fix grammar and typos
- Improve admonition messaging to be more actionable
- Simplify toggle step wording for clarity

Slack thread with team-auth: https://supabase.slack.com/archives/C022071RB2L/p1785945149999009

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that audit logs are stored in external log storage by default.
  * Documented optional database storage in `auth.audit_log_entries`.
  * Added instructions for enabling or disabling database storage with the “Write audit logs to the database” toggle.
  * Noted that enabling database storage incurs additional database storage costs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->