### PR TITLE
fix(docker): use correct slash separator for postgres image prefix in utility scripts

### DIFF
--- a/docker/utils/db-passwd.sh
+++ b/docker/utils/db-passwd.sh
@@ -41,7 +41,7 @@ new_passwd="$(openssl rand -hex 16)"
 # new_passwd="d0notUseSpecialSymbolsForPq123-"
 
 # Check Postgres service
-db_image_prefix="supabase.postgres:"
+db_image_prefix="supabase/postgres:"
 
 compose_output=$(docker compose ps \
   --format '{{.Image}}\t{{.Service}}\t{{.Status}}' 2>/dev/null | \

--- a/docker/utils/reassign-owner.sh
+++ b/docker/utils/reassign-owner.sh
@@ -20,7 +20,7 @@ if ! docker compose version >/dev/null 2>&1; then
 fi
 
 # Check Postgres service
-db_image_prefix="supabase.postgres:"
+db_image_prefix="supabase/postgres:"
 
 compose_output=$(docker compose ps \
     --format '{{.Image}}\t{{.Service}}\t{{.Status}}' 2>/dev/null |


### PR DESCRIPTION
# What is the purpose of this Pull Request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other: 

## Description

Hey team, noticed a small bug where the `db-passwd.sh` and `reassign-owner.sh` utility scripts are failing to find the Postgres container on self-hosted setups.

It looks like the `docker compose ps` command in these scripts uses `--format '{{.Image}}'`, which outputs the canonical image name with a slash (e.g., `supabase/postgres:17.6.1.136`). However, the `db_image_prefix` variable being grepped against was still using a dot (`supabase.postgres:`). This mismatch causes the scripts to instantly exit without doing anything.

I just updated the prefix string in both scripts to use the correct slash separator so they can properly detect the container again.

## Testing

Tested locally against a fresh self-hosted stack.

**Before:**
```bash
$ sh utils/db-passwd.sh
Postgres container not found. Exiting.
```

**After:**
```bash
$ sh utils/db-passwd.sh

*** Check configuration below before updating database passwords! ***

Service name: supabase-db
Service status: Up 2 minutes
Service port (.env): 5432
Image: supabase/postgres:17.6.1.136

Admin user: supabase_admin
New database password: <hidden>

Update database passwords? (y/N) 
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected database container detection in password and ownership utility scripts.
  - Database-related maintenance commands now reliably locate the PostgreSQL container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->