### PR TITLE
fix: correct AI tools link on docs homepage

### DIFF
--- a/apps/docs/app/page.tsx
+++ b/apps/docs/app/page.tsx
@@ -177,7 +177,7 @@ const additionalResources = [
     title: 'AI tools',
     description: 'Develop with Supabase AI-first using plugins, MCP, and skills.',
     icon: 'ai-tools',
-    href: '/guides/ai',
+    href: '/guides/ai-tools',
   },
   {
     title: 'Platform guides',


### PR DESCRIPTION
## Summary

- The "AI tools" card in the "Explore more" section of the docs homepage links to `/guides/ai` (the AI & Vectors / pgvector page) instead of `/guides/ai-tools` (the MCP, plugins, and coding agent page)
- The card description says "Develop with Supabase AI-first using plugins, MCP, and skills" which matches `/guides/ai-tools`, not `/guides/ai`
- Changed `href: '/guides/ai'` to `href: '/guides/ai-tools'` for the AI tools card only

## Test plan

- [ ] Visit supabase.com/docs and click "AI tools" in the Explore more section
- [ ] Confirm it lands on /guides/ai-tools (MCP, plugins, coding agents)
- [ ] Confirm the "AI & Vectors" card still correctly links to /guides/ai

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the “AI tools” link on the documentation homepage to direct visitors to the correct guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->