### PR TITLE
Add Studio Explorer query renderers

### DIFF
--- a/apps/studio/.claude/skills/explorer/SKILL.md
+++ b/apps/studio/.claude/skills/explorer/SKILL.md
@@ -78,3 +78,86 @@ Use `ExplorerQueryViewport` when a query owns the content area of an Explorer ta
 - A result renderer that can grow supplies its own `min-h-0 flex-1 overflow-auto` container.
 - The shell owns layout only. Query models, source resolution, execution, results, display selection, and saved configuration stay controlled by the consumer.
 - Compose approval prompts, confirmation notices, and other surface-specific content as children between the standard regions.
+
+## Query editor and results
+
+The query renderers are separate Studio components so the consuming notebook, chat block, or snippet adapter chooses what to compose:
+
+```tsx
+import type {
+  QueryResultChartConfig,
+  QueryResultData,
+  QueryResultTableConfig,
+} from '@/components/interfaces/Explorer/ExplorerQuery'
+import { QueryResultChart } from '@/components/interfaces/Explorer/QueryResultChart'
+import { QueryResultTable } from '@/components/interfaces/Explorer/QueryResultTable'
+import { QuerySqlEditor } from '@/components/interfaces/Explorer/QuerySqlEditor'
+```
+
+### SQL editor
+
+`QuerySqlEditor` is controlled and source-agnostic:
+
+```tsx
+<QuerySqlEditor
+  value={sql}
+  onValueChange={setSql}
+  onExecute={(selectedOrFullSql) => execute(sourceId, selectedOrFullSql)}
+/>
+```
+
+- `onExecute` receives the selected SQL, or the full document when there is no selection.
+- The editor never resolves a source, sends a request, stores SQL, or stores execution state.
+- Use the caller-owned `value`, loading state, and result state to connect it to a notebook, chat, or snippet model.
+- The default editor spacing is compact and balanced; pass Monaco `options` only for a surface-specific requirement.
+
+### Result data
+
+Both result renderers use a source-neutral `QueryResultData` contract with explicit columns:
+
+```tsx
+const data: QueryResultData = {
+  columns: [
+    { key: 'week', dataType: 'date', width: 180 },
+    { key: 'signups', dataType: 'int8', align: 'right' },
+  ],
+  rows: [{ week: '2026-08-10', signups: 172 }],
+}
+```
+
+Explicit columns preserve schema, order, labels, source types, and widths when a successful query returns no rows.
+
+### Table
+
+```tsx
+<QueryResultTable data={data} config={tableConfig} onConfigChange={setTableConfig} />
+```
+
+The table is virtualized and intentionally dense. Column widths are controlled through `config`; the consumer decides whether and where to persist them.
+
+### Chart
+
+```tsx
+<QueryResultChart
+  data={data}
+  config={{ type: 'bar', xKey: 'week', yKey: 'signups', showGrid: true }}
+/>
+```
+
+Charts support bar and line displays plus cumulative, grid, label, log-scale, and color configuration. Keep chart configuration controlled and persist it with the surrounding query model when needed.
+
+### Display ownership
+
+The query shell does not choose a result display:
+
+```tsx
+<ExplorerQueryResults>
+  {display.kind === 'chart' ? (
+    <QueryResultChart data={resultData} config={display.config} />
+  ) : (
+    <QueryResultTable data={resultData} config={display.config} />
+  )}
+</ExplorerQueryResults>
+```
+
+The consumer owns the display choice and can add JSON, logs, explain-plan, or future result views without changing `ExplorerQuery`.

--- a/apps/studio/components/interfaces/Explorer/ExplorerQuery/ExplorerQuery.types.ts
+++ b/apps/studio/components/interfaces/Explorer/ExplorerQuery/ExplorerQuery.types.ts
@@ -1,0 +1,50 @@
+export type QueryResultColumn = {
+  /** Stable key used to read this column from each result row. */
+  key: string
+  /** Optional display label. Defaults to `key`. */
+  label?: string
+  /** Source-provided type metadata, such as `int8`, `timestamp`, or `json`. */
+  dataType?: string
+  /** Preferred initial width in pixels. */
+  width?: number
+  /** Minimum resizable width in pixels. */
+  minWidth?: number
+  align?: 'left' | 'right'
+}
+
+export type QueryResultRow = Readonly<Record<string, unknown>>
+
+/**
+ * Source-neutral result data. Columns are explicit so an empty result can still
+ * preserve its schema, order, labels, and types.
+ */
+export type QueryResultData = {
+  columns: readonly QueryResultColumn[]
+  rows: readonly QueryResultRow[]
+}
+
+export type QueryResultState =
+  | { status: 'idle' }
+  | { status: 'running' }
+  | { status: 'success'; data: QueryResultData }
+  | { status: 'error'; error: string }
+
+export type QueryResultTableConfig = {
+  columnWidths?: Readonly<Record<string, number>>
+}
+
+export type QueryResultChartConfig = {
+  type: 'bar' | 'line'
+  xKey: string
+  yKey: string
+  cumulative?: boolean
+  showGrid?: boolean
+  showLabels?: boolean
+  logScale?: boolean
+  color?: string
+}
+
+/** Persisted display choice owned by the ExplorerQuery consumer. */
+export type QueryDisplay =
+  | { kind: 'table'; config?: QueryResultTableConfig }
+  | { kind: 'chart'; config: QueryResultChartConfig }

--- a/apps/studio/components/interfaces/Explorer/ExplorerQuery/index.tsx
+++ b/apps/studio/components/interfaces/Explorer/ExplorerQuery/index.tsx
@@ -78,6 +78,16 @@ const ExplorerQueryFooter = ({ className, ...props }: ExplorerQueryFooterProps) 
 )
 ExplorerQueryFooter.displayName = 'ExplorerQueryFooter'
 
+export type {
+  QueryDisplay,
+  QueryResultChartConfig,
+  QueryResultColumn,
+  QueryResultData,
+  QueryResultRow,
+  QueryResultState,
+  QueryResultTableConfig,
+} from './ExplorerQuery.types'
+
 export {
   ExplorerQuery,
   ExplorerQueryEditor,

--- a/apps/studio/components/interfaces/Explorer/QueryResultChart/QueryResultChart.test.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryResultChart/QueryResultChart.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { QueryResultData } from '../ExplorerQuery/ExplorerQuery.types'
+import { QueryResultChart } from './index'
+
+const data: QueryResultData = {
+  columns: [
+    { key: 'week', dataType: 'date' },
+    { key: 'count', label: 'Total count', dataType: 'int8' },
+  ],
+  rows: [
+    { week: '2026-08-03', count: '0' },
+    { week: '2026-08-10', count: '12' },
+  ],
+}
+
+describe('QueryResultChart', () => {
+  it('renders a successful empty state', () => {
+    render(
+      <QueryResultChart
+        data={{ ...data, rows: [] }}
+        config={{ type: 'bar', xKey: 'week', yKey: 'count' }}
+      />
+    )
+
+    expect(screen.getByRole('status')).toHaveTextContent('Success. No rows returned')
+  })
+
+  it('validates configured columns before rendering', () => {
+    render(
+      <QueryResultChart data={data} config={{ type: 'line', xKey: 'missing', yKey: 'count' }} />
+    )
+
+    expect(screen.getByRole('status')).toHaveTextContent('Select valid X and Y columns')
+  })
+
+  it('falls back from log scale for non-positive values', () => {
+    const rectSpy = vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      bottom: 300,
+      height: 300,
+      left: 0,
+      right: 600,
+      top: 0,
+      width: 600,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    })
+
+    const { container } = render(
+      <QueryResultChart
+        data={data}
+        config={{ type: 'bar', xKey: 'week', yKey: 'count', logScale: true, showGrid: true }}
+      />
+    )
+
+    expect(container.querySelector('[data-slot="query-result-chart"]')).toBeInTheDocument()
+    expect(container.querySelector('.recharts-xAxis')).toBeInTheDocument()
+    expect(container.querySelector('.recharts-yAxis')).toBeInTheDocument()
+    expect(container.querySelector('.recharts-cartesian-grid')).toBeInTheDocument()
+    expect(screen.getByText(/Log scale is unavailable/)).toBeInTheDocument()
+    expect(container.querySelector('[data-chart] style')).toHaveTextContent(
+      '--color-queryValue: hsl(var(--chart-1));'
+    )
+
+    rectSpy.mockRestore()
+  })
+})

--- a/apps/studio/components/interfaces/Explorer/QueryResultChart/index.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryResultChart/index.tsx
@@ -1,0 +1,179 @@
+'use client'
+
+import { useMemo } from 'react'
+import { Bar, BarChart, CartesianGrid, Line, LineChart, XAxis, YAxis } from 'recharts'
+import { ChartContainer, ChartTooltip, ChartTooltipContent, cn, type ChartConfig } from 'ui'
+
+import type { QueryResultChartConfig, QueryResultData } from '../ExplorerQuery/ExplorerQuery.types'
+
+export type QueryResultChartProps = {
+  data: QueryResultData
+  config: QueryResultChartConfig
+  ariaLabel?: string
+  className?: string
+}
+
+const chartValueKey = 'queryValue'
+
+const toFiniteNumber = (value: unknown): number | null => {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null
+  if (typeof value !== 'string' || value.trim() === '') return null
+
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+const formatYAxisTick = (value: number) =>
+  new Intl.NumberFormat(undefined, { notation: 'compact', maximumFractionDigits: 1 }).format(value)
+
+/** Controlled chart renderer. Display configuration and persistence stay with the caller. */
+const QueryResultChart = ({
+  data,
+  config,
+  ariaLabel = 'Query results chart',
+  className,
+}: QueryResultChartProps) => {
+  const columnKeys = useMemo(() => new Set(data.columns.map(({ key }) => key)), [data.columns])
+
+  const chartData = useMemo(() => {
+    let cumulativeValue = 0
+
+    return data.rows.flatMap((row) => {
+      const numericValue = toFiniteNumber(row[config.yKey])
+      if (numericValue === null) return []
+
+      cumulativeValue += numericValue
+      return [
+        {
+          ...row,
+          [chartValueKey]: config.cumulative ? cumulativeValue : numericValue,
+        },
+      ]
+    })
+  }, [config.cumulative, config.yKey, data.rows])
+
+  const hasConfiguredColumns = columnKeys.has(config.xKey) && columnKeys.has(config.yKey)
+  const yColumn = data.columns.find(({ key }) => key === config.yKey)
+  const hasNonPositiveValues = chartData.some((row) => Number(row[chartValueKey]) <= 0)
+  const useLogScale = !!config.logScale && !hasNonPositiveValues
+  const color = config.color ?? 'hsl(var(--chart-1))'
+  const showLabels = config.showLabels ?? true
+  const chartConfig = {
+    [chartValueKey]: {
+      label: yColumn?.label ?? config.yKey,
+      color,
+    },
+  } satisfies ChartConfig
+
+  if (data.rows.length === 0) {
+    return (
+      <div
+        data-slot="query-result-chart"
+        role="status"
+        className={cn('flex min-h-48 flex-1 items-center justify-center p-4', className)}
+      >
+        <p className="text-xs text-foreground-light">Success. No rows returned</p>
+      </div>
+    )
+  }
+
+  if (!hasConfiguredColumns) {
+    return (
+      <div
+        data-slot="query-result-chart"
+        role="status"
+        className={cn('flex min-h-48 flex-1 items-center justify-center p-4', className)}
+      >
+        <p className="text-xs text-foreground-light">Select valid X and Y columns</p>
+      </div>
+    )
+  }
+
+  if (chartData.length === 0) {
+    return (
+      <div
+        data-slot="query-result-chart"
+        role="status"
+        className={cn('flex min-h-48 flex-1 items-center justify-center p-4', className)}
+      >
+        <p className="text-xs text-foreground-light">The Y column must contain numeric values</p>
+      </div>
+    )
+  }
+
+  const commonChartProps = {
+    accessibilityLayer: true,
+    data: chartData,
+    margin: { top: 12, right: 12, bottom: 4, left: 0 },
+  }
+
+  const cartesianGrid = config.showGrid ? <CartesianGrid vertical={false} /> : null
+  const xAxis = (
+    <XAxis
+      dataKey={config.xKey}
+      axisLine={false}
+      tickLine={false}
+      tick={showLabels}
+      tickMargin={8}
+      minTickGap={24}
+    />
+  )
+  const yAxis = (
+    <YAxis
+      axisLine={false}
+      tickLine={false}
+      tick={showLabels}
+      tickMargin={8}
+      scale={useLogScale ? 'log' : 'auto'}
+      domain={useLogScale ? [1, 'auto'] : undefined}
+      allowDataOverflow={useLogScale}
+      tickFormatter={formatYAxisTick}
+    />
+  )
+  const tooltip = <ChartTooltip content={<ChartTooltipContent />} />
+
+  return (
+    <div
+      data-slot="query-result-chart"
+      className={cn('flex min-h-48 w-full flex-1 flex-col overflow-hidden', className)}
+    >
+      {config.logScale && hasNonPositiveValues && (
+        <p className="shrink-0 px-3 pt-2 text-xs text-foreground-light">
+          Log scale is unavailable because the data contains zero or negative values.
+        </p>
+      )}
+      <ChartContainer
+        aria-label={ariaLabel}
+        className="min-h-48 flex-1 aspect-auto px-3 py-2"
+        config={chartConfig}
+      >
+        {config.type === 'line' ? (
+          <LineChart {...commonChartProps}>
+            {cartesianGrid}
+            {xAxis}
+            {yAxis}
+            {tooltip}
+            <Line
+              dataKey={chartValueKey}
+              type="monotone"
+              stroke={`var(--color-${chartValueKey})`}
+              strokeWidth={2}
+              dot={false}
+            />
+          </LineChart>
+        ) : (
+          <BarChart {...commonChartProps}>
+            {cartesianGrid}
+            {xAxis}
+            {yAxis}
+            {tooltip}
+            <Bar dataKey={chartValueKey} fill={`var(--color-${chartValueKey})`} radius={4} />
+          </BarChart>
+        )}
+      </ChartContainer>
+    </div>
+  )
+}
+QueryResultChart.displayName = 'QueryResultChart'
+
+export { QueryResultChart }

--- a/apps/studio/components/interfaces/Explorer/QueryResultTable/QueryResultTable.test.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryResultTable/QueryResultTable.test.tsx
@@ -1,0 +1,93 @@
+import { act, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { QueryResultData } from '../ExplorerQuery/ExplorerQuery.types'
+import { QueryResultTable } from './index'
+
+let gridProps: Record<string, any> = {}
+
+vi.mock('react-data-grid', () => ({
+  default: (props: Record<string, any>) => {
+    gridProps = props
+    return (
+      <div role="grid" aria-label={props['aria-label']}>
+        <div role="row">
+          {props.columns.map((column: Record<string, any>) => (
+            <div role="columnheader" key={column.key}>
+              {column.renderHeaderCell()}
+            </div>
+          ))}
+        </div>
+        {props.rows.length === 0
+          ? props.renderers?.noRowsFallback
+          : props.rows.map((row: Record<string, unknown>, index: number) => (
+              <div role="row" key={index}>
+                {props.columns.map((column: Record<string, any>) => (
+                  <div role="gridcell" key={column.key}>
+                    {column.renderCell({ row })}
+                  </div>
+                ))}
+              </div>
+            ))}
+      </div>
+    )
+  },
+}))
+
+const data: QueryResultData = {
+  columns: [
+    { key: 'id', dataType: 'int8', align: 'right' },
+    { key: 'payload', dataType: 'jsonb' },
+    { key: 'note', dataType: 'text' },
+  ],
+  rows: [{ id: 1, payload: { ready: true }, note: null }],
+}
+
+describe('QueryResultTable', () => {
+  beforeEach(() => {
+    gridProps = {}
+  })
+
+  it('renders explicit columns and formats source-neutral values', () => {
+    render(<QueryResultTable data={data} />)
+
+    expect(screen.getByRole('grid', { name: 'Query results' })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: 'id' }).firstElementChild).toHaveClass(
+      'heading-meta',
+      'text-foreground-lighter'
+    )
+    expect(screen.getByRole('columnheader', { name: 'payload' })).toBeInTheDocument()
+    expect(screen.getByText('{"ready":true}')).toBeInTheDocument()
+    expect(screen.getByText('NULL')).toBeInTheDocument()
+
+    expect(gridProps).toMatchObject({ headerRowHeight: 32, rowHeight: 32 })
+    expect(gridProps.className).toContain('[&_.rdg-header-row>.rdg-cell]:bg-200')
+    expect(gridProps.rowClass(data.rows[0], 0)).toContain('hover:bg-surface-200')
+    expect(gridProps.rowClass(data.rows[0], 0)).toContain('[&>.rdg-cell]:border-b-0!')
+  })
+
+  it('preserves columns for an empty result and renders its successful empty state', () => {
+    render(<QueryResultTable data={{ ...data, rows: [] }} />)
+
+    expect(screen.getAllByRole('columnheader')).toHaveLength(3)
+    expect(screen.getByText('Success. No rows returned')).toBeInTheDocument()
+  })
+
+  it('emits controlled column-width configuration', () => {
+    const onConfigChange = vi.fn()
+
+    render(
+      <QueryResultTable
+        data={data}
+        config={{ columnWidths: { id: 140 } }}
+        onConfigChange={onConfigChange}
+      />
+    )
+
+    act(() => gridProps.onColumnResize(1, 280))
+
+    expect(onConfigChange).toHaveBeenCalledWith({
+      columnWidths: { id: 140, payload: 280 },
+    })
+  })
+})

--- a/apps/studio/components/interfaces/Explorer/QueryResultTable/index.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryResultTable/index.tsx
@@ -1,0 +1,145 @@
+'use client'
+
+import type { Key, ReactNode } from 'react'
+import { useMemo } from 'react'
+import DataGrid, { type Column } from 'react-data-grid'
+import { cn } from 'ui'
+
+import type {
+  QueryResultColumn,
+  QueryResultData,
+  QueryResultRow,
+  QueryResultTableConfig,
+} from '../ExplorerQuery/ExplorerQuery.types'
+
+export type QueryResultTableProps = {
+  data: QueryResultData
+  config?: QueryResultTableConfig
+  onConfigChange?: (config: QueryResultTableConfig) => void
+  getRowKey?: (row: QueryResultRow) => Key
+  renderValue?: (args: {
+    column: QueryResultColumn
+    row: QueryResultRow
+    value: unknown
+  }) => ReactNode
+  ariaLabel?: string
+  className?: string
+}
+
+const formatQueryResultValue = (value: unknown): string => {
+  if (value === null) return 'NULL'
+  if (value === undefined) return ''
+  if (value instanceof Date) return value.toISOString()
+  if (typeof value === 'string') return value
+  if (typeof value === 'bigint') return value.toString()
+
+  if (typeof value === 'object') {
+    try {
+      return JSON.stringify(value)
+    } catch {
+      return String(value)
+    }
+  }
+
+  return String(value)
+}
+
+/** Virtualized, controlled renderer for source-neutral query results. */
+const QueryResultTable = ({
+  data,
+  config,
+  onConfigChange,
+  getRowKey,
+  renderValue,
+  ariaLabel = 'Query results',
+  className,
+}: QueryResultTableProps) => {
+  const columns = useMemo<readonly Column<QueryResultRow>[]>(
+    () =>
+      data.columns.map((column) => ({
+        key: column.key,
+        name: column.label ?? column.key,
+        width: config?.columnWidths?.[column.key] ?? column.width,
+        minWidth: column.minWidth ?? 120,
+        resizable: true,
+        renderHeaderCell: () => (
+          <div
+            className={cn(
+              'heading-meta flex h-full w-full items-center whitespace-nowrap text-foreground-lighter transition-colors',
+              column.align === 'right' && 'justify-end text-right'
+            )}
+            title={column.dataType}
+          >
+            {column.label ?? column.key}
+          </div>
+        ),
+        renderCell: ({ row }) => {
+          const value = row[column.key]
+          const formattedValue = formatQueryResultValue(value)
+
+          return (
+            <div
+              className={cn(
+                'flex h-full w-full items-center overflow-hidden text-xs transition-colors',
+                column.align === 'right' && 'justify-end text-right',
+                value === null && 'text-foreground-lighter'
+              )}
+              title={formattedValue}
+            >
+              <span className="truncate">
+                {renderValue ? renderValue({ column, row, value }) : formattedValue}
+              </span>
+            </div>
+          )
+        },
+      })),
+    [config?.columnWidths, data.columns, renderValue]
+  )
+
+  return (
+    <div
+      data-slot="query-result-table"
+      className={cn('flex min-h-0 w-full flex-1 flex-col overflow-hidden', className)}
+    >
+      <DataGrid<QueryResultRow>
+        aria-label={ariaLabel}
+        columns={columns}
+        rows={data.rows}
+        rowKeyGetter={getRowKey}
+        className={cn(
+          'min-h-0 flex-1 border-0! bg-dash-canvas text-xs',
+          '[&_.rdg-header-row>.rdg-cell]:border-0! [&_.rdg-header-row>.rdg-cell]:border-b! [&_.rdg-header-row>.rdg-cell]:bg-200 [&_.rdg-header-row>.rdg-cell]:px-3!'
+        )}
+        headerRowHeight={32}
+        rowHeight={32}
+        rowClass={(_, rowIndex) =>
+          cn(
+            'group bg-dash-canvas transition-colors hover:bg-surface-200',
+            '[&>.rdg-cell]:items-center [&>.rdg-cell]:border-0! [&>.rdg-cell]:border-b! [&>.rdg-cell]:px-3!',
+            rowIndex === data.rows.length - 1 && '[&>.rdg-cell]:border-b-0!'
+          )
+        }
+        renderers={{
+          noRowsFallback: (
+            <p className="m-0 p-3 text-xs text-foreground-muted">Success. No rows returned</p>
+          ),
+        }}
+        onColumnResize={(index, width) => {
+          const column = data.columns[index]
+          if (!column) return
+
+          onConfigChange?.({
+            ...config,
+            columnWidths: {
+              ...config?.columnWidths,
+              [column.key]: width,
+            },
+          })
+        }}
+      />
+    </div>
+  )
+}
+QueryResultTable.displayName = 'QueryResultTable'
+
+export { formatQueryResultValue, QueryResultTable }

--- a/apps/studio/components/interfaces/Explorer/QuerySqlEditor/QuerySqlEditor.test.tsx
+++ b/apps/studio/components/interfaces/Explorer/QuerySqlEditor/QuerySqlEditor.test.tsx
@@ -1,0 +1,93 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { QuerySqlEditor } from './index'
+
+let editorProps: Record<string, any> = {}
+
+vi.mock('@monaco-editor/react', () => ({
+  default: (props: Record<string, any>) => {
+    editorProps = props
+    return (
+      <textarea
+        aria-label={props.options?.ariaLabel}
+        readOnly={props.options?.readOnly}
+        value={props.value}
+        onChange={(event) => props.onChange?.(event.currentTarget.value, {})}
+      />
+    )
+  },
+}))
+
+describe('QuerySqlEditor', () => {
+  beforeEach(() => {
+    editorProps = {}
+  })
+
+  it('is controlled and forwards editor state without owning persistence', () => {
+    const onValueChange = vi.fn()
+
+    render(
+      <QuerySqlEditor
+        value="select 1"
+        readOnly
+        hideLineNumbers
+        ariaLabel="Notebook SQL"
+        onValueChange={onValueChange}
+      />
+    )
+
+    const editor = screen.getByRole('textbox', { name: 'Notebook SQL' })
+    expect(editor).toHaveValue('select 1')
+    expect(editor).toHaveAttribute('readonly')
+    expect(editorProps.options).toMatchObject({
+      lineNumbers: 'off',
+      minimap: { enabled: false },
+      padding: { top: 8, bottom: 8 },
+      readOnly: true,
+    })
+
+    fireEvent.change(editor, { target: { value: 'select 2' } })
+    expect(onValueChange).toHaveBeenCalledWith('select 2')
+  })
+
+  it('uses compact, balanced editor spacing by default', () => {
+    render(<QuerySqlEditor value="select 1" />)
+
+    expect(editorProps.options).toMatchObject({
+      lineNumbersMinChars: 3,
+      padding: { top: 8, bottom: 8 },
+    })
+  })
+
+  it('emits the selection for run and falls back to the whole document', () => {
+    const onExecute = vi.fn()
+    const addAction = vi.fn()
+    const getValueInRange = vi.fn().mockReturnValue('  select selected  ')
+    const fakeEditor = {
+      addAction,
+      focus: vi.fn(),
+      getModel: () => ({ getValueInRange }),
+      getSelection: () => ({ startLineNumber: 1 }),
+      getValue: () => 'select everything',
+    }
+    const fakeMonaco = {
+      KeyCode: { Enter: 3 },
+      KeyMod: { CtrlCmd: 2048 },
+    }
+
+    render(<QuerySqlEditor id="explorer-1" value="select everything" onExecute={onExecute} />)
+
+    act(() => editorProps.onMount(fakeEditor, fakeMonaco))
+
+    const action = addAction.mock.calls[0][0]
+    expect(action).toMatchObject({ id: 'run-query-explorer-1', label: 'Run query' })
+
+    act(() => action.run())
+    expect(onExecute).toHaveBeenLastCalledWith('select selected')
+
+    getValueInRange.mockReturnValue('   ')
+    act(() => action.run())
+    expect(onExecute).toHaveBeenLastCalledWith('select everything')
+  })
+})

--- a/apps/studio/components/interfaces/Explorer/QuerySqlEditor/index.tsx
+++ b/apps/studio/components/interfaces/Explorer/QuerySqlEditor/index.tsx
@@ -1,0 +1,134 @@
+'use client'
+
+import Editor, { type EditorProps, type Monaco, type OnMount } from '@monaco-editor/react'
+import type { editor as MonacoEditor } from 'monaco-editor'
+import { useRef, type RefObject } from 'react'
+import { cn } from 'ui'
+
+const DEFAULT_OPTIONS: MonacoEditor.IStandaloneEditorConstructionOptions = {
+  ariaLabel: 'SQL editor',
+  contextmenu: true,
+  fixedOverflowWidgets: true,
+  fontSize: 13,
+  minimap: { enabled: false },
+  padding: { top: 8, bottom: 8 },
+  scrollBeyondLastLine: false,
+  tabSize: 2,
+  wordWrap: 'on',
+}
+
+export type QuerySqlEditorProps = {
+  value: string
+  onValueChange?: (value: string) => void
+  /** Called with the selected SQL, or the whole document when there is no selection. */
+  onExecute?: (sql: string) => void
+  id?: string
+  readOnly?: boolean
+  autoFocus?: boolean
+  hideLineNumbers?: boolean
+  ariaLabel?: string
+  className?: string
+  editorClassName?: string
+  theme?: EditorProps['theme']
+  loading?: EditorProps['loading']
+  options?: EditorProps['options']
+  beforeMount?: EditorProps['beforeMount']
+  onMount?: OnMount
+  editorRef?: RefObject<MonacoEditor.IStandaloneCodeEditor | null>
+  monacoRef?: RefObject<Monaco | null>
+}
+
+/**
+ * Controlled, source-agnostic SQL editor. Query execution is exposed only as
+ * a callback; resolving a source and persisting SQL remain caller concerns.
+ */
+const QuerySqlEditor = ({
+  value,
+  onValueChange,
+  onExecute,
+  id,
+  readOnly = false,
+  autoFocus = false,
+  hideLineNumbers = false,
+  ariaLabel = 'SQL editor',
+  className,
+  editorClassName,
+  theme,
+  loading,
+  options,
+  beforeMount,
+  onMount,
+  editorRef,
+  monacoRef,
+}: QuerySqlEditorProps) => {
+  const onExecuteRef = useRef(onExecute)
+  onExecuteRef.current = onExecute
+
+  const handleMount: OnMount = (editor, monaco) => {
+    if (editorRef) editorRef.current = editor
+    if (monacoRef) monacoRef.current = monaco
+
+    if (onExecuteRef.current) {
+      editor.addAction({
+        id: `run-query${id ? `-${id}` : ''}`,
+        label: 'Run query',
+        keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter],
+        contextMenuGroupId: 'operation',
+        contextMenuOrder: 0,
+        run: () => {
+          const selection = editor.getSelection()
+          const selectedSql = selection
+            ? editor.getModel()?.getValueInRange(selection).trim()
+            : undefined
+
+          onExecuteRef.current?.(selectedSql || editor.getValue())
+        },
+      })
+    }
+
+    if (autoFocus) editor.focus()
+    onMount?.(editor, monaco)
+  }
+
+  const mergedOptions: EditorProps['options'] = {
+    ...DEFAULT_OPTIONS,
+    ariaLabel,
+    domReadOnly: readOnly,
+    readOnly,
+    lineNumbers: hideLineNumbers ? 'off' : 'on',
+    glyphMargin: hideLineNumbers ? false : undefined,
+    lineNumbersMinChars: hideLineNumbers ? 0 : 3,
+    folding: hideLineNumbers ? false : undefined,
+    ...options,
+    minimap: {
+      ...DEFAULT_OPTIONS.minimap,
+      ...options?.minimap,
+    },
+  }
+
+  return (
+    <div
+      data-slot="query-sql-editor"
+      data-read-only={readOnly || undefined}
+      className={cn('h-full min-h-0 w-full overflow-hidden', className)}
+    >
+      <Editor
+        path={id}
+        value={value}
+        language="pgsql"
+        theme={theme}
+        loading={loading}
+        height="100%"
+        width="100%"
+        className={cn('h-full', editorClassName)}
+        options={mergedOptions}
+        beforeMount={beforeMount}
+        onMount={handleMount}
+        onChange={(nextValue) => onValueChange?.(nextValue ?? '')}
+      />
+    </div>
+  )
+}
+QuerySqlEditor.displayName = 'QuerySqlEditor'
+
+export { QuerySqlEditor }


### PR DESCRIPTION
## Summary

Adds Studio-owned controlled editor and result renderers for `ExplorerQuery`:

- `QuerySqlEditor`, a compact Monaco SQL editor that emits edits and run requests without executing queries
- `QueryResultTable`, a dense virtualized table using source-neutral explicit columns and rows
- `QueryResultChart`, controlled bar and line charts composed from shared UI chart primitives
- caller-owned table widths, chart configuration, display choice, source resolution, execution, returned data, and persistence
- source-neutral result types shared through the Studio `ExplorerQuery` folder
- expanded project-local Explorer agent guidance covering composition and ownership boundaries

Each component has its own folder under `apps/studio/components/interfaces/Explorer`. Studio already owns the Monaco, Recharts, and data-grid dependencies, so this PR adds no dependency or lockfile changes. It no longer changes `ui-patterns` or the design-system app.

## Stack

- Base: #48926
- This PR targets `chore/query-cell-shell`, so its review diff contains only the editor and result-renderer layer.
- This PR remains draft while Explorer integrations are developed.

## Validation

- Focused Studio Explorer suite — 5 files, 15 tests passed
- `pnpm --filter studio typecheck`
- Prettier
- `git diff --check`
- Each PR diff in the stack contains only `apps/studio` files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a SQL query editor with editing, read-only mode, loading states, and keyboard shortcuts for running queries.
  * Added virtualized result tables with formatting, resizing, accessibility labels, and empty-result handling.
  * Added configurable bar and line charts with tooltips, cumulative values, logarithmic scales, and validation feedback.
  * Added shared configuration and query-result types for consistent table and chart displays.
* **Documentation**
  * Added guidance for configuring Explorer query editors and result renderers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->