### PR TITLE
test(docs): scan global elements outside the article on Docs E2E

### DIFF
--- a/.github/workflows/docs-e2e-global-elements.yml
+++ b/.github/workflows/docs-e2e-global-elements.yml
@@ -41,9 +41,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
-      # Runs before checkout. Decides whether a Vercel docs preview exists to
-      # test against; a harness-only change has none, so production serves the
-      # markup this suite scans.
+      # Runs before checkout. A harness-only change has no preview to test.
       - name: Detect changed paths
         id: changes
         if: github.event_name == 'pull_request'
@@ -117,8 +115,7 @@ jobs:
             exit 0
           fi
 
-          # A harness-only change ships no markup, so production serves exactly
-          # the markup this suite is meant to scan.
+          # A harness-only change ships no markup, so production serves ours.
           if [ "$DOCS_APP_CHANGED" != "true" ]; then
             echo "url=https://supabase.com" >> "$GITHUB_OUTPUT"
             echo "use_bypass=false" >> "$GITHUB_OUTPUT"
@@ -126,7 +123,6 @@ jobs:
             exit 0
           fi
 
-          # This pull request changes global elements and nothing is serving them.
           # Production would scan the old markup and pass for the wrong reason.
           echo "url=" >> "$GITHUB_OUTPUT"
           echo "use_bypass=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/docs-e2e-global-elements.yml
+++ b/.github/workflows/docs-e2e-global-elements.yml
@@ -1,10 +1,6 @@
 name: Docs Global Elements E2E Tests
 
-# Unlike "Docs E2E", this check is not required on master, so it can use a
-# `paths` trigger filter: pull requests that touch no global elements simply
-# never start it. Scope is the fixed page list in
-# e2e/docs/utils/docs-global-elements.ts — one page per layout — because these
-# elements are global and do not vary by content.
+# Not a required check, unlike "Docs E2E", so a `paths` filter is safe here.
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]

--- a/.github/workflows/docs-e2e-global-elements.yml
+++ b/.github/workflows/docs-e2e-global-elements.yml
@@ -1,0 +1,164 @@
+name: Docs Global Elements E2E Tests
+
+# Unlike "Docs E2E", this check is not required on master, so it can use a
+# `paths` trigger filter: pull requests that touch no global elements simply
+# never start it. Scope is the fixed page list in
+# e2e/docs/utils/docs-global-elements.ts — one page per layout — because these
+# elements are global and do not vary by content.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
+    branches: ['master']
+    paths:
+      - 'apps/docs/app/**'
+      - 'apps/docs/components/**'
+      - 'apps/docs/features/ui/**'
+      - 'apps/docs/layouts/**'
+      - 'e2e/docs/**'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/docs-e2e-global-elements.yml'
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: 'Base URL to test against'
+        required: false
+        default: 'https://supabase.com'
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  statuses: read
+  pull-requests: read
+
+env:
+  CI: true
+
+jobs:
+  global-elements:
+    name: Docs Global Elements E2E
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
+    timeout-minutes: 30
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+
+    steps:
+      # Runs before checkout. Decides whether a Vercel docs preview exists to
+      # test against; a harness-only change has none, so production serves the
+      # markup this suite scans.
+      - name: Detect changed paths
+        id: changes
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          filters: |
+            docs_app:
+              - 'apps/docs/**'
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          sparse-checkout: |
+            e2e/docs
+            scripts
+            patches
+
+      - name: Use Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: '.nvmrc'
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        name: Install pnpm
+        with:
+          run_install: false
+
+      - name: Enable pnpm store cache
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      # Same Vercel handling as docs-e2e.yml. See scripts/waitForVercelDocsPreview.js.
+      - name: Wait for Vercel docs preview
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && steps.changes.outputs.docs_app == 'true'
+        id: deployment
+        continue-on-error: true
+        run: node scripts/waitForVercelDocsPreview.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
+
+      - name: Resolve base URL
+        id: base-url
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_URL_INPUT: ${{ inputs.base_url }}
+          DEPLOYMENT_URL: ${{ steps.deployment.outputs.deployment-url }}
+          DOCS_APP_CHANGED: ${{ steps.changes.outputs.docs_app }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            printf 'url=%s\n' "$BASE_URL_INPUT" >> "$GITHUB_OUTPUT"
+            if [ "$BASE_URL_INPUT" = "https://supabase.com" ]; then
+              echo "use_bypass=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "use_bypass=true" >> "$GITHUB_OUTPUT"
+            fi
+            echo "should_test=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ -n "$DEPLOYMENT_URL" ]; then
+            printf 'url=%s\n' "$DEPLOYMENT_URL" >> "$GITHUB_OUTPUT"
+            echo "use_bypass=true" >> "$GITHUB_OUTPUT"
+            echo "should_test=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # A harness-only change ships no markup, so production serves exactly
+          # the markup this suite is meant to scan.
+          if [ "$DOCS_APP_CHANGED" != "true" ]; then
+            echo "url=https://supabase.com" >> "$GITHUB_OUTPUT"
+            echo "use_bypass=false" >> "$GITHUB_OUTPUT"
+            echo "should_test=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # This pull request changes global elements and nothing is serving them.
+          # Production would scan the old markup and pass for the wrong reason.
+          echo "url=" >> "$GITHUB_OUTPUT"
+          echo "use_bypass=false" >> "$GITHUB_OUTPUT"
+          echo "should_test=false" >> "$GITHUB_OUTPUT"
+          echo "::warning::No Vercel docs preview URL for this pull request, so nothing is serving the global elements it changes. Skipping rather than scanning production, which still has the old markup."
+
+      - name: Install dependencies
+        if: steps.base-url.outputs.should_test == 'true'
+        run: pnpm install --frozen-lockfile --filter=e2e-docs...
+
+      - name: Install Playwright Chromium
+        if: steps.base-url.outputs.should_test == 'true'
+        run: pnpm -C e2e/docs exec playwright install chromium --with-deps --only-shell
+
+      - name: Run docs global elements E2E
+        if: steps.base-url.outputs.should_test == 'true'
+        working-directory: e2e/docs
+        run: pnpm run e2e:docs:global-elements
+        env:
+          PLAYWRIGHT_BASE_URL: ${{ steps.base-url.outputs.url }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ steps.base-url.outputs.use_bypass == 'true' && secrets.VERCEL_AUTOMATION_BYPASS_DOCS || '' }}
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: docs-global-elements-playwright-report
+          path: |
+            e2e/docs/playwright-report-global-elements/
+            e2e/docs/test-results/
+          retention-days: 7

--- a/apps/docs/components/Breadcrumbs.tsx
+++ b/apps/docs/components/Breadcrumbs.tsx
@@ -58,7 +58,7 @@ const BreadcrumbsInternal = ({
   )
 
   return (
-    <Breadcrumb className={cn(className)}>
+    <Breadcrumb data-test="sb-docs-breadcrumbs" className={cn(className)}>
       <BreadcrumbList className="text-foreground-lighter p-0">
         {breadcrumbs.length >= ITEMS_TO_DISPLAY && (
           <>

--- a/apps/docs/components/GuidesSidebar.tsx
+++ b/apps/docs/components/GuidesSidebar.tsx
@@ -129,7 +129,10 @@ const GuidesSidebar = ({
   const tocVideoPreview = `https://img.youtube.com/vi/${video}/0.jpg`
 
   return (
-    <div className={cn('thin-scrollbar overflow-y-auto h-fit', 'px-px', className)}>
+    <div
+      data-test="sb-docs-toc-sidebar"
+      className={cn('thin-scrollbar overflow-y-auto h-fit', 'px-px', className)}
+    >
       <div className="w-full relative border-l flex flex-col gap-6 lg:gap-8 px-2 h-fit">
         {video && (
           <div className="relative pl-5">

--- a/apps/docs/components/Navigation/Footer.tsx
+++ b/apps/docs/components/Navigation/Footer.tsx
@@ -5,7 +5,7 @@ import { LayoutMainContent } from '~/layouts/DefaultLayout'
 
 const Footer = ({ className }: { className?: string }) => (
   <LayoutMainContent className={cn('pt-0', className)}>
-    <footer role="contentinfo" aria-label="footer">
+    <footer role="contentinfo" aria-label="footer" data-test="sb-docs-footer">
       <div className="mt-16">
         <ul className="flex flex-col gap-2">
           {primaryLinks.map(({ url, featherIcon: Icon, text, ctaLabel }) => (

--- a/apps/docs/components/Navigation/NavigationMenu/GlobalMobileMenu.tsx
+++ b/apps/docs/components/Navigation/NavigationMenu/GlobalMobileMenu.tsx
@@ -113,6 +113,7 @@ const GlobalMobileMenu = ({ open, setOpen }: Props) => {
       <AnimatePresence mode="wait">
         {open && (
           <m.div
+            data-test="sb-docs-mobile-menu"
             variants={container}
             initial="hidden"
             animate="show"

--- a/apps/docs/components/Navigation/NavigationMenu/TopNavBar.tsx
+++ b/apps/docs/components/Navigation/NavigationMenu/TopNavBar.tsx
@@ -33,6 +33,7 @@ const TopNavBar: FC = () => {
     <>
       <nav
         aria-label="top bar"
+        data-test="sb-docs-top-nav"
         className="w-full z-40 flex flex-col border-b backdrop-blur-sm backdrop-filter bg-default/75"
       >
         <div className="w-full px-5 lg:pl-10 flex justify-between h-(--header-height) gap-3">

--- a/apps/docs/components/Navigation/NavigationMenu/TopNavBar.tsx
+++ b/apps/docs/components/Navigation/NavigationMenu/TopNavBar.tsx
@@ -60,6 +60,7 @@ const TopNavBar: FC = () => {
               <button
                 tabIndex={0}
                 title="Menu dropdown button"
+                data-test="sb-docs-mobile-menu-trigger"
                 className={cn(
                   buttonVariants({ variant: 'default' }),
                   'flex lg:hidden border-default bg-surface-100/75 text-foreground-light rounded-md min-w-[30px] w-[30px] h-[30px] data-open:bg-overlay-hover/30'

--- a/apps/docs/layouts/MainSkeleton.tsx
+++ b/apps/docs/layouts/MainSkeleton.tsx
@@ -307,6 +307,7 @@ const NavContainer = memo(function NavContainer({ children }: PropsWithChildren)
   return (
     <nav
       aria-labelledby="main-nav-title"
+      data-test="sb-docs-sidebar-nav"
       className={cn(
         'fixed lg:relative z-40 lg:z-auto',
         mobileMenuOpen ? 'w-[75%] sm:w-[50%] md:w-[33%] left-0' : 'w-0 -left-full',

--- a/e2e/docs/.gitignore
+++ b/e2e/docs/.gitignore
@@ -2,5 +2,6 @@ node_modules/
 /test-results/
 /playwright-report/
 /playwright-report-local-smoke/
+/playwright-report-global-elements/
 /blob-report/
 /playwright/.cache/

--- a/e2e/docs/README.md
+++ b/e2e/docs/README.md
@@ -235,6 +235,12 @@ are `GLOBAL_ELEMENTS_ENFORCED_RULES` in `utils/axe-helpers.ts`. A violation in a
 global element appears on every docs page, so keep that list green rather than
 growing it.
 
+Everything on that list passes today and is applicable on every scanned surface,
+so each rule guards something. Before adding one, check that axe reports passing
+nodes for it rather than reporting it as inapplicable, and that it has no
+`incomplete` nodes. Inapplicable rules guard nothing, and undecided ones can flip
+to failing on an unrelated change.
+
 `button-name` is reported rather than blocking. The filter comboboxes on
 `/docs/guides/troubleshooting` have no accessible name, and they also trip
 `aria-required-attr`. The sidebar toggle in `layouts/MainSkeleton.tsx` is

--- a/e2e/docs/README.md
+++ b/e2e/docs/README.md
@@ -16,6 +16,7 @@ This page covers:
   scope is wrong
 - [What the suite covers](#what-the-suite-covers) — in-scope paths and limits
 - [Accessibility scans](#accessibility-scans) — WCAG coverage and skipped rules
+- [Global element scans](#global-element-scans) — navigation, sidebar, and footer
 - [Debug failures](#debug-failures) — reports and traces
 - [How CI uses this suite](#how-ci-uses-this-suite) — pull request behavior
 
@@ -185,13 +186,60 @@ own content.
 
 `EXCLUDED_RULES` in `utils/axe-helpers.ts` lists the rules the scan skips.
 `color-contrast` is most of the scan time and finds nothing inside an article, since
-docs contrast comes from shared tokens and chrome. The rest target `<html>`, `<head>`,
-and `<body>`, which an article-scoped scan can't reach.
+docs contrast comes from shared tokens and global elements. The rest target `<html>`,
+`<head>`, and `<body>`, which an article-scoped scan can't reach.
 
 Cross-origin frames are skipped, so a third-party embed isn't reported as ours.
 
-Not covered: `/docs/reference/*`, shared chrome, and most of WCAG. Keyboard
-navigation, focus management, and screen reader behavior need manual testing.
+Not covered: `/docs/reference/*` articles and most of WCAG. Keyboard navigation,
+focus management, and screen reader behavior need manual testing. For everything
+outside the article, see [Global element scans](#global-element-scans).
+
+## Global element scans
+
+This suite scans what the per-page suite excludes: the top navigation bar,
+sidebar navigation, table of contents, breadcrumbs, and footer.
+
+```bash
+PLAYWRIGHT_BASE_URL=https://supabase.com pnpm e2e:docs:global-elements
+```
+
+These elements are global, so scope is a fixed list — one page per layout, in
+`utils/docs-global-elements.ts` — instead of the changed-files scope the
+per-page suite uses. A second page on a layout already covered would scan the
+same markup for the same result. Add a page only for a layout the list doesn't
+reach yet.
+
+Each page asserts that its regions are still in the DOM, then scans the page
+with the article excluded. Regions are matched on `data-test` attributes in
+`apps/docs`, so a styling or markup change can't quietly drop one from the scan.
+A missing region is a soft failure: the test still reports its scan.
+
+This suite keeps the page-level rules the article scan skips — `color-contrast`,
+`html-has-lang`, `document-title` — because global elements are where those
+live. It only drops `page-has-heading-one`, whose target is the excluded article.
+
+Like the article scan, most findings are reported as warnings. Blocking rules
+are `GLOBAL_ELEMENTS_ENFORCED_RULES` in `utils/axe-helpers.ts`. A violation in a
+global element appears on every docs page, so keep that list green rather than
+growing it.
+
+`button-name` is reported rather than blocking: the filter comboboxes on
+`/docs/guides/troubleshooting` have no accessible name, and they also trip
+`aria-required-attr`. Promote the rule once those are named.
+
+Runs live in their own config (`playwright.global-elements.config.ts`) and
+report folder (`playwright-report-global-elements/`), so `pnpm e2e:docs` on a
+content pull request never picks them up.
+
+Not covered:
+
+- Mobile layouts. The suite runs one desktop viewport.
+- Global elements that arrive through `packages/ui` rather than `apps/docs`. CI
+  doesn't watch that path, so run this manually when a shared component changes.
+- Client library reference pages such as `/docs/reference/javascript/*`, which
+  serve a bare link list to a headless browser and render nothing to scan.
+  `/docs/reference/cli/introduction` covers the reference layout instead.
 
 ## Debug failures
 
@@ -218,3 +266,9 @@ owned docs content, partials, or `e2e/docs`.
 Draft pull requests stay skipped until you mark them ready for review. Manual
 `workflow_dispatch` runs require a `page_paths` input and accept an optional
 `base_url`, which defaults to production.
+
+The global element suite runs from `.github/workflows/docs-e2e-global-elements.yml` on pull
+requests that touch docs layout code or `e2e/docs`. That check isn't required on
+master, so it uses a `paths` trigger and simply never starts on other pull
+requests. It scans the Vercel preview when `apps/docs` changed, production when
+only the harness changed, and skips when a change to those elements has no preview to test.

--- a/e2e/docs/README.md
+++ b/e2e/docs/README.md
@@ -225,9 +225,10 @@ elements to expect at which width lives in `GLOBAL_ELEMENTS`. A missing element
 is a soft failure: the test still reports its scan.
 
 This suite keeps the page-level rules the article scan skips, such as
-`html-has-lang` and `document-title`, because global elements are where those
-live. It drops `page-has-heading-one`, whose target is the excluded article, and
-`color-contrast`, which is most of the scan time.
+`color-contrast`, `html-has-lang`, and `document-title`, because global elements
+are where those live. It drops only `page-has-heading-one`, whose target is the
+excluded article. `color-contrast` is most of the scan time, and this is the
+only suite that runs it.
 
 Like the article scan, most findings are reported as warnings. Blocking rules
 are `GLOBAL_ELEMENTS_ENFORCED_RULES` in `utils/axe-helpers.ts`. A violation in a
@@ -246,8 +247,6 @@ content pull request never picks them up.
 
 Not covered:
 
-- `color-contrast`, which the suite skips for speed. Nothing checks docs
-  contrast now.
 - Keyboard behavior in the mobile menu, including focus order and focus
   trapping. Axe reports the markup, not the interaction.
 - Global elements that arrive through `packages/ui` rather than `apps/docs`. CI

--- a/e2e/docs/README.md
+++ b/e2e/docs/README.md
@@ -198,7 +198,7 @@ outside the article, see [Global element scans](#global-element-scans).
 ## Global element scans
 
 This suite scans what the per-page suite excludes: the top navigation bar,
-sidebar navigation, table of contents, breadcrumbs, and footer.
+sidebar navigation, content sidebar, breadcrumbs, and footer.
 
 ```bash
 PLAYWRIGHT_BASE_URL=https://supabase.com pnpm e2e:docs:global-elements
@@ -210,23 +210,35 @@ per-page suite uses. A second page on a layout already covered would scan the
 same markup for the same result. Add a page only for a layout the list doesn't
 reach yet.
 
-Each page asserts that its regions are still in the DOM, then scans the page
-with the article excluded. Regions are matched on `data-test` attributes in
-`apps/docs`, so a styling or markup change can't quietly drop one from the scan.
-A missing region is a soft failure: the test still reports its scan.
+Every page runs at two viewports, 1280x800 and 390x844. A layout hides
+different elements at each width, so the two runs scan different markup. One
+extra test opens the mobile menu overlay and scans it, because that markup only
+exists once opened. The overlay is the same list on every page, so one page
+covers it.
 
-This suite keeps the page-level rules the article scan skips — `color-contrast`,
-`html-has-lang`, `document-title` — because global elements are where those
-live. It only drops `page-has-heading-one`, whose target is the excluded article.
+Each page asserts that its elements are visible, then scans the page with the
+article excluded. Elements are matched on `data-test` attributes in `apps/docs`,
+so a styling or markup change can't quietly drop one from the scan. Visibility
+rather than presence matters here, since axe skips hidden subtrees and an
+attached element that renders nothing would pass while scanning nothing. Which
+elements to expect at which width lives in `GLOBAL_ELEMENTS`. A missing element
+is a soft failure: the test still reports its scan.
+
+This suite keeps the page-level rules the article scan skips, such as
+`html-has-lang` and `document-title`, because global elements are where those
+live. It drops `page-has-heading-one`, whose target is the excluded article, and
+`color-contrast`, which is most of the scan time.
 
 Like the article scan, most findings are reported as warnings. Blocking rules
 are `GLOBAL_ELEMENTS_ENFORCED_RULES` in `utils/axe-helpers.ts`. A violation in a
 global element appears on every docs page, so keep that list green rather than
 growing it.
 
-`button-name` is reported rather than blocking: the filter comboboxes on
+`button-name` is reported rather than blocking. The filter comboboxes on
 `/docs/guides/troubleshooting` have no accessible name, and they also trip
-`aria-required-attr`. Promote the rule once those are named.
+`aria-required-attr`. The sidebar toggle in `layouts/MainSkeleton.tsx` is
+icon-only and unnamed, which shows up at mobile width. Promote the rule once
+those are named.
 
 Runs live in their own config (`playwright.global-elements.config.ts`) and
 report folder (`playwright-report-global-elements/`), so `pnpm e2e:docs` on a
@@ -234,7 +246,10 @@ content pull request never picks them up.
 
 Not covered:
 
-- Mobile layouts. The suite runs one desktop viewport.
+- `color-contrast`, which the suite skips for speed. Nothing checks docs
+  contrast now.
+- Keyboard behavior in the mobile menu, including focus order and focus
+  trapping. Axe reports the markup, not the interaction.
 - Global elements that arrive through `packages/ui` rather than `apps/docs`. CI
   doesn't watch that path, so run this manually when a shared component changes.
 - Client library reference pages such as `/docs/reference/javascript/*`, which

--- a/e2e/docs/README.md
+++ b/e2e/docs/README.md
@@ -247,9 +247,13 @@ to failing on an unrelated change.
 icon-only and unnamed, which shows up at mobile width. Promote the rule once
 those are named.
 
-Runs live in their own config (`playwright.global-elements.config.ts`) and
-report folder (`playwright-report-global-elements/`), so `pnpm e2e:docs` on a
-content pull request never picks them up.
+Runs live in their own config, so `pnpm e2e:docs` on a content pull request
+never picks them up. The two suites keep separate reports:
+
+| Suite           | Command                         | Report folder                        |
+| --------------- | ------------------------------- | ------------------------------------ |
+| Per-page        | `pnpm e2e:docs`                 | `playwright-report/`                 |
+| Global elements | `pnpm e2e:docs:global-elements` | `playwright-report-global-elements/` |
 
 Not covered:
 
@@ -287,8 +291,20 @@ Draft pull requests stay skipped until you mark them ready for review. Manual
 `workflow_dispatch` runs require a `page_paths` input and accept an optional
 `base_url`, which defaults to production.
 
-The global element suite runs from `.github/workflows/docs-e2e-global-elements.yml` on pull
-requests that touch docs layout code or `e2e/docs`. That check isn't required on
-master, so it uses a `paths` trigger and simply never starts on other pull
-requests. It scans the Vercel preview when `apps/docs` changed, production when
-only the harness changed, and skips when a change to those elements has no preview to test.
+The global element suite runs from `.github/workflows/docs-e2e-global-elements.yml`
+on pull requests that touch `apps/docs/app/**`, `apps/docs/components/**`,
+`apps/docs/features/ui/**`, `apps/docs/layouts/**`, `e2e/docs/**`,
+`pnpm-lock.yaml`, or the workflow itself. That check isn't required on master, so
+it uses a `paths` trigger and simply never starts on other pull requests. It
+scans the Vercel preview when `apps/docs` changed, production when only the
+harness changed, and skips when a change to those elements has no preview to
+test.
+
+Fork pull requests run without repository secrets, so the preview wait is
+limited to same-repository pull requests and a fork's docs change resolves no
+preview. The job skips with a warning rather than scanning stale production
+markup. To cover a fork change, run the workflow manually against its preview:
+
+```bash
+gh workflow run docs-e2e-global-elements.yml -f base_url=<preview-url>
+```

--- a/e2e/docs/global-elements/docs-global-elements.spec.ts
+++ b/e2e/docs/global-elements/docs-global-elements.spec.ts
@@ -1,0 +1,107 @@
+import { expect, test } from '@playwright/test'
+import type { TestInfo } from '@playwright/test'
+
+import {
+  attachScanReport,
+  blockingViolations,
+  GLOBAL_ELEMENTS_ENFORCED_RULES,
+  GLOBAL_ELEMENTS_EXCLUDED_RULES,
+  formatViolations,
+  scanLooksEmpty,
+  scanOutsideArticle,
+  settleForAxe,
+  shouldEnforceAll,
+  unloadedResult,
+} from '../utils/axe-helpers.js'
+import {
+  articleSelectorsOnPage,
+  GLOBAL_ELEMENTS,
+  GLOBAL_ELEMENT_PAGES,
+} from '../utils/docs-global-elements.js'
+
+function annotate(testInfo: TestInfo, description: string) {
+  testInfo.annotations.push({ type: 'warning', description })
+  console.warn(`::warning title=Accessibility::${description}`)
+}
+
+test.describe('Docs global elements', () => {
+  // Without this, every test in this file runs on one worker.
+  test.describe.configure({ mode: 'parallel' })
+
+  for (const { path, layout, landmarks } of GLOBAL_ELEMENT_PAGES) {
+    test(`${path} (${layout}) global elements have no blocking accessibility violations @global-elements`, async ({
+      page,
+    }, testInfo) => {
+      test.setTimeout(120_000)
+
+      let response
+      try {
+        response = await page.goto(path)
+      } catch (error) {
+        await attachScanReport(
+          testInfo,
+          unloadedResult(path, path, null, 'document', GLOBAL_ELEMENTS_EXCLUDED_RULES)
+        )
+        throw error
+      }
+
+      const status = response?.status() ?? null
+
+      if (!response?.ok()) {
+        await attachScanReport(
+          testInfo,
+          unloadedResult(path, page.url(), status, 'document', GLOBAL_ELEMENTS_EXCLUDED_RULES)
+        )
+        expect(
+          response?.ok(),
+          `Expected a successful response for ${path}, got ${status}`
+        ).toBeTruthy()
+        return
+      }
+
+      await settleForAxe(page)
+
+      // Soft, so a missing landmark still reports its scan instead of hiding it.
+      for (const landmark of landmarks) {
+        const { selector, label } = GLOBAL_ELEMENTS[landmark]
+        await expect
+          .soft(page.locator(selector).first(), `${path} should render the ${label} (${selector})`)
+          .toBeAttached()
+      }
+
+      const exclude = await articleSelectorsOnPage(page)
+      const result = await scanOutsideArticle(page, path, exclude)
+      result.status = status
+
+      await attachScanReport(testInfo, result)
+
+      if (scanLooksEmpty(result)) {
+        annotate(
+          testInfo,
+          `${path} scanned only ${result.elementCount} element(s) outside the article, so a clean ` +
+            'result here proves nothing. Most likely the page had not finished rendering.'
+        )
+      }
+
+      const blocking = blockingViolations(result, GLOBAL_ELEMENTS_ENFORCED_RULES)
+
+      const reported = result.violations.filter((violation) => !blocking.includes(violation))
+      if (reported.length) {
+        annotate(
+          testInfo,
+          `${path} global elements have ${reported.length} non-blocking accessibility finding(s): ` +
+            reported.map((v) => `${v.id} (${v.nodes.length})`).join(', ')
+        )
+      }
+
+      const enforced = shouldEnforceAll()
+        ? 'all WCAG 2.1 A/AA rules'
+        : GLOBAL_ELEMENTS_ENFORCED_RULES.join(', ')
+
+      expect(
+        blocking.map((violation) => violation.id).sort(),
+        `${path} global elements have blocking a11y violations (${enforced}):\n${formatViolations(blocking)}`
+      ).toEqual([])
+    })
+  }
+})

--- a/e2e/docs/global-elements/docs-global-elements.spec.ts
+++ b/e2e/docs/global-elements/docs-global-elements.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test'
-import type { TestInfo } from '@playwright/test'
+import type { Page, TestInfo } from '@playwright/test'
 
 import {
   attachScanReport,
@@ -15,8 +15,13 @@ import {
 } from '../utils/axe-helpers.js'
 import {
   articleSelectorsOnPage,
+  elementsForViewport,
   GLOBAL_ELEMENTS,
   GLOBAL_ELEMENT_PAGES,
+  MOBILE_MENU_SELECTOR,
+  renderedLocator,
+  VIEWPORTS,
+  type ViewportName,
 } from '../utils/docs-global-elements.js'
 
 function annotate(testInfo: TestInfo, description: string) {
@@ -24,84 +29,133 @@ function annotate(testInfo: TestInfo, description: string) {
   console.warn(`::warning title=Accessibility::${description}`)
 }
 
+async function load(page: Page, testInfo: TestInfo, path: string, surface: string) {
+  let response
+  try {
+    response = await page.goto(path)
+  } catch (error) {
+    await attachScanReport(
+      testInfo,
+      unloadedResult(surface, path, null, 'document', GLOBAL_ELEMENTS_EXCLUDED_RULES)
+    )
+    throw error
+  }
+
+  const status = response?.status() ?? null
+
+  if (!response?.ok()) {
+    await attachScanReport(
+      testInfo,
+      unloadedResult(surface, page.url(), status, 'document', GLOBAL_ELEMENTS_EXCLUDED_RULES)
+    )
+    expect(response?.ok(), `Expected a successful response for ${path}, got ${status}`).toBeTruthy()
+  }
+
+  return status
+}
+
+async function scanAndAssert(
+  page: Page,
+  testInfo: TestInfo,
+  surface: string,
+  status: number | null
+) {
+  const exclude = await articleSelectorsOnPage(page)
+  const result = await scanOutsideArticle(page, surface, exclude)
+  result.status = status
+
+  await attachScanReport(testInfo, result)
+
+  if (scanLooksEmpty(result)) {
+    annotate(
+      testInfo,
+      `${surface} scanned only ${result.elementCount} element(s) outside the article, so a clean ` +
+        'result here proves nothing. Most likely the page had not finished rendering.'
+    )
+  }
+
+  const blocking = blockingViolations(result, GLOBAL_ELEMENTS_ENFORCED_RULES)
+
+  const reported = result.violations.filter((violation) => !blocking.includes(violation))
+  if (reported.length) {
+    annotate(
+      testInfo,
+      `${surface} global elements have ${reported.length} non-blocking accessibility finding(s): ` +
+        reported.map((v) => `${v.id} (${v.nodes.length})`).join(', ')
+    )
+  }
+
+  const enforced = shouldEnforceAll()
+    ? 'all WCAG 2.1 A/AA rules'
+    : GLOBAL_ELEMENTS_ENFORCED_RULES.join(', ')
+
+  expect(
+    blocking.map((violation) => violation.id).sort(),
+    `${surface} global elements have blocking a11y violations (${enforced}):\n${formatViolations(blocking)}`
+  ).toEqual([])
+}
+
 test.describe('Docs global elements', () => {
   // Without this, every test in this file runs on one worker.
   test.describe.configure({ mode: 'parallel' })
 
-  for (const { path, layout, landmarks } of GLOBAL_ELEMENT_PAGES) {
-    test(`${path} (${layout}) global elements have no blocking accessibility violations @global-elements`, async ({
-      page,
-    }, testInfo) => {
-      test.setTimeout(120_000)
+  for (const { path, layout, elements } of GLOBAL_ELEMENT_PAGES) {
+    for (const viewport of Object.keys(VIEWPORTS) as ViewportName[]) {
+      const surface = `${path} at ${viewport}`
 
-      let response
-      try {
-        response = await page.goto(path)
-      } catch (error) {
-        await attachScanReport(
-          testInfo,
-          unloadedResult(path, path, null, 'document', GLOBAL_ELEMENTS_EXCLUDED_RULES)
-        )
-        throw error
-      }
+      test(`${surface} (${layout}) global elements have no blocking accessibility violations @global-elements`, async ({
+        page,
+      }, testInfo) => {
+        test.setTimeout(120_000)
 
-      const status = response?.status() ?? null
+        await page.setViewportSize(VIEWPORTS[viewport])
 
-      if (!response?.ok()) {
-        await attachScanReport(
-          testInfo,
-          unloadedResult(path, page.url(), status, 'document', GLOBAL_ELEMENTS_EXCLUDED_RULES)
-        )
-        expect(
-          response?.ok(),
-          `Expected a successful response for ${path}, got ${status}`
-        ).toBeTruthy()
-        return
-      }
+        const status = await load(page, testInfo, path, surface)
+        if (status && status >= 400) return
 
-      await settleForAxe(page)
+        await settleForAxe(page)
 
-      // Soft, so a missing landmark still reports its scan instead of hiding it.
-      for (const landmark of landmarks) {
-        const { selector, label } = GLOBAL_ELEMENTS[landmark]
-        await expect
-          .soft(page.locator(selector).first(), `${path} should render the ${label} (${selector})`)
-          .toBeAttached()
-      }
+        // Visible, not just attached: axe skips hidden subtrees, so an attached
+        // element that renders nothing would pass while scanning nothing.
+        // Soft, so a missing element still reports its scan instead of hiding it.
+        for (const name of elementsForViewport(elements, viewport)) {
+          const { selector, label } = GLOBAL_ELEMENTS[name]
+          await expect
+            .soft(
+              renderedLocator(page, selector),
+              `${surface} should render the ${label} (${selector})`
+            )
+            .toBeVisible()
+        }
 
-      const exclude = await articleSelectorsOnPage(page)
-      const result = await scanOutsideArticle(page, path, exclude)
-      result.status = status
-
-      await attachScanReport(testInfo, result)
-
-      if (scanLooksEmpty(result)) {
-        annotate(
-          testInfo,
-          `${path} scanned only ${result.elementCount} element(s) outside the article, so a clean ` +
-            'result here proves nothing. Most likely the page had not finished rendering.'
-        )
-      }
-
-      const blocking = blockingViolations(result, GLOBAL_ELEMENTS_ENFORCED_RULES)
-
-      const reported = result.violations.filter((violation) => !blocking.includes(violation))
-      if (reported.length) {
-        annotate(
-          testInfo,
-          `${path} global elements have ${reported.length} non-blocking accessibility finding(s): ` +
-            reported.map((v) => `${v.id} (${v.nodes.length})`).join(', ')
-        )
-      }
-
-      const enforced = shouldEnforceAll()
-        ? 'all WCAG 2.1 A/AA rules'
-        : GLOBAL_ELEMENTS_ENFORCED_RULES.join(', ')
-
-      expect(
-        blocking.map((violation) => violation.id).sort(),
-        `${path} global elements have blocking a11y violations (${enforced}):\n${formatViolations(blocking)}`
-      ).toEqual([])
-    })
+        await scanAndAssert(page, testInfo, surface, status)
+      })
+    }
   }
+
+  // The overlay is a static list, identical on every page, so one page covers
+  // it. Its markup only exists once opened.
+  test('the mobile menu overlay has no blocking accessibility violations @global-elements', async ({
+    page,
+  }, testInfo) => {
+    test.setTimeout(120_000)
+
+    const path = '/docs'
+    const surface = '/docs with the mobile menu open'
+
+    await page.setViewportSize(VIEWPORTS.mobile)
+
+    const status = await load(page, testInfo, path, surface)
+    if (status && status >= 400) return
+
+    await renderedLocator(page, GLOBAL_ELEMENTS.menuTrigger.selector).click()
+    await expect(
+      page.locator(MOBILE_MENU_SELECTOR),
+      `${surface} should open the mobile menu overlay`
+    ).toBeVisible()
+
+    await settleForAxe(page)
+
+    await scanAndAssert(page, testInfo, surface, status)
+  })
 })

--- a/e2e/docs/global-elements/docs-global-elements.spec.ts
+++ b/e2e/docs/global-elements/docs-global-elements.spec.ts
@@ -96,9 +96,6 @@ async function scanAndAssert(
 }
 
 test.describe('Docs global elements', () => {
-  // Without this, every test in this file runs on one worker.
-  test.describe.configure({ mode: 'parallel' })
-
   for (const { path, layout, elements } of GLOBAL_ELEMENT_PAGES) {
     for (const viewport of Object.keys(VIEWPORTS) as ViewportName[]) {
       const surface = `${path} at ${viewport}`
@@ -111,7 +108,6 @@ test.describe('Docs global elements', () => {
         await page.setViewportSize(VIEWPORTS[viewport])
 
         const status = await load(page, testInfo, path, surface)
-        if (status && status >= 400) return
 
         await settleForAxe(page)
 
@@ -144,7 +140,6 @@ test.describe('Docs global elements', () => {
     await page.setViewportSize(VIEWPORTS.mobile)
 
     const status = await load(page, testInfo, path, surface)
-    if (status && status >= 400) return
 
     await renderedLocator(page, GLOBAL_ELEMENTS.menuTrigger.selector).click()
     await expect(

--- a/e2e/docs/global-elements/docs-global-elements.spec.ts
+++ b/e2e/docs/global-elements/docs-global-elements.spec.ts
@@ -115,9 +115,8 @@ test.describe('Docs global elements', () => {
 
         await settleForAxe(page)
 
-        // Visible, not just attached: axe skips hidden subtrees, so an attached
-        // element that renders nothing would pass while scanning nothing.
-        // Soft, so a missing element still reports its scan instead of hiding it.
+        // Visible, not attached: axe skips hidden subtrees.
+        // Soft, so a missing element still reports its scan.
         for (const name of elementsForViewport(elements, viewport)) {
           const { selector, label } = GLOBAL_ELEMENTS[name]
           await expect
@@ -133,8 +132,7 @@ test.describe('Docs global elements', () => {
     }
   }
 
-  // The overlay is a static list, identical on every page, so one page covers
-  // it. Its markup only exists once opened.
+  // Same overlay on every page, and its markup only exists once opened.
   test('the mobile menu overlay has no blocking accessibility violations @global-elements', async ({
     page,
   }, testInfo) => {

--- a/e2e/docs/package.json
+++ b/e2e/docs/package.json
@@ -7,6 +7,7 @@
     "e2e:docs": "node --experimental-strip-types scripts/run-e2e-docs.ts",
     "e2e:docs:all": "node --experimental-strip-types scripts/run-e2e-docs.ts --all",
     "e2e:docs:a11y": "node --experimental-strip-types scripts/run-e2e-docs.ts --grep @a11y",
+    "e2e:docs:global-elements": "node --experimental-strip-types scripts/run-e2e-docs-global-elements.ts",
     "e2e:ui": "node --experimental-strip-types scripts/run-e2e-docs.ts --ui",
     "e2e:docs:local-smoke": "playwright test --config=playwright.local-smoke.config.ts",
     "resolve-docs-scope": "node --experimental-strip-types scripts/resolve-docs-scope.ts"

--- a/e2e/docs/playwright.global-elements.config.ts
+++ b/e2e/docs/playwright.global-elements.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig } from '@playwright/test'
+
+const IS_CI = !!process.env.CI
+
+// A separate config rather than a project in playwright.config.ts, so
+// `pnpm e2e:docs` on a content pull request never picks these up.
+export default defineConfig({
+  testDir: './global-elements',
+  testMatch: /.*\.spec\.ts/,
+  timeout: 120_000,
+  forbidOnly: IS_CI,
+  retries: IS_CI ? 2 : 0,
+  maxFailures: 3,
+  expect: {
+    timeout: 15_000,
+  },
+  fullyParallel: false,
+  workers: 1,
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3001',
+    browserName: 'chromium',
+    headless: true,
+    navigationTimeout: 30_000,
+    screenshot: 'only-on-failure',
+    trace: 'retain-on-failure',
+    video: 'off',
+    extraHTTPHeaders: process.env.VERCEL_AUTOMATION_BYPASS_SECRET
+      ? {
+          'x-vercel-protection-bypass': process.env.VERCEL_AUTOMATION_BYPASS_SECRET,
+          'x-vercel-set-bypass-cookie': 'true',
+        }
+      : undefined,
+  },
+  reporter: IS_CI
+    ? [['list'], ['html', { open: 'never', outputFolder: './playwright-report-global-elements' }]]
+    : [
+        ['list'],
+        ['html', { open: 'never', outputFolder: './playwright-report-global-elements' }],
+        ['json', { outputFile: './test-results/global-elements-results.json' }],
+      ],
+  outputDir: './test-results',
+})

--- a/e2e/docs/playwright.global-elements.config.ts
+++ b/e2e/docs/playwright.global-elements.config.ts
@@ -2,8 +2,7 @@ import { defineConfig } from '@playwright/test'
 
 const IS_CI = !!process.env.CI
 
-// A separate config rather than a project in playwright.config.ts, so
-// `pnpm e2e:docs` on a content pull request never picks these up.
+// Separate config, so `pnpm e2e:docs` never picks these up.
 export default defineConfig({
   testDir: './global-elements',
   testMatch: /.*\.spec\.ts/,

--- a/e2e/docs/playwright.global-elements.config.ts
+++ b/e2e/docs/playwright.global-elements.config.ts
@@ -2,6 +2,22 @@ import { defineConfig } from '@playwright/test'
 
 const IS_CI = !!process.env.CI
 
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3001'
+
+// Never send the bypass secret anywhere that can't be a Supabase deployment.
+function isSupabaseHost(url: string): boolean {
+  try {
+    const { hostname } = new URL(url)
+    return (
+      hostname === 'supabase.com' ||
+      hostname.endsWith('.supabase.com') ||
+      hostname.endsWith('.vercel.app')
+    )
+  } catch {
+    return false
+  }
+}
+
 // Separate config, so `pnpm e2e:docs` never picks these up.
 export default defineConfig({
   testDir: './global-elements',
@@ -9,26 +25,28 @@ export default defineConfig({
   timeout: 120_000,
   forbidOnly: IS_CI,
   retries: IS_CI ? 2 : 0,
-  maxFailures: 3,
+  // Report every page: an early stop hides findings from the rest.
+  maxFailures: 0,
   expect: {
     timeout: 15_000,
   },
-  fullyParallel: false,
-  workers: 1,
+  fullyParallel: true,
+  workers: IS_CI ? 2 : undefined,
   use: {
-    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3001',
+    baseURL: BASE_URL,
     browserName: 'chromium',
     headless: true,
     navigationTimeout: 30_000,
     screenshot: 'only-on-failure',
     trace: 'retain-on-failure',
     video: 'off',
-    extraHTTPHeaders: process.env.VERCEL_AUTOMATION_BYPASS_SECRET
-      ? {
-          'x-vercel-protection-bypass': process.env.VERCEL_AUTOMATION_BYPASS_SECRET,
-          'x-vercel-set-bypass-cookie': 'true',
-        }
-      : undefined,
+    extraHTTPHeaders:
+      process.env.VERCEL_AUTOMATION_BYPASS_SECRET && isSupabaseHost(BASE_URL)
+        ? {
+            'x-vercel-protection-bypass': process.env.VERCEL_AUTOMATION_BYPASS_SECRET,
+            'x-vercel-set-bypass-cookie': 'true',
+          }
+        : undefined,
   },
   reporter: IS_CI
     ? [['list'], ['html', { open: 'never', outputFolder: './playwright-report-global-elements' }]]

--- a/e2e/docs/scripts/run-e2e-docs-global-elements.ts
+++ b/e2e/docs/scripts/run-e2e-docs-global-elements.ts
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+/**
+ * Entry for `pnpm e2e:docs:global-elements`. Scope is the fixed page list in
+ * utils/docs-global-elements.ts, so unlike `pnpm e2e:docs` this resolves nothing from
+ * git. Extra CLI args are forwarded to Playwright.
+ */
+import { spawn } from 'node:child_process'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const E2E_DOCS_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+// Mirrors the default in playwright.global-elements.config.ts.
+const DEFAULT_BASE_URL = 'http://localhost:3001'
+const PREFLIGHT_TIMEOUT_MS = 3_000
+
+async function isBaseUrlReachable(baseUrl: string): Promise<boolean> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), PREFLIGHT_TIMEOUT_MS)
+  try {
+    await fetch(baseUrl, { signal: controller.signal })
+    return true
+  } catch {
+    return false
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+async function main() {
+  const playwrightArgs = process.argv.slice(2).filter((arg) => arg !== '--')
+
+  const baseUrl = process.env.PLAYWRIGHT_BASE_URL?.trim() || DEFAULT_BASE_URL
+  if (!(await isBaseUrlReachable(baseUrl))) {
+    console.error(`No docs server responding at ${baseUrl}.`)
+    if (!process.env.PLAYWRIGHT_BASE_URL) {
+      console.error('Start it with `pnpm dev:docs`, or point at a deployed site:')
+      console.error('  PLAYWRIGHT_BASE_URL=https://supabase.com pnpm e2e:docs:global-elements')
+    } else {
+      console.error('Check that the URL is correct and reachable.')
+    }
+    process.exit(1)
+  }
+
+  const child = spawn(
+    'pnpm',
+    [
+      'exec',
+      'playwright',
+      'test',
+      '--config=playwright.global-elements.config.ts',
+      ...playwrightArgs,
+    ],
+    {
+      cwd: E2E_DOCS_ROOT,
+      env: process.env,
+      stdio: 'inherit',
+      shell: process.platform === 'win32',
+    }
+  )
+
+  child.on('exit', (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal)
+      return
+    }
+    process.exit(code ?? 1)
+  })
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exit(1)
+})

--- a/e2e/docs/scripts/run-e2e-docs-global-elements.ts
+++ b/e2e/docs/scripts/run-e2e-docs-global-elements.ts
@@ -59,6 +59,11 @@ async function main() {
     }
   )
 
+  child.on('error', (error) => {
+    console.error(`Failed to start Playwright: ${error.message}`)
+    process.exitCode = 1
+  })
+
   child.on('exit', (code, signal) => {
     if (signal) {
       process.kill(process.pid, signal)

--- a/e2e/docs/utils/axe-helpers.ts
+++ b/e2e/docs/utils/axe-helpers.ts
@@ -6,6 +6,14 @@ export const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa']
 
 export const ENFORCED_RULES = ['heading-order', 'page-has-heading-one']
 
+// A violation in a global element lands on every docs page, so keep this list
+// green rather than growing it with findings that aren't fixed yet.
+export const GLOBAL_ELEMENTS_ENFORCED_RULES = ['link-name']
+
+// Page-level rules stay on here, unlike the article scan, which can't reach
+// them. Only `page-has-heading-one` goes: its target is the excluded article.
+export const GLOBAL_ELEMENTS_EXCLUDED_RULES = ['page-has-heading-one']
+
 export const EXCLUDED_RULES = [
   'color-contrast',
   'html-has-lang',
@@ -22,6 +30,7 @@ export interface A11yScanResult {
   surface: string
   url: string
   include: string
+  exclude?: string[]
   excludedRules: string[]
   loaded: boolean
   status: number | null
@@ -95,17 +104,64 @@ export async function scanArticle(
   }
 }
 
+export async function scanOutsideArticle(
+  page: Page,
+  surface: string,
+  exclude: string[]
+): Promise<A11yScanResult> {
+  const scan = () =>
+    exclude.reduce(
+      (builder, selector) => builder.exclude(selector),
+      new AxeBuilder({ page }).setLegacyMode(true)
+    )
+
+  const reported = await scan()
+    .withTags(WCAG_TAGS)
+    .disableRules(GLOBAL_ELEMENTS_EXCLUDED_RULES)
+    .analyze()
+
+  const enforced = await scan().withRules(GLOBAL_ELEMENTS_ENFORCED_RULES).analyze()
+
+  const byRule = new Map(
+    [...reported.violations, ...enforced.violations].map((violation) => [violation.id, violation])
+  )
+
+  const elementCount = await page.evaluate(
+    (selectors) =>
+      document.body.querySelectorAll('*').length -
+      selectors.reduce(
+        (sum, selector) =>
+          sum + (document.querySelector(selector)?.querySelectorAll('*').length ?? 0) + 1,
+        0
+      ),
+    exclude
+  )
+
+  return {
+    surface,
+    url: page.url(),
+    include: 'document',
+    exclude,
+    excludedRules: GLOBAL_ELEMENTS_EXCLUDED_RULES,
+    loaded: true,
+    status: null,
+    elementCount,
+    violations: [...byRule.values()],
+  }
+}
+
 export function unloadedResult(
   surface: string,
   url: string,
   status: number | null,
-  include: string
+  include: string,
+  excludedRules: string[] = EXCLUDED_RULES
 ): A11yScanResult {
   return {
     surface,
     url,
     include,
-    excludedRules: EXCLUDED_RULES,
+    excludedRules,
     loaded: false,
     status,
     elementCount: 0,
@@ -129,9 +185,12 @@ export async function attachScanReport(testInfo: TestInfo, result: A11yScanResul
   })
 }
 
-export function blockingViolations(result: A11yScanResult): Result[] {
+export function blockingViolations(
+  result: A11yScanResult,
+  enforcedRules: string[] = ENFORCED_RULES
+): Result[] {
   if (shouldEnforceAll()) return result.violations
-  return result.violations.filter((violation) => ENFORCED_RULES.includes(violation.id))
+  return result.violations.filter((violation) => enforcedRules.includes(violation.id))
 }
 
 export function formatViolations(violations: Result[]): string {

--- a/e2e/docs/utils/axe-helpers.ts
+++ b/e2e/docs/utils/axe-helpers.ts
@@ -12,10 +12,10 @@ export const ENFORCED_RULES = ['heading-order', 'page-has-heading-one']
 // scanOutsideArticle finds them in its one tagged pass.
 export const GLOBAL_ELEMENTS_ENFORCED_RULES = ['link-name']
 
-// Page-level rules the article scan can't reach stay on here.
-// `page-has-heading-one` targets the excluded article; `color-contrast` is most
-// of the scan time.
-export const GLOBAL_ELEMENTS_EXCLUDED_RULES = ['color-contrast', 'page-has-heading-one']
+// Page-level rules the article scan can't reach stay on here, including
+// `color-contrast`, which docs takes from shared tokens. Only
+// `page-has-heading-one` goes: its target is the excluded article.
+export const GLOBAL_ELEMENTS_EXCLUDED_RULES = ['page-has-heading-one']
 
 export const EXCLUDED_RULES = [
   'color-contrast',

--- a/e2e/docs/utils/axe-helpers.ts
+++ b/e2e/docs/utils/axe-helpers.ts
@@ -6,11 +6,8 @@ export const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa']
 
 export const ENFORCED_RULES = ['heading-order', 'page-has-heading-one']
 
-// A violation in a global element lands on every docs page, so keep this list
-// green rather than growing it with findings that aren't fixed yet. Rules must
-// be within WCAG_TAGS and absent from GLOBAL_ELEMENTS_EXCLUDED_RULES, since
-// scanOutsideArticle finds them in its one tagged pass. Every rule here is
-// applicable on all scanned surfaces, so it guards something today.
+// Keep this list green: a violation here lands on every docs page. Rules must
+// be within WCAG_TAGS, since scanOutsideArticle makes one tagged pass.
 export const GLOBAL_ELEMENTS_ENFORCED_RULES = [
   'aria-allowed-attr',
   'aria-deprecated-role',
@@ -27,9 +24,7 @@ export const GLOBAL_ELEMENTS_ENFORCED_RULES = [
   'nested-interactive',
 ]
 
-// Page-level rules the article scan can't reach stay on here, including
-// `color-contrast`, which docs takes from shared tokens. Only
-// `page-has-heading-one` goes: its target is the excluded article.
+// `page-has-heading-one` targets the excluded article.
 export const GLOBAL_ELEMENTS_EXCLUDED_RULES = ['page-has-heading-one']
 
 export const EXCLUDED_RULES = [

--- a/e2e/docs/utils/axe-helpers.ts
+++ b/e2e/docs/utils/axe-helpers.ts
@@ -7,12 +7,15 @@ export const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa']
 export const ENFORCED_RULES = ['heading-order', 'page-has-heading-one']
 
 // A violation in a global element lands on every docs page, so keep this list
-// green rather than growing it with findings that aren't fixed yet.
+// green rather than growing it with findings that aren't fixed yet. Rules must
+// be within WCAG_TAGS and absent from GLOBAL_ELEMENTS_EXCLUDED_RULES, since
+// scanOutsideArticle finds them in its one tagged pass.
 export const GLOBAL_ELEMENTS_ENFORCED_RULES = ['link-name']
 
-// Page-level rules stay on here, unlike the article scan, which can't reach
-// them. Only `page-has-heading-one` goes: its target is the excluded article.
-export const GLOBAL_ELEMENTS_EXCLUDED_RULES = ['page-has-heading-one']
+// Page-level rules the article scan can't reach stay on here.
+// `page-has-heading-one` targets the excluded article; `color-contrast` is most
+// of the scan time.
+export const GLOBAL_ELEMENTS_EXCLUDED_RULES = ['color-contrast', 'page-has-heading-one']
 
 export const EXCLUDED_RULES = [
   'color-contrast',
@@ -109,22 +112,15 @@ export async function scanOutsideArticle(
   surface: string,
   exclude: string[]
 ): Promise<A11yScanResult> {
-  const scan = () =>
-    exclude.reduce(
-      (builder, selector) => builder.exclude(selector),
-      new AxeBuilder({ page }).setLegacyMode(true)
-    )
+  const builder = exclude.reduce(
+    (acc, selector) => acc.exclude(selector),
+    new AxeBuilder({ page }).setLegacyMode(true)
+  )
 
-  const reported = await scan()
+  const reported = await builder
     .withTags(WCAG_TAGS)
     .disableRules(GLOBAL_ELEMENTS_EXCLUDED_RULES)
     .analyze()
-
-  const enforced = await scan().withRules(GLOBAL_ELEMENTS_ENFORCED_RULES).analyze()
-
-  const byRule = new Map(
-    [...reported.violations, ...enforced.violations].map((violation) => [violation.id, violation])
-  )
 
   const elementCount = await page.evaluate(
     (selectors) =>
@@ -146,7 +142,7 @@ export async function scanOutsideArticle(
     loaded: true,
     status: null,
     elementCount,
-    violations: [...byRule.values()],
+    violations: reported.violations,
   }
 }
 

--- a/e2e/docs/utils/axe-helpers.ts
+++ b/e2e/docs/utils/axe-helpers.ts
@@ -137,7 +137,11 @@ export async function scanOutsideArticle(
       document.body.querySelectorAll('*').length -
       selectors.reduce(
         (sum, selector) =>
-          sum + (document.querySelector(selector)?.querySelectorAll('*').length ?? 0) + 1,
+          sum +
+          [...document.querySelectorAll(selector)].reduce(
+            (nodes, root) => nodes + root.querySelectorAll('*').length + 1,
+            0
+          ),
         0
       ),
     exclude

--- a/e2e/docs/utils/axe-helpers.ts
+++ b/e2e/docs/utils/axe-helpers.ts
@@ -9,8 +9,23 @@ export const ENFORCED_RULES = ['heading-order', 'page-has-heading-one']
 // A violation in a global element lands on every docs page, so keep this list
 // green rather than growing it with findings that aren't fixed yet. Rules must
 // be within WCAG_TAGS and absent from GLOBAL_ELEMENTS_EXCLUDED_RULES, since
-// scanOutsideArticle finds them in its one tagged pass.
-export const GLOBAL_ELEMENTS_ENFORCED_RULES = ['link-name']
+// scanOutsideArticle finds them in its one tagged pass. Every rule here is
+// applicable on all scanned surfaces, so it guards something today.
+export const GLOBAL_ELEMENTS_ENFORCED_RULES = [
+  'aria-allowed-attr',
+  'aria-deprecated-role',
+  'aria-hidden-focus',
+  'aria-roles',
+  'aria-valid-attr',
+  'bypass',
+  'document-title',
+  'html-has-lang',
+  'html-lang-valid',
+  'image-alt',
+  'link-name',
+  'meta-viewport',
+  'nested-interactive',
+]
 
 // Page-level rules the article scan can't reach stay on here, including
 // `color-contrast`, which docs takes from shared tokens. Only

--- a/e2e/docs/utils/docs-global-elements.ts
+++ b/e2e/docs/utils/docs-global-elements.ts
@@ -9,9 +9,7 @@ export const VIEWPORTS = {
 
 export type ViewportName = keyof typeof VIEWPORTS
 
-// Selectors match `data-test` attributes in apps/docs, so restyling or
-// remarkup cannot silently drop an element out of the scan. `viewports` lists
-// where an element is expected to be visible; it defaults to both.
+// `viewports` lists where an element renders. It defaults to both.
 export const GLOBAL_ELEMENTS = {
   topNav: { selector: '[data-test="sb-docs-top-nav"]', label: 'top navigation bar' },
   sidebarNav: {
@@ -45,8 +43,7 @@ export interface GlobalElementPage {
   elements: GlobalElement[]
 }
 
-// One page per layout. These elements are global, so a second page on a layout
-// already covered scans the same markup for the same result.
+// One page per layout. A second page on a covered layout scans the same markup.
 export const GLOBAL_ELEMENT_PAGES: GlobalElementPage[] = [
   {
     path: '/docs',
@@ -80,8 +77,7 @@ export const GLOBAL_ELEMENT_PAGES: GlobalElementPage[] = [
   },
 ]
 
-// The top bar ships twice, once in a `hidden lg:flex` wrapper and once in a
-// `flex lg:hidden` one, so match whichever copy renders at this viewport.
+// The top bar ships twice, desktop and mobile, so match the copy that renders.
 export function renderedLocator(page: Page, selector: string) {
   return page.locator(`${selector}:visible`).first()
 }

--- a/e2e/docs/utils/docs-global-elements.ts
+++ b/e2e/docs/utils/docs-global-elements.ts
@@ -1,0 +1,67 @@
+import type { Page } from '@playwright/test'
+
+import { GUIDE_ARTICLE_SELECTOR, TROUBLESHOOTING_ARTICLE_SELECTOR } from './docs-links.js'
+
+// Selectors match `data-test` attributes in apps/docs, so restyling or
+// remarkup cannot silently drop a region out of the scan.
+export const GLOBAL_ELEMENTS = {
+  topNav: { selector: '[data-test="sb-docs-top-nav"]', label: 'top navigation bar' },
+  sidebarNav: { selector: '[data-test="sb-docs-sidebar-nav"]', label: 'sidebar navigation' },
+  tocSidebar: { selector: '[data-test="sb-docs-toc-sidebar"]', label: 'table of contents sidebar' },
+  breadcrumbs: { selector: '[data-test="sb-docs-breadcrumbs"]', label: 'breadcrumbs' },
+  footer: { selector: '[data-test="sb-docs-footer"]', label: 'site footer' },
+} as const
+
+export type GlobalElement = keyof typeof GLOBAL_ELEMENTS
+
+export interface GlobalElementPage {
+  path: string
+  layout: string
+  landmarks: GlobalElement[]
+}
+
+// One page per layout. These elements are global, so a second page on a layout
+// already covered scans the same markup for the same result.
+export const GLOBAL_ELEMENT_PAGES: GlobalElementPage[] = [
+  {
+    path: '/docs',
+    layout: 'home',
+    landmarks: ['topNav', 'footer'],
+  },
+  {
+    path: '/docs/guides/getting-started',
+    layout: 'guides section landing',
+    landmarks: ['topNav', 'sidebarNav', 'tocSidebar', 'footer'],
+  },
+  {
+    path: '/docs/guides/database/postgres/row-level-security',
+    layout: 'guide with table of contents',
+    landmarks: ['topNav', 'sidebarNav', 'tocSidebar', 'breadcrumbs', 'footer'],
+  },
+  {
+    path: '/docs/guides/troubleshooting',
+    layout: 'troubleshooting index',
+    landmarks: ['topNav', 'footer'],
+  },
+  {
+    path: '/docs/guides/troubleshooting/all-about-supabase-egress-a_Sg_e',
+    layout: 'troubleshooting entry',
+    landmarks: ['topNav', 'breadcrumbs', 'footer'],
+  },
+  {
+    path: '/docs/reference/cli/introduction',
+    layout: 'reference',
+    landmarks: ['topNav', 'sidebarNav', 'footer'],
+  },
+]
+
+const ARTICLE_SELECTORS = [GUIDE_ARTICLE_SELECTOR, TROUBLESHOOTING_ARTICLE_SELECTOR]
+
+// Excluding a selector that matches nothing would silently widen the scan.
+export async function articleSelectorsOnPage(page: Page): Promise<string[]> {
+  const present: string[] = []
+  for (const selector of ARTICLE_SELECTORS) {
+    if ((await page.locator(selector).count()) > 0) present.push(selector)
+  }
+  return present
+}

--- a/e2e/docs/utils/docs-global-elements.ts
+++ b/e2e/docs/utils/docs-global-elements.ts
@@ -2,22 +2,47 @@ import type { Page } from '@playwright/test'
 
 import { GUIDE_ARTICLE_SELECTOR, TROUBLESHOOTING_ARTICLE_SELECTOR } from './docs-links.js'
 
+export const VIEWPORTS = {
+  desktop: { width: 1280, height: 800 },
+  mobile: { width: 390, height: 844 },
+} as const
+
+export type ViewportName = keyof typeof VIEWPORTS
+
 // Selectors match `data-test` attributes in apps/docs, so restyling or
-// remarkup cannot silently drop a region out of the scan.
+// remarkup cannot silently drop an element out of the scan. `viewports` lists
+// where an element is expected to be visible; it defaults to both.
 export const GLOBAL_ELEMENTS = {
   topNav: { selector: '[data-test="sb-docs-top-nav"]', label: 'top navigation bar' },
-  sidebarNav: { selector: '[data-test="sb-docs-sidebar-nav"]', label: 'sidebar navigation' },
-  tocSidebar: { selector: '[data-test="sb-docs-toc-sidebar"]', label: 'table of contents sidebar' },
+  sidebarNav: {
+    selector: '[data-test="sb-docs-sidebar-nav"]',
+    label: 'sidebar navigation',
+    // In the DOM at mobile, but collapsed to `w-0 -left-full`.
+    viewports: ['desktop'],
+  },
+  tocSidebar: {
+    selector: '[data-test="sb-docs-toc-sidebar"]',
+    label: 'content sidebar',
+    // `hidden md:flex`, so axe skips it below 768px.
+    viewports: ['desktop'],
+  },
   breadcrumbs: { selector: '[data-test="sb-docs-breadcrumbs"]', label: 'breadcrumbs' },
   footer: { selector: '[data-test="sb-docs-footer"]', label: 'site footer' },
+  menuTrigger: {
+    selector: '[data-test="sb-docs-mobile-menu-trigger"]',
+    label: 'mobile menu trigger',
+    viewports: ['mobile'],
+  },
 } as const
 
 export type GlobalElement = keyof typeof GLOBAL_ELEMENTS
 
+export const MOBILE_MENU_SELECTOR = '[data-test="sb-docs-mobile-menu"]'
+
 export interface GlobalElementPage {
   path: string
   layout: string
-  landmarks: GlobalElement[]
+  elements: GlobalElement[]
 }
 
 // One page per layout. These elements are global, so a second page on a layout
@@ -26,34 +51,50 @@ export const GLOBAL_ELEMENT_PAGES: GlobalElementPage[] = [
   {
     path: '/docs',
     layout: 'home',
-    landmarks: ['topNav', 'footer'],
+    elements: ['topNav', 'menuTrigger', 'footer'],
   },
   {
     path: '/docs/guides/getting-started',
     layout: 'guides section landing',
-    landmarks: ['topNav', 'sidebarNav', 'tocSidebar', 'footer'],
+    elements: ['topNav', 'menuTrigger', 'sidebarNav', 'tocSidebar', 'footer'],
   },
   {
     path: '/docs/guides/database/postgres/row-level-security',
     layout: 'guide with table of contents',
-    landmarks: ['topNav', 'sidebarNav', 'tocSidebar', 'breadcrumbs', 'footer'],
+    elements: ['topNav', 'menuTrigger', 'sidebarNav', 'tocSidebar', 'breadcrumbs', 'footer'],
   },
   {
     path: '/docs/guides/troubleshooting',
     layout: 'troubleshooting index',
-    landmarks: ['topNav', 'footer'],
+    elements: ['topNav', 'menuTrigger', 'footer'],
   },
   {
     path: '/docs/guides/troubleshooting/all-about-supabase-egress-a_Sg_e',
     layout: 'troubleshooting entry',
-    landmarks: ['topNav', 'breadcrumbs', 'footer'],
+    elements: ['topNav', 'menuTrigger', 'breadcrumbs', 'footer'],
   },
   {
     path: '/docs/reference/cli/introduction',
     layout: 'reference',
-    landmarks: ['topNav', 'sidebarNav', 'footer'],
+    elements: ['topNav', 'menuTrigger', 'sidebarNav', 'footer'],
   },
 ]
+
+// The top bar ships twice, once in a `hidden lg:flex` wrapper and once in a
+// `flex lg:hidden` one, so match whichever copy renders at this viewport.
+export function renderedLocator(page: Page, selector: string) {
+  return page.locator(`${selector}:visible`).first()
+}
+
+export function elementsForViewport(
+  elements: GlobalElement[],
+  viewport: ViewportName
+): GlobalElement[] {
+  return elements.filter((name) => {
+    const viewports = (GLOBAL_ELEMENTS[name] as { viewports?: readonly ViewportName[] }).viewports
+    return !viewports || viewports.includes(viewport)
+  })
+}
 
 const ARTICLE_SELECTORS = [GUIDE_ARTICLE_SELECTOR, TROUBLESHOOTING_ARTICLE_SELECTOR]
 

--- a/e2e/docs/utils/docs-global-elements.ts
+++ b/e2e/docs/utils/docs-global-elements.ts
@@ -9,7 +9,13 @@ export const VIEWPORTS = {
 
 export type ViewportName = keyof typeof VIEWPORTS
 
-// `viewports` lists where an element renders. It defaults to both.
+interface GlobalElementConfig {
+  selector: string
+  label: string
+  // Where the element renders. Defaults to both viewports.
+  viewports?: readonly ViewportName[]
+}
+
 export const GLOBAL_ELEMENTS = {
   topNav: { selector: '[data-test="sb-docs-top-nav"]', label: 'top navigation bar' },
   sidebarNav: {
@@ -87,7 +93,7 @@ export function elementsForViewport(
   viewport: ViewportName
 ): GlobalElement[] {
   return elements.filter((name) => {
-    const viewports = (GLOBAL_ELEMENTS[name] as { viewports?: readonly ViewportName[] }).viewports
+    const { viewports } = GLOBAL_ELEMENTS[name] as GlobalElementConfig
     return !viewports || viewports.includes(viewport)
   })
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "e2e:docs": "pnpm --prefix e2e/docs run e2e:docs",
     "e2e:docs:all": "pnpm --prefix e2e/docs run e2e:docs:all",
     "e2e:docs:a11y": "pnpm --prefix e2e/docs run e2e:docs:a11y",
+    "e2e:docs:global-elements": "pnpm --prefix e2e/docs run e2e:docs:global-elements",
     "e2e:docs:ui": "pnpm --prefix e2e/docs run e2e:ui",
     "e2e:docs:local-smoke": "pnpm --prefix e2e/docs run e2e:docs:local-smoke",
     "perf:kong": "ab -t 5 -c 20 -T application/json http://localhost:8000/",

--- a/scripts/waitForVercelDocsPreview.js
+++ b/scripts/waitForVercelDocsPreview.js
@@ -80,6 +80,14 @@ async function main() {
     const latest = await fetchLatestStatus(repository, sha, githubToken)
 
     if (latest?.state === 'success') {
+      // A skipped build still posts success, but its target_url points at an
+      // older deployment that does not have this commit's changes. Resolve no
+      // URL so the caller skips rather than testing the wrong markup.
+      if (/^skipped/i.test(latest.description ?? '')) {
+        console.error(`Vercel skipped the docs build for ${sha}: ${latest.description}`)
+        return
+      }
+
       if (!latest.target_url) {
         throw new Error(
           'Vercel docs commit status succeeded but had no target_url to resolve a deployment from'


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Test coverage. Closes DOCS-1284.

## What is the current behavior?

The docs accessibility scan only covers the main article. Nothing checks the
navigation, sidebars, breadcrumbs, or footer, so a violation in any of those
shows up on every docs page and no test catches it.

## What is the new behavior?

A new suite scans everything outside the article, on six pages that cover one
layout each. Every page runs at a desktop and a mobile width, since each width
hides different elements, and one test opens the mobile menu and scans that too.

Most findings are reported as warnings. Thirteen WCAG rules block, all of them
passing today, so the suite holds the line rather than failing on day one. It
already caught an unnamed sidebar toggle that only appears at mobile width.

The suite runs as its own CI job on pull requests that touch docs UI code, and
`pnpm e2e:docs` does not pick it up.

## Manual Testing

Run against the local server. Production does not have the new `data-test`
attributes until this merges.

1. Start the docs server:

   ```bash
   pnpm dev:docs
   ```

2. In a second terminal, run the suite:

   ```bash
   PLAYWRIGHT_BASE_URL=http://localhost:3001 pnpm e2e:docs:global-elements
   ```

   All 13 tests pass in about 39 seconds. Some print accessibility warnings,
   which do not fail the run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated accessibility checks for global documentation elements across desktop and mobile layouts.
  * Added coverage for navigation, breadcrumbs, sidebars, footers, and mobile menus.
  * Added visibility checks and reporting for accessibility findings.

* **Documentation**
  * Documented how to run global-element accessibility scans, interpret results, and use the CI workflow.

* **Tests**
  * Added dedicated end-to-end coverage for relevant documentation changes, including failure reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->