### PR TITLE
docs: link query optimization guide from monitoring page

### DIFF
--- a/apps/docs/data/content-listings/telemetry.data.ts
+++ b/apps/docs/data/content-listings/telemetry.data.ts
@@ -57,6 +57,11 @@ export const telemetryMonitoring: ContentListingGroup = {
       description: 'Correlate browser requests end-to-end using W3C Trace Context.',
     },
     {
+      title: 'Query optimization',
+      href: '/guides/database/query-optimization',
+      description: 'Find and fix slow queries using indexes and query plan analysis.',
+    },
+    {
       title: 'Sentry integration',
       href: '/guides/monitoring-and-debugging/sentry-monitoring',
       description: 'Send errors to Sentry for alerting and grouping.',


### PR DESCRIPTION
Adds a Query optimization card to the Monitoring listing on /docs/guides/monitoring-and-debugging, pointing at /docs/guides/database/query-optimization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a “Query optimization” entry to the telemetry monitoring content.
  * Links readers to guidance on analyzing database indexes and query plans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->