### PR TITLE
fix(pg-meta): allow null return_type for stored procedures in read-path Zod schema

### DIFF
--- a/packages/pg-meta/src/pg-meta-functions.ts
+++ b/packages/pg-meta/src/pg-meta-functions.ts
@@ -217,7 +217,7 @@ export type PGSavedFunction = Omit<
 > & {
   argument_types: SafeSqlFragment
   identity_argument_types: SafeSqlFragment
-  return_type: SafeSqlFragment
+  return_type: SafeSqlFragment | null
   config_params: Record<string, SafeSqlFragment> | null
 }
 
@@ -339,6 +339,7 @@ export function update(
             args,
             config_params: currentFunc.config_params ?? {},
             type: currentFunc.type,
+            return_type: currentFunc.return_type ?? undefined,
           },
           { replace: true }
         )

--- a/packages/pg-meta/src/pg-meta-functions.ts
+++ b/packages/pg-meta/src/pg-meta-functions.ts
@@ -40,7 +40,7 @@ export const pgFunctionZod = z.object({
   argument_types: z.string(),
   identity_argument_types: z.string(),
   return_type_id: z.number(),
-  return_type: z.string(),
+  return_type: z.union([z.string(), z.null()]),
   return_type_relation_id: z.union([z.number(), z.null()]),
   is_set_returning_function: z.boolean(),
   behavior: z.union([z.literal('IMMUTABLE'), z.literal('STABLE'), z.literal('VOLATILE')]),

--- a/packages/pg-meta/test/functions.test.ts
+++ b/packages/pg-meta/test/functions.test.ts
@@ -412,3 +412,38 @@ withTestDatabase(
     await executeQuery(removeSql)
   }
 )
+
+withTestDatabase(
+  'create procedure and parse with functions.list() and functions.retrieve()',
+  async ({ executeQuery }) => {
+    const { sql: createSql } = pgMeta.functions.create({
+      type: 'procedure',
+      name: 'test_procedure_p1',
+      schema: 'public',
+      definition: 'BEGIN NULL; END',
+      language: 'plpgsql',
+    })
+    await executeQuery(createSql)
+
+    const { sql: listSql, zod: listZod } = pgMeta.functions.list()
+    const listResult = listZod.parse(await executeQuery(listSql))
+    const proc = listResult.find(({ name }) => name === 'test_procedure_p1')
+    expect(proc).toBeDefined()
+    expect(proc!.type).toBe('procedure')
+    expect(proc!.return_type).toBeNull()
+
+    const { sql: retrieveSql, zod: retrieveZod } = pgMeta.functions.retrieve({
+      name: 'test_procedure_p1',
+      schema: 'public',
+      args: [],
+    })
+    const retrieveResult = retrieveZod.parse((await executeQuery(retrieveSql))[0])
+    expect(retrieveResult).toBeDefined()
+    expect(retrieveResult!.type).toBe('procedure')
+    expect(retrieveResult!.return_type).toBeNull()
+
+    const { sql: removeSql } = pgMeta.functions.remove(asSavedFunction(proc!))
+    await executeQuery(removeSql)
+  }
+)
+

--- a/packages/pg-meta/test/functions.test.ts
+++ b/packages/pg-meta/test/functions.test.ts
@@ -442,7 +442,16 @@ withTestDatabase(
     expect(retrieveResult!.type).toBe('procedure')
     expect(retrieveResult!.return_type).toBeNull()
 
-    const { sql: removeSql } = pgMeta.functions.remove(asSavedFunction(proc!))
+    const { sql: updateSql } = pgMeta.functions.update(asSavedFunction(retrieveResult!), {
+      definition: 'BEGIN NULL; END;',
+    })
+    await executeQuery(updateSql)
+
+    const updatedResult = retrieveZod.parse((await executeQuery(retrieveSql))[0])
+    expect(updatedResult!.definition).toBe('BEGIN NULL; END;')
+    expect(updatedResult!.return_type).toBeNull()
+
+    const { sql: removeSql } = pgMeta.functions.remove(asSavedFunction(updatedResult!))
     await executeQuery(removeSql)
   }
 )


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix in `packages/pg-meta`.

## What is the current behavior?

Fixes #48814

When `pgMeta.functions.list()` or `pgMeta.functions.retrieve()` queries Postgres stored procedures created with `type: 'procedure'`, `zod.parse()` throws a validation error:

```
ZodError: [{ code: 'invalid_type', expected: 'string', received: 'null', path: ['return_type'] }]
```

This occurs because Postgres stored procedures return `NULL` for `pg_get_function_result(f.oid)`, whereas `pgFunctionZod` expected `return_type` to always be a string.

## What is the new behavior?

- Updated `return_type` in `pgFunctionZod` to `z.union([z.string(), z.null()])` so procedure rows parse cleanly.
- Added a unit test in `packages/pg-meta/test/functions.test.ts` that creates a procedure and parses it through `functions.list()` and `functions.retrieve()`.

## Additional context

No breaking changes. This only affects the Zod schema validation contract on the read path when stored procedures exist in the database.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of database procedures that do not specify a return type.
  - Function metadata can now correctly represent a missing return type without errors.
  - Updating procedures with no return value now preserves their expected SQL behavior.

- **Tests**
  - Added coverage for creating, listing, retrieving, parsing, updating, and cleaning up procedures through the functions API.
  - Added verification for procedures with nullable return types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->