### PR TITLE
fix(studio): replace __dirname with dirname in vitest.config.ts

### DIFF
--- a/apps/studio/vitest.config.ts
+++ b/apps/studio/vitest.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      '@ui': resolve(__dirname, './../../packages/ui/src'),
+      '@ui': resolve(dirname, './../../packages/ui/src'),
     },
   },
   test: {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

In `apps/studio/vitest.config.ts`, line 21 resolved the `@ui` alias using `__dirname`:
`@ui': resolve(__dirname, './../../packages/ui/src')`
Since the config file is an ES module, `__dirname` is undefined.

## What is the new behavior?

Replaces `__dirname` with `dirname`, which is already defined at line 10 (`const dirname = fileURLToPath(new URL('.', import.meta.url))`).

## Additional context

Fixes Vitest alias resolution for `@ui` in Studio.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test configuration compatibility by resolving the UI module path correctly across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->