### PR TITLE
fix: use SUPABASE_PUBLISHABLE_KEY in Flask quickstart

### DIFF
--- a/apps/studio/components/interfaces/ConnectSheet/content/flask/supabasepy/content.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/content/flask/supabasepy/content.tsx
@@ -9,7 +9,7 @@ const ContentFile = ({ projectKeys }: StepContentProps) => {
       language: 'bash',
       code: `
 SUPABASE_URL=${projectKeys.apiUrl ?? 'your-project-url'}
-SUPABASE_KEY=${projectKeys.publishableKey ?? projectKeys.anonKey ?? 'your-anon-key'}
+SUPABASE_PUBLISHABLE_KEY=${projectKeys.publishableKey ?? projectKeys.anonKey ?? 'your-anon-key'}
         `,
     },
     {
@@ -27,7 +27,7 @@ app = Flask(__name__)
 
 supabase: Client = create_client(
     os.environ.get("SUPABASE_URL"),
-    os.environ.get("SUPABASE_KEY")
+    os.environ.get("SUPABASE_PUBLISHABLE_KEY")
 )
 
 @app.route('/')


### PR DESCRIPTION
## Summary

- Update the Flask Connect panel example to use `SUPABASE_PUBLISHABLE_KEY`, matching the Flask quickstart.
- Update the generated Flask code to read `SUPABASE_PUBLISHABLE_KEY`.

Fixes #48826

## Verification

local verification not run; relying on upstream CI

The worktree did not have the repository dependencies installed, so the local npm checks were structurally unavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Flask connection example to use `SUPABASE_PUBLISHABLE_KEY` when configuring environment variables and initializing the Python client.
  * Retained compatibility with the anon key or a placeholder as a fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->