### PR TITLE
fix(sql-editor): keep list invalidation when a save is coalesced by a later edit

### DIFF
--- a/apps/studio/state/sql-editor/sql-editor-save.test.ts
+++ b/apps/studio/state/sql-editor/sql-editor-save.test.ts
@@ -136,6 +136,35 @@ describe('save mechanism — saveSnippet', () => {
     expect(t.invalidate).toHaveBeenCalledWith('ref')
   })
 
+  it('does not let an in-flight non-invalidating save clear an obligation queued after it started', async () => {
+    const t = setup({ snippets: { 'snippet-1': makeStateSnippet({ status: 'saved' }) } })
+    let finishFirstUpsert: () => void = () => {}
+    t.upsertContent.mockImplementationOnce(
+      () =>
+        new Promise<null>((resolve) => {
+          finishFirstUpsert = () => resolve(null)
+        })
+    )
+
+    // A keystroke save starts and blocks on the network.
+    t.mechanism.saveSnippet({ id: 'snippet-1', projectRef: 'ref', shouldInvalidate: false })
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(t.upsertContent).toHaveBeenCalledTimes(1)
+
+    // A rename lands while that save is still in flight, so an invalidation is owed.
+    t.mechanism.saveSnippet({ id: 'snippet-1', projectRef: 'ref', shouldInvalidate: true })
+
+    // The in-flight save completes without having invalidated anything.
+    finishFirstUpsert()
+    await vi.advanceTimersByTimeAsync(0)
+
+    // A further keystroke must not be able to drop the rename's invalidation.
+    t.mechanism.saveSnippet({ id: 'snippet-1', projectRef: 'ref', shouldInvalidate: false })
+    await vi.runAllTimersAsync()
+
+    expect(t.invalidate).toHaveBeenCalledWith('ref')
+  })
+
   it('transitions to save_failed when the upsert rejects', async () => {
     const t = setup({ snippets: { 'snippet-1': makeStateSnippet({ status: 'saved' }) } })
     t.upsertContent.mockRejectedValueOnce(new Error('network'))

--- a/apps/studio/state/sql-editor/sql-editor-save.test.ts
+++ b/apps/studio/state/sql-editor/sql-editor-save.test.ts
@@ -121,6 +121,21 @@ describe('save mechanism — saveSnippet', () => {
     expect(t.invalidate).toHaveBeenCalledWith('ref')
   })
 
+  it('still invalidates when an invalidating save is coalesced with a later non-invalidating one', async () => {
+    const t = setup({ snippets: { 'snippet-1': makeStateSnippet({ status: 'saved' }) } })
+
+    // A rename / favorite / AI-title save needs the lists refreshed...
+    t.mechanism.saveSnippet({ id: 'snippet-1', projectRef: 'ref', shouldInvalidate: true })
+    // ...and a keystroke lands inside the debounce window, which does not.
+    vi.advanceTimersByTime(200)
+    t.mechanism.saveSnippet({ id: 'snippet-1', projectRef: 'ref', shouldInvalidate: false })
+
+    await vi.runAllTimersAsync()
+
+    expect(t.upsertContent).toHaveBeenCalledTimes(1)
+    expect(t.invalidate).toHaveBeenCalledWith('ref')
+  })
+
   it('transitions to save_failed when the upsert rejects', async () => {
     const t = setup({ snippets: { 'snippet-1': makeStateSnippet({ status: 'saved' }) } })
     t.upsertContent.mockRejectedValueOnce(new Error('network'))

--- a/apps/studio/state/sql-editor/sql-editor-save.ts
+++ b/apps/studio/state/sql-editor/sql-editor-save.ts
@@ -101,8 +101,14 @@ export function createSaveMechanism(deps: SaveMechanismDeps) {
     try {
       snippet.status = statusOnSaveStart(snippet.status)
       await upsertContent({ projectRef, payload })
-      if (shouldInvalidate) await invalidate(projectRef)
-      pendingInvalidation.delete(id)
+      // Only a save that actually invalidated may clear the obligation. A save
+      // running with `shouldInvalidate: false` was scheduled while nothing was
+      // latched, so clearing it here would discard an obligation queued by a
+      // newer save while this one was in flight.
+      if (shouldInvalidate) {
+        await invalidate(projectRef)
+        pendingInvalidation.delete(id)
+      }
       snippet.status = statusOnSaveSuccess()
     } catch (error) {
       snippet.status = statusOnSaveError(snippet.status)

--- a/apps/studio/state/sql-editor/sql-editor-save.ts
+++ b/apps/studio/state/sql-editor/sql-editor-save.ts
@@ -81,6 +81,16 @@ export function createSaveMechanism(deps: SaveMechanismDeps) {
     debounceMs = 1000,
   } = deps
 
+  /**
+   * Snippet ids whose pending save still owes a list invalidation. `debounce`
+   * keeps only the *last* call's arguments, so an invalidating save (a rename,
+   * a favorite toggle, an AI-generated title) coalesced with a later
+   * non-invalidating one (a keystroke) would otherwise drop its invalidation
+   * and leave the snippet lists stale. Latched here until the save that owes
+   * the invalidation actually performs it.
+   */
+  const pendingInvalidation = new Set<string>()
+
   async function saveSnippet({ id, projectRef, shouldInvalidate }: SaveSnippetArgs) {
     const snippet = state.snippets[id]?.snippet
     // Only persist a snippet whose content has been loaded — otherwise we would
@@ -92,6 +102,7 @@ export function createSaveMechanism(deps: SaveMechanismDeps) {
       snippet.status = statusOnSaveStart(snippet.status)
       await upsertContent({ projectRef, payload })
       if (shouldInvalidate) await invalidate(projectRef)
+      pendingInvalidation.delete(id)
       snippet.status = statusOnSaveSuccess()
     } catch (error) {
       snippet.status = statusOnSaveError(snippet.status)
@@ -102,7 +113,11 @@ export function createSaveMechanism(deps: SaveMechanismDeps) {
 
   /** Debounced per snippet id; rapid edits to one snippet coalesce to one save. */
   function scheduleSaveSnippet(args: SaveSnippetArgs) {
-    memoizedSaveSnippet(args.id)(args)
+    if (args.shouldInvalidate) pendingInvalidation.add(args.id)
+    memoizedSaveSnippet(args.id)({
+      ...args,
+      shouldInvalidate: pendingInvalidation.has(args.id),
+    })
   }
 
   async function createFolder({ projectRef, name, placeholderId }: CreateFolderArgs) {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix. A SQL editor snippet save can silently drop its list invalidation, leaving the sidebar lists stale.

## What is the current behavior?

The save mechanism debounces per snippet id:

```ts
const memoizedSaveSnippet = memoize((_id: string) => debounce(saveSnippet, debounceMs))
```

lodash `debounce` invokes the target with the arguments of the **last** call. When two saves for the same snippet land inside the 1000ms window they coalesce into one save, and the later `shouldInvalidate` wins outright instead of being combined with the earlier one.

The queue points disagree about that flag on purpose:

- `updateSnippet`, `addFavorite`, `removeFavorite` and `addNeedsSaving` queue `true`, because a rename or a favorite toggle has to refresh the lists
- `setSql` queues whatever the caller passes, and `useSnippetEditor` passes `wasNeverPersisted(snippet.status)`, so a keystroke on an already persisted snippet queues `false`

So an invalidating save followed within a second by a keystroke loses its invalidation. The snippet content itself still persists, since the payload is built when the coalesced save finally runs, but `contentKeys.sqlSnippets`, `contentKeys.count` and `contentKeys.folders` are never invalidated, so those lists stay stale until something else happens to refetch them.

The easiest way to hit it is AI title generation. `useSnippetTitleGenerator.setAiTitle` renames the snippet and calls `addNeedsSaving(id)` from a background mutation that resolves shortly after a query runs, which is exactly when the user is still typing in the editor.

## Evidence

This test is in the PR and it fails on current master:

```ts
it('still invalidates when an invalidating save is coalesced with a later non-invalidating one', async () => {
  const t = setup({ snippets: { 'snippet-1': makeStateSnippet({ status: 'saved' }) } })

  // A rename / favorite / AI-title save needs the lists refreshed...
  t.mechanism.saveSnippet({ id: 'snippet-1', projectRef: 'ref', shouldInvalidate: true })
  // ...and a keystroke lands inside the debounce window, which does not.
  vi.advanceTimersByTime(200)
  t.mechanism.saveSnippet({ id: 'snippet-1', projectRef: 'ref', shouldInvalidate: false })

  await vi.runAllTimersAsync()

  expect(t.upsertContent).toHaveBeenCalledTimes(1)
  expect(t.invalidate).toHaveBeenCalledWith('ref')
})
```

On master the save runs once as expected, and `invalidate` is called zero times.

The existing test next to it only exercises `true` and `false` in separate debounce windows, which is why the coalesced case slipped through.

## What is the new behavior?

`scheduleSaveSnippet` latches the ids that still owe an invalidation, so the flag is sticky across coalesced calls instead of being overwritten. The latch is cleared once a save has actually performed the invalidation, so a failed save keeps the obligation for the retry.

Twelve lines in one file. No change to when saves happen or to any status transition.

## Additional context

#41422 fixed an adjacent missed invalidation for new snippets by computing the flag at the call site in `useSnippetEditor`. That fix is still correct and is untouched here. This one closes the same class of bug one level down, inside the mechanism, where the coalescing actually happens, so every queue point benefits rather than just the editor path.

Worst case after this change is one redundant invalidation if a save is queued while an earlier one is still in flight. That is a refetch, not a correctness problem, and it seemed clearly better than the current failure mode of dropping one.

Gates run locally on this branch:

- `pnpm test:prettier` passes repo wide
- `pnpm typecheck --filter=studio` passes
- `pnpm --filter studio run lint:ratchet` passes
- studio vitest: 5188 pass, 1 pre-existing failure in `lib/local-storage.test.ts` that fails identically on clean master with my change stashed, so it is not from this PR

I did not run `pnpm build`, which cannot complete in my environment because the docs `build:federated-content` step needs `DOCS_GITHUB_APP_PRIVATE_KEY`.

Freshman contributor. I found this reading the save path with Claude Code's help, and I wrote and ran the failing test myself to confirm it before changing anything.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where saving a snippet in quick succession could prevent the snippet list from refreshing.
  * Ensured list updates are reliably applied after debounced saves.

* **Tests**
  * Added regression coverage for consecutive saves with different refresh requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->