### PR TITLE
fix(sql-editor): avoid silent return and shows error for undefined

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/useSqlEditorAi.ts
+++ b/apps/studio/components/interfaces/SQLEditor/useSqlEditorAi.ts
@@ -155,13 +155,13 @@ export function useSqlEditorAi({
 
       if (!sourceSqlDiff || !editor.isReady() || !diffController.isMounted()) {
         toast.error('Unable to apply the AI SQL diff right now. Please try again.')
-        throw new Error('AI diff could not be applied: editor/diff state unavailable')
+        return
       }
 
       const sql = diffController.getModifiedValue()
       if (sql === undefined) {
         toast.error('Unable to apply the AI edit because the diff editor returned no SQL.')
-        throw new Error('AI diff accepted, but modified SQL was undefined')
+        return
       }
 
       if (selectedDiffType === DiffType.NewSnippet) {

--- a/apps/studio/components/interfaces/SQLEditor/useSqlEditorAi.ts
+++ b/apps/studio/components/interfaces/SQLEditor/useSqlEditorAi.ts
@@ -153,11 +153,16 @@ export function useSqlEditorAi({
     try {
       setIsAcceptDiffLoading(true)
 
-      // TODO: show error if undefined
-      if (!sourceSqlDiff || !editor.isReady() || !diffController.isMounted()) return
+      if (!sourceSqlDiff || !editor.isReady() || !diffController.isMounted()) {
+        toast.error('Unable to apply the AI SQL diff right now. Please try again.')
+        throw new Error('AI diff could not be applied: editor/diff state unavailable')
+      }
 
       const sql = diffController.getModifiedValue()
-      if (sql === undefined) return
+      if (sql === undefined) {
+        toast.error('Unable to apply the AI edit because the diff editor returned no SQL.')
+        throw new Error('AI diff accepted, but modified SQL was undefined')
+      }
 
       if (selectedDiffType === DiffType.NewSnippet) {
         const { title } = await generateSqlTitle({ sql })


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

 The code previously returned early without surfacing a visible error.

## What is the new behavior?

It throws a descriptive `Error` for that exceptional branch so the failure is observable instead of silent.

## Additional context

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when AI-generated SQL cannot be applied due to missing editor data or unavailable comparison views.
  * Ensured loading indicators are cleared even when an error occurs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->