### PR TITLE
fix: use publishable key in Flask Connect example

### DIFF
--- a/apps/studio/components/interfaces/ConnectSheet/content/flask/supabasepy/content.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/content/flask/supabasepy/content.tsx
@@ -9,7 +9,7 @@ const ContentFile = ({ projectKeys }: StepContentProps) => {
       language: 'bash',
       code: `
 SUPABASE_URL=${projectKeys.apiUrl ?? 'your-project-url'}
-SUPABASE_KEY=${projectKeys.publishableKey ?? projectKeys.anonKey ?? 'your-anon-key'}
+SUPABASE_PUBLISHABLE_KEY=${projectKeys.publishableKey ?? projectKeys.anonKey ?? 'your-anon-key'}
         `,
     },
     {
@@ -27,7 +27,7 @@ app = Flask(__name__)
 
 supabase: Client = create_client(
     os.environ.get("SUPABASE_URL"),
-    os.environ.get("SUPABASE_KEY")
+    os.environ.get("SUPABASE_PUBLISHABLE_KEY")
 )
 
 @app.route('/')


### PR DESCRIPTION
HUMAN:

AGENT:

## Why

Keep the Flask Connect panel example aligned with the Flask quickstart's current public-key naming convention.

## Summary

- Uses `SUPABASE_PUBLISHABLE_KEY` in the generated `.env` example.
- Reads the same variable in the generated Flask application.

## Issue Number

Closes #48826

## How to Test

- `git apply --check --recount` passed.
- `git apply --recount` applied cleanly.
- `git diff --check` passed.
- Local verification not run; relying on upstream CI.

## Type

- [x] Bug fix

## Notes

Draft kept pending upstream CI and maintainer review.