### PR TITLE
fix(studio): keep the new SQL editor tab from being pruned on first keystroke

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/useSnippetEditor.test.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/useSnippetEditor.test.tsx
@@ -1,0 +1,56 @@
+import { act, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { useSnippetEditor } from './useSnippetEditor'
+import { sqlEditorState } from '@/state/sql-editor/sql-editor-state'
+import { createMockProfileContext } from '@/tests/lib/profile-helpers'
+import {
+  renderSqlEditorHook,
+  resetSqlEditorStores,
+  seedSnippet,
+  setupSqlEditorMocks,
+} from '@/tests/lib/sql-editor-test-utils'
+
+const PROFILE_CONTEXT = createMockProfileContext()
+
+describe('useSnippetEditor', () => {
+  beforeEach(() => {
+    resetSqlEditorStores()
+    setupSqlEditorMocks()
+  })
+
+  it('writing in a newly opened tab does not overwrite an already-open tab', async () => {
+    seedSnippet({ id: 'existing-tab', sql: 'select existing;' })
+
+    // Mount the editor for the already-open tab, mirroring the keyed
+    // MonacoEditor mount for that snippet id, then unmount it the way opening
+    // a new tab would (the `key={id}` wrapper swaps to a brand new instance).
+    const first = renderSqlEditorHook(useSnippetEditor, {
+      initialProps: { id: 'existing-tab', snippetName: 'Existing tab' },
+      profileContext: PROFILE_CONTEXT,
+    })
+    await waitFor(() => expect(first.result.current.snippet).toBeDefined())
+    first.unmount()
+
+    // Mount a fresh instance for a brand new tab, as clicking "+" would.
+    const second = renderSqlEditorHook(useSnippetEditor, {
+      initialProps: { id: 'new-tab-id', snippetName: 'New query' },
+      profileContext: PROFILE_CONTEXT,
+    })
+
+    // `handleEditorChange` only creates the new snippet once the project has
+    // loaded, so retry the keystroke until that happens.
+    await waitFor(() => {
+      act(() => {
+        second.result.current.handleEditorChange('select typed content;')
+      })
+      expect(sqlEditorState.snippets['new-tab-id']?.snippet.content?.unchecked_sql).toContain(
+        'typed content'
+      )
+    })
+
+    expect(sqlEditorState.snippets['existing-tab'].snippet.content?.unchecked_sql).toContain(
+      'select existing'
+    )
+  })
+})

--- a/apps/studio/components/interfaces/SQLEditor/useSnippetIdentity.route-change.test.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/useSnippetIdentity.route-change.test.tsx
@@ -1,0 +1,59 @@
+import { act, waitFor } from '@testing-library/react'
+import mockRouter from 'next-router-mock'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useSnippetIdentity } from './useSnippetIdentity'
+import {
+  renderSqlEditorHook,
+  resetSqlEditorStores,
+  seedSnippet,
+} from '@/tests/lib/sql-editor-test-utils'
+
+// `common`'s `useParams` is globally stubbed (see tests/vitestSetup.ts) to a
+// constant `{ ref: 'default' }` so most tests don't have to think about
+// routing. This suite is specifically about behavior across route changes, so
+// it swaps in the real implementation (still backed by the `next-router-mock`
+// router the rest of the app is wired to in tests).
+vi.mock('common', async (importOriginal) => {
+  const actual = (await importOriginal()) as object
+  return { ...actual }
+})
+
+describe('useSnippetIdentity across route changes', () => {
+  beforeEach(() => {
+    resetSqlEditorStores()
+    mockRouter.setCurrentUrl('/project/default/sql/existing-tab')
+  })
+
+  it('generates a fresh id for each new tab, never reusing the previous one', async () => {
+    seedSnippet({ id: 'existing-tab', sql: 'select existing;' })
+
+    const { result } = renderSqlEditorHook(useSnippetIdentity)
+
+    await waitFor(() => expect(result.current.id).toEqual('existing-tab'))
+
+    // Click "+" to open a new tab.
+    await act(async () => {
+      await mockRouter.push('/project/default/sql/new?skip=true')
+    })
+    const firstNewTabId = result.current.id
+    expect(firstNewTabId).not.toEqual('existing-tab')
+
+    // Typing in the new tab creates its snippet and shallow-navigates to it
+    // (mirrors the `router.push` inside `useSnippetEditor.handleEditorChange`).
+    seedSnippet({ id: firstNewTabId, sql: 'select typed content;' })
+    await act(async () => {
+      await mockRouter.push(`/project/default/sql/${firstNewTabId}`)
+    })
+    await waitFor(() => expect(result.current.id).toEqual(firstNewTabId))
+
+    // Click "+" again to open a second new tab.
+    await act(async () => {
+      await mockRouter.push('/project/default/sql/new?skip=true')
+    })
+    const secondNewTabId = result.current.id
+
+    expect(secondNewTabId).not.toEqual(firstNewTabId)
+    expect(secondNewTabId).not.toEqual('existing-tab')
+  })
+})

--- a/apps/studio/components/layouts/Tabs/Tabs.utils.test.tsx
+++ b/apps/studio/components/layouts/Tabs/Tabs.utils.test.tsx
@@ -1,9 +1,11 @@
 import { act, renderHook } from '@testing-library/react'
 import type { ReactNode } from 'react'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 
 import { useSqlEditorTabsCleanup } from './Tabs.utils'
+import { sqlEditorState } from '@/state/sql-editor/sql-editor-state'
 import { createTabsState, TabsStateContext, type Tab } from '@/state/tabs'
+import { seedSnippet } from '@/tests/lib/sql-editor-test-utils'
 
 const dbTab = (id: string): Tab => ({
   id: `sql-${id}`,
@@ -29,6 +31,28 @@ function renderCleanup(store: ReturnType<typeof createTabsState>) {
 }
 
 describe('useSqlEditorTabsCleanup', () => {
+  afterEach(() => {
+    for (const key of Object.keys(sqlEditorState.snippets)) delete sqlEditorState.snippets[key]
+  })
+
+  it('keeps the tab of a locally-created snippet that has not been persisted yet', () => {
+    const store = createTabsState('default')
+    store.addTab(dbTab('existing'))
+    store.addTab(dbTab('brand-new'))
+
+    // A snippet created by typing in a new tab: it lives in the local store with
+    // a never-persisted status, but the server-fetched snippet list can't know
+    // about it yet.
+    seedSnippet({ id: 'brand-new', name: 'Untitled query', sql: 'select 1;' })
+
+    const cleanup = renderCleanup(store)
+    act(() => cleanup({ snippets: [{ id: 'existing', type: 'sql', name: 'existing' }] }))
+
+    expect(store.tabsMap['sql-brand-new']).toBeDefined()
+    expect(store.openTabs).toContain('sql-brand-new')
+    expect(store.activeTab).toEqual('sql-brand-new')
+  })
+
   it('prunes tabs for deleted snippets (database and logs) while keeping live ones', () => {
     const store = createTabsState('default')
     store.addTab(dbTab('db-stale'))

--- a/apps/studio/components/layouts/Tabs/Tabs.utils.ts
+++ b/apps/studio/components/layouts/Tabs/Tabs.utils.ts
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useRef } from 'react'
 
 import { Entity } from '@/data/entity-types/entity-types-infinite-query'
 import { useLatest } from '@/hooks/misc/useLatest'
+import { wasNeverPersisted } from '@/state/sql-editor/sql-editor-lifecycle'
+import { getSqlEditorV2StateSnapshot } from '@/state/sql-editor/sql-editor-state'
 import { createTabId, editorEntityTypes, useTabsStateSnapshot } from '@/state/tabs'
 
 export function useTableEditorTabsCleanUp() {
@@ -91,9 +93,20 @@ export function useSqlEditorTabsCleanup() {
         ...IGNORED_TAB_IDS,
       ]
 
+      // A snippet created during this session (by typing in a new tab) exists only
+      // in the local store until its first save lands, so the server-fetched list
+      // legitimately doesn't contain it yet. Without this, invalidating the snippet
+      // lists on that first keystroke prunes the tab that was just opened — the URL
+      // and editor stay on the new snippet while the tab bar falls back to whichever
+      // tab was open before, making it look like the previous tab is being edited.
+      const localSnippets = getSqlEditorV2StateSnapshot().snippets
+      const isUnpersistedLocalSnippet = (sqlId: string | undefined) =>
+        sqlId !== undefined && wasNeverPersisted(localSnippets[sqlId]?.snippet.status)
+
       const isPrunable = (id: string) =>
         id.startsWith('sql') &&
         !currentContentIds.includes(id) &&
+        !isUnpersistedLocalSnippet(tabMapRef.current[id]?.metadata?.sqlId) &&
         (canPruneLogsTabs || tabMapRef.current[id]?.metadata?.sqlSource !== 'logs')
 
       // Remove any snippet tabs that might no longer be existing (removed outside of the dashboard session)
@@ -108,6 +121,7 @@ export function useSqlEditorTabsCleanup() {
               .filter(
                 (item) =>
                   !currentContentIds.includes(item.id) &&
+                  !isUnpersistedLocalSnippet(item.metadata?.sqlId) &&
                   (canPruneLogsTabs || item.metadata?.sqlSource !== 'logs')
               )
               .map((item) => item.id)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

With a snippet already open in the SQL Editor, clicking the `+` button and typing in the new tab made it look like the previously open tab was being taken over: the tab bar showed the *old* snippet's name while the editor showed the newly typed content. With several tabs open, the rightmost one appeared to be the one taken over.

`useSqlEditorTabsCleanup` prunes any `sql-*` tab whose snippet is absent from the server-fetched snippet list, so tabs for snippets deleted in another session don't linger. But a snippet created by typing in a new tab exists only in the local store until its first save lands, so it is legitimately absent from that list — and the same keystroke that creates it calls `setSql({ shouldInvalidate: true })`, invalidating the snippet lists and triggering a refetch that pruned the tab that had just been opened.

`removeTab` then reassigns `activeTab` to a neighbor, so the tab bar fell back to whichever tab was open before, while the URL, sidebar, and editor content all stayed correctly on the new snippet — none of them read from the tabs store.

Confirmed from a user's persisted tab state, which showed a single tab in `openTabs` pointing at the previous snippet while the URL pointed at the new one.

No snippet content was ever lost — this was tab state only.

## What is the new behavior?

Tabs (and recent items) whose snippet is present in the local store with a never-persisted status (`new`, `new_saving`, `new_save_failed`) are preserved by the cleanup pass. Genuine stale-tab pruning for snippets removed outside the session is unaffected.

## Additional context

The regression test in `Tabs.utils.test.tsx` fails without the fix (`expected undefined to be defined`) and passes with it. The pre-existing pruning tests still pass, confirming legitimate cleanup still works.

Also adds two tests covering adjacent invariants that were verified while narrowing this down: snippet content isolation between tabs, and unique snippet id generation across `/sql/new` navigations.

Verified: 343 tests pass across `components/layouts/Tabs` and `components/interfaces/SQLEditor`; typecheck clean; ESLint warning count unchanged (ratchet safe); Prettier clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved newly created SQL editor tabs and recent items before their first save.
  - Prevented unsaved snippets from being removed during tab cleanup.
  - Ensured editing a new tab does not overwrite content in existing tabs.
  - Ensured successive new SQL tabs receive distinct identities.

- **Tests**
  - Added regression coverage for snippet editing, route changes, and tab cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->