### PR TITLE
Add cancel query action for database connections

### DIFF
--- a/apps/studio/components/interfaces/Observability/DatabaseConnections/ActivityRow.tsx
+++ b/apps/studio/components/interfaces/Observability/DatabaseConnections/ActivityRow.tsx
@@ -28,6 +28,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from 'ui'
+import { Admonition } from 'ui-patterns/Admonition'
 import { CodeBlock } from 'ui-patterns/CodeBlock'
 
 import {
@@ -472,17 +473,33 @@ export const ActivityRow = ({
       <AlertDialog open={showTerminateConfirmDialog} onOpenChange={setShowTerminateConfirmDialog}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Confirm to terminate this process?</AlertDialogTitle>
+            <AlertDialogTitle>Confirm to terminate this session?</AlertDialogTitle>
+            {activity.state === 'active' && (
+              <Admonition
+                type="warning"
+                className="border-x-0 rounded-none border-t-0"
+                title="This session is currently running a query"
+                description="Cancelling it may solve the problem without closing the connection."
+              />
+            )}
             <AlertDialogDescription>
-              This will force the query to stop running.
+              Ending this session will close its connection and roll back any open transaction. The
+              application will need to reconnect.
             </AlertDialogDescription>
           </AlertDialogHeader>
 
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction variant="warning" onClick={onConfirmTerminate}>
-              Terminate
-            </AlertDialogAction>
+          <AlertDialogFooter className={cn(activity.state === 'active' && 'sm:justify-between')}>
+            <AlertDialogCancel>Back</AlertDialogCancel>
+            <div className="flex items-center gap-x-2">
+              {activity.state === 'active' && (
+                <AlertDialogAction variant="default" onClick={onCancelQuery}>
+                  Cancel query
+                </AlertDialogAction>
+              )}
+              <AlertDialogAction variant="warning" onClick={onConfirmTerminate}>
+                Terminate
+              </AlertDialogAction>
+            </div>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/apps/studio/components/interfaces/Observability/DatabaseConnections/ActivityRow.tsx
+++ b/apps/studio/components/interfaces/Observability/DatabaseConnections/ActivityRow.tsx
@@ -1,4 +1,4 @@
-import { ChevronRight, Minus, MoreVertical, StopCircle } from 'lucide-react'
+import { ChevronRight, CircleX, Minus, MoreVertical, StopCircle } from 'lucide-react'
 import { parseAsInteger, parseAsString, useQueryState } from 'nuqs'
 import { Fragment, useState } from 'react'
 import { toast } from 'sonner'
@@ -17,6 +17,7 @@ import {
   copyToClipboard,
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
   HoverCard,
   HoverCardContent,
@@ -45,7 +46,8 @@ import { DropdownMenuItemTooltip } from '@/components/ui/DropdownMenuItemTooltip
 import { InlineLinkClassName } from '@/components/ui/InlineLink'
 import { useDatabaseRolesQuery } from '@/data/database-roles/database-roles-query'
 import { useDatabaseActivityQuery, type DatabaseActivity } from '@/data/database/activity-query'
-import { useQueryAbortMutation } from '@/data/sql/abort-query-mutation'
+import { useQueryCancelMutation } from '@/data/sql/cancel-query-mutation'
+import { useSessionTerminateMutation } from '@/data/sql/terminate-session-mutation'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { formatSql } from '@/lib/formatSql'
 import { useTrack } from '@/lib/telemetry/track'
@@ -120,9 +122,13 @@ export const ActivityRow = ({
   })
   const superuserRoles = roles?.filter((role) => role.isSuperuser).map((role) => role.name)
 
-  const { mutateAsync: abortQuery } = useQueryAbortMutation({
+  const { mutateAsync: cancelQuery } = useQueryCancelMutation({
+    onError: () => {}, // [Joshen] Error handled at call site
+  })
+
+  const { mutateAsync: terminateSession } = useSessionTerminateMutation({
     onSuccess: () => {
-      toast.success(`Successfully aborted query (ID: ${activity.pid})`)
+      toast.success(`Successfully terminated session (ID: ${activity.pid})`)
     },
   })
 
@@ -140,11 +146,41 @@ export const ActivityRow = ({
         activity.state === 'idle in transaction (aborted)') &&
         durationSeconds >= WARN_DURATION_IDLE_TXN))
 
+  const onCancelQuery = async () => {
+    const isBlocking = (data ?? []).some((x) => x.blocked_by.includes(activity.pid))
+    track('query_cancel_button_clicked', {
+      activityState: activity.state,
+      isBlocking,
+    })
+
+    const toastId = toast.loading(`Cancelling query (ID: ${activity.pid})`)
+    try {
+      await cancelQuery({
+        pid: activity.pid,
+        projectRef: project?.ref,
+        connectionString: project?.connectionString,
+      })
+      toast.success(`Successfully cancelled query (ID: ${activity.pid})`, { id: toastId })
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+      toast.error(`Failed to cancel query: ${errorMessage}`, { id: toastId })
+    }
+  }
+
+  const onSelectTerminate = () => {
+    const isBlocking = (data ?? []).some((x) => x.blocked_by.includes(activity.pid))
+    track('session_terminate_button_clicked', {
+      activityState: activity.state,
+      isBlocking,
+    })
+    setShowTerminateConfirmDialog(true)
+  }
+
   const onConfirmTerminate = async () => {
     const isBlocking = (data ?? []).some((x) => x.blocked_by.includes(activity.pid))
     track('session_terminate_submitted', { activityState: activity.state, isBlocking })
     try {
-      await abortQuery({
+      await terminateSession({
         pid: activity.pid,
         projectRef: project?.ref,
         connectionString: project?.connectionString,
@@ -394,24 +430,39 @@ export const ActivityRow = ({
             <DropdownMenuContent align="end" className="w-44">
               <DropdownMenuItemTooltip
                 className="gap-x-2"
-                disabled={superuserRoles?.includes(activity.role_name)}
-                onClick={() => {
-                  const isBlocking = (data ?? []).some((x) => x.blocked_by.includes(activity.pid))
-                  track('session_terminate_button_clicked', {
-                    activityState: activity.state,
-                    isBlocking,
-                  })
-                  setShowTerminateConfirmDialog(true)
-                }}
+                disabled={
+                  activity.state !== 'active' || superuserRoles?.includes(activity.role_name)
+                }
+                onClick={onCancelQuery}
                 tooltip={{
                   content: {
                     side: 'left',
-                    text: 'Unable to terminate queries run by superuser roles',
+                    text:
+                      activity.state !== 'active'
+                        ? 'No running queries to cancel'
+                        : 'Unable to terminate queries run by superuser roles',
+                  },
+                }}
+              >
+                <CircleX size={12} />
+                <span>Cancel query</span>
+              </DropdownMenuItemTooltip>
+
+              <DropdownMenuSeparator />
+
+              <DropdownMenuItemTooltip
+                className="gap-x-2"
+                disabled={superuserRoles?.includes(activity.role_name)}
+                onClick={onSelectTerminate}
+                tooltip={{
+                  content: {
+                    side: 'left',
+                    text: 'Unable to terminate sessions owned by superuser roles',
                   },
                 }}
               >
                 <StopCircle size={12} />
-                <span>Terminate</span>
+                <span>Terminate session</span>
               </DropdownMenuItemTooltip>
             </DropdownMenuContent>
           </DropdownMenu>

--- a/apps/studio/components/interfaces/SQLEditor/OngoingQueriesPanel.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/OngoingQueriesPanel.tsx
@@ -67,9 +67,9 @@ export const OngoingQueriesPanel = () => {
     }
   }, [viewOngoingQueries])
 
-  const { mutate: abortQuery, isPending } = useSessionTerminateMutation({
+  const { mutate: terminateSession, isPending } = useSessionTerminateMutation({
     onSuccess: () => {
-      toast.success(`Successfully aborted query (ID: ${selectedId})`)
+      toast.success(`Successfully terminated session (ID: ${selectedId})`)
       setSelectedId(undefined)
     },
   })
@@ -173,19 +173,22 @@ export const OngoingQueriesPanel = () => {
       <ConfirmationModal
         loading={isPending}
         variant="warning"
-        title={`Confirm to abort this query? (ID: ${selectedId})`}
+        title={`Confirm to terminate this session? (ID: ${selectedId})`}
         visible={selectedId !== undefined}
         onCancel={() => setSelectedId(undefined)}
         onConfirm={() => {
           if (selectedId !== undefined)
-            abortQuery({
+            terminateSession({
               pid: selectedId,
               projectRef: project?.ref,
               connectionString: database?.connectionString,
             })
         }}
       >
-        <p className="text-sm">This will force the query to stop running.</p>
+        <p className="text-sm">
+          Terminating this session will close its connection and roll back any open transaction. The
+          application will need to reconnect.
+        </p>
       </ConfirmationModal>
     </>
   )

--- a/apps/studio/components/interfaces/SQLEditor/OngoingQueriesPanel.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/OngoingQueriesPanel.tsx
@@ -21,8 +21,8 @@ import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 
 import { AlertError } from '@/components/ui/AlertError'
 import { useReadReplicasQuery } from '@/data/read-replicas/replicas-query'
-import { useQueryAbortMutation } from '@/data/sql/abort-query-mutation'
 import { useOngoingQueriesQuery } from '@/data/sql/ongoing-queries-query'
+import { useSessionTerminateMutation } from '@/data/sql/terminate-session-mutation'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { useUrlState } from '@/hooks/ui/useUrlState'
 import { IS_PLATFORM } from '@/lib/constants'
@@ -67,7 +67,7 @@ export const OngoingQueriesPanel = () => {
     }
   }, [viewOngoingQueries])
 
-  const { mutate: abortQuery, isPending } = useQueryAbortMutation({
+  const { mutate: abortQuery, isPending } = useSessionTerminateMutation({
     onSuccess: () => {
       toast.success(`Successfully aborted query (ID: ${selectedId})`)
       setSelectedId(undefined)

--- a/apps/studio/data/sql/cancel-query-mutation.ts
+++ b/apps/studio/data/sql/cancel-query-mutation.ts
@@ -1,0 +1,53 @@
+import { getCancelQuerySQL } from '@supabase/pg-meta'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+
+import { sqlKeys } from './keys'
+import { executeSql } from '@/data/sql/execute-sql-mutation'
+import type { ResponseError, UseCustomMutationOptions } from '@/types'
+
+type QueryCancelVariables = {
+  pid: number
+  projectRef?: string
+  connectionString?: string | null
+}
+
+async function cancelQuery({ pid, projectRef, connectionString }: QueryCancelVariables) {
+  const sql = getCancelQuerySQL({ pid })
+  const { result } = await executeSql({
+    projectRef,
+    connectionString,
+    sql,
+    queryKey: ['cancel-query'],
+  })
+  return result
+}
+
+type QueryCancelData = Awaited<ReturnType<typeof cancelQuery>>
+
+export const useQueryCancelMutation = ({
+  onSuccess,
+  onError,
+  ...options
+}: Omit<
+  UseCustomMutationOptions<QueryCancelData, ResponseError, QueryCancelVariables>,
+  'mutationFn'
+> = {}) => {
+  const queryClient = useQueryClient()
+  return useMutation<QueryCancelData, ResponseError, QueryCancelVariables>({
+    mutationFn: (vars) => cancelQuery(vars),
+    async onSuccess(data, variables, context) {
+      const { projectRef } = variables
+      await queryClient.invalidateQueries({ queryKey: sqlKeys.ongoingQueries(projectRef) })
+      await onSuccess?.(data, variables, context)
+    },
+    async onError(data, variables, context) {
+      if (onError === undefined) {
+        toast.error(`Failed to cancel query: ${data.message}`)
+      } else {
+        onError(data, variables, context)
+      }
+    },
+    ...options,
+  })
+}

--- a/apps/studio/data/sql/terminate-session-mutation.ts
+++ b/apps/studio/data/sql/terminate-session-mutation.ts
@@ -47,7 +47,7 @@ export const useSessionTerminateMutation = ({
     },
     async onError(data, variables, context) {
       if (onError === undefined) {
-        toast.error(`Failed to abort query: ${data.message}`)
+        toast.error(`Failed to terminate session: ${data.message}`)
       } else {
         onError(data, variables, context)
       }

--- a/apps/studio/data/sql/terminate-session-mutation.ts
+++ b/apps/studio/data/sql/terminate-session-mutation.ts
@@ -1,4 +1,4 @@
-import { getAbortQuerySQL } from '@supabase/pg-meta'
+import { getTerminateSessionSQL } from '@supabase/pg-meta'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
@@ -17,7 +17,7 @@ export async function terminateSession({
   projectRef,
   connectionString,
 }: SessionTerminateVariables) {
-  const sql = getAbortQuerySQL({ pid })
+  const sql = getTerminateSessionSQL({ pid })
   const { result } = await executeSql({
     projectRef,
     connectionString,

--- a/apps/studio/data/sql/terminate-session-mutation.ts
+++ b/apps/studio/data/sql/terminate-session-mutation.ts
@@ -6,31 +6,40 @@ import { sqlKeys } from './keys'
 import { executeSql } from '@/data/sql/execute-sql-mutation'
 import type { ResponseError, UseCustomMutationOptions } from '@/types'
 
-export type QueryAbortVariables = {
+type SessionTerminateVariables = {
   pid: number
   projectRef?: string
   connectionString?: string | null
 }
 
-export async function abortQuery({ pid, projectRef, connectionString }: QueryAbortVariables) {
+export async function terminateSession({
+  pid,
+  projectRef,
+  connectionString,
+}: SessionTerminateVariables) {
   const sql = getAbortQuerySQL({ pid })
-  const { result } = await executeSql({ projectRef, connectionString, sql })
+  const { result } = await executeSql({
+    projectRef,
+    connectionString,
+    sql,
+    queryKey: ['terminate-session'],
+  })
   return result
 }
 
-type QueryAbortData = Awaited<ReturnType<typeof abortQuery>>
+type QueryAbortData = Awaited<ReturnType<typeof terminateSession>>
 
-export const useQueryAbortMutation = ({
+export const useSessionTerminateMutation = ({
   onSuccess,
   onError,
   ...options
 }: Omit<
-  UseCustomMutationOptions<QueryAbortData, ResponseError, QueryAbortVariables>,
+  UseCustomMutationOptions<QueryAbortData, ResponseError, SessionTerminateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()
-  return useMutation<QueryAbortData, ResponseError, QueryAbortVariables>({
-    mutationFn: (vars) => abortQuery(vars),
+  return useMutation<QueryAbortData, ResponseError, SessionTerminateVariables>({
+    mutationFn: (vars) => terminateSession(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
       await queryClient.invalidateQueries({ queryKey: sqlKeys.ongoingQueries(projectRef) })

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -1605,6 +1605,25 @@ export interface SessionTerminateSubmittedEvent {
 }
 
 /**
+ * User clicked the Cancel query menu item for a database session in the Database Connections activity table.
+ *
+ * @group Events
+ * @source studio
+ * @page /dashboard/project/{ref}/observability/connections
+ */
+export interface QueryCancelButtonClickedEvent {
+  action: 'query_cancel_button_clicked'
+  properties: {
+    activityState: DatabaseActivityState
+    /**
+     * Whether the session whose query is being cancelled was itself blocking one or more other sessions.
+     */
+    isBlocking: boolean
+  }
+  groups: TelemetryGroups
+}
+
+/**
  * Index Advisor create indexes button clicked event.
  *
  * @group Events
@@ -3770,6 +3789,7 @@ export type TelemetryEvent =
   | DatabaseConnectionsBannerCtaButtonClickedEvent
   | SessionTerminateButtonClickedEvent
   | SessionTerminateSubmittedEvent
+  | QueryCancelButtonClickedEvent
   | IndexAdvisorCreateIndexesButtonClickedEvent
   | EdgeFunctionDeployButtonClickedEvent
   | EdgeFunctionDeployUpdatesConfirmClickedEvent

--- a/packages/pg-meta/src/sql/studio/sql-editor/abort-query.ts
+++ b/packages/pg-meta/src/sql/studio/sql-editor/abort-query.ts
@@ -1,5 +1,9 @@
 import { literal, safeSql, type SafeSqlFragment } from '../../../pg-format'
 
+export const getCancelQuerySQL = ({ pid }: { pid: number }): SafeSqlFragment => {
+  return safeSql`select pg_cancel_backend(${literal(pid)})`
+}
+
 export const getAbortQuerySQL = ({ pid }: { pid: number }): SafeSqlFragment => {
   return safeSql`select pg_terminate_backend(${literal(pid)})`
 }

--- a/packages/pg-meta/src/sql/studio/sql-editor/abort-query.ts
+++ b/packages/pg-meta/src/sql/studio/sql-editor/abort-query.ts
@@ -4,6 +4,6 @@ export const getCancelQuerySQL = ({ pid }: { pid: number }): SafeSqlFragment => 
   return safeSql`select pg_cancel_backend(${literal(pid)})`
 }
 
-export const getAbortQuerySQL = ({ pid }: { pid: number }): SafeSqlFragment => {
+export const getTerminateSessionSQL = ({ pid }: { pid: number }): SafeSqlFragment => {
   return safeSql`select pg_terminate_backend(${literal(pid)})`
 }


### PR DESCRIPTION
## Context

Related to Database Connections
- Adds a "cancel query" action for "active" sessions using `pg_cancel_backend`
  - Gentler alternative as the connection stays alive, unlike terminating the session
  - Not applicable for queries idle in transaction as there's no query running (Disabled in this case)
- Rename "Terminate" to "Terminate session"
- Rename "Abort query" to "Terminate session"

For active queries:
<img width="220" height="135" alt="image" src="https://github.com/user-attachments/assets/d6ca790d-bb6a-4582-8554-24431388483a" />

For idle in txn queries:
<img width="433" height="135" alt="image" src="https://github.com/user-attachments/assets/615d0651-9f5b-4efc-a5cf-72f93727aa91" />

Also updating confirmation modal for terminating session CTA:

For active queries:
<img width="407" height="301" alt="image" src="https://github.com/user-attachments/assets/e5f56764-11b9-4c10-ba01-d7547aaec872" />

All other queries:
<img width="410" height="212" alt="image" src="https://github.com/user-attachments/assets/8631633f-5d4a-40a7-b089-6980a5180219" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added a separate **Cancel query** action for active database queries.
- Added **Terminate session** to close connections and roll back active transactions.
- Added safeguards based on query activity and permissions.
- Added confirmation guidance for active queries, including cancellation options.
- Added loading, success, and error feedback for query cancellation and session termination.
- Added telemetry for query-cancellation actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->