### PR TITLE
docs(blog): point CI integrations link at the GitHub Actions guide

### DIFF
--- a/apps/www/_blog/2025-04-01-supabase-edge-functions-deploy-dashboard-deno-2-1.mdx
+++ b/apps/www/_blog/2025-04-01-supabase-edge-functions-deploy-dashboard-deno-2-1.mdx
@@ -73,7 +73,7 @@ You can download Edge Functions source code via Supabase CLI using `supabase fun
 
 <Admonition type="caution">
 
-The Dashboard's Edge Function editor currently does not support versioning or rollbacks. We recommend using it only for quick testing and prototypes. When you’re ready to go to production, store Edge Functions code in a source code repository (e.g. git) and deploy it using one of the [CI integrations](https://supabase.com/docs/guides/functions/cicd-workflow).
+The Dashboard's Edge Function editor currently does not support versioning or rollbacks. We recommend using it only for quick testing and prototypes. When you’re ready to go to production, store Edge Functions code in a source code repository (e.g. git) and deploy it using one of the [CI integrations](https://supabase.com/docs/guides/functions/examples/github-actions).
 
 </Admonition>
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs fix (broken link).

## What is the current behavior?

`2025-04-01-supabase-edge-functions-deploy-dashboard-deno-2-1.mdx` links "CI integrations" to `/docs/guides/functions/cicd-workflow`, which returns 404 and is not in the docs sitemap.

## What is the new behavior?

That link now points at `/docs/guides/functions/examples/github-actions`, which returns 200 and is titled "GitHub Actions". The paragraph recommends storing functions in git and deploying through CI, which is exactly what that guide covers.

## Additional context

One line, one file.

The same dead URL appears in two other places, and I deliberately did not touch either:

- `apps/www/app/(products)/edge-functions/_components/LocalDXSection.tsx` is being rewritten in #43455, whose diff carries this link forward unchanged. Editing it here would conflict with a 190 line refactor for a one line fix, so I left a note on that PR instead.
- `apps/www/data/products/functions/page.tsx` cannot currently be edited without breaking `pnpm typecheck --filter=www`. Any modification to that file, including appending a single newline, makes the TypeScript compiler panic:

```
panic: Diagnostic emitted without context [recovered, repanicked]
  declarations.throwDiagnostic (transformers/declarations/transform.go:276)
  declarations/tracker.go:211 -> :194
  checker/symboltracker.go:30
```

Clean master passes 3 out of 3 runs, that file edited fails 3 out of 3, and an equivalent edit to `apps/www/data/features.tsx` passes, so it is isolated to that one file rather than to my change or to www generally. I am filing that separately rather than describing it further here.

Verification: old URL confirmed 404 and absent from the sitemap, new URL confirmed 200. Gates run locally on this branch: `test:prettier` passes repo wide and `typecheck --filter=www --force` passes 8 of 8. I did not run `pnpm build`, which cannot complete in my environment because the docs `build:federated-content` step needs `DOCS_GITHUB_APP_PRIVATE_KEY`.

Freshman contributor, put this together with Claude Code's help and checked the URLs and the failure isolation myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the production deployment guidance to link to the GitHub Actions example for CI integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->