### PR TITLE
feat(studio): role-aware access feedback in scoped token creation

### DIFF
--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/NewScopedTokenForm.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/NewScopedTokenForm.tsx
@@ -8,6 +8,7 @@ import { Admonition } from 'ui-patterns/Admonition'
 
 import { CLASSIC_TOKEN_WARNING } from '../../AccessToken.constants'
 import { countConfigured, PermissionMode } from '../../AccessToken.permissions'
+import { useTokenAccessEvaluation } from '../../hooks/useTokenAccessEvaluation'
 import { DEFAULT_EXPIRY, TokenFormSchema, TokenFormValues } from './NewScopedTokenForm.utils'
 import { NewScopedTokenFormReview } from './NewScopedTokenFormReview'
 import { PermissionsAccordion } from './PermissionsAccordion'
@@ -49,10 +50,24 @@ export const NewScopedTokenForm = ({
   const resourceSectionRef = useRef<HTMLDivElement>(null)
   const resourceAccess = useWatch({ control: form.control, name: 'resourceAccess' })
   const selection = useWatch({ control: form.control, name: 'permissions' })
+  const organizationSlugs = useWatch({
+    control: form.control,
+    name: 'organizationSlugs',
+    defaultValue: [],
+  })
+  const projectRefs = useWatch({ control: form.control, name: 'projectRefs', defaultValue: [] })
   const configuredCount = useWatch({
     control: form.control,
     name: 'permissions',
     compute: (selection) => countConfigured(selection),
+  })
+
+  const access = useTokenAccessEvaluation({
+    selection,
+    resourceAccess,
+    organizationSlugs,
+    projectRefs,
+    enabled: resourceAccess !== 'account',
   })
 
   const { data: permissionScopeMap, isError } = useGetEnabledEndpointsForCapability()
@@ -140,6 +155,7 @@ export const NewScopedTokenForm = ({
                     selection={selection}
                     onChange={handlePermissionChange}
                     permissionScopeMap={permissionScopeMap}
+                    access={access}
                   />
                   {showMissingPermissionsWarning && (
                     <div className="space-y-3 px-5 sm:px-6 pb-6">
@@ -160,6 +176,7 @@ export const NewScopedTokenForm = ({
         ) : (
           <NewScopedTokenFormReview
             values={formValues}
+            access={access}
             permissionScopeMap={permissionScopeMap}
             onSelectLegacyToken={() => {
               handleSelectLegacyMode()
@@ -174,11 +191,16 @@ export const NewScopedTokenForm = ({
         ) : (
           <StepIndicator step={step === 'form' ? 1 : 2} total={2} label="Configure" />
         )}
-        <div className="flex gap-2">
+        <div className="flex items-center gap-3">
           {step === 'review' && (
-            <Button variant="default" disabled={isPending} onClick={() => setStep('form')}>
-              Back
-            </Button>
+            <>
+              <span className="text-xs text-foreground-lighter">
+                Access can't be changed after creation
+              </span>
+              <Button variant="default" disabled={isPending} onClick={() => setStep('form')}>
+                Back
+              </Button>
+            </>
           )}
           <SheetClose asChild disabled={isPending}>
             <Button variant="default">Cancel</Button>

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/NewScopedTokenFormReview.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/NewScopedTokenFormReview.tsx
@@ -1,71 +1,66 @@
 import dayjs from 'dayjs'
 import { useMemo } from 'react'
-import { Badge, cn } from 'ui'
 import { Admonition } from 'ui-patterns/Admonition'
 
 import {
   computeOverallRisk,
-  PERMISSION_CATALOG_BY_CATEGORY,
+  PERMISSION_MODE_LABEL,
   selectionToScopes,
-  type OverallRisk,
-  type PermissionCatalogEntry,
-  type PermissionMode,
-  type RiskLevel,
 } from '../../AccessToken.permissions'
-import { useOrgAndProjectData } from '../../hooks/useOrgAndProjectData'
-import { McpUnsupportedWarning } from '../McpUnsupportedWarning'
-import { EXPIRY_OPTIONS, type TokenFormValues } from './NewScopedTokenForm.utils'
 import {
-  getEnabledEndpointsForCapability,
-  getEnabledMcpTools,
-  PermissionScopeMap,
-} from '@/data/scoped-access-tokens/permission-scope-map-query'
+  groupFailingResources,
+  TOKEN_ROLE_LABEL,
+  type TokenAccessEvaluation,
+} from '../../AccessToken.roles'
+import { useCapabilitySummary } from '../../hooks/useCapabilitySummary'
+import { useOrgAndProjectData } from '../../hooks/useOrgAndProjectData'
+import { failingResourceLine } from '../ExceedsRoleBadge'
+import { McpUnsupportedWarning } from '../McpUnsupportedWarning'
+import { CapabilityCategoryList, ResourceSummaryItem, RiskLevelSummary } from '../TokenSummaryRows'
+import { EXPIRY_OPTIONS, type TokenFormValues } from './NewScopedTokenForm.utils'
+import { PermissionScopeMap } from '@/data/scoped-access-tokens/permission-scope-map-query'
 
 interface ReviewStepProps {
   values: TokenFormValues
+  access: TokenAccessEvaluation
   permissionScopeMap: PermissionScopeMap | undefined
   /** Switches the form back to step one in legacy (account-wide) token mode. */
   onSelectLegacyToken: () => void
 }
 
-const RISK_TONE_VARIANT: Record<
-  OverallRisk['tone'],
-  'default' | 'success' | 'warning' | 'destructive'
-> = {
-  default: 'default',
-  low: 'success',
-  medium: 'warning',
-  high: 'destructive',
-}
-
-const modeLabel = (mode: PermissionMode) =>
-  mode === 'readwrite' ? 'Read-write' : mode === 'read' ? 'Read' : 'None'
-
-const RISK_DOT_CLASS: Record<RiskLevel, string> = {
-  low: 'bg-brand-600',
-  medium: 'bg-warning-600',
-  high: 'bg-destructive-600',
-}
-
 export const NewScopedTokenFormReview = ({
   values,
+  access,
   permissionScopeMap,
   onSelectLegacyToken,
 }: ReviewStepProps) => {
   const { organizations, projects } = useOrgAndProjectData()
   const selection = values.permissions
   const grantedScopes = useMemo(() => selectionToScopes(selection), [selection])
+
+  const hasExceedingCapabilities = access.exceedingEntryKeys.length > 0
+
+  // Exceeded permissions grouped by the resource where they fail, so the admonition reads per
+  // org/project rather than as one flat permission list.
+  const exceedingByResource = useMemo(
+    () => groupFailingResources(access, selection),
+    [access, selection]
+  )
+
   const risk = useMemo(
-    () => computeOverallRisk(selection, values.resourceAccess),
-    [selection, values.resourceAccess]
+    () => computeOverallRisk(access.effectiveSelection, values.resourceAccess),
+    [access.effectiveSelection, values.resourceAccess]
   )
 
   const resourceSummary = useMemo(() => {
     if (values.resourceAccess === 'project') {
       const selectedProjects = projects.filter((p) => values.projectRefs.includes(p.ref))
       return {
-        title: 'Project',
-        items: selectedProjects.length > 0 ? selectedProjects.map((p) => p.name) : ['-'],
+        title: 'Projects',
+        items:
+          selectedProjects.length > 0
+            ? selectedProjects.map((p) => ({ key: p.ref, label: p.name, sublabel: p.ref }))
+            : [{ key: 'none', label: '-', sublabel: undefined }],
       }
     }
     if (values.resourceAccess === 'organization') {
@@ -73,11 +68,17 @@ export const NewScopedTokenFormReview = ({
         values.organizationSlugs.includes(o.slug)
       )
       return {
-        title: 'Organization',
-        items: selectedOrganizations.length > 0 ? selectedOrganizations.map((o) => o.name) : ['-'],
+        title: 'Organizations',
+        items:
+          selectedOrganizations.length > 0
+            ? selectedOrganizations.map((o) => ({ key: o.slug, label: o.name, sublabel: o.slug }))
+            : [{ key: 'none', label: '-', sublabel: undefined }],
       }
     }
-    return { title: 'Account', items: ['Account-level access'] }
+    return {
+      title: 'Account',
+      items: [{ key: 'account', label: 'Account-level access', sublabel: undefined }],
+    }
   }, [values, projects, organizations])
 
   const expiresSummary = useMemo(() => {
@@ -89,43 +90,13 @@ export const NewScopedTokenFormReview = ({
     return EXPIRY_OPTIONS.find((o) => o.value === values.expiresAt)?.label ?? values.expiresAt
   }, [values])
 
-  const activeByCategory = useMemo(
-    () =>
-      PERMISSION_CATALOG_BY_CATEGORY.map((category) => ({
-        ...category,
-        entries: category.entries
-          .map((entry) => ({ entry, mode: selection[entry.key] ?? 'none' }))
-          .filter(({ mode }) => mode !== 'none'),
-      })).filter((category) => category.entries.length > 0),
-    [selection]
-  )
-
   const hasCapabilities = grantedScopes.length > 0
 
-  const mcpTools = useMemo(
-    () => getEnabledMcpTools({ grantedScopes, permissionScopeMap }),
-    [grantedScopes, permissionScopeMap]
-  )
-
-  const capabilityGroups = useMemo(() => {
-    const groups: { entry: PermissionCatalogEntry; mode: PermissionMode; endpoints: string[][] }[] =
-      []
-    for (const category of activeByCategory) {
-      for (const { entry, mode } of category.entries) {
-        const capabilityScopes =
-          mode === 'readwrite' ? [...entry.readScopes, ...entry.writeScopes] : entry.readScopes
-        const endpoints = getEnabledEndpointsForCapability({
-          capabilityScopes,
-          allGrantedScopes: grantedScopes,
-          permissionScopeMap,
-        })
-        if (endpoints.length > 0) {
-          groups.push({ entry, mode, endpoints: endpoints.map((e) => [e.method, e.path]) })
-        }
-      }
-    }
-    return groups
-  }, [activeByCategory, grantedScopes, permissionScopeMap])
+  const { activeByCategory, mcpTools, capabilityGroups } = useCapabilitySummary({
+    selection,
+    grantedScopes,
+    permissionScopeMap,
+  })
 
   const rows: [string, React.ReactNode][] = [
     ['Name', values.tokenName || <span className="text-foreground-lighter">Untitled token</span>],
@@ -138,9 +109,7 @@ export const NewScopedTokenFormReview = ({
         </p>
         <div className="divide-y">
           {resourceSummary.items.map((item) => (
-            <p key={item} className="py-2 text-sm text-foreground">
-              {item}
-            </p>
+            <ResourceSummaryItem key={item.key} label={item.label} sublabel={item.sublabel} />
           ))}
         </div>
       </div>,
@@ -148,66 +117,51 @@ export const NewScopedTokenFormReview = ({
     [
       'Capabilities',
       hasCapabilities ? (
-        <div className="space-y-4">
-          {activeByCategory.map((category) => (
-            <div key={category.key} className="space-y-2">
-              <p className="text-[11px] font-mono uppercase tracking-wide text-foreground-lighter">
-                {category.name}
-              </p>
-              <div className="divide-y">
-                {category.entries.map(({ entry, mode }) => (
-                  <div
-                    key={entry.key}
-                    className="flex items-center justify-between gap-2 text-sm py-2"
-                  >
-                    <span className="flex items-center gap-2">
-                      <span
-                        className={cn(
-                          'h-1.5 w-1.5 shrink-0 rounded-full',
-                          RISK_DOT_CLASS[entry.risk]
-                        )}
-                      />
-                      <span className="text-foreground text-wrap">{entry.name}</span>
-                    </span>
-                    <span className="text-foreground-lighter text-xs font-mono uppercase font-normal text-right">
-                      {modeLabel(mode)}
-                    </span>
-                  </div>
-                ))}
-              </div>
-            </div>
-          ))}
-        </div>
+        <CapabilityCategoryList categories={activeByCategory} accessEntries={access.entries} />
       ) : (
         <span className="text-foreground-lighter">No capabilities selected</span>
       ),
     ],
     [
       'Risk level',
-      <span key="risk" className="flex flex-wrap items-center gap-2">
-        <span className="flex">
-          <Badge variant={RISK_TONE_VARIANT[risk.tone]}>{risk.level} Risk</Badge>
-        </span>
-        <span className="text-sm text-foreground leading-px">
-          {risk.text.replace(`${risk.level} — `, '')}
-        </span>
-      </span>,
+      <RiskLevelSummary key="risk" risk={risk} showRoleCaveat={hasExceedingCapabilities} />,
     ],
   ]
 
   return (
     <div className="space-y-6 px-5 sm:px-6 py-6">
-      {hasCapabilities ? (
-        <Admonition
-          type="warning"
-          title="Token access can't be updated after creation"
-          description="To change its access, delete this token and create a new one."
-        />
-      ) : (
+      {!hasCapabilities && (
         <Admonition
           type="warning"
           title="This token has no capabilities"
           description="Go back and grant at least one permission before creating it."
+        />
+      )}
+      {hasExceedingCapabilities && (
+        <Admonition
+          type="warning"
+          title="Some permissions exceed your current role for the selected resources"
+          description={
+            <div className="space-y-2">
+              <p>
+                A token only works with permissions you currently hold. Requests with these
+                permissions will be denied until your role includes them:
+              </p>
+              {exceedingByResource.map((group) => (
+                <div key={`${group.type}:${group.resource.id}`}>
+                  <p className="font-medium">{failingResourceLine(group.resource)}</p>
+                  <ul className="list-disc pl-4">
+                    {group.entries.map((groupEntry) => (
+                      <li key={groupEntry.key}>
+                        {groupEntry.name} ({PERMISSION_MODE_LABEL[groupEntry.mode]}) — requires{' '}
+                        {TOKEN_ROLE_LABEL[groupEntry.requiredRole]}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+            </div>
+          }
         />
       )}
       <div className="flex flex-col gap-3">
@@ -236,7 +190,7 @@ export const NewScopedTokenFormReview = ({
                   <div className="flex items-center justify-between border-b bg-surface-100 px-3 py-2">
                     <span className="text-xs text-foreground">{entry.name}</span>
                     <span className="text-[11px] font-mono uppercase text-foreground-lighter">
-                      {mode === 'readwrite' ? 'Read-write' : 'Read'}
+                      {PERMISSION_MODE_LABEL[mode]}
                     </span>
                   </div>
                   <div className="divide-y">

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/PermissionRow.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/PermissionRow.tsx
@@ -1,6 +1,8 @@
 import { Label, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from 'ui'
 
 import type { PermissionCatalogEntry, PermissionMode } from '../../AccessToken.permissions'
+import type { EntryAccess } from '../../AccessToken.roles'
+import { ExceedsRoleBadge } from '../ExceedsRoleBadge'
 import { RiskMarker } from './RiskMarker'
 import { PermissionScopeMap } from '@/data/scoped-access-tokens/permission-scope-map-query'
 
@@ -9,6 +11,7 @@ interface PermissionRowProps {
   mode: PermissionMode
   onChange: (mode: PermissionMode) => void
   permissionScopeMap: PermissionScopeMap | undefined
+  entryAccess?: EntryAccess
 }
 
 export const PermissionRow = ({
@@ -16,6 +19,7 @@ export const PermissionRow = ({
   mode,
   onChange,
   permissionScopeMap,
+  entryAccess,
 }: PermissionRowProps) => {
   return (
     <div className="flex items-center justify-between gap-4 py-4">
@@ -27,6 +31,9 @@ export const PermissionRow = ({
             </span>
           </Label>
           <RiskMarker entry={entry} permissionScopeMap={permissionScopeMap} />
+          {entryAccess?.status === 'exceeds-role' && (
+            <ExceedsRoleBadge entry={entry} mode={mode} access={entryAccess} />
+          )}
         </span>
         <p id={`${entry.key}-permissions-description`} className="text-xs text-foreground-lighter">
           {entry.description}

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/PermissionsAccordion.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/PermissionsAccordion.tsx
@@ -7,19 +7,24 @@ import {
   type PermissionMode,
   type PermissionSelection,
 } from '../../AccessToken.permissions'
+import type { TokenAccessEvaluation } from '../../AccessToken.roles'
 import { PermissionRow } from './PermissionRow'
+import { InlineLink } from '@/components/ui/InlineLink'
 import { PermissionScopeMap } from '@/data/scoped-access-tokens/permission-scope-map-query'
+import { DOCS_URL } from '@/lib/constants'
 
 interface PermissionsAccordionProps {
   selection: PermissionSelection
   onChange: (key: string, mode: PermissionMode) => void
   permissionScopeMap: PermissionScopeMap | undefined
+  access?: TokenAccessEvaluation
 }
 
 export const PermissionsAccordion = ({
   selection,
   onChange,
   permissionScopeMap,
+  access,
 }: PermissionsAccordionProps) => {
   const [openCategories, setOpenCategories] = useState<string[]>([])
 
@@ -28,7 +33,12 @@ export const PermissionsAccordion = ({
       <div>
         <h3 className="text-sm text-foreground">Permissions</h3>
         <p className="text-foreground-lighter text-sm">
-          Grant the minimum access this token needs. Everything defaults to None.
+          Grant the minimum access this token needs. Everything defaults to None. Permissions follow
+          your role in the organizations and projects you're a member of — see{' '}
+          <InlineLink href={`${DOCS_URL}/guides/platform/access-control`}>
+            access control
+          </InlineLink>{' '}
+          for how roles work.
         </p>
       </div>
 
@@ -72,6 +82,7 @@ export const PermissionsAccordion = ({
                         mode={selection[entry.key] ?? 'none'}
                         onChange={(mode) => onChange(entry.key, mode)}
                         permissionScopeMap={permissionScopeMap}
+                        entryAccess={access?.entries[entry.key]}
                       />
                     </div>
                   ))}

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/ResourceAccessStep.test.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/ResourceAccessStep.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import {
+  MOCK_ORG,
+  MOCK_PROJECT,
+  mockPermissionsApi,
+  mockScopedTokenEnvironment,
+  readonlyRows,
+} from '../../AccessToken.fixtures'
+import { NewScopedTokenSheet } from '../NewScopedTokenSheet'
+import { customRender } from '@/tests/lib/custom-render'
+import { createMockProfileContext } from '@/tests/lib/profile-helpers'
+
+// Disabling orgs for project-scoped members reads /platform/profile/permissions, which only
+// fires on the platform for a logged-in user — neither is true in the default test environment.
+vi.mock('common', async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof import('common')
+  return { ...actual, useIsLoggedIn: () => true }
+})
+
+vi.mock('@/lib/constants', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return { ...actual, IS_PLATFORM: true }
+})
+
+const user = userEvent.setup()
+
+describe('ResourceAccessStep organization selector', () => {
+  beforeEach(() => {
+    mockScopedTokenEnvironment()
+  })
+
+  const openOrganizationSelector = async () => {
+    customRender(<NewScopedTokenSheet onCreateExperimentalToken={() => {}} />, {
+      profileContext: createMockProfileContext(),
+    })
+    fireEvent.click(await screen.findByRole('button', { name: 'Generate new token' }))
+    await screen.findByRole('dialog')
+    await user.click(await screen.findByRole('radio', { name: /Organization/ }))
+    fireEvent.click(await screen.findByRole('combobox', { name: 'Organizations' }))
+  }
+
+  test('disables organizations where the user only has project-level access', async () => {
+    mockPermissionsApi(readonlyRows(MOCK_ORG.slug, [MOCK_PROJECT.ref]))
+    await openOrganizationSelector()
+
+    const option = await screen.findByRole('option', { name: new RegExp(MOCK_ORG.name) })
+    expect(option).toHaveAttribute('aria-disabled', 'true')
+    expect(
+      await screen.findByText(
+        'Your access is limited to specific projects. Create a project-scoped token instead.'
+      )
+    ).toBeInTheDocument()
+  })
+
+  test('keeps organizations selectable for members with org-wide access', async () => {
+    mockPermissionsApi(readonlyRows(MOCK_ORG.slug))
+    await openOrganizationSelector()
+
+    const option = await screen.findByRole('option', { name: new RegExp(MOCK_ORG.name) })
+    expect(option).not.toHaveAttribute('aria-disabled', 'true')
+    expect(
+      screen.queryByText(
+        'Your access is limited to specific projects. Create a project-scoped token instead.'
+      )
+    ).toBeNull()
+  })
+})

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/ResourceAccessStep.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/ResourceAccessStep.tsx
@@ -24,9 +24,11 @@ import {
 } from 'ui-patterns/multi-select'
 
 import type { ResourceAccessMode } from '../../AccessToken.permissions'
+import { getIsProjectScopedOnly } from '../../AccessToken.roles'
 import { useOrgAndProjectData } from '../../hooks/useOrgAndProjectData'
 import type { TokenFormValues } from './NewScopedTokenForm.utils'
 import { InlineLinkClassName } from '@/components/ui/InlineLink'
+import { usePermissionsQuery } from '@/data/permissions/permissions-query'
 import { ProjectInfoInfinite } from '@/data/projects/projects-infinite-query'
 import { Organization } from '@/types'
 
@@ -89,6 +91,20 @@ export const ResourceAccessStep = ({
   const resourceAccess = useWatch({ control, name: 'resourceAccess' })
   const organizationSlugs = useWatch({ control, name: 'organizationSlugs', defaultValue: [] })
 
+  // Users invited to specific projects (rather than the whole org) can't select that org for an
+  // org-wide token. Skipped while permissions are still loading so nothing gets disabled by
+  // mistake. The project list itself needs no permission filter — /platform/projects is already
+  // scoped server-side to what the user can access.
+  const { data: permissions } = usePermissionsQuery()
+  const projectScopedOrgSlugs = useMemo(() => {
+    if (permissions === undefined) return new Set<string>()
+    return new Set(
+      organizations
+        .map((org) => org.slug)
+        .filter((slug) => getIsProjectScopedOnly(permissions, slug))
+    )
+  }, [permissions, organizations])
+
   const projectsForOrg = useMemo(
     () => projects.filter((project) => organizationSlugs.includes(project.organization_slug)),
     [projects, organizationSlugs]
@@ -108,9 +124,9 @@ export const ResourceAccessStep = ({
                 Need a token with full access to your account or one for the Supabase MCP server?{' '}
                 <button
                   type="button"
+                  tabIndex={0}
                   className={InlineLinkClassName}
                   onClick={onSelectLegacyToken}
-                  tabIndex={0}
                 >
                   Create legacy token
                 </button>
@@ -198,7 +214,7 @@ export const ResourceAccessStep = ({
                 <MultiSelector
                   onValuesChange={field.onChange}
                   values={field.value}
-                  disabled={!organizationSlugs}
+                  disabled={organizationSlugs.length === 0}
                   className="w-full"
                 >
                   <MultiSelectorTrigger
@@ -257,11 +273,26 @@ export const ResourceAccessStep = ({
                 <MultiSelectorContent>
                   <MultiSelectorInput placeholder="Search organizations" showResetIcon />
                   <MultiSelectorList>
-                    {organizations.map((organization) => (
-                      <MultiSelectorItem key={organization.slug} value={organization.slug}>
-                        {organization.name}
-                      </MultiSelectorItem>
-                    ))}
+                    {organizations.map((organization) => {
+                      const isProjectScopedOnly = projectScopedOrgSlugs.has(organization.slug)
+                      return (
+                        <MultiSelectorItem
+                          key={organization.slug}
+                          value={organization.slug}
+                          disabled={isProjectScopedOnly}
+                        >
+                          <span className="flex flex-col gap-0.5">
+                            <span>{organization.name}</span>
+                            {isProjectScopedOnly && (
+                              <span className="text-foreground-lighter">
+                                Your access is limited to specific projects. Create a project-scoped
+                                token instead.
+                              </span>
+                            )}
+                          </span>
+                        </MultiSelectorItem>
+                      )
+                    })}
                   </MultiSelectorList>
                 </MultiSelectorContent>
               </MultiSelector>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Remaining bits of #48714


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added role-aware access checks throughout scoped token creation.
  * Organization selectors now disable project-only organizations and recommend project-scoped tokens when appropriate.
  * Review screens highlight missing capabilities and permissions exceeding your current role.
  * Permission rows display indicators when access exceeds your role.
  * Added resource keys, labels, and summaries to improve token review clarity.

* **Documentation**
  * Updated permission guidance with links to access-control documentation.

* **Bug Fixes**
  * Corrected project selector behavior when no organization is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->