### PR TITLE
fix: correct sort comparator in Realtime table selector

### DIFF
--- a/apps/studio/components/interfaces/Realtime/Inspector/RealtimeFilterPopover/TableSelector.tsx
+++ b/apps/studio/components/interfaces/Realtime/Inspector/RealtimeFilterPopover/TableSelector.tsx
@@ -71,7 +71,7 @@ const TableSelector = ({
   const searchTables = debounce(setSearchInput)
 
   const entities = (data?.pages[0].data.entities ? [...data?.pages[0].data.entities] : []).sort(
-    (a, b) => (a.name > b.name ? 0 : -1)
+    (a, b) => a.name.localeCompare(b.name)
   )
 
   return (


### PR DESCRIPTION
The sort comparator in `TableSelector.tsx` returned `0` (equal) when `a.name > b.name` instead of a positive number:

```ts
// before — broken
(a, b) => (a.name > b.name ? 0 : -1)

// after — correct
(a, b) => a.name.localeCompare(b.name)
```

A comparator must return a **positive** value when `a` should sort after `b`. Returning `0` tells the sort engine they are equal, so out-of-order pairs are never swapped. The result is that tables in the Realtime inspector's table dropdown appear in arbitrary API-returned order rather than alphabetical order.

`localeCompare` is the idiomatic fix — handles locale-aware ordering and covers the equal-name edge case.