### PR TITLE
docs(auth): correct OAuth grant methods and response shape

### DIFF
--- a/apps/docs/content/guides/auth/oauth-server/oauth-flows.mdx
+++ b/apps/docs/content/guides/auth/oauth-server/oauth-flows.mdx
@@ -798,7 +798,7 @@ Users can view and manage the OAuth applications they've authorized to access th
 Users can retrieve a list of all OAuth clients they've authorized:
 
 ```javascript
-const { data: grants, error } = await supabase.auth.oauth.getUserGrants()
+const { data: grants, error } = await supabase.auth.oauth.listGrants()
 
 if (error) {
   console.error('Error fetching grants:', error)
@@ -812,12 +812,14 @@ The response includes details about each authorized OAuth client:
 ```json
 [
   {
-    "id": "grant-uuid",
-    "client_id": "9a8b7c6d-5e4f-3a2b-1c0d-9e8f7a6b5c4d",
-    "client_name": "My Third-Party App",
+    "client": {
+      "id": "9a8b7c6d-5e4f-3a2b-1c0d-9e8f7a6b5c4d",
+      "name": "My Third-Party App",
+      "uri": "https://example.com",
+      "logo_uri": "https://example.com/logo.png"
+    },
     "scopes": ["email", "profile"],
-    "created_at": "2025-01-15T10:30:00.000Z",
-    "updated_at": "2025-01-15T10:30:00.000Z"
+    "granted_at": "2025-01-15T10:30:00.000Z"
   }
 ]
 ```
@@ -827,7 +829,7 @@ The response includes details about each authorized OAuth client:
 Users can revoke access for a specific OAuth client at any time. When access is revoked, all active sessions and refresh tokens for that client are immediately invalidated:
 
 ```javascript
-const { error } = await supabase.auth.oauth.revokeGrant(clientId)
+const { error } = await supabase.auth.oauth.revokeGrant({ clientId })
 
 if (error) {
   console.error('Error revoking access:', error)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update.

## What is the current behavior?

The OAuth flows guide calls `supabase.auth.oauth.getUserGrants()`, which doesn't exist on the client, passes a positional client ID to `revokeGrant()`, and shows a flat grant object with `client_name` and `created_at`.

Fixes #48918

## What is the new behavior?

The samples use `listGrants()` and `revokeGrant({ clientId })`, and the response block matches the `OAuthGrant` type in `@supabase/auth-js`: a nested `client` object plus `scopes` and `granted_at`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated OAuth grant-management examples to use `listGrants()` for retrieving grants.
  - Updated grant response examples to include nested client details and the `granted_at` timestamp.
  - Updated grant revocation examples to pass the client ID using `{ clientId }`.
  - Replaced references to the deprecated `getUserGrants()` method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->