### PR TITLE
ref(studio): converge notebook UI types with canonical content schema

### DIFF
--- a/apps/studio/components/interfaces/Explorer/__tests__/NotebookEditor.test.tsx
+++ b/apps/studio/components/interfaces/Explorer/__tests__/NotebookEditor.test.tsx
@@ -36,7 +36,7 @@ function makeNotebook(id: string, overrides: Partial<Notebook> = {}): Notebook {
     favorite: false,
     owner_id: 7,
     project_id: 42,
-    content: { schema_version: '1.0', cells: [] },
+    content: { schema_version: 1, cells: [] },
     ...overrides,
   }
 }

--- a/apps/studio/components/interfaces/Explorer/hooks.ts
+++ b/apps/studio/components/interfaces/Explorer/hooks.ts
@@ -26,7 +26,7 @@ export const useCreateNotebook = () => {
       visibility: 'project',
       favorite: false,
       content: {
-        schema_version: '1.0',
+        schema_version: 1,
         cells: [],
       },
       owner_id: profile.id,

--- a/apps/studio/state/notebooks/notebooks-state.test.ts
+++ b/apps/studio/state/notebooks/notebooks-state.test.ts
@@ -13,7 +13,7 @@ function makeNotebook(id: string, overrides: Partial<Notebook> = {}): Notebook {
     favorite: false,
     owner_id: 7,
     project_id: 42,
-    content: { schema_version: '1.0', cells: [] },
+    content: { schema_version: 1, cells: [] },
     ...overrides,
   }
 }
@@ -44,7 +44,7 @@ describe('notebooksState', () => {
 
     notebooksState.updateCells({
       id: 'notebook-1',
-      cells: [{ type: 'markdown', content: 'hello' }],
+      cells: [{ _tag: 'markdown_cell', id: 'cell-1', text: 'hello' }],
     })
 
     expect(notebooksState.notebooks['notebook-1'].status).toBe('unsaved')
@@ -56,7 +56,7 @@ describe('notebooksState', () => {
 
     notebooksState.updateCells({
       id: 'notebook-1',
-      cells: [{ type: 'markdown', content: 'hello' }],
+      cells: [{ _tag: 'markdown_cell', id: 'cell-1', text: 'hello' }],
     })
 
     expect(notebooksState.notebooks['notebook-1'].status).toBe('new')
@@ -66,7 +66,7 @@ describe('notebooksState', () => {
     notebooksState.setNotebook({ projectRef: 'ref', notebook: makeNotebook('notebook-1') })
     notebooksState.updateCells({
       id: 'notebook-1',
-      cells: [{ type: 'markdown', content: 'hello' }],
+      cells: [{ _tag: 'markdown_cell', id: 'cell-1', text: 'hello' }],
     })
     expect(notebooksState.notebooks['notebook-1'].status).toBe('unsaved')
 

--- a/apps/studio/state/notebooks/notebooks-state.ts
+++ b/apps/studio/state/notebooks/notebooks-state.ts
@@ -2,8 +2,9 @@ import { useMemo } from 'react'
 import { proxy, snapshot, useSnapshot } from 'valtio'
 import { proxyMap } from 'valtio/utils'
 
-import type { Notebook, NotebookCell, StateNotebook } from './types'
+import type { Notebook, StateNotebook } from './types'
 import type { SnippetStatus } from '@/data/content/snippet-status'
+import type { Notebooks } from '@/types'
 
 // [Joshen] Deliberately copied from sql-editor-lifecycle cause we might deprecate
 // that in favor of notebooks in the long run
@@ -80,7 +81,7 @@ export const notebooksState = proxy({
     skipSave,
   }: {
     id: string
-    cells: NotebookCell[]
+    cells: Notebooks.Cell[]
     skipSave?: boolean
   }) => {
     const stateNotebook = notebooksState.notebooks[id]

--- a/apps/studio/state/notebooks/types.ts
+++ b/apps/studio/state/notebooks/types.ts
@@ -1,19 +1,5 @@
 import { SnippetStatus } from '@/data/content/snippet-status'
-
-/** Start and end follows ISO8601 convention */
-type AbsoluteTimeRange = { start: string; end: string }
-type RelativeTimeRange = { unit: 'm' | 'h' | 'd' | 'w' | 'M' | 'y'; amount: number }
-type TimeRange = AbsoluteTimeRange | RelativeTimeRange
-
-type DatabaseQueryCell = { type: 'sql'; sql: string }
-type LogsQueryCell = { type: 'logs'; sql: string; range: TimeRange }
-type MarkdownCell = { type: 'markdown'; content: string }
-export type NotebookCell = DatabaseQueryCell | LogsQueryCell | MarkdownCell
-
-interface NotebookContent {
-  schema_version: string
-  cells: NotebookCell[]
-}
+import type { Notebooks } from '@/types'
 
 export interface Notebook {
   id: string
@@ -24,7 +10,7 @@ export interface Notebook {
   favorite: boolean
   owner_id: number
   project_id: number
-  content?: NotebookContent // Undefined until loaded
+  content?: Notebooks.Content // Undefined until loaded
 }
 
 export interface StateNotebook {


### PR DESCRIPTION
## Summary
- Joshen's `state/notebooks/types.ts` (Explorer/notebook editor UI) redefined its own `TimeRange`, cell union, and `NotebookContent` shapes, duplicating the canonical schema from `data/content/notebooks/notebook-schema.ts` (#48813, #48815).
- Points `Notebook.content` and `notebooksState.updateCells` at the canonical `Notebooks.Content` / `Notebooks.Cell` types (via `@/types`) instead, and fixes the handful of call sites that constructed notebook content by hand to match the real wire shape: `schema_version: 1` (not `'1.0'`) and `_tag`-discriminated cells (e.g. `{ _tag: 'markdown_cell', id, text }` instead of `{ type: 'markdown', content }`).
- No behavioral changes — Joshen's state management, editor component, and hooks are untouched aside from the type-level fixes needed to compile against the canonical schema.

## Test plan
- [x] `pnpm exec tsc --noEmit` — no new errors
- [x] `pnpm exec vitest run state/notebooks/notebooks-state.test.ts components/interfaces/Explorer/__tests__/NotebookEditor.test.tsx` — 8/8 passing
- [x] `pnpm exec eslint` on changed files — clean
- [x] `pnpm exec prettier --check` on changed files — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated notebook content handling to use the current schema version format.
  * Improved compatibility for markdown cells, including their identifiers and text.
  * Standardized notebook content and cell updates for more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->