### PR TITLE
fix(studio): resolve next run for cron schedules without wildcards

### DIFF
--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobTableCell.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobTableCell.tsx
@@ -1,4 +1,3 @@
-import parser from 'cron-parser'
 import dayjs from 'dayjs'
 import { Copy, Edit, Minus, MoreVertical, Play, Trash } from 'lucide-react'
 import { parseAsString, useQueryState } from 'nuqs'
@@ -38,41 +37,11 @@ import { CodeBlock } from 'ui-patterns/CodeBlock'
 import { TimestampInfo } from 'ui-patterns/TimestampInfo'
 
 import { type CronTableColumn } from './CronJobs.constants'
+import { getNextRun } from './CronJobTableCell.utils'
 import { useDatabaseCronJobRunCommandMutation } from '@/data/database-cron-jobs/database-cron-job-run-mutation'
 import { type CronJob } from '@/data/database-cron-jobs/database-cron-jobs-infinite-query'
 import { useDatabaseCronJobToggleMutation } from '@/data/database-cron-jobs/database-cron-jobs-toggle-mutation'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
-
-const getNextRun = (schedule: string, lastRun?: string) => {
-  // cron-parser can only deal with the traditional cron syntax but technically users can also
-  // use strings like "30 seconds" now, For the latter case, we try our best to parse the next run
-  // (can't guarantee as scope is quite big)
-  if (schedule.includes('*') || schedule.includes('$')) {
-    try {
-      // pg_cron uses '$' for "last day of month", but cron-parser uses 'L'
-      // Convert pg_cron syntax to cron-parser syntax before parsing
-      const normalizedSchedule = schedule.replace(/\$/g, 'L')
-      const interval = parser.parseExpression(normalizedSchedule, { tz: 'UTC' })
-      return interval.next().getTime()
-    } catch (error) {
-      return undefined
-    }
-  } else {
-    // [Joshen] Only going to attempt to parse if the schedule is as simple as "n second" or "n seconds"
-    // Returned undefined otherwise - we can revisit this perhaps if we get feedback about this
-    const [value, unit] = schedule.toLocaleLowerCase().split(' ')
-    if (
-      ['second', 'seconds'].includes(unit) &&
-      !Number.isNaN(Number(value)) &&
-      lastRun !== undefined
-    ) {
-      const parsedLastRun = dayjs(lastRun).add(Number(value), unit as dayjs.ManipulateType)
-      return parsedLastRun.valueOf()
-    } else {
-      return undefined
-    }
-  }
-}
 
 interface CronJobTableCellProps {
   col: CronTableColumn

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobTableCell.utils.test.ts
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobTableCell.utils.test.ts
@@ -1,0 +1,78 @@
+import dayjs from 'dayjs'
+import { describe, expect, it } from 'vitest'
+
+import { getNextRun } from './CronJobTableCell.utils'
+
+const asIso = (timestamp: number | undefined) =>
+  timestamp === undefined ? undefined : dayjs.utc(timestamp).toISOString()
+
+describe('getNextRun', () => {
+  describe('cron expressions', () => {
+    it('parses an expression that uses wildcards', () => {
+      const nextRun = getNextRun('*/5 * * * *')
+
+      expect(nextRun).toBeTypeOf('number')
+      expect(nextRun).toBeGreaterThan(Date.now() - 60_000)
+    })
+
+    // pg_cron and the Studio schedule validator both accept expressions with every field
+    // restricted. They used to be handed to the "n seconds" branch and reported as
+    // unparseable, which surfaced as "Unable to parse next run for job" in the table.
+    it.each([
+      ['0 3 1 1 1', '01-01T03:00:00'],
+      ['30 8 15 6 2', '06-15T08:30:00'],
+      ['0 0 1 1 0', '01-01T00:00:00'],
+    ])('parses %s, which contains no wildcard', (schedule) => {
+      expect(getNextRun(schedule)).toBeTypeOf('number')
+    })
+
+    it('parses a list of values with no wildcard', () => {
+      expect(getNextRun('0,30 1 1 1 1')).toBeTypeOf('number')
+    })
+
+    it('translates the pg_cron $ (last day of month) into cron-parser L', () => {
+      const nextRun = getNextRun('0 0 $ * *')
+
+      expect(nextRun).toBeTypeOf('number')
+      // The last day of a month is always the 28th or later
+      expect(dayjs.utc(nextRun).date()).toBeGreaterThanOrEqual(28)
+    })
+
+    it('resolves the schedule in UTC', () => {
+      const nextRun = getNextRun('0 0 * * *')
+
+      expect(dayjs.utc(nextRun).hour()).toBe(0)
+      expect(dayjs.utc(nextRun).minute()).toBe(0)
+    })
+
+    it('returns undefined for an unparseable schedule', () => {
+      expect(getNextRun('not a cron expression')).toBeUndefined()
+      expect(getNextRun('99 99 99 99 99')).toBeUndefined()
+      expect(getNextRun('')).toBeUndefined()
+    })
+  })
+
+  describe('"n seconds" intervals', () => {
+    const lastRun = '2026-08-11T10:00:00.000Z'
+
+    it('adds the interval to the last run', () => {
+      expect(asIso(getNextRun('30 seconds', lastRun))).toBe('2026-08-11T10:00:30.000Z')
+    })
+
+    it('accepts the singular form', () => {
+      expect(asIso(getNextRun('1 second', lastRun))).toBe('2026-08-11T10:00:01.000Z')
+    })
+
+    it('is case and whitespace insensitive', () => {
+      expect(asIso(getNextRun('  30 SECONDS  ', lastRun))).toBe('2026-08-11T10:00:30.000Z')
+    })
+
+    it('returns undefined when the job has never run', () => {
+      expect(getNextRun('30 seconds')).toBeUndefined()
+    })
+
+    it('returns undefined when the last run is not a valid date', () => {
+      expect(getNextRun('30 seconds', 'whenever')).toBeUndefined()
+    })
+  })
+})

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobTableCell.utils.test.ts
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobTableCell.utils.test.ts
@@ -63,8 +63,12 @@ describe('getNextRun', () => {
       expect(asIso(getNextRun('1 second', lastRun))).toBe('2026-08-11T10:00:01.000Z')
     })
 
+    // secondsPattern separates the two parts with \s+, so the schedule validator admits any
+    // run of whitespace. The previous implementation split on a single space and read the
+    // unit as an empty string.
     it('is case and whitespace insensitive', () => {
       expect(asIso(getNextRun('  30 SECONDS  ', lastRun))).toBe('2026-08-11T10:00:30.000Z')
+      expect(asIso(getNextRun('30  seconds', lastRun))).toBe('2026-08-11T10:00:30.000Z')
     })
 
     it('returns undefined when the job has never run', () => {

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobTableCell.utils.ts
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobTableCell.utils.ts
@@ -1,0 +1,42 @@
+import parser from 'cron-parser'
+import dayjs from 'dayjs'
+
+import { secondsPattern } from './CronJobs.constants'
+
+/**
+ * Works out when a cron job is next due to run.
+ *
+ * pg_cron accepts two schedule syntaxes: a standard 5-field cron expression, and (since
+ * pg_cron 1.5) an interval such as "30 seconds". The interval form is the narrow, fully
+ * specified case, so it's detected first and everything else is handed to cron-parser.
+ *
+ * Sniffing for a "*" to decide instead would skip cron-parser for valid expressions that
+ * restrict every field, e.g. "0 3 1 1 1", and report them as unparseable.
+ *
+ * Returns a millisecond timestamp, or undefined when the next run can't be determined.
+ */
+export const getNextRun = (schedule: string, lastRun?: string): number | undefined => {
+  const normalizedSchedule = schedule.trim().toLocaleLowerCase()
+
+  // cron-parser defaults omitted fields to "*", so it happily parses an empty expression as
+  // "every minute". A job with no schedule has no next run.
+  if (normalizedSchedule === '') return undefined
+
+  if (secondsPattern.test(normalizedSchedule)) {
+    // Best effort only: the interval runs from the last run, so without one there's
+    // nothing to count forward from.
+    if (lastRun === undefined) return undefined
+
+    const [seconds] = normalizedSchedule.split(/\s+/)
+    const nextRun = dayjs(lastRun).add(Number(seconds), 'second')
+    return nextRun.isValid() ? nextRun.valueOf() : undefined
+  }
+
+  try {
+    // pg_cron uses '$' for "last day of month", but cron-parser uses 'L'
+    const cronExpression = schedule.trim().replace(/\$/g, 'L')
+    return parser.parseExpression(cronExpression, { tz: 'UTC' }).next().getTime()
+  } catch (error) {
+    return undefined
+  }
+}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

In **Integrations → Cron Jobs**, the **Next run** column shows no value for schedules that Studio itself considers valid.

`getNextRun` in `CronJobTableCell.tsx` decides which of pg_cron's two schedule syntaxes it is looking at by sniffing for a wildcard:

```ts
if (schedule.includes('*') || schedule.includes('$')) {
  // ...cron-parser
} else {
  // ...only "n second(s)"
  const [value, unit] = schedule.toLocaleLowerCase().split(' ')
  ...
}
```

A cron expression that restricts every field contains no `*`, so it is routed to the `"n seconds"` branch, fails the `['second', 'seconds'].includes(unit)` check, and returns `undefined`. The column renders a `—` instead of the next run.

These are all accepted by the create/edit form (`cronPattern` in `CronJobs.constants.tsx` requires neither a `*` nor a `$`), so a job can be created through the UI and immediately show no next run:

| Schedule | Meaning | Next run today |
| --- | --- | --- |
| `0 3 1 1 1` | 03:00 on Jan 1 and every Monday | `—` |
| `30 8 15 6 2` | 08:30 on Jun 15 and every Tuesday | `—` |
| `0,30 1 1 1 1` | 01:00 and 01:30 on Jan 1 and every Monday | `—` |

The `"n seconds"` branch has a second, narrower issue: it splits on a single space (`split(' ')`), while the validator that admits the value uses `\s+` (`secondsPattern = /^\d+\s+seconds*$/`). A schedule saved as `30  seconds` passes validation and then parses to `unit === ''`, so it also renders `—`.

## What is the new behavior?

Detection is inverted: the `"n seconds"` interval is the narrow, fully specified form, so it is matched first with the repo's existing `secondsPattern`, and everything else is handed to `cron-parser`, which already knows how to reject genuinely invalid expressions.

```ts
if (secondsPattern.test(normalizedSchedule)) {
  // interval, counted forward from the last run
}
// otherwise: cron-parser, with pg_cron's `$` translated to cron-parser's `L`
```

Behaviour changes:

- Valid expressions with every field restricted now resolve to a real next run.
- `30  seconds` (any `\s+` separator, any case, surrounding whitespace) is now recognised, matching the `isSecondsFormat` helper the rest of the feature uses to classify the same strings.
- An empty schedule still returns `undefined`, now via an explicit guard. `cron-parser` defaults omitted fields to `*`, so it parses `''` as "every minute"; without the guard, routing the empty string to `cron-parser` would have started showing a next run one minute away.
- An interval with an unparseable `lastRun` returns `undefined` rather than `NaN`.

Everything else is unchanged: wildcard expressions, `$` → `L` translation, UTC resolution, intervals with no recorded last run, and unparseable schedules all behave exactly as before.

`getNextRun` moves to a sibling `CronJobTableCell.utils.ts` so it can be unit tested — `CronJobs.utils.tsx` already imports `CronJobTableCell`, so testing it in place (or reusing `isSecondsFormat` from there) would introduce a cycle. `CronJobTableCell.tsx` itself only loses the inline function and its now-unused `cron-parser` import.

Adds `CronJobTableCell.utils.test.ts` (13 tests). Six of the assertions fail against the current implementation: the four no-wildcard expressions above, `  30 SECONDS  `, and the invalid-`lastRun` case (currently `NaN`).

## Additional context

Checks run locally:

- `pnpm --filter studio exec vitest run components/interfaces/Integrations/CronJobs` → 75 passed (4 files), including the 3 pre-existing CronJobs suites
- `pnpm --filter studio run typecheck` → clean
- `pnpm --filter studio run lint:ratchet` → "Nice! Some rules improved."
- `prettier --check` on all three files → clean

Not touched, but noted while tracing the render path: the `Unable to parse next run for job` message on line 237 of `CronJobTableCell.tsx` is unreachable, because `hasValue` for `next_run` is defined as `!!formattedValue` — so a schedule that can't be parsed always takes the earlier `!hasValue` branch and renders `—`. That is why the symptom above is a dash rather than the message. Left alone here to keep this PR to the parsing bug; happy to fix it in this PR or a follow-up if you'd prefer the message to show.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved next-run time calculations for cron jobs, including interval schedules, wildcard and restricted expressions, value lists, and pg_cron syntax.
  * Standardized schedule parsing in UTC for more consistent execution times.
  * Invalid, incomplete, or unsupported schedules are now handled safely without producing incorrect run times.

* **Tests**
  * Added coverage for valid schedules, invalid inputs, missing run times, date handling, and case variations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->