### PR TITLE
fix(studio): validate Go template syntax in auth email templates (#48877)

### DIFF
--- a/apps/studio/components/interfaces/Auth/EmailTemplates/AuthTemplatesValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/AuthTemplatesValidation.tsx
@@ -1,6 +1,20 @@
 import * as z from 'zod'
 
 import type { AuthTemplate, TemplateVariable, TemplateVariableName } from './EmailTemplates.types'
+import { validateGoTemplate } from './EmailTemplates.utils'
+
+const createSubjectSchema = (subjectKey: string) =>
+  z.object({
+    [subjectKey]: z
+      .string()
+      .min(1, 'Subject is required.')
+      .refine(
+        (val) => validateGoTemplate(val).valid,
+        (val) => ({
+          message: `Invalid template syntax: ${validateGoTemplate(val).error}`,
+        })
+      ),
+  })
 
 const TemplateVariables: Record<TemplateVariableName, TemplateVariable> = {
   ConfirmationURL: {
@@ -98,9 +112,7 @@ const CONFIRMATION: AuthTemplate = {
     TemplateVariables.Data,
     TemplateVariables.RedirectTo,
   ],
-  validationSchema: z.object({
-    MAILER_SUBJECTS_CONFIRMATION: z.string().min(1, 'Subject is required.'),
-  }),
+  validationSchema: createSubjectSchema('MAILER_SUBJECTS_CONFIRMATION'),
   misc: {
     emailTemplateType: 'authentication',
   },
@@ -127,9 +139,7 @@ const INVITE: AuthTemplate = {
     TemplateVariables.Data,
     TemplateVariables.RedirectTo,
   ],
-  validationSchema: z.object({
-    MAILER_SUBJECTS_INVITE: z.string().min(1, 'Subject is required.'),
-  }),
+  validationSchema: createSubjectSchema('MAILER_SUBJECTS_INVITE'),
   misc: {
     emailTemplateType: 'authentication',
   },
@@ -156,9 +166,7 @@ const MAGIC_LINK: AuthTemplate = {
     TemplateVariables.Data,
     TemplateVariables.RedirectTo,
   ],
-  validationSchema: z.object({
-    MAILER_SUBJECTS_MAGIC_LINK: z.string().min(1, 'Subject is required.'),
-  }),
+  validationSchema: createSubjectSchema('MAILER_SUBJECTS_MAGIC_LINK'),
   misc: {
     emailTemplateType: 'authentication',
   },
@@ -186,9 +194,7 @@ const EMAIL_CHANGE: AuthTemplate = {
     TemplateVariables.Data,
     TemplateVariables.RedirectTo,
   ],
-  validationSchema: z.object({
-    MAILER_SUBJECTS_EMAIL_CHANGE: z.string().min(1, 'Subject is required.'),
-  }),
+  validationSchema: createSubjectSchema('MAILER_SUBJECTS_EMAIL_CHANGE'),
   misc: {
     emailTemplateType: 'authentication',
   },
@@ -215,9 +221,7 @@ const RECOVERY: AuthTemplate = {
     TemplateVariables.Data,
     TemplateVariables.RedirectTo,
   ],
-  validationSchema: z.object({
-    MAILER_SUBJECTS_RECOVERY: z.string().min(1, 'Subject is required.'),
-  }),
+  validationSchema: createSubjectSchema('MAILER_SUBJECTS_RECOVERY'),
   misc: {
     emailTemplateType: 'authentication',
   },
@@ -238,9 +242,7 @@ const REAUTHENTICATION: AuthTemplate = {
     TemplateVariables.Email,
     TemplateVariables.Data,
   ],
-  validationSchema: z.object({
-    MAILER_SUBJECTS_REAUTHENTICATION: z.string().min(1, 'Subject is required.'),
-  }),
+  validationSchema: createSubjectSchema('MAILER_SUBJECTS_REAUTHENTICATION'),
   misc: {
     emailTemplateType: 'authentication',
   },
@@ -257,9 +259,7 @@ const PASSWORD_CHANGED_NOTIFICATION: AuthTemplate = {
     MAILER_TEMPLATES_PASSWORD_CHANGED_NOTIFICATION_CONTENT: { title: 'Body', type: 'code' },
   },
   variables: [TemplateVariables.Email, TemplateVariables.Data, TemplateVariables.SiteURL],
-  validationSchema: z.object({
-    MAILER_SUBJECTS_PASSWORD_CHANGED_NOTIFICATION: z.string().min(1, 'Subject is required.'),
-  }),
+  validationSchema: createSubjectSchema('MAILER_SUBJECTS_PASSWORD_CHANGED_NOTIFICATION'),
   misc: {
     emailTemplateType: 'security',
   },
@@ -280,9 +280,7 @@ const EMAIL_CHANGED_NOTIFICATION: AuthTemplate = {
     TemplateVariables.Data,
     TemplateVariables.SiteURL,
   ],
-  validationSchema: z.object({
-    MAILER_SUBJECTS_EMAIL_CHANGED_NOTIFICATION: z.string().min(1, 'Subject is required.'),
-  }),
+  validationSchema: createSubjectSchema('MAILER_SUBJECTS_EMAIL_CHANGED_NOTIFICATION'),
   misc: {
     emailTemplateType: 'security',
   },
@@ -304,9 +302,7 @@ const PHONE_CHANGED_NOTIFICATION: AuthTemplate = {
     TemplateVariables.Data,
     TemplateVariables.SiteURL,
   ],
-  validationSchema: z.object({
-    MAILER_SUBJECTS_PHONE_CHANGED_NOTIFICATION: z.string().min(1, 'Subject is required.'),
-  }),
+  validationSchema: createSubjectSchema('MAILER_SUBJECTS_PHONE_CHANGED_NOTIFICATION'),
   misc: {
     emailTemplateType: 'security',
   },
@@ -327,9 +323,7 @@ const IDENTITY_LINKED_NOTIFICATION: AuthTemplate = {
     TemplateVariables.Data,
     TemplateVariables.SiteURL,
   ],
-  validationSchema: z.object({
-    MAILER_SUBJECTS_IDENTITY_LINKED_NOTIFICATION: z.string().min(1, 'Subject is required.'),
-  }),
+  validationSchema: createSubjectSchema('MAILER_SUBJECTS_IDENTITY_LINKED_NOTIFICATION'),
   misc: {
     emailTemplateType: 'security',
   },
@@ -350,9 +344,7 @@ const IDENTITY_UNLINKED_NOTIFICATION: AuthTemplate = {
     TemplateVariables.Data,
     TemplateVariables.SiteURL,
   ],
-  validationSchema: z.object({
-    MAILER_SUBJECTS_IDENTITY_UNLINKED_NOTIFICATION: z.string().min(1, 'Subject is required.'),
-  }),
+  validationSchema: createSubjectSchema('MAILER_SUBJECTS_IDENTITY_UNLINKED_NOTIFICATION'),
   misc: {
     emailTemplateType: 'security',
   },
@@ -373,9 +365,7 @@ const MFA_FACTOR_ENROLLED_NOTIFICATION: AuthTemplate = {
     TemplateVariables.Data,
     TemplateVariables.SiteURL,
   ],
-  validationSchema: z.object({
-    MAILER_SUBJECTS_MFA_FACTOR_ENROLLED_NOTIFICATION: z.string().min(1, 'Subject is required.'),
-  }),
+  validationSchema: createSubjectSchema('MAILER_SUBJECTS_MFA_FACTOR_ENROLLED_NOTIFICATION'),
   misc: {
     emailTemplateType: 'security',
   },
@@ -396,9 +386,7 @@ const MFA_FACTOR_UNENROLLED_NOTIFICATION: AuthTemplate = {
     TemplateVariables.Data,
     TemplateVariables.SiteURL,
   ],
-  validationSchema: z.object({
-    MAILER_SUBJECTS_MFA_FACTOR_UNENROLLED_NOTIFICATION: z.string().min(1, 'Subject is required.'),
-  }),
+  validationSchema: createSubjectSchema('MAILER_SUBJECTS_MFA_FACTOR_UNENROLLED_NOTIFICATION'),
   misc: {
     emailTemplateType: 'security',
   },

--- a/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.utils.test.ts
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.utils.test.ts
@@ -5,6 +5,7 @@ import {
   hasCustomEmailSender,
   isCustomEmailTemplateEditingRestricted,
   isCustomEmailTemplateRestrictionStatusKnown,
+  validateGoTemplate,
 } from './EmailTemplates.utils'
 import type { Organization } from '@/types'
 
@@ -134,4 +135,74 @@ describe('EmailTemplates.utils', () => {
       })
     ).toBe(false)
   })
+
+  describe('validateGoTemplate', () => {
+    it('accepts valid template strings', () => {
+      expect(validateGoTemplate('')).toEqual({ valid: true })
+      expect(validateGoTemplate('<h2>Hello</h2>')).toEqual({ valid: true })
+      expect(validateGoTemplate('<p><a href="{{ .ConfirmationURL }}">Confirm</a></p>')).toEqual({
+        valid: true,
+      })
+      expect(
+        validateGoTemplate(
+          '{{ if .Data.name }}Hello {{ .Data.name }}{{ else }}Hello user{{ end }}'
+        )
+      ).toEqual({ valid: true })
+      expect(validateGoTemplate('{{/* A Go comment */}} <p>{{ .SiteURL }}</p>')).toEqual({
+        valid: true,
+      })
+      expect(validateGoTemplate('<p>{{ printf "Hello %s" .Email }}</p>')).toEqual({ valid: true })
+    })
+
+    it('rejects extra opening braces inside actions (e.g. {{{ .RedirectTo }}})', () => {
+      const res = validateGoTemplate('<p><a href="{{{ .RedirectTo }}}">Sign in</a></p>')
+      expect(res.valid).toBe(false)
+      expect(res.error).toContain('Unexpected "{" in command')
+    })
+
+    it('rejects unclosed template actions', () => {
+      const res = validateGoTemplate('<p>{{ .ConfirmationURL </p>')
+      expect(res.valid).toBe(false)
+      expect(res.error).toBe('Unclosed template action "{{ ... }}"')
+    })
+
+    it('rejects empty template actions', () => {
+      const res = validateGoTemplate('<p>{{ }}</p>')
+      expect(res.valid).toBe(false)
+      expect(res.error).toBe('Empty template action "{{ }}"')
+    })
+
+    it('rejects invalid syntax like default: "test"', () => {
+      const res = validateGoTemplate('<p>{{ .Data.display_name | default: "test" }}</p>')
+      expect(res.valid).toBe(false)
+      expect(res.error).toContain('Unexpected ":" in command')
+    })
+
+    it('rejects unclosed or unexpected control structures', () => {
+      expect(validateGoTemplate('{{ if .Email }} Hi')).toEqual({
+        valid: false,
+        error: 'Unclosed control structure "{{ if .Email }}"',
+      })
+      expect(validateGoTemplate('{{ end }}')).toEqual({
+        valid: false,
+        error: 'Unexpected "{{ end }}" without matching block',
+      })
+      expect(validateGoTemplate('{{ else }}')).toEqual({
+        valid: false,
+        error: 'Unexpected "{{ else }}" without matching block',
+      })
+    })
+
+    it('rejects unclosed parenthesized expressions', () => {
+      expect(validateGoTemplate('{{ (print .Email }}')).toEqual({
+        valid: false,
+        error: 'Unclosed parenthesized expression in command',
+      })
+      expect(validateGoTemplate('{{ print .Email ) }}')).toEqual({
+        valid: false,
+        error: 'Unexpected ")" in command',
+      })
+    })
+  })
 })
+

--- a/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.utils.ts
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.utils.ts
@@ -73,3 +73,378 @@ export const isCustomEmailTemplateEditingRestricted = ({
   // Temporary Studio-side paygate while Platform/Auth own the exact eligibility cohort.
   return !hasCustomEmailSender(authConfig)
 }
+
+export type TemplateValidationError = {
+  valid: boolean
+  error?: string
+}
+
+/**
+ * Validates a Go template string (html/template or text/template syntax used by GoTrue/Supabase Auth).
+ * Returns { valid: true } if valid, or { valid: false, error: string } if syntax is invalid.
+ */
+export const validateGoTemplate = (template: string): TemplateValidationError => {
+  if (!template) return { valid: true }
+
+  let i = 0
+  const n = template.length
+  const blockStack: { type: string; action: string }[] = []
+
+  while (i < n) {
+    const openIdx = template.indexOf('{{', i)
+    if (openIdx === -1) {
+      break
+    }
+
+    let actionStart = openIdx + 2
+    if (actionStart < n && template[actionStart] === '-') {
+      actionStart++
+    }
+
+    // Check for comment starting with /* immediately after {{ or {{-
+    const trimmedFromAction = template.slice(actionStart).trimStart()
+    if (trimmedFromAction.startsWith('/*')) {
+      const commentClose = template.indexOf('*/', actionStart)
+      if (commentClose === -1) {
+        return { valid: false, error: 'Unclosed comment in template action' }
+      }
+      const closeDelim = template.indexOf('}}', commentClose + 2)
+      if (closeDelim === -1) {
+        return { valid: false, error: 'Unclosed template action "{{ ... }}"' }
+      }
+      i = closeDelim + 2
+      continue
+    }
+
+    // Scan for closing }} or -}}
+    let actionEnd = -1
+    let inDoubleQuote = false
+    let inRawQuote = false
+    let inComment = false
+    let j = actionStart
+
+    while (j < n) {
+      const char = template[j]
+      const nextChar = template[j + 1]
+
+      if (inComment) {
+        if (char === '*' && nextChar === '/') {
+          inComment = false
+          j += 2
+          continue
+        }
+        j++
+        continue
+      }
+
+      if (inDoubleQuote) {
+        if (char === '\\') {
+          j += 2
+          continue
+        }
+        if (char === '"') {
+          inDoubleQuote = false
+        }
+        j++
+        continue
+      }
+
+      if (inRawQuote) {
+        if (char === '`') {
+          inRawQuote = false
+        }
+        j++
+        continue
+      }
+
+      if (char === '"') {
+        inDoubleQuote = true
+        j++
+        continue
+      }
+
+      if (char === '`') {
+        inRawQuote = true
+        j++
+        continue
+      }
+
+      if (char === '/' && nextChar === '*') {
+        inComment = true
+        j += 2
+        continue
+      }
+
+      if (char === '}' && nextChar === '}') {
+        actionEnd = j
+        break
+      }
+      if (char === '-' && nextChar === '}' && template[j + 2] === '}') {
+        actionEnd = j
+        break
+      }
+
+      j++
+    }
+
+    if (inDoubleQuote) {
+      return { valid: false, error: 'Unclosed string literal in template action' }
+    }
+    if (inRawQuote) {
+      return { valid: false, error: 'Unclosed raw string literal in template action' }
+    }
+    if (inComment) {
+      return { valid: false, error: 'Unclosed comment in template action' }
+    }
+    if (actionEnd === -1) {
+      return { valid: false, error: 'Unclosed template action "{{ ... }}"' }
+    }
+
+    const actionText = template.substring(actionStart, actionEnd).trim()
+    const closeLen = template[actionEnd] === '-' ? 3 : 2
+    i = actionEnd + closeLen
+
+    if (!actionText) {
+      return { valid: false, error: 'Empty template action "{{ }}"' }
+    }
+
+    const actionValidation = validateActionContent(actionText, blockStack)
+    if (!actionValidation.valid) {
+      return actionValidation
+    }
+  }
+
+  if (blockStack.length > 0) {
+    const unclosed = blockStack[blockStack.length - 1]
+    return {
+      valid: false,
+      error: `Unclosed control structure "{{ ${unclosed.action} }}"`,
+    }
+  }
+
+  return { valid: true }
+}
+
+const validateActionContent = (
+  actionText: string,
+  blockStack: { type: string; action: string }[]
+): TemplateValidationError => {
+  let inDoubleQuote = false
+  let inRawQuote = false
+  let inComment = false
+  let parenDepth = 0
+
+  const len = actionText.length
+  let k = 0
+
+  while (k < len) {
+    const char = actionText[k]
+    const nextChar = actionText[k + 1]
+
+    if (inComment) {
+      if (char === '*' && nextChar === '/') {
+        inComment = false
+        k += 2
+        continue
+      }
+      k++
+      continue
+    }
+
+    if (inDoubleQuote) {
+      if (char === '\\') {
+        k += 2
+        continue
+      }
+      if (char === '"') {
+        inDoubleQuote = false
+      }
+      k++
+      continue
+    }
+
+    if (inRawQuote) {
+      if (char === '`') {
+        inRawQuote = false
+      }
+      k++
+      continue
+    }
+
+    if (char === '"') {
+      inDoubleQuote = true
+      k++
+      continue
+    }
+
+    if (char === '`') {
+      inRawQuote = true
+      k++
+      continue
+    }
+
+    if (char === '/' && nextChar === '*') {
+      inComment = true
+      k += 2
+      continue
+    }
+
+    // Inside action outside quotes/comments:
+    // Curly braces '{' or '}' are unexpected inside Go template actions
+    if (char === '{' || char === '}') {
+      return { valid: false, error: `Unexpected "${char}" in command` }
+    }
+
+    if (char === '(') {
+      parenDepth++
+      k++
+      continue
+    }
+
+    if (char === ')') {
+      if (parenDepth === 0) {
+        return { valid: false, error: 'Unexpected ")" in command' }
+      }
+      parenDepth--
+      k++
+      continue
+    }
+
+    // Check for invalid standalone colons (not part of := assignment)
+    if (char === ':') {
+      const prevChar = actionText[k - 1]
+      const isAssignment = prevChar === '=' || nextChar === '='
+      if (!isAssignment) {
+        return { valid: false, error: 'Unexpected ":" in command' }
+      }
+    }
+
+    k++
+  }
+
+  if (parenDepth > 0) {
+    return { valid: false, error: 'Unclosed parenthesized expression in command' }
+  }
+
+  // Tokenize action text to inspect block control keywords (if, else, end, with, range, block, define)
+  const tokens = tokenizeActionText(actionText)
+  if (tokens.length > 0) {
+    let commandToken = tokens[0]
+    if (tokens.length >= 3 && (tokens[1] === ':=' || tokens[1] === '=')) {
+      commandToken = tokens[2]
+    }
+
+    const blockTypeKeywords = ['if', 'with', 'range', 'block', 'define']
+    if (blockTypeKeywords.includes(commandToken)) {
+      blockStack.push({ type: commandToken, action: actionText })
+    } else if (commandToken === 'else') {
+      if (blockStack.length === 0) {
+        return { valid: false, error: 'Unexpected "{{ else }}" without matching block' }
+      }
+      const currentBlock = blockStack[blockStack.length - 1].type
+      if (!['if', 'with', 'range', 'block'].includes(currentBlock)) {
+        return { valid: false, error: `Unexpected "{{ else }}" in "{{ ${currentBlock} }}" block` }
+      }
+    } else if (commandToken === 'end') {
+      if (blockStack.length === 0) {
+        return { valid: false, error: 'Unexpected "{{ end }}" without matching block' }
+      }
+      blockStack.pop()
+    }
+  }
+
+  return { valid: true }
+}
+
+const tokenizeActionText = (actionText: string): string[] => {
+  const tokens: string[] = []
+  let currentToken = ''
+  let inDoubleQuote = false
+  let inRawQuote = false
+  let inComment = false
+  let k = 0
+  const len = actionText.length
+
+  while (k < len) {
+    const char = actionText[k]
+    const nextChar = actionText[k + 1]
+
+    if (inComment) {
+      if (char === '*' && nextChar === '/') {
+        inComment = false
+        k += 2
+        continue
+      }
+      k++
+      continue
+    }
+
+    if (inDoubleQuote) {
+      if (char === '\\') {
+        k += 2
+        continue
+      }
+      if (char === '"') {
+        inDoubleQuote = false
+      }
+      k++
+      continue
+    }
+
+    if (inRawQuote) {
+      if (char === '`') {
+        inRawQuote = false
+      }
+      k++
+      continue
+    }
+
+    if (char === '"') {
+      if (currentToken) {
+        tokens.push(currentToken)
+        currentToken = ''
+      }
+      inDoubleQuote = true
+      k++
+      continue
+    }
+
+    if (char === '`') {
+      if (currentToken) {
+        tokens.push(currentToken)
+        currentToken = ''
+      }
+      inRawQuote = true
+      k++
+      continue
+    }
+
+    if (char === '/' && nextChar === '*') {
+      if (currentToken) {
+        tokens.push(currentToken)
+        currentToken = ''
+      }
+      inComment = true
+      k += 2
+      continue
+    }
+
+    if (/\s/.test(char) || char === '|' || char === '(' || char === ')') {
+      if (currentToken) {
+        tokens.push(currentToken)
+        currentToken = ''
+      }
+    } else {
+      currentToken += char
+    }
+
+    k++
+  }
+
+  if (currentToken) {
+    tokens.push(currentToken)
+  }
+
+  return tokens
+}
+

--- a/apps/studio/components/interfaces/Auth/EmailTemplates/TemplateEditor.test.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/TemplateEditor.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor, within } from '@testing-library/react'
+import { fireEvent, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { toast } from 'sonner'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -275,3 +275,54 @@ describe('TemplateEditor reset to default', () => {
     expect(toast.error).not.toHaveBeenCalled()
   })
 })
+
+describe('TemplateEditor syntax validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    validateSpamMock.mockImplementation((_vars, callbacks) => callbacks?.onSuccess?.({ rules: [] }))
+  })
+
+  it('rejects saving when body has extra opening braces (e.g. {{{ .RedirectTo }}})', async () => {
+    renderTemplateEditor()
+
+    const bodySource = screen.getByLabelText('Body source')
+    fireEvent.change(bodySource, {
+      target: { value: '<p><a href="{{{ .RedirectTo }}}">Sign in</a></p>' },
+    })
+
+    const saveButton = screen.getByRole('button', { name: 'Save changes' })
+    await waitFor(() => expect(saveButton).not.toBeDisabled())
+    fireEvent.submit(saveButton.closest('form')!)
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Invalid template syntax: Unexpected "{" in command'
+    )
+    expect(toast.error).toHaveBeenCalledWith(
+      'Invalid template syntax: Unexpected "{" in command'
+    )
+    expect(updateAuthConfigMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects saving when subject has invalid Go template syntax', async () => {
+    renderTemplateEditor()
+
+    const subjectInput = screen.getByLabelText('Subject')
+    fireEvent.change(subjectInput, {
+      target: { value: 'Confirm {{{ .Email }}}' },
+    })
+
+    const saveButton = screen.getByRole('button', { name: 'Save changes' })
+    await waitFor(() => expect(saveButton).not.toBeDisabled())
+    fireEvent.submit(saveButton.closest('form')!)
+
+    expect(
+      await screen.findByText('Invalid template syntax: Unexpected "{" in command')
+    ).toBeInTheDocument()
+    expect(updateAuthConfigMock).not.toHaveBeenCalled()
+  })
+})
+
+
+
+
+

--- a/apps/studio/components/interfaces/Auth/EmailTemplates/TemplateEditor.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/TemplateEditor.tsx
@@ -28,7 +28,7 @@ import {
   AUTH_EMAIL_TEMPLATES_TERMINOLOGY_ANCHOR,
 } from './EmailTemplates.constants'
 import type { AuthTemplate } from './EmailTemplates.types'
-import { hasCustomEmailSender } from './EmailTemplates.utils'
+import { hasCustomEmailSender, validateGoTemplate } from './EmailTemplates.utils'
 import { ResetTemplateDialog } from './ResetTemplateDialog'
 import { SpamValidation } from './SpamValidation'
 import { DiscardChangesConfirmationDialog } from '@/components/ui-patterns/Dialogs/DiscardChangesConfirmationDialog'
@@ -103,6 +103,7 @@ export const TemplateEditor = ({ template, isReadOnly = false }: TemplateEditorP
 
   const [validationResult, setValidationResult] = useState<ValidateSpamResponse>()
   const [bodyValue, setBodyValue] = useState((authConfig && authConfig[messageSlug]) ?? '')
+  const [bodyError, setBodyError] = useState<string | undefined>()
   const [, setHasUnsavedChanges] = useState(false)
   const [isSavingTemplate, setIsSavingTemplate] = useState(false)
   const [activeView, setActiveView] = useState<'source' | 'preview'>('source')
@@ -157,7 +158,17 @@ export const TemplateEditor = ({ template, isReadOnly = false }: TemplateEditorP
     // Because the template content uses the code editor which is not a form component
     // its state is kept separately from the form state, hence why we manually inject it here
     delete payload[messageSlug]
-    if (messageProperty) payload[messageSlug] = bodyValue
+    if (messageProperty) {
+      payload[messageSlug] = bodyValue
+      const bodyValidation = validateGoTemplate(bodyValue)
+      if (!bodyValidation.valid) {
+        setIsSavingTemplate(false)
+        setBodyError(bodyValidation.error)
+        toast.error(`Invalid template syntax: ${bodyValidation.error}`)
+        return
+      }
+    }
+    setBodyError(undefined)
 
     const [subjectKey] = Object.keys(properties)
 
@@ -249,6 +260,7 @@ export const TemplateEditor = ({ template, isReadOnly = false }: TemplateEditorP
     if (authConfig) {
       form.reset(getFormValuesFromConfig(authConfig))
       setBodyValue((authConfig && authConfig[messageSlug]) ?? '')
+      setBodyError(undefined)
     }
   }, [authConfig, getFormValuesFromConfig, messageSlug, form])
 
@@ -294,6 +306,8 @@ export const TemplateEditor = ({ template, isReadOnly = false }: TemplateEditorP
                   name={x}
                   render={({ field }) => (
                     <FormItemLayout
+                      id={x}
+                      name={x}
                       className="gap-y-3"
                       layout="vertical"
                       label={property.title}
@@ -355,14 +369,24 @@ export const TemplateEditor = ({ template, isReadOnly = false }: TemplateEditorP
                       isReadOnly={!canEdit}
                       className="mb-0! relative h-96 outline-hidden outline-offset-0 outline-width-0 outline-0"
                       onInputChange={(e: string | undefined) => {
-                        setBodyValue(e ?? '')
-                        if (bodyValue !== e) setHasUnsavedChanges(true)
+                        const val = e ?? ''
+                        setBodyValue(val)
+                        if (bodyValue !== val) setHasUnsavedChanges(true)
+                        if (bodyError) {
+                          const check = validateGoTemplate(val)
+                          if (check.valid) setBodyError(undefined)
+                        }
                       }}
                       options={{ wordWrap: 'on', contextmenu: false, padding: { top: 16 } }}
                       value={bodyValue}
                       editorRef={editorRef}
                     />
                   </div>
+                  {bodyError && (
+                    <p className="text-destructive text-sm" role="alert">
+                      Invalid template syntax: {bodyError}
+                    </p>
+                  )}
 
                   <div className="flex flex-col gap-y-2">
                     <div className="flex flex-col">
@@ -443,6 +467,7 @@ export const TemplateEditor = ({ template, isReadOnly = false }: TemplateEditorP
                   onResetSuccess={(config: AuthConfigResponse) => {
                     form.reset(getFormValuesFromConfig(config))
                     setBodyValue((config && config[messageSlug]) ?? '')
+                    setBodyError(undefined)
                     setValidationResult(undefined)
                     setHasUnsavedChanges(false)
                   }}
@@ -456,6 +481,7 @@ export const TemplateEditor = ({ template, isReadOnly = false }: TemplateEditorP
                     onClick={() => {
                       form.reset(INITIAL_VALUES)
                       setBodyValue((authConfig && authConfig[messageSlug]) ?? '')
+                      setBodyError(undefined)
                       setHasUnsavedChanges(false)
                     }}
                   >
@@ -484,3 +510,4 @@ export const TemplateEditor = ({ template, isReadOnly = false }: TemplateEditorP
     </Form>
   )
 }
+


### PR DESCRIPTION
### Summary of Changes

Fixes #48877: Prevents invalid Go template syntax (such as extra opening braces `{{{ .RedirectTo }}}`, invalid function calls, or unclosed template actions/strings/control-structures) from saving silently in Auth Email Templates.

Previously, invalid templates were accepted without warning at save time, leading to `templatemailer_template_body_parse_error` log errors at send time and a silent fallback to default templates (making magic links fall back to the Site URL).

### Details

- **`EmailTemplates.utils.ts`**: Added `validateGoTemplate(template: string)` function to parse and validate Go `text/template` / `html/template` syntax.
- **`AuthTemplatesValidation.tsx`**: Integrated `validateGoTemplate` into the Zod validation schema for email template subject fields.
- **`TemplateEditor.tsx`**: Validates the template body content before submission, blocking save and displaying inline error messages when syntax is invalid.
- **Unit Tests**: Added comprehensive test coverage in `EmailTemplates.utils.test.ts` and `TemplateEditor.test.tsx` for valid templates and syntax error edge cases.

### Verification

- Executed unit tests (`pnpm exec vitest --run EmailTemplates.utils.test.ts TemplateEditor.test.tsx`): 27/27 tests passed cleanly.
- Verified TypeScript type checking without errors in `apps/studio`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for Go template syntax in authentication and security email subjects and bodies.
  * Displays inline errors for invalid templates and prevents saving until issues are corrected.
  * Clears validation errors when templates are fixed or reset.
* **Bug Fixes**
  * Improved detection of malformed template actions, delimiters, literals, and unmatched control structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->