### PR TITLE
fix(e2e): install e2e-shared when CI filters to a single suite

### DIFF
--- a/e2e/docs/package.json
+++ b/e2e/docs/package.json
@@ -12,7 +12,8 @@
     "resolve-docs-scope": "node --experimental-strip-types scripts/resolve-docs-scope.ts"
   },
   "dependencies": {
-    "@playwright/test": "^1.59.1"
+    "@playwright/test": "^1.59.1",
+    "e2e-shared": "workspace:*"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.12.1",

--- a/e2e/www/package.json
+++ b/e2e/www/package.json
@@ -8,7 +8,8 @@
     "e2e:www:all": "node --experimental-strip-types scripts/run-e2e-www.ts --all"
   },
   "dependencies": {
-    "@playwright/test": "^1.59.1"
+    "@playwright/test": "^1.59.1",
+    "e2e-shared": "workspace:*"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.12.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2023,6 +2023,9 @@ importers:
       '@playwright/test':
         specifier: ^1.59.1
         version: 1.59.1
+      e2e-shared:
+        specifier: workspace:*
+        version: link:../shared
     devDependencies:
       '@axe-core/playwright':
         specifier: ^4.12.1
@@ -2083,6 +2086,9 @@ importers:
       '@playwright/test':
         specifier: ^1.59.1
         version: 1.59.1
+      e2e-shared:
+        specifier: workspace:*
+        version: link:../shared
     devDependencies:
       '@axe-core/playwright':
         specifier: ^4.12.1


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix. Unblocks the WWW E2E check on `master`.

## What is the current behavior?

The WWW E2E job fails before running any test:

```
Error: Cannot find package '@axe-core/playwright' imported from /home/runner/_work/supabase/supabase/e2e/shared/axe.ts
Error: No tests found
```

Both E2E workflows install with a filter:

```
pnpm install --frozen-lockfile --filter=e2e-www...
```

The `...` suffix pulls in a package's declared dependencies. Neither `e2e-www` nor `e2e-docs` declared `e2e-shared`; both reach it through relative imports such as `../../shared/axe.ts`, which pnpm's dependency graph cannot see. So the filter selected one project, `e2e/shared/node_modules` was never created, and Node resolving `@axe-core/playwright` from `e2e/shared/axe.ts` walked up to a root that does not carry it under pnpm's isolated layout.

`e2e-docs` is broken the same way. It had not run against the shared module yet, so it has not gone red.

## What is the new behavior?

`e2e-shared` is declared as a workspace dependency of both suites, so the filter installs it.

| | Filter scope | Importing `e2e/shared/axe.ts` |
| --- | --- | --- |
| Before | 1 of 28 projects | `Cannot find package '@axe-core/playwright'` |
| After | 2 of 28 projects | Imports cleanly |

The lockfile gains two `link:../shared` entries and no new downloads.

## Manual Testing

1. Check out this branch and delete the shared package's modules: `rm -rf e2e/shared/node_modules`
2. Run the command CI runs: `pnpm install --frozen-lockfile --filter=e2e-www...`
3. Confirm the output reports `Scope: 2 of 28 workspace projects` and that `e2e/shared/node_modules` exists again.
4. Repeat steps 1 - 3 with `--filter=e2e-docs...`.

## Additional context

Fixing only the workflow lines, by adding a second `--filter=e2e-shared`, would work as well. Declaring the dependency was chosen instead because the dependency is real and every consumer of the filter gets it, not just the two workflow files.

The imports stay relative. Declaring the workspace dependency is enough to get the package installed, so no import paths change in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated end-to-end test packages to use shared testing utilities at runtime.
  * Improved consistency between documentation and website test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->