### PR TITLE
fix(www): point Infinite Query announcement at its live docs page

### DIFF
--- a/apps/www/components/Wrapped/Pages/ProductAnnouncements.tsx
+++ b/apps/www/components/Wrapped/Pages/ProductAnnouncements.tsx
@@ -144,7 +144,7 @@ const months: Month[] = [
       },
       {
         title: 'Supabase UI Library now includes Infinite Query block',
-        url: 'https://supabase.com/library/docs/infinite-query-hook',
+        url: 'https://supabase.com/library/docs/react/infinite-query',
       },
       {
         title: 'Supabase UI Library now includes Social Auth',


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix (broken link on the Wrapped product announcements page).

## What is the current behavior?

`ProductAnnouncements.tsx` links the "Supabase UI Library now includes Infinite Query block" entry to `https://supabase.com/library/docs/infinite-query-hook`, which returns 404.

The docs page for that block is framework scoped, and the slug does not carry the `-hook` suffix. The content only exists for two frameworks:

| URL | status |
| --- | --- |
| `/library/docs/infinite-query-hook` (current) | 404 |
| `/library/docs/react/infinite-query` | 200 |
| `/library/docs/vue/infinite-query` | 200 |
| `/library/docs/nextjs/infinite-query` | 404 |

Those two match the content tree exactly, `apps/ui-library/content/docs/{react,vue}/infinite-query.mdx`, and there is no `nextjs` variant.

## What is the new behavior?

The entry points at `/library/docs/react/infinite-query`, confirmed 200.

I picked React rather than Vue deliberately. That page is the original, added in #34650 ("Infinite query hook block"), and its front matter is `title: Infinite Query Hook` with `description: React hook for infinite lists, fetching data from Supabase`, which is what the announcement is describing. Vue and Nuxt came later in #44426. The `-hook` in the old URL matches the registry item name (`<RegistryBlock itemName="infinite-query-hook" />`), not the docs slug, which is probably how the two drifted apart.

## Additional context

This one was already stale before the recent rename. #48668 moved `/ui` to `/library` and rewrote this line mechanically from `/ui/docs/infinite-query-hook` to `/library/docs/infinite-query-hook`, so the dead path was carried across rather than introduced. Both spellings 404 today, so it reproduces on current master either way.

The rename itself looks correct, and I checked rather than assumed:

- every other `/library` URL referenced anywhere in the repo returns 200, including the sibling `nextjs/social-auth` entry immediately below this one
- the two specific `/ui/docs/ai-editors-rules/*` redirects sit above the new `/ui/:path*` catch all in `redirects.js`, so first match wins keeps them working
- `https://supabase.com/library/docs` also 404s, but that is a `BASE_URL` constant in the two `build-llms-txt.ts` scripts that gets concatenated with a page path, not a link anyone follows, so I left it alone

One file, one line.

Verification: every status code above was checked against production, including a deliberate nonsense URL to confirm the check was actually running. Gates on this branch: `test:prettier` passes repo wide, `typecheck --filter=www --force` passes 8/8, the www vitest suite passes (6 files, 74 tests), and `next.config.test.ts` passes. I did not run `pnpm build`, which cannot finish in my environment because the docs `build:federated-content` step needs `DOCS_GITHUB_APP_PRIVATE_KEY`.

Freshman contributor here. Found this with Claude Code's help while checking the URLs touched by the `/ui` to `/library` rename, and I verified every status code and the page history myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the April 2025 Infinite Query announcement link to point to the React-specific documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->