### PR TITLE
docs: scope studio-ui-patterns skill description to apps/studio

### DIFF
--- a/.claude/skills/studio-ui-patterns/SKILL.md
+++ b/.claude/skills/studio-ui-patterns/SKILL.md
@@ -1,8 +1,10 @@
 ---
 name: studio-ui-patterns
-description: Design system UI patterns for Supabase Studio. Use when building or updating
-  pages, forms, tables, charts, empty states, navigation, cards, alerts, or side panels
-  (sheets). Covers layout selection, component choice, and placement conventions.
+description: Design system UI patterns for the Supabase Studio dashboard codebase
+  (apps/studio). Use when building or updating pages, forms, tables, charts, empty states,
+  navigation, cards, alerts, or side panels (sheets) in apps/studio. Covers layout
+  selection, component choice, and placement conventions. Not for UI outside apps/studio,
+  such as the marketing site (apps/www), the docs site, or example apps.
 ---
 
 # Studio UI Patterns


### PR DESCRIPTION
## Problem

The `studio-ui-patterns` skill description has no codebase scope in its trigger sentence:

> Use when building or updating pages, forms, tables, charts, empty states, navigation, cards, alerts, or side panels (sheets).

In a monorepo with seven apps, that sentence matches UI work in `apps/www`, `apps/docs`, and `examples/`. When it triggers there, the skill recommends Studio-only components — `PageContainer`, `FormItemLayout layout="flex-row-reverse"`, `SheetSection` — that don't belong in those codebases. There is also no negative signal telling an agent when to skip the skill.

The repo already treats this skill as Studio-scoped:

- `.coderabbit.yaml` binds it to `applyTo: 'apps/studio/**/*.{ts,tsx}'`
- `apps/studio/CLAUDE.md` lists it in the Studio skills table

The description was simply the one place that never said so, so the routing signal disagreed with the repo's own configuration.

## Change

Frontmatter `description` only — no changes to the skill body.

The new wording names `apps/studio` in the trigger sentence and adds a short negative clause. This follows how other skills in `.claude/skills/` already scope themselves:

- `docs-content` — "anywhere in `apps/docs`"
- `studio-queries` — "in `apps/studio/data/`"
- `studio-e2e-tests` — "(`e2e/studio`)"
- `copywriting` / `react-hook-form` — explicitly "anywhere in the monorepo"

I kept the phrasing close to the existing house style rather than adopting a `Do not use for...` block, since no other skill in the repo uses that construction.

## Note for reviewers

`react-hook-form` is described as applying "anywhere in the monorepo" and cross-references this skill for form layout guidance. If that cross-reference is intended to hold outside `apps/studio`, the negative clause here should be softened — happy to adjust to whatever scope you actually want.

Closes #45347


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the UI pattern guidance for the Supabase Studio dashboard.
  * Listed the dashboard areas covered by the guidance.
  * Specified which sites and example applications are excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->