### PR TITLE
fix(www): remove dead o11y section that panics typescript-go typechecker

### DIFF
--- a/apps/www/data/products/functions/page.tsx
+++ b/apps/www/data/products/functions/page.tsx
@@ -7,9 +7,6 @@ import Examples from '~/data/Examples'
 import solutions from '~/data/MainProducts'
 
 const FunctionsHero = dynamic(() => import('~/components/Products/Functions/FunctionsHero'))
-const RealtimeLogs = dynamic(() => import('~/components/Products/Functions/RealtimeLogs'))
-const Metrics = dynamic(() => import('~/components/Products/Functions/Metrics'))
-const QueryLogs = dynamic(() => import('~/components/Products/Functions/QueryLogs'))
 const LocalDXImage = dynamic(() => import('~/components/Products/Functions/LocalDXImage'))
 const ParityImage = dynamic(() => import('~/components/Products/Functions/ParityImage'))
 const NpmEcosystem = dynamic(() => import('~/components/Products/Functions/NpmEcosystem'))
@@ -280,34 +277,6 @@ export default (isMobile?: boolean) => ({
       {
         label: 'Secure',
         paragraph: 'Scale with confidence with SSL, Firewall and DDOS protection built in',
-      },
-    ],
-  },
-  o11y: {
-    title: 'Built-in observability',
-    panels: [
-      {
-        id: 'realtime-logs',
-        label: 'Realtime logs',
-        icon: '',
-        paragraph:
-          'Stream logs to the dashboard in realtime. Logs are populated with rich metadata to help debugging',
-        image: RealtimeLogs,
-      },
-      {
-        id: 'log-explorer',
-        label: 'Query Logs via Log explorer',
-        icon: '',
-        paragraph:
-          'Get deeper insights into how your functions are behaving by writing SQL queries on function logs',
-        image: QueryLogs,
-      },
-      {
-        id: 'metrics',
-        label: 'Metrics',
-        icon: '',
-        paragraph: 'Dashboards show the health of your functions at all times',
-        image: Metrics,
       },
     ],
   },


### PR DESCRIPTION
## Summary

The `o11y` section in `apps/www/data/products/functions/page.tsx` stores references to dynamically-imported components (`RealtimeLogs`, `Metrics`, `QueryLogs`) whose props types are private (non-exported). This causes the typescript-go declaration emitter to panic with `Diagnostic emitted without context` on any edit to the file, since TS4082 (private name `Props`) cannot be surfaced as an error.

## Root cause

The `ObservabilitySection.tsx` component in the app router already renders observability cards with its own self-contained dynamic imports and card definitions. The `o11y` data object in `page.tsx` has been unused since that migration, but remains in the file. Its stored component references leak a non-exported `interface Props` from `RealtimeLogs.tsx`, which the typescript-go compiler cannot name during declaration emit → panic instead of a proper error.

## Fix

Remove the dead `o11y` section (31 lines) and its 3 now-unused dynamic imports. This:

- Fixes the typechecker panic (#48876)
- Eliminates dead data and unused imports
- Keeps `ObservabilitySection.tsx` as the single source of truth for observability UI

## Verification

- Reproduced the panic with the original file (`tsc --noEmit` → `panic: Diagnostic emitted without context`)
- Confirmed no panic after the fix
- Confirmed JS tsc with `--declaration` reports zero TS4082 errors on this file post-fix

Closes #48876


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed Features**
  * Removed the observability section from the Functions page, including realtime logs, log exploration, and metrics panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->