### PR TITLE
Add optional title field to notebook cells

### DIFF
--- a/apps/studio/data/content/notebooks/notebook-schema.ts
+++ b/apps/studio/data/content/notebooks/notebook-schema.ts
@@ -45,6 +45,7 @@ const markdownCellSchema = z.object({
 const databaseCellSchema = z.object({
   _tag: z.literal('database_cell'),
   id: z.string(),
+  title: z.string().optional(),
   sql: z.string(),
   row_limit: z.number(),
   chart: chartConfigSchema.optional(),
@@ -53,6 +54,7 @@ const databaseCellSchema = z.object({
 const logCellSchema = z.object({
   _tag: z.literal('log_cell'),
   id: z.string(),
+  title: z.string().optional(),
   sql: z.string(),
   time_range: timeRangeSchema,
   chart: chartConfigSchema.optional(),


### PR DESCRIPTION
## Summary

- Adds optional `title` field to `databaseCellSchema` and `logCellSchema` in notebook schema
- Allows database and logs notebook cells to carry descriptive titles
- Field automatically propagates through derived schemas (wire, writable, agent, domain) via Zod inheritance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional titles to database and log notebook cells.
  * Cell titles are now preserved across notebook editing, viewing, and agent workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->