### PR TITLE
fix(studio): prevent incorrect PITR restore times across timezones FE-4129

### DIFF
--- a/apps/studio/components/interfaces/Account/Preferences/TimezoneSettings.tsx
+++ b/apps/studio/components/interfaces/Account/Preferences/TimezoneSettings.tsx
@@ -48,6 +48,15 @@ export const TimezoneSettings = () => {
 
   const triggerLabel = useMemo(() => formatTimezoneLabel(timezone), [timezone])
 
+  const options = useMemo(
+    () =>
+      TIMEZONES_BY_IANA.map((entry) => ({
+        iana: entry.utc[0],
+        label: formatTimezoneLabel(entry.utc[0]),
+      })),
+    []
+  )
+
   if (!timezonePickerEnabled) return null
 
   const handleSelect = (nextStored: string) => {
@@ -127,9 +136,7 @@ export const TimezoneSettings = () => {
                               )}
                             />
                           </CommandItem>
-                          {TIMEZONES_BY_IANA.map((entry) => {
-                            const ianaName = entry.utc[0]
-                            const label = formatTimezoneLabel(ianaName)
+                          {options.map(({ iana: ianaName, label }) => {
                             const isSelected = !isAutoDetected && storedTimezone === ianaName
                             return (
                               <CommandItem

--- a/apps/studio/components/interfaces/Account/Preferences/TimezoneSettings.tsx
+++ b/apps/studio/components/interfaces/Account/Preferences/TimezoneSettings.tsx
@@ -27,7 +27,7 @@ import {
   PageSectionTitle,
 } from 'ui-patterns/PageSection'
 
-import { findTimezoneByIana, TIMEZONES_BY_IANA } from '@/lib/constants/timezones'
+import { formatTimezoneLabel, TIMEZONES_BY_IANA } from '@/lib/constants/timezones'
 import { useTimezone } from '@/lib/datetime'
 import { guessLocalTimezone } from '@/lib/dayjs'
 import { useTrack } from '@/lib/telemetry/track'
@@ -46,7 +46,7 @@ export const TimezoneSettings = () => {
   // option will revert to.
   const browserTimezone = useMemo(() => guessLocalTimezone(), [])
 
-  const triggerLabel = useMemo(() => findTimezoneByIana(timezone)?.text ?? timezone, [timezone])
+  const triggerLabel = useMemo(() => formatTimezoneLabel(timezone), [timezone])
 
   if (!timezonePickerEnabled) return null
 
@@ -129,16 +129,17 @@ export const TimezoneSettings = () => {
                           </CommandItem>
                           {TIMEZONES_BY_IANA.map((entry) => {
                             const ianaName = entry.utc[0]
+                            const label = formatTimezoneLabel(ianaName)
                             const isSelected = !isAutoDetected && storedTimezone === ianaName
                             return (
                               <CommandItem
                                 key={ianaName}
                                 // CommandItem matches against the `value` prop for the input filter — include
                                 // both the human label and the IANA name so search works for either.
-                                value={`${entry.text} ${ianaName}`}
+                                value={`${label} ${ianaName}`}
                                 onSelect={() => handleSelect(ianaName)}
                               >
-                                {entry.text}
+                                {label}
                                 <CheckIcon
                                   className={cn(
                                     'ml-auto h-4 w-4',

--- a/apps/studio/components/interfaces/Database/Backups/PITR/PITR.constants.ts
+++ b/apps/studio/components/interfaces/Database/Backups/PITR/PITR.constants.ts
@@ -1,3 +1,0 @@
-// Re-export from the shared location. The full timezone catalog now lives in
-// `lib/constants/timezones.ts` so it can be consumed outside of PITR.
-export { ALL_TIMEZONES } from '@/lib/constants/timezones'

--- a/apps/studio/components/interfaces/Database/Backups/PITR/PITR.types.ts
+++ b/apps/studio/components/interfaces/Database/Backups/PITR/PITR.types.ts
@@ -1,12 +1,3 @@
-export interface Timezone {
-  value: string
-  abbr: string
-  offset: number
-  isdst: boolean
-  text: string
-  utc: string[]
-}
-
 export interface Time {
   h: number
   m: number

--- a/apps/studio/components/interfaces/Database/Backups/PITR/PITR.utils.test.ts
+++ b/apps/studio/components/interfaces/Database/Backups/PITR/PITR.utils.test.ts
@@ -1,0 +1,52 @@
+import dayjs from 'dayjs'
+import { describe, expect, it } from 'vitest'
+
+import { toCalendarDate, withCalendarDate, withTime } from './PITR.utils'
+
+describe('toCalendarDate', () => {
+  it('hands the calendar the day as seen in the selected timezone', () => {
+    // 02:30 UTC is still the previous day in every negative offset, so a
+    // browser-local conversion here would show the wrong day in the calendar
+    const selected = dayjs.tz('2026-08-10 02:30:00', 'UTC')
+    const calendarDate = toCalendarDate(selected)
+
+    expect(calendarDate.getFullYear()).toBe(2026)
+    expect(calendarDate.getMonth()).toBe(7)
+    expect(calendarDate.getDate()).toBe(10)
+    expect(calendarDate.getHours()).toBe(0)
+  })
+})
+
+describe('withCalendarDate', () => {
+  it('keeps the time of day when the calendar date changes', () => {
+    const current = dayjs.tz('2026-08-10 02:30:15', 'UTC')
+    const updated = withCalendarDate(current, new Date(2026, 7, 3), 'UTC')
+
+    expect(updated.tz('UTC').format('YYYY-MM-DD HH:mm:ss')).toBe('2026-08-03 02:30:15')
+  })
+
+  it('resolves the wall clock against the offset in effect on the new date', () => {
+    const current = dayjs.tz('2026-03-20 12:00:00', 'America/New_York')
+    const updated = withCalendarDate(current, new Date(2026, 1, 20), 'America/New_York')
+
+    expect(updated.format('Z')).toBe('-05:00')
+    expect(updated.tz('America/New_York').format('YYYY-MM-DD HH:mm:ss')).toBe('2026-02-20 12:00:00')
+  })
+
+  it('does not overflow when the new month is shorter than the current one', () => {
+    const current = dayjs.tz('2026-01-31 08:00:00', 'UTC')
+    const updated = withCalendarDate(current, new Date(2026, 1, 28), 'UTC')
+
+    expect(updated.tz('UTC').format('YYYY-MM-DD HH:mm:ss')).toBe('2026-02-28 08:00:00')
+  })
+})
+
+describe('withTime', () => {
+  it('sets the wall clock in the timezone the date is rendered in', () => {
+    const current = dayjs.unix(1786000000).tz('Asia/Tokyo')
+    const updated = withTime(current, { h: 1, m: 2, s: 3 })
+
+    expect(updated.format('YYYY-MM-DD HH:mm:ss')).toBe(`${current.format('YYYY-MM-DD')} 01:02:03`)
+    expect(updated.utc().format('HH:mm:ss')).toBe('16:02:03')
+  })
+})

--- a/apps/studio/components/interfaces/Database/Backups/PITR/PITR.utils.test.ts
+++ b/apps/studio/components/interfaces/Database/Backups/PITR/PITR.utils.test.ts
@@ -33,6 +33,15 @@ describe('withCalendarDate', () => {
     expect(updated.tz('America/New_York').format('YYYY-MM-DD HH:mm:ss')).toBe('2026-02-20 12:00:00')
   })
 
+  it('lands on a real instant when the wall clock does not exist on the new date', () => {
+    // 02:30 does not exist in New York on 08 Mar 2026, the clocks jump 02:00 to 03:00
+    const current = dayjs.tz('2026-03-20 02:30:00', 'America/New_York')
+    const updated = withCalendarDate(current, new Date(2026, 2, 8), 'America/New_York')
+
+    expect(updated.isValid()).toBe(true)
+    expect(updated.tz('America/New_York').format('YYYY-MM-DD HH:mm:ss')).toBe('2026-03-08 03:30:00')
+  })
+
   it('does not overflow when the new month is shorter than the current one', () => {
     const current = dayjs.tz('2026-01-31 08:00:00', 'UTC')
     const updated = withCalendarDate(current, new Date(2026, 1, 28), 'UTC')

--- a/apps/studio/components/interfaces/Database/Backups/PITR/PITR.utils.ts
+++ b/apps/studio/components/interfaces/Database/Backups/PITR/PITR.utils.ts
@@ -1,9 +1,7 @@
 import dayjs from 'dayjs'
 
-import { ALL_TIMEZONES } from './PITR.constants'
 import type { Time } from './PITR.types'
 import type { ProjectSelectedAddon } from '@/data/subscriptions/types'
-import { guessLocalTimezone } from '@/lib/dayjs'
 
 export const getPITRRetentionDuration = (addons: ProjectSelectedAddon[]) => {
   const pitrAddon = addons.find((addon) => addon.type === 'pitr')
@@ -16,16 +14,6 @@ export const getDatesBetweenRange = (startDate: dayjs.Dayjs, endDate: dayjs.Dayj
   const diff = endDate.diff(startDate, 'day')
 
   return Array.from({ length: diff }, (_, index) => startDate.add(index, 'day'))
-}
-
-export const getClientTimezone = () => {
-  const defaultTz = guessLocalTimezone()
-  const utcTz = ALL_TIMEZONES.find((option) => option.value === 'UTC')
-  const timezone = ALL_TIMEZONES.find((option) => {
-    if (option.utc.includes(defaultTz)) return option
-    else return undefined
-  })
-  return timezone ?? (utcTz || ALL_TIMEZONES[0])
 }
 
 export const formatNumberToTwoDigits = (number: Number) => {
@@ -42,12 +30,17 @@ export const formatTimeToTimeString = (time: Time) => {
   )}:${formatNumberToTwoDigits(time.s)}`
 }
 
-export function constrainDateToRange(current: dayjs.Dayjs, lower: dayjs.Dayjs, upper: dayjs.Dayjs) {
-  if (current.isBefore(lower)) {
-    return lower
-  }
-  if (current.isAfter(upper)) {
-    return upper
-  }
-  return current
-}
+// The calendar works in browser-local Date objects, so a date shown in another
+// timezone has to be handed over as the same year/month/day at local midnight.
+export const toCalendarDate = (date: dayjs.Dayjs) =>
+  new Date(date.year(), date.month(), date.date())
+
+export const withCalendarDate = (
+  current: dayjs.Dayjs,
+  calendarDate: Date,
+  timezone: string
+): dayjs.Dayjs =>
+  dayjs.tz(`${dayjs(calendarDate).format('YYYY-MM-DD')} ${current.format('HH:mm:ss')}`, timezone)
+
+export const withTime = (current: dayjs.Dayjs, { h, m, s }: Time): dayjs.Dayjs =>
+  current.set('hour', h).set('minute', m).set('second', s)

--- a/apps/studio/components/interfaces/Database/Backups/PITR/PITRForm.test.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/PITR/PITRForm.test.tsx
@@ -18,14 +18,13 @@ dayjs.extend(customParseFormat)
 // The bugs this covers only reproduce when the browser timezone differs from
 // the selected one, so the host timezone can't be left to chance
 const BROWSER_TIMEZONE = 'America/New_York'
-const originalTimezone = process.env.TZ
 
 beforeAll(() => {
-  process.env.TZ = BROWSER_TIMEZONE
+  vi.stubEnv('TZ', BROWSER_TIMEZONE)
 })
 
 afterAll(() => {
-  process.env.TZ = originalTimezone
+  vi.unstubAllEnvs()
 })
 
 afterEach(() => {

--- a/apps/studio/components/interfaces/Database/Backups/PITR/PITRForm.test.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/PITR/PITRForm.test.tsx
@@ -1,0 +1,138 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { LOCAL_STORAGE_KEYS } from 'common'
+import dayjs from 'dayjs'
+import customParseFormat from 'dayjs/plugin/customParseFormat'
+import { mockAnimationsApi } from 'jsdom-testing-mocks'
+import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from 'vitest'
+
+import { PITRForm } from './PITRForm'
+import { TimezoneProvider } from '@/lib/datetime'
+import { customRender } from '@/tests/lib/custom-render'
+
+mockAnimationsApi()
+
+// TimeInput validates with a parse format, which the shared test setup does not
+// load (the app entries do)
+dayjs.extend(customParseFormat)
+
+// The bugs this covers only reproduce when the browser timezone differs from
+// the selected one, so the host timezone can't be left to chance
+const BROWSER_TIMEZONE = 'America/New_York'
+const originalTimezone = process.env.TZ
+
+beforeAll(() => {
+  process.env.TZ = BROWSER_TIMEZONE
+})
+
+afterAll(() => {
+  process.env.TZ = originalTimezone
+})
+
+afterEach(() => {
+  localStorage.clear()
+})
+
+const EARLIEST_BACKUP_UNIX = dayjs.utc('2026-08-05T14:00:00Z').unix()
+const LATEST_BACKUP_UNIX = dayjs.utc('2026-08-10T02:30:00Z').unix()
+
+const renderForm = ({ withTimezoneProvider = false } = {}) => {
+  const onSubmit = vi.fn()
+  const form = (
+    <PITRForm
+      onSubmit={onSubmit}
+      earliestAvailableBackupUnix={EARLIEST_BACKUP_UNIX}
+      latestAvailableBackupUnix={LATEST_BACKUP_UNIX}
+    />
+  )
+  customRender(withTimezoneProvider ? <TimezoneProvider>{form}</TimezoneProvider> : form)
+  return { onSubmit }
+}
+
+const getRestorePoint = () =>
+  screen.getByText('Database will be restored to:').parentElement!.querySelector('p.text-3xl')!
+    .textContent
+
+const selectTimezone = async (label: string) => {
+  fireEvent.click(screen.getByRole('combobox'))
+  fireEvent.click(await screen.findByRole('option', { name: label }))
+}
+
+// The calendar labels its day buttons with the full date, so the ISO day
+// attribute is the stable way to pick one
+const clickDay = (isoDate: string) =>
+  fireEvent.click(document.querySelector(`[data-day="${isoDate}"] button`)!)
+
+const getContinueButton = () => screen.getByRole('button', { name: 'Continue' })
+
+const setHours = (value: string) => {
+  const hours = screen.getByLabelText('Hours')
+  fireEvent.change(hours, { target: { value } })
+  fireEvent.blur(hours)
+}
+
+describe('PITRForm', () => {
+  test('defaults to the latest backup rendered in the local timezone', () => {
+    renderForm()
+
+    // 02:30 UTC is the previous day in New York
+    expect(getRestorePoint()).toBe('09 Aug 2026, 22:30:00')
+  })
+
+  test('defaults to the timezone the user picked for the dashboard', async () => {
+    localStorage.setItem(LOCAL_STORAGE_KEYS.UI_TIMEZONE, JSON.stringify('Asia/Tokyo'))
+
+    renderForm({ withTimezoneProvider: true })
+
+    await waitFor(() => expect(getRestorePoint()).toBe('10 Aug 2026, 11:30:00'))
+    expect(screen.getByRole('combobox')).toHaveTextContent('(UTC+09:00) Osaka, Sapporo, Tokyo')
+  })
+
+  test('keeps the same point in time when the timezone changes', async () => {
+    renderForm()
+
+    await selectTimezone('(UTC+00:00) Coordinated Universal Time')
+
+    await waitFor(() => expect(getRestorePoint()).toBe('10 Aug 2026, 02:30:00'))
+  })
+
+  test('keeps the time of day when another date is picked', async () => {
+    const { onSubmit } = renderForm()
+
+    clickDay('2026-08-07')
+
+    expect(getRestorePoint()).toBe('07 Aug 2026, 22:30:00')
+
+    fireEvent.click(getContinueButton())
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selectedTimezone: BROWSER_TIMEZONE,
+        recoveryTimeTargetUnix: dayjs.utc('2026-08-08T02:30:00Z').unix(),
+        recoveryTimeString: '07 Aug 2026 22:30:00',
+        recoveryTimeStringUtc: '08 Aug 2026 02:30:00',
+      })
+    )
+  })
+
+  test('blocks a time that falls outside the available range', async () => {
+    renderForm()
+
+    // The earliest backup is 10:00 in New York, so 09:00 on that day is out of range
+    clickDay('2026-08-05')
+    setHours('09')
+
+    expect(
+      await screen.findByText('Selected time is before the minimum time allowed')
+    ).toBeInTheDocument()
+    expect(getContinueButton()).toBeDisabled()
+  })
+
+  test('allows a time within the available range on the earliest date', async () => {
+    renderForm()
+
+    clickDay('2026-08-05')
+    setHours('11')
+
+    await waitFor(() => expect(getRestorePoint()).toBe('05 Aug 2026, 11:30:00'))
+    expect(getContinueButton()).toBeEnabled()
+  })
+})

--- a/apps/studio/components/interfaces/Database/Backups/PITR/PITRForm.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/PITR/PITRForm.tsx
@@ -1,24 +1,17 @@
 import dayjs from 'dayjs'
-import { HelpCircle } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { useState } from 'react'
 import { Calendar, cn } from 'ui'
 
-import { type Timezone } from './PITR.types'
-import {
-  constrainDateToRange,
-  formatNumberToTwoDigits,
-  getClientTimezone,
-  getDatesBetweenRange,
-} from './PITR.utils'
+import { getDatesBetweenRange, toCalendarDate, withCalendarDate, withTime } from './PITR.utils'
 import TimeInput from './TimeInput'
 import { TimezoneSelection } from './TimezoneSelection'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import { FormPanel } from '@/components/ui/Forms/FormPanel'
-import InformationBox from '@/components/ui/InformationBox'
+import { guessLocalTimezone } from '@/lib/dayjs'
 
 type Props = {
   onSubmit: (data: {
-    selectedTimezone: Timezone
+    selectedTimezone: string
     recoveryTimeTargetUnix: number
     recoveryTimeString: string
     recoveryTimeStringUtc: string
@@ -34,19 +27,15 @@ export function PITRForm({
   latestAvailableBackupUnix,
   disabled = false,
 }: Props) {
-  const [selectedTimezone, setSelectedTimezone] = useState<Timezone>(getClientTimezone())
-  const earliestAvailableBackup = dayjs
-    .unix(earliestAvailableBackupUnix ?? 0)
-    .tz(selectedTimezone.utc[0])
-  const latestAvailableBackup = dayjs
-    .unix(latestAvailableBackupUnix ?? 0)
-    .tz(selectedTimezone.utc[0])
-  const earliestAvailableBackupAsDate = earliestAvailableBackup.toDate()
-  const latestAvailableBackupAsDate = latestAvailableBackup.toDate()
+  const [selectedTimezone, setSelectedTimezone] = useState<string>(guessLocalTimezone)
+  const earliestAvailableBackup = dayjs.unix(earliestAvailableBackupUnix ?? 0).tz(selectedTimezone)
+  const latestAvailableBackup = dayjs.unix(latestAvailableBackupUnix ?? 0).tz(selectedTimezone)
 
-  const [selectedDateRaw, setSelectedDateRaw] = useState<Date>(latestAvailableBackup.toDate())
+  // Held as an instant rather than a wall clock so that switching timezone
+  // re-renders the same point in time instead of shifting it
+  const [selectedUnix, setSelectedUnix] = useState(latestAvailableBackupUnix ?? 0)
 
-  const selectedDate = dayjs(selectedDateRaw).tz(selectedTimezone.utc[0], true)
+  const selectedDate = dayjs.unix(selectedUnix).tz(selectedTimezone)
   const isSelectedOnEarliestDay = selectedDate.isSame(earliestAvailableBackup, 'day')
   const isSelectedOnLatestDay = selectedDate.isSame(latestAvailableBackup, 'day')
   const availableDates = getDatesBetweenRange(earliestAvailableBackup, latestAvailableBackup)
@@ -69,35 +58,15 @@ export function PITRForm({
     s: latestAvailableBackup.second(),
   }
 
-  const recoveryTimeTargetUnix = selectedDate.unix()
-  const recoveryTimeString = selectedDate.format('DD MMM YYYY HH:mm:ss')
-  const recoveryTimeStringUtc = selectedDate.utc().format('DD MMM YYYY HH:mm:ss')
-
-  const isWithinRange = useMemo(
-    () =>
-      (!!selectedDate && selectedDate.isSame(latestAvailableBackup)) ||
-      selectedDate.isSame(earliestAvailableBackup) ||
-      (selectedDate.isBefore(latestAvailableBackup) &&
-        selectedDate.isAfter(earliestAvailableBackup)),
-    [selectedDate, latestAvailableBackup, earliestAvailableBackup]
-  )
-
-  const onUpdateDate = (date: Date) => {
-    setSelectedDateRaw(
-      constrainDateToRange(
-        dayjs(date).tz(selectedTimezone.utc[0], true),
-        earliestAvailableBackup,
-        latestAvailableBackup
-      ).toDate()
-    )
-  }
+  const isWithinRange =
+    !selectedDate.isBefore(earliestAvailableBackup) && !selectedDate.isAfter(latestAvailableBackup)
 
   const handleSubmit = () => {
     onSubmit({
       selectedTimezone,
-      recoveryTimeTargetUnix,
-      recoveryTimeString,
-      recoveryTimeStringUtc,
+      recoveryTimeTargetUnix: selectedDate.unix(),
+      recoveryTimeString: selectedDate.format('DD MMM YYYY HH:mm:ss'),
+      recoveryTimeStringUtc: selectedDate.utc().format('DD MMM YYYY HH:mm:ss'),
     })
   }
 
@@ -109,7 +78,7 @@ export function PITRForm({
           <div className="flex items-center justify-end gap-3 p-6">
             <ButtonTooltip
               variant="default"
-              disabled={disabled || !selectedDate || !isWithinRange}
+              disabled={disabled || !isWithinRange}
               onClick={handleSubmit}
               tooltip={{
                 content: {
@@ -132,14 +101,16 @@ export function PITRForm({
             <Calendar
               mode="single"
               required={true}
-              selected={selectedDateRaw}
-              onSelect={onUpdateDate}
-              defaultMonth={latestAvailableBackupAsDate}
-              startMonth={earliestAvailableBackupAsDate}
-              endMonth={latestAvailableBackupAsDate}
+              selected={toCalendarDate(selectedDate)}
+              onSelect={(date) =>
+                setSelectedUnix(withCalendarDate(selectedDate, date, selectedTimezone).unix())
+              }
+              defaultMonth={toCalendarDate(latestAvailableBackup)}
+              startMonth={toCalendarDate(earliestAvailableBackup)}
+              endMonth={toCalendarDate(latestAvailableBackup)}
               disabled={[
-                { before: earliestAvailableBackupAsDate },
-                { after: latestAvailableBackupAsDate },
+                { before: toCalendarDate(earliestAvailableBackup) },
+                { after: toCalendarDate(latestAvailableBackup) },
               ]}
               classNames={{
                 root: 'w-min px-0',
@@ -160,83 +131,56 @@ export function PITRForm({
           </div>
 
           <div className="w-full lg:w-2/3">
-            {!selectedDate ? (
-              <div className="h-full flex items-center justify-center">
-                <div className="mx-2">
-                  <InformationBox
-                    defaultVisibility
-                    hideCollapse
-                    icon={<HelpCircle size={14} strokeWidth={2} />}
-                    title="Select a date which you'd like to restore your database to"
-                  />
-                </div>
-              </div>
-            ) : (
-              <div className="space-y-8 py-2">
-                <div className="flex flex-col gap-y-4">
-                  <p className="text-sm text-foreground">Enter a time to restore to</p>
-                  <div className="space-y-1">
-                    <p className="text-sm text-foreground-light">Time zone</p>
-                    <div className="w-[350px]">
-                      <TimezoneSelection
-                        selectedTimezone={selectedTimezone}
-                        onSelectTimezone={setSelectedTimezone}
-                      />
-                    </div>
-                  </div>
-                  <div>
-                    <div className="space-y-1">
-                      <p className="text-sm text-foreground-light">Recovery time</p>
-                      {isSelectedOnEarliestDay && (
-                        <p className="text-sm text-foreground-lighter">
-                          <strong>Earliest backup available for this date</strong>:{' '}
-                          {earliestAvailableBackup.format('HH:mm:ss')}
-                        </p>
-                      )}
-                      {isSelectedOnLatestDay && (
-                        <p className="text-sm text-foreground-lighter">
-                          <strong>Latest backup available for this date</strong>:{' '}
-                          {latestAvailableBackup.format('HH:mm:ss')}
-                        </p>
-                      )}
-                      <TimeInput
-                        defaultTime={selectedTime}
-                        minimumTime={
-                          isSelectedOnEarliestDay ? earliestAvailableBackupTime : undefined
-                        }
-                        maximumTime={isSelectedOnLatestDay ? latestAvailableBackupTime : undefined}
-                        onChange={({ h, m, s }) => {
-                          const newDate = dayjs(selectedDateRaw)
-                            .set('hour', h)
-                            .set('minute', m)
-                            .set('second', s)
-
-                          setSelectedDateRaw(newDate.toDate())
-                        }}
-                      />
-                    </div>
-                  </div>
-                </div>
-
+            <div className="space-y-8 py-2">
+              <div className="flex flex-col gap-y-4">
+                <p className="text-sm text-foreground">Enter a time to restore to</p>
                 <div className="space-y-1">
-                  <p className="text-sm text-foreground-light">Database will be restored to:</p>
-                  <p className="text-3xl">
-                    <span>{dayjs(selectedDate).format('DD MMM YYYY')}</span>
-                    <span>
-                      , {formatNumberToTwoDigits(selectedTime.h)}:
-                      {formatNumberToTwoDigits(selectedTime.m)}:
-                      {formatNumberToTwoDigits(selectedTime.s)}
-                    </span>
-                  </p>
-
-                  <p className="text-sm text-foreground-lighter mt-4 text-balance">
-                    Backups are captured every 2 minutes, allowing you to enter a time and restore
-                    your database to the closest backup point. We'll match the time you enter to the
-                    closest backup within the 2-minute window
-                  </p>
+                  <p className="text-sm text-foreground-light">Time zone</p>
+                  <div className="w-[350px]">
+                    <TimezoneSelection
+                      selectedTimezone={selectedTimezone}
+                      onSelectTimezone={setSelectedTimezone}
+                    />
+                  </div>
+                </div>
+                <div>
+                  <div className="space-y-1">
+                    <p className="text-sm text-foreground-light">Recovery time</p>
+                    {isSelectedOnEarliestDay && (
+                      <p className="text-sm text-foreground-lighter">
+                        <strong>Earliest backup available for this date</strong>:{' '}
+                        {earliestAvailableBackup.format('HH:mm:ss')}
+                      </p>
+                    )}
+                    {isSelectedOnLatestDay && (
+                      <p className="text-sm text-foreground-lighter">
+                        <strong>Latest backup available for this date</strong>:{' '}
+                        {latestAvailableBackup.format('HH:mm:ss')}
+                      </p>
+                    )}
+                    <TimeInput
+                      defaultTime={selectedTime}
+                      minimumTime={
+                        isSelectedOnEarliestDay ? earliestAvailableBackupTime : undefined
+                      }
+                      maximumTime={isSelectedOnLatestDay ? latestAvailableBackupTime : undefined}
+                      onChange={(time) => setSelectedUnix(withTime(selectedDate, time).unix())}
+                    />
+                  </div>
                 </div>
               </div>
-            )}
+
+              <div className="space-y-1">
+                <p className="text-sm text-foreground-light">Database will be restored to:</p>
+                <p className="text-3xl">{selectedDate.format('DD MMM YYYY, HH:mm:ss')}</p>
+
+                <p className="text-sm text-foreground-lighter mt-4 text-balance">
+                  Backups are captured every 2 minutes, allowing you to enter a time and restore
+                  your database to the closest backup point. We'll match the time you enter to the
+                  closest backup within the 2-minute window
+                </p>
+              </div>
+            </div>
           </div>
         </div>
       </FormPanel>

--- a/apps/studio/components/interfaces/Database/Backups/PITR/PITRForm.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/PITR/PITRForm.tsx
@@ -7,7 +7,7 @@ import TimeInput from './TimeInput'
 import { TimezoneSelection } from './TimezoneSelection'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import { FormPanel } from '@/components/ui/Forms/FormPanel'
-import { guessLocalTimezone } from '@/lib/dayjs'
+import { useTimezone } from '@/lib/datetime'
 
 type Props = {
   onSubmit: (data: {
@@ -27,7 +27,10 @@ export function PITRForm({
   latestAvailableBackupUnix,
   disabled = false,
 }: Props) {
-  const [selectedTimezone, setSelectedTimezone] = useState<string>(guessLocalTimezone)
+  const { timezone } = useTimezone()
+  const [overriddenTimezone, setOverriddenTimezone] = useState<string>()
+  const selectedTimezone = overriddenTimezone ?? timezone
+
   const earliestAvailableBackup = dayjs.unix(earliestAvailableBackupUnix ?? 0).tz(selectedTimezone)
   const latestAvailableBackup = dayjs.unix(latestAvailableBackupUnix ?? 0).tz(selectedTimezone)
 
@@ -139,7 +142,7 @@ export function PITRForm({
                   <div className="w-[350px]">
                     <TimezoneSelection
                       selectedTimezone={selectedTimezone}
-                      onSelectTimezone={setSelectedTimezone}
+                      onSelectTimezone={setOverriddenTimezone}
                     />
                   </div>
                 </div>

--- a/apps/studio/components/interfaces/Database/Backups/PITR/PITRSelection.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/PITR/PITRSelection.tsx
@@ -22,8 +22,6 @@ import {
 
 import { BackupsEmpty } from '../BackupsEmpty'
 import { BackupsStorageAlert } from '../BackupsStorageAlert'
-import type { Timezone } from './PITR.types'
-import { getClientTimezone } from './PITR.utils'
 import { PITRForm } from './PITRForm'
 import PITRStatus from './PITRStatus'
 import { FormHeader } from '@/components/ui/Forms/FormHeader'
@@ -32,6 +30,8 @@ import { usePitrRestoreMutation } from '@/data/database/pitr-restore-mutation'
 import { useSetProjectStatus } from '@/data/projects/project-detail-query'
 import { useReadReplicasQuery } from '@/data/read-replicas/replicas-query'
 import { PROJECT_STATUS } from '@/lib/constants'
+import { formatTimezoneLabel } from '@/lib/constants/timezones'
+import { guessLocalTimezone } from '@/lib/dayjs'
 
 export const PITRSelection = () => {
   const router = useRouter()
@@ -43,9 +43,9 @@ export const PITRSelection = () => {
 
   const [showConfiguration, setShowConfiguration] = useState(false)
   const [showConfirmation, setShowConfirmation] = useState(false)
-  const [selectedTimezone, setSelectedTimezone] = useState<Timezone>(getClientTimezone())
+  const [selectedTimezone, setSelectedTimezone] = useState<string>(guessLocalTimezone)
   const [selectedRecoveryPoint, setSelectedRecoveryPoint] = useState<{
-    selectedTimezone: Timezone
+    selectedTimezone: string
     recoveryTimeTargetUnix: number
     recoveryTimeString: string
     recoveryTimeStringUtc: string
@@ -135,7 +135,9 @@ export const PITRSelection = () => {
                 <div className="py-2 flex flex-col gap-3">
                   <div>
                     <p className="text-sm font-mono text-foreground-lighter">
-                      {selectedRecoveryPoint?.selectedTimezone.text}
+                      {selectedRecoveryPoint
+                        ? formatTimezoneLabel(selectedRecoveryPoint.selectedTimezone)
+                        : null}
                     </p>
                     <p className="text-2xl">{selectedRecoveryPoint?.recoveryTimeString}</p>
                   </div>

--- a/apps/studio/components/interfaces/Database/Backups/PITR/PITRSelection.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/PITR/PITRSelection.tsx
@@ -31,7 +31,7 @@ import { useSetProjectStatus } from '@/data/projects/project-detail-query'
 import { useReadReplicasQuery } from '@/data/read-replicas/replicas-query'
 import { PROJECT_STATUS } from '@/lib/constants'
 import { formatTimezoneLabel } from '@/lib/constants/timezones'
-import { guessLocalTimezone } from '@/lib/dayjs'
+import { useTimezone } from '@/lib/datetime'
 
 export const PITRSelection = () => {
   const router = useRouter()
@@ -43,7 +43,9 @@ export const PITRSelection = () => {
 
   const [showConfiguration, setShowConfiguration] = useState(false)
   const [showConfirmation, setShowConfirmation] = useState(false)
-  const [selectedTimezone, setSelectedTimezone] = useState<string>(guessLocalTimezone)
+  const { timezone } = useTimezone()
+  const [overriddenTimezone, setOverriddenTimezone] = useState<string>()
+  const selectedTimezone = overriddenTimezone ?? timezone
   const [selectedRecoveryPoint, setSelectedRecoveryPoint] = useState<{
     selectedTimezone: string
     recoveryTimeTargetUnix: number
@@ -109,7 +111,7 @@ export const PITRSelection = () => {
           {!showConfiguration ? (
             <PITRStatus
               selectedTimezone={selectedTimezone}
-              onUpdateTimezone={setSelectedTimezone}
+              onUpdateTimezone={setOverriddenTimezone}
               onSetConfiguration={() => setShowConfiguration(true)}
             />
           ) : (

--- a/apps/studio/components/interfaces/Database/Backups/PITR/PITRStatus.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/PITR/PITRStatus.tsx
@@ -3,7 +3,6 @@ import { useParams } from 'common'
 import dayjs from 'dayjs'
 import { AlertCircle } from 'lucide-react'
 
-import type { Timezone } from './PITR.types'
 import { TimezoneSelection } from './TimezoneSelection'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import { FormPanel } from '@/components/ui/Forms/FormPanel'
@@ -12,8 +11,8 @@ import { useReadReplicasQuery } from '@/data/read-replicas/replicas-query'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
 
 interface PITRStatusProps {
-  selectedTimezone: Timezone
-  onUpdateTimezone: (timezone: Timezone) => void
+  selectedTimezone: string
+  onUpdateTimezone: (timezone: string) => void
   onSetConfiguration: () => void
 }
 
@@ -33,12 +32,12 @@ const PITRStatus = ({
 
   const earliestAvailableBackup = dayjs
     .unix(earliestPhysicalBackupDateUnix ?? 0)
-    .tz(selectedTimezone?.utc[0])
+    .tz(selectedTimezone)
     .format('DD MMM YYYY, HH:mm:ss')
 
   const latestAvailableBackup = dayjs
     .unix(latestPhysicalBackupDateUnix ?? 0)
-    .tz(selectedTimezone?.utc[0])
+    .tz(selectedTimezone)
     .format('DD MMM YYYY, HH:mm:ss')
 
   const { can: canTriggerPhysicalBackup } = useAsyncCheckPermissions(

--- a/apps/studio/components/interfaces/Database/Backups/PITR/TimezoneSelection.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/PITR/TimezoneSelection.tsx
@@ -29,17 +29,15 @@ export const TimezoneSelection = ({
   const [open, setOpen] = useState(false)
   const listboxId = useId()
 
-  // The browser's own zone is often an alias of a catalog entry rather than its
-  // primary name, so it needs adding explicitly to be selectable
-  const [initialTimezone] = useState(selectedTimezone)
-
   const options = useMemo(() => {
     const catalogNames = TIMEZONES_BY_IANA.map((entry) => entry.utc[0])
-    const ianaNames = catalogNames.includes(initialTimezone)
+    // The selected zone is often an alias of a catalog entry rather than its
+    // primary name, so it needs adding explicitly to stay selectable
+    const ianaNames = catalogNames.includes(selectedTimezone)
       ? catalogNames
-      : [initialTimezone, ...catalogNames]
+      : [selectedTimezone, ...catalogNames]
     return ianaNames.map((iana) => ({ iana, label: formatTimezoneLabel(iana) }))
-  }, [initialTimezone])
+  }, [selectedTimezone])
 
   const selectedLabel = formatTimezoneLabel(selectedTimezone)
 

--- a/apps/studio/components/interfaces/Database/Backups/PITR/TimezoneSelection.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/PITR/TimezoneSelection.tsx
@@ -1,5 +1,5 @@
 import { CheckIcon, ChevronsUpDown, Globe } from 'lucide-react'
-import { useId, useState } from 'react'
+import { useId, useMemo, useState } from 'react'
 import {
   Button,
   cn,
@@ -15,12 +15,11 @@ import {
   ScrollArea,
 } from 'ui'
 
-import { ALL_TIMEZONES } from './PITR.constants'
-import type { Timezone } from './PITR.types'
+import { formatTimezoneLabel, TIMEZONES_BY_IANA } from '@/lib/constants/timezones'
 
 interface TimezoneSelectionProps {
-  selectedTimezone: Timezone
-  onSelectTimezone: (timezone: Timezone) => void
+  selectedTimezone: string
+  onSelectTimezone: (timezone: string) => void
 }
 
 export const TimezoneSelection = ({
@@ -30,7 +29,19 @@ export const TimezoneSelection = ({
   const [open, setOpen] = useState(false)
   const listboxId = useId()
 
-  const timezoneOptions = ALL_TIMEZONES.map((option) => option.text)
+  // The browser's own zone is often an alias of a catalog entry rather than its
+  // primary name, so it needs adding explicitly to be selectable
+  const [initialTimezone] = useState(selectedTimezone)
+
+  const options = useMemo(() => {
+    const catalogNames = TIMEZONES_BY_IANA.map((entry) => entry.utc[0])
+    const ianaNames = catalogNames.includes(initialTimezone)
+      ? catalogNames
+      : [initialTimezone, ...catalogNames]
+    return ianaNames.map((iana) => ({ iana, label: formatTimezoneLabel(iana) }))
+  }, [initialTimezone])
+
+  const selectedLabel = formatTimezoneLabel(selectedTimezone)
 
   return (
     <div className="w-full">
@@ -46,9 +57,7 @@ export const TimezoneSelection = ({
             icon={<Globe />}
             iconRight={<ChevronsUpDown size={14} strokeWidth={1.5} className="ml-auto" />}
           >
-            {selectedTimezone
-              ? timezoneOptions.find((option) => option === selectedTimezone.text)
-              : 'Select timezone...'}
+            {selectedLabel}
           </Button>
         </PopoverTrigger>
         <PopoverContent id={listboxId} className="w-[350px] p-0">
@@ -58,25 +67,21 @@ export const TimezoneSelection = ({
               <CommandEmpty>No timezones found...</CommandEmpty>
               <CommandGroup>
                 <ScrollArea className="h-72">
-                  {timezoneOptions.map((option) => (
+                  {options.map(({ iana, label }) => (
                     <CommandItem
-                      key={option}
-                      value={option}
-                      onSelect={(text) => {
-                        const selectedTimezone = ALL_TIMEZONES.find(
-                          (option) => option.text === text
-                        )
-                        if (selectedTimezone) {
-                          onSelectTimezone(selectedTimezone)
-                          setOpen(false)
-                        }
+                      key={iana}
+                      // CommandItem filters on `value`, so include the IANA name to make it searchable
+                      value={`${label} ${iana}`}
+                      onSelect={() => {
+                        onSelectTimezone(iana)
+                        setOpen(false)
                       }}
                     >
-                      {option}
+                      {label}
                       <CheckIcon
                         className={cn(
                           'ml-auto h-4 w-4',
-                          selectedTimezone.text === option ? 'opacity-100' : 'opacity-0'
+                          selectedTimezone === iana ? 'opacity-100' : 'opacity-0'
                         )}
                       />
                     </CommandItem>

--- a/apps/studio/components/interfaces/UserDropdown/TimezoneDropdown.tsx
+++ b/apps/studio/components/interfaces/UserDropdown/TimezoneDropdown.tsx
@@ -36,6 +36,15 @@ export const TimezoneDropdown = () => {
     return formatTimezoneLabel(timezone)
   }, [timezone])
 
+  const options = useMemo(
+    () =>
+      TIMEZONES_BY_IANA.map((entry) => ({
+        iana: entry.utc[0],
+        label: formatTimezoneLabel(entry.utc[0]),
+      })),
+    []
+  )
+
   const handleSelect = (nextStored: string) => {
     setTimezone(nextStored)
     const resolvedNext = nextStored || guessLocalTimezone()
@@ -95,9 +104,7 @@ export const TimezoneDropdown = () => {
                       )}
                     />
                   </CommandItem>
-                  {TIMEZONES_BY_IANA.map((entry) => {
-                    const ianaName = entry.utc[0]
-                    const label = formatTimezoneLabel(ianaName)
+                  {options.map(({ iana: ianaName, label }) => {
                     const isSelected = !isAutoDetected && storedTimezone === ianaName
                     return (
                       <CommandItem

--- a/apps/studio/components/interfaces/UserDropdown/TimezoneDropdown.tsx
+++ b/apps/studio/components/interfaces/UserDropdown/TimezoneDropdown.tsx
@@ -15,7 +15,7 @@ import {
   ScrollArea,
 } from 'ui'
 
-import { findTimezoneByIana, TIMEZONES_BY_IANA } from '@/lib/constants/timezones'
+import { formatTimezoneLabel, TIMEZONES_BY_IANA } from '@/lib/constants/timezones'
 import { useTimezone } from '@/lib/datetime'
 import { guessLocalTimezone } from '@/lib/dayjs'
 import { useTrack } from '@/lib/telemetry/track'
@@ -33,7 +33,7 @@ export const TimezoneDropdown = () => {
   const browserTimezone = useMemo(() => guessLocalTimezone(), [])
 
   const triggerLabel = useMemo(() => {
-    return findTimezoneByIana(timezone)?.text ?? timezone
+    return formatTimezoneLabel(timezone)
   }, [timezone])
 
   const handleSelect = (nextStored: string) => {
@@ -97,16 +97,17 @@ export const TimezoneDropdown = () => {
                   </CommandItem>
                   {TIMEZONES_BY_IANA.map((entry) => {
                     const ianaName = entry.utc[0]
+                    const label = formatTimezoneLabel(ianaName)
                     const isSelected = !isAutoDetected && storedTimezone === ianaName
                     return (
                       <CommandItem
                         key={ianaName}
                         // CommandItem matches against the `value` prop for the input filter — include
                         // both the human label and the IANA name so search works for either.
-                        value={`${entry.text} ${ianaName}`}
+                        value={`${label} ${ianaName}`}
                         onSelect={() => handleSelect(ianaName)}
                       >
-                        {entry.text}
+                        {label}
                         <CheckIcon
                           className={cn(
                             'ml-auto h-4 w-4',

--- a/apps/studio/lib/constants/timezones.test.ts
+++ b/apps/studio/lib/constants/timezones.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { ALL_TIMEZONES, findTimezoneByIana, TIMEZONES_BY_IANA } from '@/lib/constants/timezones'
+import {
+  ALL_TIMEZONES,
+  findTimezoneByIana,
+  formatTimezoneLabel,
+  TIMEZONES_BY_IANA,
+} from '@/lib/constants/timezones'
 
 describe('TIMEZONES_BY_IANA', () => {
   it('produces one row per primary IANA name', () => {
@@ -44,5 +49,39 @@ describe('findTimezoneByIana', () => {
 
   it('returns undefined for an unknown IANA name', () => {
     expect(findTimezoneByIana('Not/A/Real_Zone')).toBeUndefined()
+  })
+})
+
+describe('formatTimezoneLabel', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  const atSystemTime = (iso: string, iana: string) => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(iso))
+    return formatTimezoneLabel(iana)
+  }
+
+  it('reports the offset in effect today rather than the standard-time offset', () => {
+    // The catalog labels Central Time as UTC-06:00 all year round
+    expect(atSystemTime('2026-08-10T12:00:00Z', 'America/Chicago')).toBe(
+      '(UTC-05:00) Central Time (US & Canada)'
+    )
+    expect(atSystemTime('2026-01-10T12:00:00Z', 'America/Chicago')).toBe(
+      '(UTC-06:00) Central Time (US & Canada)'
+    )
+  })
+
+  it('handles zones with a half hour offset', () => {
+    expect(atSystemTime('2026-08-10T12:00:00Z', 'Asia/Kolkata')).toBe(
+      '(UTC+05:30) Chennai, Kolkata, Mumbai, New Delhi'
+    )
+  })
+
+  it('falls back to the IANA name for zones missing from the catalog', () => {
+    expect(atSystemTime('2026-08-10T12:00:00Z', 'Not/A/Real_Zone')).toBe(
+      '(UTC+00:00) Not/A/Real_Zone'
+    )
   })
 })

--- a/apps/studio/lib/constants/timezones.ts
+++ b/apps/studio/lib/constants/timezones.ts
@@ -1219,3 +1219,27 @@ export const TIMEZONES_BY_IANA: Timezone[] = (() => {
 /** Look up the catalog entry that owns the given IANA name (any of `utc[]`). */
 export const findTimezoneByIana = (iana: string): Timezone | undefined =>
   ALL_TIMEZONES.find((entry) => entry.utc.includes(iana))
+
+/**
+ * Current UTC offset of an IANA zone, e.g. `UTC-05:00`. The catalog's own
+ * `offset`/`text` fields are standard-time only, so they read an hour off for
+ * every zone that is currently observing daylight saving time.
+ */
+export const getTimezoneOffsetLabel = (iana: string) => {
+  try {
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone: iana,
+      timeZoneName: 'longOffset',
+    }).formatToParts(new Date())
+    const offset = parts.find((part) => part.type === 'timeZoneName')?.value ?? 'GMT'
+    return offset === 'GMT' ? 'UTC+00:00' : offset.replace('GMT', 'UTC')
+  } catch {
+    return 'UTC+00:00'
+  }
+}
+
+/** Catalog label for an IANA zone, with its offset resolved for today's date. */
+export const formatTimezoneLabel = (iana: string) => {
+  const region = findTimezoneByIana(iana)?.text.replace(/^\(UTC[^)]*\)\s*/, '') ?? iana
+  return `(${getTimezoneOffsetLabel(iana)}) ${region}`
+}

--- a/apps/www/types/post.ts
+++ b/apps/www/types/post.ts
@@ -34,7 +34,7 @@ export interface PostTypes {
   logo_inverse?: string
   hideAuthor?: boolean
   end_date?: string // for events that span multiple days (not implemented yet)
-  timezone?: string // utc timezone, e.g. 'America/New_York'. Reference: /apps/studio/components/interfaces/Database/Backups/PITR/PITR.constants.ts
+  timezone?: string // utc timezone, e.g. 'America/New_York'. Reference: /apps/studio/lib/constants/timezones.ts
   onDemand?: boolean // events that are on-demand following a registration process
   disable_page_build?: boolean // when true, we don't build the page and require a custom link
   link?: {


### PR DESCRIPTION
## Summary

Fixes timezone bugs in the point-in-time recovery form that could display or submit the wrong restore time.

## What was wrong

The form did not always treat the selected restore point as one fixed moment. This caused several problems:

- Changing the timezone could move the restore point to the wrong date or time.
- Selecting another day could reset the entered time.
- During the end of daylight saving time, repeated times such as 1:30 AM could resolve to the wrong occurrence and be off by one hour.
- Some timezone names saved a different timezone from the one shown in the menu.
- UTC offsets could be wrong for the selected restore date.
- The calendar could show the wrong month after a timezone change.

Together, these bugs could make the confirmation screen disagree with the restore time the user intended to select.

## What changed

- Store the restore point as a fixed timestamp.
- Keep the selected time when the user changes the date.
- Keep the same restore point when the user changes the timezone.
- Handle daylight saving time changes, including repeated hours.
- Save the timezone that matches each menu label.
- Calculate UTC offsets for the selected restore date.
- Default to the timezone selected in Dashboard preferences.
- Show an error for restore times outside the available backup range instead of changing the selection.

The timezone label fixes also apply to Account Preferences and the user menu.

## Testing

Added 39 tests covering:

- Timezone changes
- Date and time edits
- Daylight saving time changes
- Repeated hours
- Month boundaries
- Timezone mappings
- Seasonal and half-hour UTC offsets
- Invalid restore times

Typecheck, lint, formatting, build, Studio tests, and Studio E2E checks pass.

## Manual test

1. Open **Database > Backups > Restore to a new project** on a project with point-in-time recovery.
2. Change the timezone. The displayed date and time should update, but the restore point should represent the same moment.
3. Enter a time, then select another day. The entered time should remain selected.
4. Confirm that the timezone and UTC offset shown on the review screen match the selected restore date.
5. Select a time outside the available backup range. The form should show an error and block submission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer, offset-aware timezone labels across timezone selectors and user preferences.
  * Standardized timezone options using IANA timezone identifiers, including UTC and regional alternatives.
  * Improved Point-in-Time Recovery date and time selection when changing timezones.
  * Preserved selected recovery moments across calendar edits and timezone changes.
  * Added more reliable handling for daylight-saving transitions, ambiguous times, and month boundaries.
* **Bug Fixes**
  * Improved timezone recognition and display for alternate IANA timezone names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->