### PR TITLE
fix(studio): surface failures when applying auth hook permissions

### DIFF
--- a/apps/studio/components/interfaces/Auth/Hooks/CreateHookSheet.tsx
+++ b/apps/studio/components/interfaces/Auth/Hooks/CreateHookSheet.tsx
@@ -43,7 +43,7 @@ import { InlineLink } from '@/components/ui/InlineLink'
 import { SchemaSelector } from '@/components/ui/SchemaSelector'
 import { AuthConfigResponse } from '@/data/auth/auth-config-query'
 import { useAuthHooksUpdateMutation } from '@/data/auth/auth-hooks-update-mutation'
-import { executeSql } from '@/data/sql/execute-sql-mutation'
+import { useExecuteSqlMutation } from '@/data/sql/execute-sql-mutation'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { useConfirmOnClose } from '@/hooks/ui/useConfirmOnClose'
 import { DOCS_URL } from '@/lib/constants'
@@ -211,22 +211,39 @@ revoke execute on function ${ident(schema)}.${ident(functionName)} from authenti
     return permissionChanges
   }, [hook, postgresValues.schema, postgresValues.functionName])
 
+  const handleHookSaved = () => {
+    toast.success(`Successfully ${isCreating ? 'created' : 'updated'} ${hookType}.`)
+    onClose()
+  }
+
+  // These statements are what let supabase_auth_admin execute the hook, and what stop anon and
+  // authenticated from calling it. Run them through the mutation so a failure is surfaced and
+  // the sheet stays open on the statements, rather than resolving after we've already reported
+  // success and closed.
+  const { mutate: applyPermissions, isPending: isApplyingPermissions } = useExecuteSqlMutation({
+    onSuccess: handleHookSaved,
+    onError: (error) => {
+      toast.error(`${hookType} was saved, but its permissions failed to apply: ${error.message}`)
+    },
+  })
+
   const { mutate: updateAuthHooks, isPending: isUpdatingAuthHooks } = useAuthHooksUpdateMutation({
     onSuccess: () => {
-      toast.success(`Successfully ${isCreating ? 'created' : 'updated'} ${hookType}.`)
       if (statements.length > 0) {
-        executeSql({
+        return applyPermissions({
           projectRef,
-          connectionString: project!.connectionString,
+          connectionString: project?.connectionString,
           sql: joinSqlFragments(statements, '\n'),
         })
       }
-      onClose()
+      handleHookSaved()
     },
     onError: (error) => {
       toast.error(`Failed to create hook: ${error.message}`)
     },
   })
+
+  const isSaving = isUpdatingAuthHooks || isApplyingPermissions
 
   const onSubmit: SubmitHandler<z.infer<typeof FormSchema>> = async (values) => {
     if (!project) return console.error('Project is required')
@@ -557,15 +574,10 @@ revoke execute on function ${ident(schema)}.${ident(functionName)} from authenti
             </div>
           )}
 
-          <Button disabled={isUpdatingAuthHooks} variant="default" onClick={confirmOnClose}>
+          <Button disabled={isSaving} variant="default" onClick={confirmOnClose}>
             Cancel
           </Button>
-          <Button
-            form={FORM_ID}
-            type="submit"
-            disabled={isUpdatingAuthHooks}
-            loading={isUpdatingAuthHooks}
-          >
+          <Button form={FORM_ID} type="submit" disabled={isSaving} loading={isSaving}>
             {isCreating ? 'Create hook' : 'Update hook'}
           </Button>
         </SheetFooter>

--- a/apps/studio/components/interfaces/Auth/Hooks/CreateHookSheet.tsx
+++ b/apps/studio/components/interfaces/Auth/Hooks/CreateHookSheet.tsx
@@ -568,7 +568,7 @@ revoke execute on function ${ident(schema)}.${ident(functionName)} from authenti
         <SheetFooter>
           {!isCreating && (
             <div className="flex-1">
-              <Button variant="danger" onClick={() => onDelete()}>
+              <Button variant="danger" disabled={isSaving} onClick={() => onDelete()}>
                 Delete hook
               </Button>
             </div>

--- a/apps/studio/tests/components/Auth/Hooks/CreateHookSheet.test.tsx
+++ b/apps/studio/tests/components/Auth/Hooks/CreateHookSheet.test.tsx
@@ -40,10 +40,13 @@ const AUTH_CONFIG = {
 let executedPermissionSql: string[] = []
 
 /**
- * Mocks the SQL endpoint so the permission statements can succeed or fail independently of the
- * schema and function lookups the sheet makes while rendering.
+ * Mocks the SQL endpoint so the permission statements can succeed, fail, or be held open
+ * independently of the schema and function lookups the sheet makes while rendering.
  */
-const mockSqlEndpoint = ({ doPermissionsFail }: { doPermissionsFail: boolean }) => {
+const mockSqlEndpoint = ({
+  doPermissionsFail = false,
+  holdPermissionsUntil,
+}: { doPermissionsFail?: boolean; holdPermissionsUntil?: Promise<void> } = {}) => {
   addAPIMock({
     method: 'post',
     path: '/platform/pg-meta/:ref/query',
@@ -54,6 +57,7 @@ const mockSqlEndpoint = ({ doPermissionsFail }: { doPermissionsFail: boolean }) 
 
       if (query.includes('grant execute on function')) {
         executedPermissionSql.push(query)
+        if (holdPermissionsUntil !== undefined) await holdPermissionsUntil
         if (doPermissionsFail) {
           return HttpResponse.json(
             { message: 'permission denied for schema public' },
@@ -138,7 +142,7 @@ describe('CreateHookSheet', () => {
   })
 
   test('applies the permission statements after saving the hook', async () => {
-    mockSqlEndpoint({ doPermissionsFail: false })
+    mockSqlEndpoint()
     const { onClose, queryClient } = renderSheet()
 
     await saveHook(queryClient)
@@ -169,5 +173,29 @@ describe('CreateHookSheet', () => {
     expect(toast.success).not.toHaveBeenCalled()
     // The sheet stays open so the statements stay visible and the save can be retried
     expect(onClose).not.toHaveBeenCalled()
+  })
+
+  // The sheet now stays open while the statements run, so the destructive action in the footer
+  // has to stay out of reach until they settle.
+  test('keeps the footer actions disabled while the permission statements are in flight', async () => {
+    let releasePermissions = () => {}
+    const permissionsHeld = new Promise<void>((resolve) => {
+      releasePermissions = resolve
+    })
+    mockSqlEndpoint({ holdPermissionsUntil: permissionsHeld })
+
+    const { onClose, queryClient } = renderSheet()
+
+    await saveHook(queryClient)
+
+    const deleteButton = await screen.findByRole('button', { name: 'Delete hook' })
+    await waitFor(() => expect(deleteButton).toBeDisabled())
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled()
+    expect(onClose).not.toHaveBeenCalled()
+
+    releasePermissions()
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled())
+    expect(deleteButton).toBeEnabled()
   })
 })

--- a/apps/studio/tests/components/Auth/Hooks/CreateHookSheet.test.tsx
+++ b/apps/studio/tests/components/Auth/Hooks/CreateHookSheet.test.tsx
@@ -150,6 +150,10 @@ describe('CreateHookSheet', () => {
     await waitFor(() => expect(toast.success).toHaveBeenCalled())
     expect(onClose).toHaveBeenCalled()
 
+    // All the statements are joined into a single query, so one round trip carries the whole
+    // permission change and none of it can be applied by halves
+    expect(executedPermissionSql).toHaveLength(1)
+
     // supabase_auth_admin needs execute on the function, and everyone else must lose it
     const [sql] = executedPermissionSql
     expect(sql).toContain('grant execute on function public.send_sms to supabase_auth_admin')

--- a/apps/studio/tests/components/Auth/Hooks/CreateHookSheet.test.tsx
+++ b/apps/studio/tests/components/Auth/Hooks/CreateHookSheet.test.tsx
@@ -1,0 +1,173 @@
+import { QueryClient } from '@tanstack/react-query'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { CreateHookSheet } from '@/components/interfaces/Auth/Hooks/CreateHookSheet'
+import type { AuthConfigResponse } from '@/data/auth/auth-config-query'
+import { projectKeys } from '@/data/projects/keys'
+import { API_URL } from '@/lib/constants'
+import { customRender } from '@/tests/lib/custom-render'
+import { addAPIMock, mswServer } from '@/tests/lib/msw'
+
+const PROJECT_REF = 'default'
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+vi.mock('common', async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof import('common')
+  return { ...actual, useParams: () => ({ ref: PROJECT_REF }) }
+})
+
+// Monaco doesn't run under jsdom, and the sheet renders it to preview the permission
+// statements. What matters here is the SQL that reaches the API, not the preview.
+vi.mock('@/components/ui/CodeEditor/CodeEditor', () => ({
+  CodeEditor: ({ value }: { value: string }) => <textarea readOnly value={value} />,
+}))
+
+const { toast } = await import('sonner')
+
+// A hook already pointed at a Postgres function, so the sheet opens in "update" mode with the
+// permission statements derived from the config and no user interaction needed to reach them.
+const AUTH_CONFIG = {
+  HOOK_SEND_SMS_ENABLED: true,
+  HOOK_SEND_SMS_URI: 'pg-functions://postgres/public/send_sms',
+  HOOK_SEND_SMS_SECRETS: '',
+} as unknown as AuthConfigResponse
+
+let executedPermissionSql: string[] = []
+
+/**
+ * Mocks the SQL endpoint so the permission statements can succeed or fail independently of the
+ * schema and function lookups the sheet makes while rendering.
+ */
+const mockSqlEndpoint = ({ doPermissionsFail }: { doPermissionsFail: boolean }) => {
+  addAPIMock({
+    method: 'post',
+    path: '/platform/pg-meta/:ref/query',
+    response: async ({ request }) => {
+      const body = await request.json()
+      const query =
+        typeof body === 'object' && body !== null ? String(Reflect.get(body, 'query')) : ''
+
+      if (query.includes('grant execute on function')) {
+        executedPermissionSql.push(query)
+        if (doPermissionsFail) {
+          return HttpResponse.json(
+            { message: 'permission denied for schema public' },
+            { status: 400 }
+          )
+        }
+      }
+
+      return HttpResponse.json([])
+    },
+  })
+}
+
+const renderSheet = () => {
+  const onClose = vi.fn()
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+
+  customRender(
+    <CreateHookSheet
+      visible
+      title="Send SMS hook"
+      authConfig={AUTH_CONFIG}
+      onClose={onClose}
+      onDelete={vi.fn()}
+    />,
+    { queryClient }
+  )
+  return { onClose, queryClient }
+}
+
+const saveHook = async (queryClient: QueryClient) => {
+  // The sheet refuses to submit until it has the selected project, which arrives asynchronously
+  const projectKey = projectKeys.detail(PROJECT_REF)
+  await waitFor(() => expect(queryClient.getQueryData(projectKey)).toBeDefined())
+
+  const saveButton = await screen.findByRole<HTMLButtonElement>('button', { name: 'Update hook' })
+
+  // The save button sits in the sheet footer and is tied to the form by the `form` attribute.
+  // jsdom doesn't implement implicit submission for that association, so submit the form the
+  // button owns rather than clicking it.
+  const form = saveButton.form
+  if (form === null) throw new Error('Save button is not associated with a form')
+  fireEvent.submit(form)
+}
+
+describe('CreateHookSheet', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    executedPermissionSql = []
+
+    addAPIMock({
+      method: 'get',
+      path: '/platform/projects/:ref',
+      response: {
+        id: 1,
+        ref: PROJECT_REF,
+        organization_id: 1,
+        name: 'Test Project',
+        status: 'ACTIVE_HEALTHY',
+        cloud_provider: 'AWS',
+        region: 'us-east-1',
+        db_host: `db.${PROJECT_REF}.supabase.co`,
+        restUrl: `https://${PROJECT_REF}.supabase.co/rest/v1/`,
+        connectionString: 'postgresql://postgres@localhost:5432/postgres',
+        subscription_id: 'sub_123',
+        inserted_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z',
+        integration_source: null,
+        is_branch_enabled: false,
+        is_physical_backups_enabled: false,
+        high_availability: false,
+      },
+    })
+
+    // Registered directly rather than through `addAPIMock`: the sheet ignores the updated config
+    // in the response, and satisfying the typed helper would mean building an entire GoTrue config.
+    mswServer.use(
+      http.patch(`${API_URL}/platform/auth/:ref/config/hooks`, () => HttpResponse.json({}))
+    )
+  })
+
+  test('applies the permission statements after saving the hook', async () => {
+    mockSqlEndpoint({ doPermissionsFail: false })
+    const { onClose, queryClient } = renderSheet()
+
+    await saveHook(queryClient)
+
+    await waitFor(() => expect(toast.success).toHaveBeenCalled())
+    expect(onClose).toHaveBeenCalled()
+
+    // supabase_auth_admin needs execute on the function, and everyone else must lose it
+    const [sql] = executedPermissionSql
+    expect(sql).toContain('grant execute on function public.send_sms to supabase_auth_admin')
+    expect(sql).toContain('grant usage on schema public to supabase_auth_admin')
+    expect(sql).toContain(
+      'revoke execute on function public.send_sms from authenticated, anon, public'
+    )
+  })
+
+  // Previously the sheet reported success and closed while these statements were still in
+  // flight, so a failed revoke left the function callable by anon and authenticated with
+  // nothing to indicate it.
+  test('surfaces a failure to apply the permission statements', async () => {
+    mockSqlEndpoint({ doPermissionsFail: true })
+    const { onClose, queryClient } = renderSheet()
+
+    await saveHook(queryClient)
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled())
+    expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('permissions failed to apply'))
+    expect(toast.success).not.toHaveBeenCalled()
+    // The sheet stays open so the statements stay visible and the save can be retried
+    expect(onClose).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

In **Authentication → Hooks**, saving a Postgres hook reports success even when the permission statements it promises to run have failed.

`CreateHookSheet.tsx` calls the bare `executeSql` helper — not the mutation — inside the config mutation's `onSuccess`, without awaiting it or catching a rejection:

```ts
onSuccess: () => {
  toast.success(`Successfully ${isCreating ? 'created' : 'updated'} ${hookType}.`)
  if (statements.length > 0) {
    executeSql({ projectRef, connectionString: project!.connectionString, sql: joinSqlFragments(statements, '\n') })
  }
  onClose()
},
```

The success toast fires and the sheet closes while the statements are still in flight, and the returned promise is dropped. If it rejects, nothing catches it — the failure surfaces only as an unhandled rejection in the console.

The statements being run are the hook's permission model:

```sql
grant execute on function <schema>.<fn> to supabase_auth_admin;
grant usage on schema <schema> to supabase_auth_admin;
revoke execute on function <schema>.<fn> from authenticated, anon, public;
```

So a silent failure has two outcomes, and the user is told "Successfully created" in both:

1. **The revoke doesn't land.** The hook function stays executable by `anon` and `authenticated`. For a function in an exposed schema that means any client holding the anon key can call it directly — for something like a password verification or MFA verification hook, that is not a function you want callable from the outside.
2. **The grants don't land.** `supabase_auth_admin` can't execute the function, so the hook silently doesn't work at runtime, with nothing in the dashboard indicating why.

The sheet explicitly tells the user *"The following statements will be executed on the selected function"* and shows them, which makes the unreported failure more surprising than it would otherwise be.

## What is the new behavior?

The statements go through `useExecuteSqlMutation`, so their result is actually observed:

- The success toast and `onClose()` now run in the mutation's `onSuccess` — after the statements have applied, not before they've been sent.
- A failure raises `` `${hookType} was saved, but its permissions failed to apply: ${error.message}` ``. The two-part message is deliberate: the hook config genuinely was saved, so reporting a flat failure would be just as misleading as reporting a flat success.
- On failure the sheet stays open, so the statements remain on screen and the save can simply be retried — the statements are idempotent.
- The submit and cancel buttons stay in their loading/disabled state for the whole operation, rather than only the config update.
- Drops a `project!` non-null assertion in favour of `project?.connectionString`; `onSubmit` already returns early when there is no project.

When a hook has no permission statements (the HTTPS hook types), the behaviour is unchanged — success toast, then close.

## Additional context

Adds `apps/studio/tests/components/Auth/Hooks/CreateHookSheet.test.tsx` (2 tests), using the standard `customRender` + `addAPIMock` setup.

Against the current implementation, *"surfaces a failure to apply the permission statements"* fails and *"applies the permission statements after saving the hook"* passes — which is the accurate characterization of the bug: the SQL is sent today, its result is just never looked at.

Two things in the test worth flagging for review:

- The save button lives in the sheet footer and is bound to the form by the `form` attribute. jsdom doesn't implement implicit submission for that association, so the test submits the form the button owns rather than clicking it.
- The `PATCH /platform/auth/{ref}/config/hooks` mock is registered directly on `mswServer` instead of through `addAPIMock`, because the typed helper would require constructing an entire GoTrue config response that the component never reads.

Checks run locally:

- `pnpm --filter studio exec vitest run tests/components/Auth/Hooks/CreateHookSheet.test.tsx` → 2 passed
- `pnpm --filter studio run typecheck` → clean
- `pnpm --filter studio run lint:ratchet` → "Nice! Some rules improved."
- `prettier --check` on both files → clean

Related but not addressed here: `SidePanelEditor.utils.tsx` has the same shape of bug in the duplicate-table flow — `identityColumns.map(async …)` is never awaited, so the `setval` that resets the copy's identity sequence can be dropped silently and leave the duplicated table issuing colliding primary keys. Happy to open that separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hook creation to complete permission updates before closing the setup sheet.
  * Added clear error handling when permission statements fail, keeping the sheet open for correction.
  * Save actions now remain disabled and show progress throughout the complete operation.
  * Improved feedback during the full hook setup process.

* **Tests**
  * Added coverage for successful hook setup and permission failures, including notifications and sheet behavior.
  * Added verification that footer actions remain unavailable while permission updates are in progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->