### PR TITLE
docs(i18n): refresh Traditional Chinese README

### DIFF
--- a/i18n/README.zh-tw.md
+++ b/i18n/README.zh-tw.md
@@ -3,62 +3,52 @@
 <img src="https://user-images.githubusercontent.com/8291514/213727225-56186826-bee8-43b5-9b15-86e839d89393.png#gh-dark-mode-only">
 </p>
 
----
-
 # Supabase
 
-[Supabase](https://supabase.com)是一個開源的 Firebase 替代品。我們正在使用企業級的開源工具構建 Firebase 的功能。
+[Supabase](https://supabase.com) 是 Postgres 開發平台。我們使用企業級開源工具建構 Firebase 提供的各項功能。
 
-- [x] 托管的 Postgres 資料庫。[文檔](https://supabase.com/docs/guides/database)
-- [x] 認證和授權。[文檔](https://supabase.com/docs/guides/auth)
-- [x] 自動生成的 API。
-  - [x] REST.[文檔](https://supabase.com/docs/guides/api#rest-api-overview)
-  - [x] GraphQL。[文件](https://supabase.com/docs/guides/api#graphql-api-overview)
-  - [x] 實時訂閱。[文檔](https://supabase.com/docs/guides/api#realtime-api-overview)
-- [x] 函數。
-  - [x] 資料庫函數。[文件](https://supabase.com/docs/guides/database/functions)
-  - [x] 邊缘功能 [文檔](https://supabase.com/docs/guides/functions)
-- [x] 文件存儲。[文件](https://supabase.com/docs/guides/storage)
+- [x] 託管式 Postgres 資料庫。[文件](https://supabase.com/docs/guides/database)
+- [x] 身分驗證與授權。[文件](https://supabase.com/docs/guides/auth)
+- [x] 自動產生的 API。
+  - [x] REST。[文件](https://supabase.com/docs/guides/api)
+  - [x] GraphQL。[文件](https://supabase.com/docs/guides/graphql)
+  - [x] 即時訂閱。[文件](https://supabase.com/docs/guides/realtime)
+- [x] 函式。
+  - [x] 資料庫函式。[文件](https://supabase.com/docs/guides/database/functions)
+  - [x] Edge Functions。[文件](https://supabase.com/docs/guides/functions)
+- [x] 檔案儲存空間。[文件](https://supabase.com/docs/guides/storage)
+- [x] AI、向量及嵌入工具組。[文件](https://supabase.com/docs/guides/ai)
 - [x] 儀表板
 
 ![Supabase Dashboard](https://raw.githubusercontent.com/supabase/supabase/master/apps/www/public/images/github/supabase-dashboard.png)
 
-## 文檔
+監看此儲存庫的「Releases」，即可收到重大更新通知。
 
-有關完整的文檔，請訪問[supabase.com/docs](https://supabase.com/docs)
+<kbd><img src="https://raw.githubusercontent.com/supabase/supabase/d5f7f413ab356dc1a92075cb3cee4e40a957d5b1/web/static/watch-repo.gif" alt="監看此儲存庫"/></kbd>
 
-要了解如何貢獻，請訪問[入門](../DEVELOPERS.md)
+## 文件
 
-## 社群與支持
+如需完整文件，請造訪 [supabase.com/docs](https://supabase.com/docs)。
 
-- [社群論壇](https://github.com/supabase/supabase/discussions)。最適合：幫助構建，討論資料庫的數佳實踐。
-- [GitHub 問题](https://github.com/supabase/supabase/issues)。最適合：你在使用 Supabase 时遇到的 bug 和错误。
-- [電子郵件支持](https://supabase.com/docs/support#business-support)。最適合：你的資料庫或數據基礎設施的問題。
-- [Discord](https://discord.supabase.com)。最適合：分享你的應用程式並與社群一起玩耍。
+如需瞭解如何貢獻，請參閱[入門指南](../DEVELOPERS.md)。
 
-## 狀態
+## 社群與支援
 
-- [x] Alpha：我們正在與一组封閉的客户測試 Supabase。
-- [x] 公開 Alpha：任何人都可以在[supabase.com/dashboard](https://supabase.com/dashboard)上註冊。但請對我們寬容一些，有一些小問題。
-- [x] 公開測試版：足夠穩定，適合大多數非企業使用的情况。
-- [ ] 公開：普遍可用 [狀態](https://supabase.com/docs/guides/getting-started/features#feature-status)
+- [社群論壇](https://github.com/supabase/supabase/discussions)。適合尋求開發協助及討論資料庫最佳實務。
+- [GitHub Issues](https://github.com/supabase/supabase/issues)。適合回報使用 Supabase 時遇到的錯誤與問題。
+- [電子郵件支援](https://supabase.com/docs/support#business-support)。適合處理資料庫或基礎架構問題。
+- [Discord](https://discord.supabase.com)。適合分享應用程式及與社群交流。
 
-我們目前正處於公開測試階段。請關注此軟體的 "發布"，以獲得重大更新的通知。
+## 運作方式
 
-<kbd><img src="https://raw.githubusercontent.com/supabase/supabase/d5f7f413ab356dc1a92075cb3cee4e40a957d5b1/web/static/watch-repo.gif" alt="Watch this repo"/></kbd>
-
----
-
-### 它是如何運作的
-
-Supabase 是一個開源工具的组合。我們正在使用企業級的開源產品來構建 Firebase 的功能。如果這些工具和社群存在，並且有 MIT、Apache 2 或同等的開放許可，我們將使用並支持該工具。如果該工具不存在，我們就自己建立並開放原始碼。Supabase 不是 Firebase 的 1 對 1 映射。我們的目標是使用開源工具為開發者提供類似 Firebase 的開發者體驗。
+Supabase 由多項開源工具組成。我們使用企業級開源產品建構 Firebase 提供的各項功能。如果已有採用 MIT、Apache 2 或同等開放授權的工具與社群，我們就會使用並支援該工具；如果尚不存在，我們則自行建置並開放原始碼。Supabase 並非逐項對應 Firebase，而是以開源工具為開發者提供類似 Firebase 的開發體驗。
 
 **架構**
 
-Supabase 是一個[托管平台](https://supabase.com/dashboard)。你可以註冊並開始使用 Supabase，無需安裝任何東西。
-你也可以[自行托管](https://supabase.com/docs/guides/hosting/overview)和[本地開發](https://supabase.com/docs/guides/local-development)。
+Supabase 是[託管式平台](https://supabase.com/dashboard)。你不必安裝任何軟體，註冊後即可開始使用 Supabase。
+你也可以[自行託管](https://supabase.com/docs/guides/hosting/overview)，或[在本機開發](https://supabase.com/docs/guides/local-development)。
 
-![架構](https://github.com/supabase/supabase/blob/master/apps/docs/public/img/supabase-architecture.svg)
+![架構](../apps/docs/public/img/supabase-architecture.svg)
 
 - [PostgreSQL](https://www.postgresql.org/)是一個物件關係型資料庫系統，經過 30 多年的積極開發，它在可靠性、功能穩健性和性能方面赢得了良好的聲譽。
 - [Realtime](https://github.com/supabase/realtime)是一個 Elixir 服務器，允許你使用 websockets 監聽 PostgreSQL 的插入、更新和刪除。Realtime 對 Postgres 内置的複製功能進行投票，以了解資料庫的數位化，將變化轉换為 JSON，然后通過 websockets 將 JSON 廣播邊授權客户。
@@ -71,15 +61,15 @@ Supabase 是一個[托管平台](https://supabase.com/dashboard)。你可以註�
 
 #### 客户端庫
 
-我們對客户端庫的做法是模塊化的。每一個子庫都是一個獨立的實現，用於單一的外部系统。這是我們支持現有工具的方法之一。
+我們以模組化方式設計用戶端程式庫。每個子程式庫都是針對單一外部系統的獨立實作，讓 Supabase 能與既有工具搭配使用。
 
 <table style="table-layout:fixed; white-space: nowrap;">
   <tr>
     <th>語言</th>
-    <th>客户端</th>
-    <th colspan="5">特徵-客户端(捆绑在Supabase客户端中)</th>
+    <th>用戶端</th>
+    <th colspan="5">功能用戶端（隨 Supabase 用戶端一併提供）</th>
   </tr>
-  
+  <!-- notranslate -->
   <tr>
     <th></th>
     <th>Supabase</th>
@@ -100,9 +90,9 @@ Supabase 是一個[托管平台](https://supabase.com/dashboard)。你可以註�
     <td><a href="https://github.com/supabase-community/storage-lang" target="_blank" rel="noopener noreferrer">storage-lang</a></td>
   </tr>
   END ROW -->
-  
-  <th colspan="7">⚡️ 官方⚡️</th>
-  
+  <!-- /notranslate -->
+  <th colspan="7">⚡️ 官方 ⚡️</th>
+  <!-- notranslate -->
   <tr>
     <td>JavaScript (TypeScript)</td>
     <td><a href="https://github.com/supabase/supabase-js" target="_blank" rel="noopener noreferrer">supabase-js</a></td>
@@ -121,9 +111,27 @@ Supabase 是一個[托管平台](https://supabase.com/dashboard)。你可以註�
     <td><a href="https://github.com/supabase/storage-dart" target="_blank" rel="noopener noreferrer">storage-dart</a></td>
     <td><a href="https://github.com/supabase/functions-dart" target="_blank" rel="noopener noreferrer">functions-dart</a></td>
   </tr>
-  
-  <th colspan="7">💚社群 💚</th>
-  
+  <tr>
+    <td>Swift</td>
+    <td><a href="https://github.com/supabase/supabase-swift" target="_blank" rel="noopener noreferrer">supabase-swift</a></td>
+    <td><a href="https://github.com/supabase/supabase-swift/tree/main/Sources/PostgREST" target="_blank" rel="noopener noreferrer">postgrest-swift</a></td>
+    <td><a href="https://github.com/supabase/supabase-swift/tree/main/Sources/Auth" target="_blank" rel="noopener noreferrer">auth-swift</a></td>
+    <td><a href="https://github.com/supabase/supabase-swift/tree/main/Sources/Realtime" target="_blank" rel="noopener noreferrer">realtime-swift</a></td>
+    <td><a href="https://github.com/supabase/supabase-swift/tree/main/Sources/Storage" target="_blank" rel="noopener noreferrer">storage-swift</a></td>
+    <td><a href="https://github.com/supabase/supabase-swift/tree/main/Sources/Functions" target="_blank" rel="noopener noreferrer">functions-swift</a></td>
+  </tr>
+  <tr>
+    <td>Python</td>
+    <td><a href="https://github.com/supabase/supabase-py" target="_blank" rel="noopener noreferrer">supabase-py</a></td>
+    <td><a href="https://github.com/supabase/postgrest-py" target="_blank" rel="noopener noreferrer">postgrest-py</a></td>
+    <td><a href="https://github.com/supabase/gotrue-py" target="_blank" rel="noopener noreferrer">gotrue-py</a></td>
+    <td><a href="https://github.com/supabase/realtime-py" target="_blank" rel="noopener noreferrer">realtime-py</a></td>
+    <td><a href="https://github.com/supabase/storage-py" target="_blank" rel="noopener noreferrer">storage-py</a></td>
+    <td><a href="https://github.com/supabase/functions-py" target="_blank" rel="noopener noreferrer">functions-py</a></td>
+  </tr>
+  <!-- /notranslate -->
+  <th colspan="7">💚 社群 💚</th>
+  <!-- notranslate -->
   <tr>
     <td>C#</td>
     <td><a href="https://github.com/supabase-community/supabase-csharp" target="_blank" rel="noopener noreferrer">supabase-csharp</a></td>
@@ -155,19 +163,10 @@ Supabase 是一個[托管平台](https://supabase.com/dashboard)。你可以註�
     <td>Kotlin</td>
     <td><a href="https://github.com/supabase-community/supabase-kt" target="_blank" rel="noopener noreferrer">supabase-kt</a></td>
     <td><a href="https://github.com/supabase-community/supabase-kt/tree/master/Postgrest" target="_blank" rel="noopener noreferrer">postgrest-kt</a></td>
-    <td><a href="https://github.com/supabase-community/supabase-kt/tree/master/GoTrue" target="_blank" rel="noopener noreferrer">gotrue-kt</a></td>
+    <td><a href="https://github.com/supabase-community/supabase-kt/tree/master/Auth" target="_blank" rel="noopener noreferrer">auth-kt</a></td>
     <td><a href="https://github.com/supabase-community/supabase-kt/tree/master/Realtime" target="_blank" rel="noopener noreferrer">realtime-kt</a></td>
     <td><a href="https://github.com/supabase-community/supabase-kt/tree/master/Storage" target="_blank" rel="noopener noreferrer">storage-kt</a></td>
     <td><a href="https://github.com/supabase-community/supabase-kt/tree/master/Functions" target="_blank" rel="noopener noreferrer">functions-kt</a></td>
-  </tr>
-  <tr>
-    <td>Python</td>
-    <td><a href="https://github.com/supabase-community/supabase-py" target="_blank" rel="noopener noreferrer">supabase-py</a></td>
-    <td><a href="https://github.com/supabase-community/postgrest-py" target="_blank" rel="noopener noreferrer">postgrest-py</a></td>
-    <td><a href="https://github.com/supabase-community/gotrue-py" target="_blank" rel="noopener noreferrer">gotrue-py</a></td>
-    <td><a href="https://github.com/supabase-community/realtime-py" target="_blank" rel="noopener noreferrer">realtime-py</a></td>
-    <td><a href="https://github.com/supabase-community/storage-py" target="_blank" rel="noopener noreferrer">storage-py</a></td>
-    <td><a href="https://github.com/supabase-community/functions-py" target="_blank" rel="noopener noreferrer">functions-py</a></td>
   </tr>
   <tr>
     <td>Ruby</td>
@@ -188,73 +187,56 @@ Supabase 是一個[托管平台](https://supabase.com/dashboard)。你可以註�
     <td>-</td>
   </tr>
   <tr>
-    <td>Swift</td>
-    <td><a href="https://github.com/supabase-community/supabase-swift" target="_blank" rel="noopener noreferrer">supabase-swift</a></td>
-    <td><a href="https://github.com/supabase-community/postgrest-swift" target="_blank" rel="noopener noreferrer">postgrest-swift</a></td>
-    <td><a href="https://github.com/supabase-community/gotrue-swift" target="_blank" rel="noopener noreferrer">gotrue-swift</a></td>
-    <td><a href="https://github.com/supabase-community/realtime-swift" target="_blank" rel="noopener noreferrer">realtime-swift</a></td>
-    <td><a href="https://github.com/supabase-community/storage-swift" target="_blank" rel="noopener noreferrer">storage-swift</a></td>
-    <td><a href="https://github.com/supabase-community/functions-swift" target="_blank" rel="noopener noreferrer">functions-swift</a></td>
-  </tr>
-  <tr>
     <td>Godot Engine (GDScript)</td>
     <td><a href="https://github.com/supabase-community/godot-engine.supabase" target="_blank" rel="noopener noreferrer">supabase-gdscript</a></td>
-    <td><a href="https://github.com/supabase-community/postgrest-gdscript" target="_blank" rel="noopener noreferrer">postgrest-gdscript</a></td>
-    <td><a href="https://github.com/supabase-community/gotrue-gdscript" target="_blank" rel="noopener noreferrer">gotrue-gdscript</a></td>
-    <td><a href="https://github.com/supabase-community/realtime-gdscript" target="_blank" rel="noopener noreferrer">realtime-gdscript</a></td>
-    <td><a href="https://github.com/supabase-community/storage-gdscript" target="_blank" rel="noopener noreferrer">storage-gdscript</a></td>
-    <td><a href="https://github.com/supabase-community/functions-gdscript" target="_blank" rel="noopener noreferrer">functions-gdscript</a></td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
   </tr>
-  
+  <!-- /notranslate -->
 </table>
 
 <!--- Remove this list if you're translating to another language, it's hard to keep updated across multiple files-->
 <!--- Keep only the link to the list of translation files-->
 
+## 徽章
+
+![Made with Supabase](../apps/www/public/badge-made-with-supabase.svg)
+
+```md
+[![Made with Supabase](https://supabase.com/badge-made-with-supabase.svg)](https://supabase.com)
+```
+
+```html
+<a href="https://supabase.com">
+  <img
+    width="168"
+    height="30"
+    src="https://supabase.com/badge-made-with-supabase.svg"
+    alt="Made with Supabase"
+  />
+</a>
+```
+
+![Made with Supabase (dark)](../apps/www/public/badge-made-with-supabase-dark.svg)
+
+```md
+[![Made with Supabase](https://supabase.com/badge-made-with-supabase-dark.svg)](https://supabase.com)
+```
+
+```html
+<a href="https://supabase.com">
+  <img
+    width="168"
+    height="30"
+    src="https://supabase.com/badge-made-with-supabase-dark.svg"
+    alt="Made with Supabase"
+  />
+</a>
+```
+
 ## 翻譯
 
-- [阿拉伯語| العربية](/i18n/README.ar.md)
-- [Albanian / Shqip](/i18n/README.sq.md)
-- [Bangla / বাংল](/i18n/README.bn.md)
-- [Bulgarian / Български](/i18n/README.bg.md)
-- [Catalan / Català](/i18n/README.ca.md)
-- [Danish / Dansk](/i18n/README.da.md)
-- [荷蘭語 / Nederlands](/i18n/README.nl.md)
-- [英語](https://github.com/supabase/supabase)
-- [芬蘭語/Suomalainen](/i18n/README.fi.md)
-- [法語/Français](/i18n/README.fr.md)
-- [德語/Deutsch](/i18n/README.de.md)
-- [希臘語 / Ελληνικά](/i18n/README.gr.md)
-- [Hebrew / עברית](/i18n/README.he.md)
-- [Hindi / हिंद](/i18n/README.hi.md)
-- [匈牙利語/馬扎爾語](/i18n/README.hu.md)
-- [尼泊爾語 / नेपाली](/i18n/README.ne.md)
-- [印尼語/印度尼西亞語](/i18n/README.id.md)
-- [意大利語/Italiano](/i18n/README.it.md)
-- [日語 / 日本語](/i18n/README.jp.md)
-- [韓語 / 한국어](/i18n/README.ko.md)
-- [Malay / Bahasa Malaysia](/i18n/README.ms.md)
-- [Norwegian (Bokmål) / Norsk (Bokmål)](/i18n/README.nb-no.md)
-- [Persian / فارسی](/i18n/README.fa.md)
-- [Polish / Polski](/i18n/README.pl.md)
-- [葡萄牙語 / Português](/i18n/README.pt.md)
-- [葡萄牙語(巴西)/Português Brasileiro](/i18n/README.pt-br.md)
-- [Romanian / Română](/i18n/README.ro.md)
-- [俄語 / Pусский](/i18n/README.ru.md)
-- [塞爾維亞語 / Srpski](/i18n/README.sr.md)
-- [Sinhala / සිංහල](/i18n/README.si.md)
-- [西班牙語 / Español](/i18n/README.es.md)
-- [Simplified Chinese / 簡體中文](/i18n/README.zh-cn.md)
-- [瑞典語 / Svenska](/i18n/README.sv.md)
-- [泰文 / ไทย](/i18n/README.th.md)
-- [Traditional Chinese / 繁體中文](/i18n/README.zh-tw.md)
-- [土耳其語 / Türkçe](/i18n/README.tr.md)
-- [烏克蘭語 / Українська](/i18n/README.uk.md)
-- [越南語/Tiếng Việt](/i18n/README.vi-vn.md)
-- [翻譯列表](/i18n/languages.md)<!--- Keep only this -->
-
----
-
-## 贊助商
-
-[![新贊助商](https://user-images.githubusercontent.com/10214025/90518111-e74bbb00-e198-11ea-8f88-c9e3c1aa4b5b.png)](https://github.com/sponsors/supabase)
+- [翻譯列表](/i18n/languages.md) <!--- Keep only this -->


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

A Traditional Chinese documentation and localization update.

## What is the current behavior?

The Traditional Chinese README has drifted from the current English source and still contains several objectively outdated items:

- the old product description, obsolete API anchors, and no AI/vector toolkit entry
- a public-beta status section that was removed from the source README in 2023
- mixed Simplified Chinese wording and mistranslated support copy
- an outdated client-library matrix that lists Swift and Python as community clients, uses the old Kotlin GoTrue path, and links to component repositories that no longer appear in the current Godot row
- no current Supabase badges, an obsolete sponsor section, and a duplicated translation list despite the source instruction to keep only the canonical list link

## What is the new behavior?

- Synchronizes the product summary, feature checklist, documentation links, release-watch guidance, support copy, hosting guidance, and architecture image with the current source.
- Uses established Traditional Chinese terminology for Taiwan readers.
- Removes the obsolete beta status and sponsor content.
- Synchronizes the client-library table with the English source, including official Swift and Python clients and the current Kotlin/Godot entries.
- Adds the current light and dark Supabase badges.
- Replaces the duplicated language list with the canonical translations index, as instructed by the source comment.

## Additional context

Open PR #48626 already corrects the GoTrue repository URL and SWT/JWT acronym in this file. To avoid duplicating or conflicting with that work, this PR intentionally leaves its entire surrounding architecture-component hunk unchanged. I verified that #48626 still applies cleanly on top of this branch.

Validation performed:

- Prettier 3.8.0 check with the repository's formatting options
- git diff --check
- GitHub GFM API render, including headings, table, architecture image, and both badges
- exact client-table structure and URL parity against the current English README
- existence checks for every newly referenced repository-local file
- all 979 open PRs inspected by changed file; #48626 is the only PR touching this file

AI assistance disclosure: Codex assisted with repository auditing, initial translation drafting, and structural validation. I reviewed the final wording against the current English source and Traditional Chinese usage in Taiwan.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Traditional Chinese Supabase README with clearer wording, refreshed links, and revised feature descriptions.
  * Expanded documentation on architecture, support resources, badges, and translation references.
  * Updated the client-library overview to include Swift, Python, Kotlin `auth-kt`, and community Godot support.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->