### PR TITLE
feat: add assistant chats to Explorer tabs

### DIFF
--- a/apps/studio/TANSTACK_MIGRATION.md
+++ b/apps/studio/TANSTACK_MIGRATION.md
@@ -326,6 +326,7 @@ These are the layout-only TanStack files. Most hold a single product layout comp
 
 - [x] A `routes/project/$ref/explorer/index.tsx` ← `pages/project/[ref]/explorer/index.tsx`
 - [x] A `routes/project/$ref/explorer/notebook/$id.tsx` ← `pages/project/[ref]/explorer/notebook/[id].tsx`
+- [x] A `routes/project/$ref/explorer/chat/$id.tsx` ← `pages/project/[ref]/explorer/chat/[id].tsx`
 
 ### Auth shell — `/sign-in`, `/sign-up`, etc.
 

--- a/apps/studio/components/interfaces/Explorer/ChatEditor.tsx
+++ b/apps/studio/components/interfaces/Explorer/ChatEditor.tsx
@@ -1,0 +1,103 @@
+import { useParams } from 'common'
+import { Loader2, MessageSquare } from 'lucide-react'
+import { useRouter } from 'next/router'
+import { useEffect, useEffectEvent } from 'react'
+import { Button } from 'ui'
+
+import { ExplorerChatToolbar } from './ExplorerChatToolbar'
+import { useCreateChat } from './hooks'
+import { SIDEBAR_KEYS } from '@/components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider'
+import { AssistantChat } from '@/components/ui/AIAssistantPanel/AssistantChat'
+import { useAiAssistantState, useAiAssistantStateSnapshot } from '@/state/ai-assistant-state'
+import { useSidebarManagerSnapshot } from '@/state/sidebar-manager-state'
+import { createTabId, useTabsStateSnapshot } from '@/state/tabs'
+
+export const ChatEditor = () => {
+  const { id, ref } = useParams()
+  const router = useRouter()
+  const tabs = useTabsStateSnapshot()
+  const aiAssistant = useAiAssistantStateSnapshot()
+  const aiAssistantState = useAiAssistantState()
+  const { createChat, openChat } = useCreateChat()
+  const { activeSidebar } = useSidebarManagerSnapshot()
+  const chat = id ? aiAssistant.chats[id] : undefined
+  const chatInstance = id ? aiAssistant.chatInstances[id] : undefined
+  const tabId = id ? createTabId('chat', { id }) : undefined
+  const shortcutsEnabled = activeSidebar?.id !== SIDEBAR_KEYS.AI_ASSISTANT
+
+  const syncChatTab = useEffectEvent(() => {
+    if (!id || !chat) return
+
+    aiAssistantState.ensureChatInstance(id)
+    const nextTabId = createTabId('chat', { id })
+    tabs.addTab({
+      id: nextTabId,
+      type: 'chat',
+      label: chat.name,
+      metadata: { chatId: id },
+      isPreview: false,
+    })
+    tabs.updateTab(nextTabId, { label: chat.name })
+  })
+
+  const removeDeletedChatTab = useEffectEvent(() => {
+    if (!tabId || !tabs.openTabs.includes(tabId)) return
+
+    tabs.handleTabClose({
+      id: tabId,
+      router,
+      editor: 'explorer',
+      onClearDashboardHistory: () => {},
+    })
+  })
+
+  useEffect(() => syncChatTab(), [id, chat?.name])
+
+  useEffect(() => {
+    if (aiAssistant.isInitialized && id && !chat) removeDeletedChatTab()
+  }, [aiAssistant.isInitialized, id, chat])
+
+  if (!aiAssistant.isInitialized || (chat && !chatInstance)) {
+    return (
+      <div className="h-full bg-surface-100 flex items-center justify-center">
+        <Loader2 className="animate-spin text-foreground-muted" />
+      </div>
+    )
+  }
+
+  if (!id || !chat) {
+    return (
+      <div className="h-full bg-surface-100 flex flex-col items-center justify-center gap-3 px-6 text-center">
+        <MessageSquare className="text-foreground-muted" />
+        <div>
+          <h2 className="text-sm text-foreground">Chat not found</h2>
+          <p className="text-sm text-foreground-lighter">
+            This chat may have been deleted or is no longer available.
+          </p>
+        </div>
+        <Button variant="default" onClick={() => router.push(`/project/${ref}/explorer`)}>
+          Back to Explorer
+        </Button>
+      </div>
+    )
+  }
+
+  const handleBranchChat = (messageId: string) => {
+    const branchId = aiAssistantState.createBranch(id, messageId)
+    if (branchId) openChat(branchId)
+  }
+
+  return (
+    <AssistantChat
+      chatId={id}
+      shortcutsEnabled={shortcutsEnabled}
+      className="bg-surface-100"
+      onNewChat={() => createChat()}
+      onSelectChat={openChat}
+      onBranchChat={handleBranchChat}
+      renderHeader={(headerProps) => (
+        <ExplorerChatToolbar {...headerProps} chatId={id} shortcutsEnabled={shortcutsEnabled} />
+      )}
+    />
+  )
+}

--- a/apps/studio/components/interfaces/Explorer/ExplorerChatToolbar.tsx
+++ b/apps/studio/components/interfaces/Explorer/ExplorerChatToolbar.tsx
@@ -1,0 +1,156 @@
+import { Clipboard, Edit, MessageSquare, MoreVertical, Settings } from 'lucide-react'
+import { KeyboardEvent, useState } from 'react'
+import { toast } from 'sonner'
+import {
+  Button,
+  copyToClipboard,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  Input,
+} from 'ui'
+
+import {
+  ExplorerToolbar,
+  ExplorerToolbarAction,
+  ExplorerToolbarActions,
+  ExplorerToolbarIcon,
+  ExplorerToolbarTitle,
+} from './ExplorerToolbar'
+import { AIAssistantMetadataWarning } from '@/components/ui/AIAssistantPanel/AIAssistantMetadataWarning'
+import type { AssistantChatHeaderProps } from '@/components/ui/AIAssistantPanel/AssistantChat'
+import { ShortcutPills } from '@/components/ui/ShortcutTooltip'
+import { useAiAssistantStateSnapshot } from '@/state/ai-assistant-state'
+import { SHORTCUT_DEFINITIONS, SHORTCUT_IDS } from '@/state/shortcuts/registry'
+import { useShortcut } from '@/state/shortcuts/useShortcut'
+
+interface ExplorerChatToolbarProps extends AssistantChatHeaderProps {
+  chatId: string
+  shortcutsEnabled: boolean
+}
+
+export const ExplorerChatToolbar = ({
+  chatId,
+  shortcutsEnabled,
+  isChatLoading,
+  showMetadataWarning,
+  updatedOptInSinceMCP,
+  isHipaaProjectDisallowed,
+  aiOptInLevel,
+}: ExplorerChatToolbarProps) => {
+  const snap = useAiAssistantStateSnapshot()
+  const chat = snap.chats[chatId]
+  const [value, setValue] = useState(chat?.name)
+  const [isEditingName, setIsEditingName] = useState(false)
+  const [isOptInModalOpen, setIsOptInModalOpen] = useState(false)
+
+  const handleCopyChatId = () => {
+    copyToClipboard(chatId, () => toast.success(`Copied chat ID for ${chat?.name}`))
+  }
+
+  const handleSaveName = () => {
+    if (value?.trim()) snap.renameChat(chatId, value.trim())
+    setIsEditingName(false)
+  }
+
+  const handleKeyDownInput = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      event.stopPropagation()
+      setValue(chat?.name)
+      setIsEditingName(false)
+    } else if (event.key === 'Enter') {
+      event.preventDefault()
+      event.stopPropagation()
+      handleSaveName()
+    }
+  }
+
+  useShortcut(SHORTCUT_IDS.AI_ASSISTANT_COPY_CHAT_ID, handleCopyChatId, {
+    enabled: shortcutsEnabled && !isChatLoading,
+  })
+  useShortcut(SHORTCUT_IDS.AI_ASSISTANT_OPEN_PERMISSIONS, () => setIsOptInModalOpen(true), {
+    enabled: shortcutsEnabled && !isChatLoading,
+  })
+
+  return (
+    <div className="z-30 sticky top-0">
+      <ExplorerToolbar aria-label="Chat toolbar">
+        <ExplorerToolbarIcon>
+          <MessageSquare />
+        </ExplorerToolbarIcon>
+        <ExplorerToolbarTitle className="flex items-center gap-x-1">
+          {isEditingName ? (
+            <Input
+              autoFocus
+              value={value}
+              size="tiny"
+              onChange={(event) => setValue(event.target.value)}
+              onKeyDown={handleKeyDownInput}
+              onBlur={handleSaveName}
+            />
+          ) : (
+            <Button
+              variant="text"
+              className="group min-w-0"
+              iconRight={<Edit className="transition opacity-0 group-hover:opacity-100" />}
+              onClick={() => {
+                setValue(chat?.name)
+                setIsEditingName(true)
+              }}
+            >
+              {chat?.name}
+            </Button>
+          )}
+        </ExplorerToolbarTitle>
+        <ExplorerToolbarActions>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <ExplorerToolbarAction
+                aria-label="More options"
+                icon={<MoreVertical />}
+                disabled={isChatLoading}
+              />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-60">
+              <DropdownMenuItem className="justify-between" onClick={handleCopyChatId}>
+                <div className="flex items-center gap-x-2">
+                  <Clipboard size={14} />
+                  <span>Copy chat ID</span>
+                </div>
+                <ShortcutPills
+                  sequence={SHORTCUT_DEFINITIONS[SHORTCUT_IDS.AI_ASSISTANT_COPY_CHAT_ID].sequence}
+                />
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                className="justify-between"
+                onClick={() => setIsOptInModalOpen(true)}
+              >
+                <div className="flex items-center gap-x-2">
+                  <Settings size={14} />
+                  <span>Permission settings</span>
+                </div>
+                <ShortcutPills
+                  sequence={
+                    SHORTCUT_DEFINITIONS[SHORTCUT_IDS.AI_ASSISTANT_OPEN_PERMISSIONS].sequence
+                  }
+                />
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </ExplorerToolbarActions>
+      </ExplorerToolbar>
+      <AIAssistantMetadataWarning
+        visible={isOptInModalOpen}
+        onVisibleChange={setIsOptInModalOpen}
+        showMetadataWarning={showMetadataWarning}
+        updatedOptInSinceMCP={updatedOptInSinceMCP}
+        isHipaaProjectDisallowed={isHipaaProjectDisallowed}
+        aiOptInLevel={aiOptInLevel}
+      />
+    </div>
+  )
+}

--- a/apps/studio/components/interfaces/Explorer/ExplorerHome.tsx
+++ b/apps/studio/components/interfaces/Explorer/ExplorerHome.tsx
@@ -1,13 +1,14 @@
 import { MessageCirclePlus, NotebookText, SquareCode } from 'lucide-react'
 import { useState } from 'react'
 
-import { useCreateNotebook } from './hooks'
+import { useCreateChat, useCreateNotebook } from './hooks'
 import { ActionCard } from '@/components/layouts/Tabs/ActionCard'
 import { AssistantChatForm } from '@/components/ui/AIAssistantPanel/AssistantChatForm'
-import { AssistantModel } from '@/state/ai-assistant-state'
+import type { AssistantModel } from '@/state/ai-assistant-state'
 
 export const ExplorerHome = () => {
   const { createNotebook } = useCreateNotebook()
+  const { createChat } = useCreateChat()
 
   const [value, setValue] = useState<string>('')
   const [selectedModel, setSelectedModal] = useState<AssistantModel>('gpt-5.4-nano')
@@ -33,7 +34,7 @@ export const ExplorerHome = () => {
           onValueChange={(e) => setValue(e.target.value)}
           selectedModel={selectedModel}
           onSelectModel={setSelectedModal}
-          onSubmit={() => {}}
+          onSubmit={(message) => createChat({ initialMessage: message, model: selectedModel })}
         />
 
         <section className="mt-6">

--- a/apps/studio/components/interfaces/Explorer/__tests__/ChatEditor.test.tsx
+++ b/apps/studio/components/interfaces/Explorer/__tests__/ChatEditor.test.tsx
@@ -1,0 +1,122 @@
+import { fireEvent, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ChatEditor } from '../ChatEditor'
+import { customRender } from '@/tests/lib/custom-render'
+
+const mocks = vi.hoisted(() => ({
+  addTab: vi.fn(),
+  createBranch: vi.fn(),
+  createChat: vi.fn(),
+  ensureChatInstance: vi.fn(),
+  handleTabClose: vi.fn(),
+  openChat: vi.fn(),
+  push: vi.fn(),
+  updateTab: vi.fn(),
+  useParams: vi.fn(),
+  assistantSnapshot: vi.fn(),
+}))
+
+vi.mock('common', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('common')>()
+  return { ...actual, useParams: () => mocks.useParams() }
+})
+
+vi.mock('next/router', () => ({
+  useRouter: () => ({ query: { ref: 'default' }, push: mocks.push }),
+}))
+
+vi.mock('@/components/interfaces/Explorer/hooks', () => ({
+  useCreateChat: () => ({ createChat: mocks.createChat, openChat: mocks.openChat }),
+}))
+
+vi.mock('@/state/tabs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/state/tabs')>()
+  return {
+    ...actual,
+    useTabsStateSnapshot: () => ({
+      addTab: mocks.addTab,
+      handleTabClose: mocks.handleTabClose,
+      openTabs: ['chat-chat-1'],
+      updateTab: mocks.updateTab,
+    }),
+  }
+})
+
+vi.mock('@/state/ai-assistant-state', () => ({
+  useAiAssistantStateSnapshot: () => mocks.assistantSnapshot(),
+  useAiAssistantState: () => ({
+    createBranch: mocks.createBranch,
+    ensureChatInstance: mocks.ensureChatInstance,
+  }),
+}))
+
+vi.mock('@/state/sidebar-manager-state', () => ({
+  useSidebarManagerSnapshot: () => ({ activeSidebar: undefined }),
+}))
+
+vi.mock('@/components/ui/AIAssistantPanel/AssistantChat', () => ({
+  AssistantChat: ({
+    chatId,
+    onSelectChat,
+  }: {
+    chatId: string
+    onSelectChat: (id: string) => void
+  }) => (
+    <button type="button" tabIndex={0} data-chat-id={chatId} onClick={() => onSelectChat('chat-2')}>
+      Assistant
+    </button>
+  ),
+}))
+
+describe('ChatEditor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.useParams.mockReturnValue({ ref: 'default', id: 'chat-1' })
+    mocks.assistantSnapshot.mockReturnValue({
+      isInitialized: true,
+      chats: { 'chat-1': { id: 'chat-1', name: 'Investigate errors' } },
+      chatInstances: { 'chat-1': {} },
+    })
+  })
+
+  it('renders and registers the routed chat without changing sidebar selection', () => {
+    customRender(<ChatEditor />)
+
+    expect(mocks.ensureChatInstance).toHaveBeenCalledWith('chat-1')
+    expect(screen.getByRole('button', { name: 'Assistant' })).toHaveAttribute(
+      'data-chat-id',
+      'chat-1'
+    )
+    expect(mocks.addTab).toHaveBeenCalledWith({
+      id: 'chat-chat-1',
+      type: 'chat',
+      label: 'Investigate errors',
+      metadata: { chatId: 'chat-1' },
+      isPreview: false,
+    })
+  })
+
+  it('routes shared chat navigation through Explorer', () => {
+    customRender(<ChatEditor />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Assistant' }))
+
+    expect(mocks.openChat).toHaveBeenCalledWith('chat-2')
+  })
+
+  it('removes an orphaned tab only after chat hydration completes', () => {
+    mocks.assistantSnapshot.mockReturnValue({
+      isInitialized: true,
+      chats: {},
+      chatInstances: {},
+    })
+
+    customRender(<ChatEditor />)
+
+    expect(screen.getByRole('heading', { name: 'Chat not found' })).toBeVisible()
+    expect(mocks.handleTabClose).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'chat-chat-1', editor: 'explorer' })
+    )
+  })
+})

--- a/apps/studio/components/interfaces/Explorer/__tests__/hooks.test.tsx
+++ b/apps/studio/components/interfaces/Explorer/__tests__/hooks.test.tsx
@@ -1,0 +1,66 @@
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useCreateChat } from '../hooks'
+
+const { mockCreateChat, mockPush, mockSelectChat, mockSetContext, mockSetModel } = vi.hoisted(
+  () => ({
+    mockCreateChat: vi.fn(() => 'chat-2'),
+    mockPush: vi.fn(),
+    mockSelectChat: vi.fn(),
+    mockSetContext: vi.fn(),
+    mockSetModel: vi.fn(),
+  })
+)
+
+vi.mock('next/router', () => ({ useRouter: () => ({ push: mockPush }) }))
+vi.mock('@/hooks/misc/useSelectedProject', () => ({
+  useSelectedProjectQuery: () => ({
+    data: { ref: 'default', connectionString: 'postgres://example' },
+  }),
+}))
+vi.mock('@/hooks/misc/useSelectedOrganization', () => ({
+  useSelectedOrganizationQuery: () => ({ data: { slug: 'acme' } }),
+}))
+vi.mock('@/state/ai-assistant-state', () => ({
+  useAiAssistantState: () => ({
+    createChat: mockCreateChat,
+    selectChat: mockSelectChat,
+    setContext: mockSetContext,
+    setModel: mockSetModel,
+  }),
+}))
+
+describe('useCreateChat', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('creates and opens Explorer chats without changing the sidebar selection', () => {
+    const { result } = renderHook(() => useCreateChat())
+
+    act(() => {
+      result.current.createChat({
+        name: 'Investigate errors',
+        initialMessage: 'What happened?',
+        model: 'gpt-5.4-nano',
+      })
+    })
+
+    expect(mockSetContext).toHaveBeenCalledWith({
+      projectRef: 'default',
+      orgSlug: 'acme',
+      connectionString: 'postgres://example',
+    })
+    expect(mockCreateChat).toHaveBeenCalledWith({
+      name: 'Investigate errors',
+      initialMessage: 'What happened?',
+    })
+    expect(mockSetModel).toHaveBeenCalledWith('gpt-5.4-nano')
+    expect(mockPush).toHaveBeenCalledWith('/project/default/explorer/chat/chat-2')
+    expect(mockSelectChat).not.toHaveBeenCalled()
+
+    act(() => result.current.openChat('chat-1'))
+
+    expect(mockPush).toHaveBeenLastCalledWith('/project/default/explorer/chat/chat-1')
+    expect(mockSelectChat).not.toHaveBeenCalled()
+  })
+})

--- a/apps/studio/components/interfaces/Explorer/hooks.ts
+++ b/apps/studio/components/interfaces/Explorer/hooks.ts
@@ -1,8 +1,11 @@
 import { useRouter } from 'next/router'
 
+import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { generateUuid } from '@/lib/api/snippets.browser'
 import { useProfile } from '@/lib/profile'
+import type { AssistantModel } from '@/state/ai-assistant-state'
+import { useAiAssistantState } from '@/state/ai-assistant-state'
 import { useNotebooksStateSnapshot } from '@/state/notebooks/notebooks-state'
 import { type Notebook } from '@/state/notebooks/types'
 
@@ -61,4 +64,48 @@ This is a sample paragraph to demonstrate the Markdown cells
   }
 
   return { createNotebook }
+}
+
+export const useCreateChat = () => {
+  const router = useRouter()
+  const { data: project } = useSelectedProjectQuery()
+  const { data: organization } = useSelectedOrganizationQuery()
+  const aiAssistantState = useAiAssistantState()
+
+  const openChat = (id: string) => {
+    if (!project) {
+      console.error('Project is required')
+      return undefined
+    }
+
+    router.push(`/project/${project.ref}/explorer/chat/${id}`)
+  }
+
+  const createChat = ({
+    name,
+    initialMessage,
+    model,
+  }: {
+    name?: string
+    initialMessage?: string
+    model?: AssistantModel
+  } = {}) => {
+    if (!project) {
+      console.error('Project is required')
+      return undefined
+    }
+
+    aiAssistantState.setContext({
+      projectRef: project.ref,
+      orgSlug: organization?.slug,
+      connectionString: project.connectionString ?? '',
+    })
+    if (model) aiAssistantState.setModel(model)
+
+    const id = aiAssistantState.createChat({ name, initialMessage })
+    router.push(`/project/${project.ref}/explorer/chat/${id}`)
+    return id
+  }
+
+  return { createChat, openChat }
 }

--- a/apps/studio/components/layouts/ExplorerLayout/ExplorerLayout.constants.tsx
+++ b/apps/studio/components/layouts/ExplorerLayout/ExplorerLayout.constants.tsx
@@ -4,7 +4,7 @@ import { type ComponentType, type PropsWithChildren } from 'react'
 import { Button, cn } from 'ui'
 import { InnerSideBarFilters, InnerSideBarFilterSearchInput } from 'ui-patterns/InnerSideMenu'
 
-import { useCreateNotebook } from '@/components/interfaces/Explorer/hooks'
+import { useCreateChat, useCreateNotebook } from '@/components/interfaces/Explorer/hooks'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 
 export type ExplorerResourceType = 'notebook' | 'chat'
@@ -52,6 +52,7 @@ export const ExplorerNavResourceWrapper = ({
   onBack: () => void
 }>) => {
   const { createNotebook } = useCreateNotebook()
+  const { createChat } = useCreateChat()
   const searchPlaceholder = EXPLORER_SECTIONS.find((x) => x.type === type)?.searchPlaceholder
 
   return (
@@ -94,6 +95,7 @@ export const ExplorerNavResourceWrapper = ({
           tooltip={{ content: { side: 'bottom', text: `New ${type}` } }}
           onClick={() => {
             if (type === 'notebook') createNotebook()
+            if (type === 'chat') createChat()
           }}
         />
       </div>

--- a/apps/studio/components/layouts/ExplorerLayout/ExplorerLayout.tsx
+++ b/apps/studio/components/layouts/ExplorerLayout/ExplorerLayout.tsx
@@ -12,7 +12,7 @@ import { type ExplorerResourceType } from './ExplorerLayout.constants'
 import { ExplorerNavChats } from './ExplorerNavChats'
 import { ExplorerNavHome } from './ExplorerNavHome'
 import { ExplorerNavNotebooks } from './ExplorerNavNotebooks'
-import { useCreateNotebook } from '@/components/interfaces/Explorer/hooks'
+import { useCreateChat, useCreateNotebook } from '@/components/interfaces/Explorer/hooks'
 
 export interface ExplorerLayoutProps extends ComponentProps<typeof ProjectLayoutWithAuth> {
   children: ReactNode
@@ -87,6 +87,7 @@ const HomeTabButton = () => {
 
 const NewTabButton = () => {
   const { createNotebook } = useCreateNotebook()
+  const { createChat } = useCreateChat()
 
   return (
     <DropdownMenu>
@@ -110,7 +111,7 @@ const NewTabButton = () => {
           <NotebookText size={14} />
           <span>New notebook</span>
         </DropdownMenuItem>
-        <DropdownMenuItem disabled className="gap-x-2">
+        <DropdownMenuItem className="gap-x-2" onClick={() => createChat()}>
           <MessageCirclePlus size={14} />
           <span>New chat</span>
         </DropdownMenuItem>

--- a/apps/studio/components/layouts/ExplorerLayout/ExplorerNavChats.test.tsx
+++ b/apps/studio/components/layouts/ExplorerLayout/ExplorerNavChats.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, screen } from '@testing-library/react'
+import type { PropsWithChildren } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { ExplorerNavChats } from './ExplorerNavChats'
+import { customRender } from '@/tests/lib/custom-render'
+
+vi.mock('common', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('common')>()
+  return { ...actual, useParams: () => ({ id: 'recent-chat' }) }
+})
+
+vi.mock('next/router', () => ({
+  useRouter: () => ({ pathname: '/project/[ref]/explorer/chat/[id]' }),
+}))
+
+vi.mock('./ExplorerLayout.constants', () => ({
+  ExplorerNavResourceWrapper: ({
+    children,
+    search,
+    setSearch,
+  }: PropsWithChildren<{ search: string; setSearch: (value: string) => void }>) => (
+    <div>
+      <input
+        aria-label="Search chats"
+        value={search}
+        onChange={(event) => setSearch(event.target.value)}
+      />
+      {children}
+    </div>
+  ),
+  rowClassName: (isActive: boolean) => (isActive ? 'active' : 'inactive'),
+}))
+
+vi.mock('@/components/interfaces/Explorer/hooks', () => ({
+  useCreateChat: () => ({ openChat: vi.fn() }),
+}))
+
+vi.mock('@/state/ai-assistant-state', () => ({
+  useAiAssistantChatList: () => [
+    { id: 'old-chat', name: 'Older investigation', updatedAt: new Date('2026-01-01') },
+    { id: 'missing-date', name: 'Rehydrated chat' },
+    { id: 'recent-chat', name: 'Recent investigation', updatedAt: new Date('2026-02-01') },
+    {
+      id: 'support',
+      name: 'Support conversation',
+      updatedAt: new Date('2026-03-01'),
+      supportMetadata: { isSupportChat: true },
+    },
+  ],
+}))
+
+describe('ExplorerNavChats', () => {
+  it('filters support chats, safely sorts rehydrated chats, and marks the route active', () => {
+    customRender(<ExplorerNavChats onBack={vi.fn()} />)
+
+    const chatButtons = screen.getAllByRole('button')
+    expect(chatButtons.map((button) => button.textContent)).toEqual([
+      'Recent investigation',
+      'Older investigation',
+      'Rehydrated chat',
+    ])
+    expect(chatButtons[0]).toHaveClass('active')
+    expect(screen.queryByText('Support conversation')).not.toBeInTheDocument()
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search chats' }), {
+      target: { value: 'rehydrated' },
+    })
+
+    expect(screen.getByRole('button')).toHaveTextContent('Rehydrated chat')
+    expect(screen.queryByText('Recent investigation')).not.toBeInTheDocument()
+  })
+})

--- a/apps/studio/components/layouts/ExplorerLayout/ExplorerNavChats.tsx
+++ b/apps/studio/components/layouts/ExplorerLayout/ExplorerNavChats.tsx
@@ -1,16 +1,60 @@
+import { useParams } from 'common'
+import { MessageSquare } from 'lucide-react'
+import { useRouter } from 'next/router'
 import { useState } from 'react'
+import { cn } from 'ui'
 
-import { ExplorerNavResourceWrapper } from './ExplorerLayout.constants'
+import { ExplorerNavResourceWrapper, rowClassName } from './ExplorerLayout.constants'
+import { useCreateChat } from '@/components/interfaces/Explorer/hooks'
+import type { ChatSession } from '@/state/ai-assistant-state'
+import { useAiAssistantChatList } from '@/state/ai-assistant-state'
+
+const getVisibleChats = (chats: ChatSession[], search: string): ChatSession[] => {
+  const normalizedSearch = search.trim().toLowerCase()
+
+  return chats
+    .filter((chat) => !chat.supportMetadata?.isSupportChat)
+    .filter((chat) => !normalizedSearch || chat.name.toLowerCase().includes(normalizedSearch))
+    .sort((a, b) => (b.updatedAt?.getTime() ?? 0) - (a.updatedAt?.getTime() ?? 0))
+}
 
 export const ExplorerNavChats = ({ onBack }: { onBack: () => void }) => {
   const [search, setSearch] = useState('')
+  const router = useRouter()
+  const { id } = useParams()
+  const { openChat } = useCreateChat()
+  const chatList = useAiAssistantChatList()
 
-  // [Joshen] Eventually will have data fetching for notebooks via useAiAssistantState
+  const chats = getVisibleChats(chatList, search)
 
   return (
     <ExplorerNavResourceWrapper type="chat" search={search} setSearch={setSearch} onBack={onBack}>
       <div className="flex flex-1 flex-col gap-px overflow-y-auto px-3 pb-3">
-        <p className="px-2 py-2 text-xs text-foreground-lighter">No chats created yet</p>
+        {chats.length === 0 ? (
+          <p className="px-2 py-2 text-xs text-foreground-lighter">
+            {search ? 'No chats found' : 'No chats created yet'}
+          </p>
+        ) : (
+          chats.map((chat) => {
+            const isActive = router.pathname.includes('/explorer/chat/') && id === chat.id
+
+            return (
+              <button
+                key={chat.id}
+                type="button"
+                tabIndex={0}
+                className={rowClassName(isActive)}
+                onClick={() => openChat(chat.id)}
+              >
+                <MessageSquare
+                  size={14}
+                  className={cn('shrink-0', isActive && 'text-foreground')}
+                />
+                <span className="truncate text-left">{chat.name}</span>
+              </button>
+            )
+          })
+        )}
       </div>
     </ExplorerNavResourceWrapper>
   )

--- a/apps/studio/components/layouts/Tabs/RecentItems.test.ts
+++ b/apps/studio/components/layouts/Tabs/RecentItems.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { getRecentItemHref } from './RecentItems'
+
+describe('getRecentItemHref', () => {
+  it('builds chat and notebook Explorer URLs from their IDs', () => {
+    expect(
+      getRecentItemHref(
+        {
+          id: 'chat-chat-1',
+          type: 'chat',
+          label: 'Chat',
+          timestamp: 1,
+          metadata: { chatId: 'chat-1' },
+        },
+        'default'
+      )
+    ).toBe('/project/default/explorer/chat/chat-1')
+
+    expect(
+      getRecentItemHref(
+        {
+          id: 'notebook-notebook-1',
+          type: 'notebook',
+          label: 'Notebook',
+          timestamp: 1,
+          metadata: { notebookId: 'notebook-1' },
+        },
+        'default'
+      )
+    ).toBe('/project/default/explorer/notebook/notebook-1')
+  })
+})

--- a/apps/studio/components/layouts/Tabs/RecentItems.tsx
+++ b/apps/studio/components/layouts/Tabs/RecentItems.tsx
@@ -7,7 +7,30 @@ import { useEditorType } from '../editors/EditorsLayout.hooks'
 import { buildTableEditorUrl } from '@/components/grid/SupabaseGrid.utils'
 import { EntityTypeIcon } from '@/components/ui/EntityTypeIcon'
 import { ENTITY_TYPE } from '@/data/entity-types/entity-type-constants'
-import { editorEntityTypes, useTabsStateSnapshot } from '@/state/tabs'
+import { editorEntityTypes, useTabsStateSnapshot, type RecentItem } from '@/state/tabs'
+
+export function getRecentItemHref(item: RecentItem, projectRef: string) {
+  switch (item.type) {
+    case 'sql':
+      return `/project/${projectRef}/sql/${item.metadata?.sqlId}`
+    case 'notebook':
+      return `/project/${projectRef}/explorer/notebook/${item.metadata?.notebookId}`
+    case 'chat':
+      return `/project/${projectRef}/explorer/chat/${item.metadata?.chatId}`
+    case 'r':
+    case 'v':
+    case 'm':
+    case 'f':
+    case 'p':
+      return buildTableEditorUrl({
+        projectRef,
+        tableId: item.metadata?.tableId!,
+        schema: item.metadata?.schema,
+      })
+    default:
+      return `/project/${projectRef}/explorer/${item.type}/${item.metadata?.schema}/${item.metadata?.name}`
+  }
+}
 
 export function RecentItems() {
   const { ref } = useParams()
@@ -53,21 +76,7 @@ export function RecentItems() {
                   transition={{ delay: index * 0.012, duration: 0.15 }}
                 >
                   <Link
-                    href={
-                      item.type === 'sql'
-                        ? `/project/${ref}/sql/${item.metadata?.sqlId}`
-                        : item.type === 'r' ||
-                            item.type === 'v' ||
-                            item.type === 'm' ||
-                            item.type === 'f' ||
-                            item.type === 'p'
-                          ? buildTableEditorUrl({
-                              projectRef: ref,
-                              tableId: item.metadata?.tableId!,
-                              schema: item.metadata?.schema,
-                            })
-                          : `/project/${ref}/explorer/${item.type}/${item.metadata?.schema}/${item.metadata?.name}`
-                    }
+                    href={getRecentItemHref(item, ref)}
                     className="flex items-center gap-4 rounded-lg bg-surface-100 py-2 transition-colors hover:bg-surface-200"
                   >
                     <div className="flex h-6 w-6 items-center justify-center rounded-sm bg-surface-100 border">

--- a/apps/studio/components/layouts/Tabs/Tabs.tsx
+++ b/apps/studio/components/layouts/Tabs/Tabs.tsx
@@ -50,7 +50,7 @@ export const EditorTabs = ({
   newTabButton,
   isCollapseButtonHidden,
 }: EditorTabsProps) => {
-  const { ref, id } = useParams()
+  const { ref } = useParams()
   const router = useRouter()
   const { setLastVisitedSnippet, setLastVisitedTable } = useDashboardHistory()
 
@@ -92,10 +92,13 @@ export const EditorTabs = ({
   const onClearDashboardHistory = () => {
     if (editor === 'table') {
       setLastVisitedTable(undefined)
-    } else if (editor === 'sql') {
+    }
+    if (editor === 'sql') {
       setLastVisitedSnippet(undefined)
     }
   }
+
+  const editorTabIds = editorTabs.map((tab) => tab.id)
 
   // Runs `performClose` immediately unless one of the tabs' registered close
   // handlers asks to confirm first (e.g. a SQL snippet with unsaved edits), in
@@ -119,44 +122,35 @@ export const EditorTabs = ({
 
   const handleCloseAll = () => {
     if (editor) {
-      const tabsToClose =
-        editor === 'table'
-          ? tabs.openTabs.filter((x) => !x.startsWith('sql'))
-          : tabs.openTabs.filter((x) => x.startsWith('sql'))
+      const tabsToClose = editorTabIds
 
       closeWithConfirmation(tabsToClose, () => {
         tabs.closeTabs(tabsToClose)
         onClearDashboardHistory()
-        router.push(`/project/${ref}/${editor === 'table' ? 'editor' : 'sql'}`)
+        let editorRoot = 'explorer'
+        if (editor === 'table') editorRoot = 'editor'
+        if (editor === 'sql') editorRoot = 'sql'
+        router.push(`/project/${ref}/${editorRoot}`)
       })
     }
   }
 
   const handleCloseOthers = (tabId: string) => {
     if (editor) {
-      const tabsToClose =
-        editor === 'table'
-          ? tabs.openTabs.filter((x) => !x.startsWith('sql') && x !== tabId)
-          : tabs.openTabs.filter((x) => x.startsWith('sql') && x !== tabId)
+      const tabsToClose = editorTabIds.filter((id) => id !== tabId)
 
       closeWithConfirmation(tabsToClose, () => {
         tabs.closeTabs(tabsToClose)
         onClearDashboardHistory()
 
-        const entityId = editor === 'table' ? tabId.split('-')[1] : tabId.split('sql-')[1]
-        if (id !== entityId) {
-          router.push(`/project/${ref}/${editor === 'table' ? 'editor' : 'sql'}/${entityId}`)
-        }
+        if (tabs.activeTab !== tabId) tabs.handleTabNavigation(tabId, router)
       })
     }
   }
 
   const handleCloseRight = (tabId: string) => {
     if (editor) {
-      const openedTabs =
-        editor === 'table'
-          ? tabs.openTabs.filter((x) => !x.startsWith('sql'))
-          : tabs.openTabs.filter((x) => x.startsWith('sql'))
+      const openedTabs = editorTabIds
       const tabIdx = openedTabs.indexOf(tabId)
       const activeTabIdx = openedTabs.indexOf(tabs.activeTab!)
       const tabsToClose = openedTabs.slice(tabIdx + 1)
@@ -166,8 +160,7 @@ export const EditorTabs = ({
 
         const isActiveTabClosed = tabIdx < activeTabIdx
         if (isActiveTabClosed) {
-          const id = editor === 'table' ? tabId.split('-')[1] : tabId.split('sql-')[1]
-          router.push(`/project/${ref}/${editor === 'table' ? 'editor' : 'sql'}/${id}`)
+          tabs.handleTabNavigation(tabId, router)
         }
       })
     }

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistantHeader.test.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistantHeader.test.tsx
@@ -1,0 +1,56 @@
+import { fireEvent, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { AIAssistantHeader } from './AIAssistantHeader'
+import { customRender } from '@/tests/lib/custom-render'
+
+const { openChat } = vi.hoisted(() => ({ openChat: vi.fn() }))
+
+vi.mock('@/state/ai-assistant-state', () => ({
+  useAiAssistantStateSnapshot: () => ({
+    activeChatId: 'chat-1',
+    activeChat: { name: 'Investigate errors' },
+    renameChat: vi.fn(),
+  }),
+}))
+
+vi.mock('@/components/interfaces/Explorer/hooks', () => ({
+  useCreateChat: () => ({ openChat }),
+}))
+
+vi.mock('@/state/shortcuts/useShortcut', () => ({ useShortcut: vi.fn() }))
+
+vi.mock('./AIAssistantChatSelector', () => ({
+  AIAssistantChatSelector: () => (
+    <button type="button" tabIndex={0}>
+      History
+    </button>
+  ),
+}))
+
+vi.mock('./AIAssistantMetadataWarning', () => ({
+  AIAssistantMetadataWarning: () => null,
+}))
+
+const defaultProps = {
+  isChatLoading: false,
+  onNewChat: vi.fn(),
+  onCloseAssistant: vi.fn(),
+  showMetadataWarning: false,
+  updatedOptInSinceMCP: true,
+  isHipaaProjectDisallowed: false,
+  aiOptInLevel: 'full',
+}
+
+describe('AIAssistantHeader', () => {
+  it('opens the active chat in Explorer and closes the sidebar', () => {
+    const onCloseAssistant = vi.fn()
+    customRender(<AIAssistantHeader {...defaultProps} onCloseAssistant={onCloseAssistant} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open in Explorer' }))
+
+    expect(openChat).toHaveBeenCalledWith('chat-1')
+    expect(onCloseAssistant).toHaveBeenCalledOnce()
+    expect(screen.queryByRole('button', { name: 'Minimize' })).not.toBeInTheDocument()
+  })
+})

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistantHeader.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistantHeader.tsx
@@ -3,7 +3,6 @@ import {
   Edit,
   Maximize,
   MessageCirclePlus,
-  Minimize,
   MoreVertical,
   Settings,
   X,
@@ -20,16 +19,15 @@ import {
   DropdownMenuTrigger,
   Input,
 } from 'ui'
-import { Admonition } from 'ui-patterns/Admonition'
 
 import { ButtonTooltip } from '../ButtonTooltip'
 import { ShortcutPills, ShortcutTooltip } from '../ShortcutTooltip'
 import { AIAssistantChatSelector } from './AIAssistantChatSelector'
-import { AIOptInModal } from './AIOptInModal'
+import { AIAssistantMetadataWarning } from './AIAssistantMetadataWarning'
+import { useCreateChat } from '@/components/interfaces/Explorer/hooks'
 import { useAiAssistantStateSnapshot } from '@/state/ai-assistant-state'
 import { SHORTCUT_DEFINITIONS, SHORTCUT_IDS } from '@/state/shortcuts/registry'
 import { useShortcut } from '@/state/shortcuts/useShortcut'
-import { useSidebarManagerSnapshot } from '@/state/sidebar-manager-state'
 
 interface AIAssistantHeaderProps {
   isChatLoading: boolean
@@ -53,10 +51,16 @@ export const AIAssistantHeader = ({
   aiOptInLevel,
 }: AIAssistantHeaderProps) => {
   const snap = useAiAssistantStateSnapshot()
-  const { isMaximised, toggleMaximise } = useSidebarManagerSnapshot()
+  const { openChat } = useCreateChat()
   const [value, setValue] = useState(snap.activeChat?.name)
   const [isEditingName, setIsEditingName] = useState(false)
   const [isOptInModalOpen, setIsOptInModalOpen] = useState(false)
+
+  const handleOpenInExplorer = () => {
+    if (!snap.activeChatId) return
+    openChat(snap.activeChatId)
+    onCloseAssistant()
+  }
 
   const handleCopyChatId = () => {
     copyToClipboard(snap.activeChatId ?? '', () => {
@@ -96,7 +100,7 @@ export const AIAssistantHeader = ({
     enabled: shortcutsEnabled && !isChatLoading,
   })
 
-  useShortcut(SHORTCUT_IDS.AI_ASSISTANT_MAXIMIZE, toggleMaximise, {
+  useShortcut(SHORTCUT_IDS.AI_ASSISTANT_MAXIMIZE, handleOpenInExplorer, {
     enabled: shortcutsEnabled && !isChatLoading,
   })
 
@@ -149,15 +153,15 @@ export const AIAssistantHeader = ({
 
             <ShortcutTooltip
               side="bottom"
-              label={isMaximised ? 'Minimize' : 'Maximize'}
+              label="Open in Explorer"
               shortcutId={SHORTCUT_IDS.AI_ASSISTANT_MAXIMIZE}
             >
               <Button
                 variant="text"
-                aria-label={isMaximised ? 'Minimize' : 'Maximize'}
+                aria-label="Open in Explorer"
                 size="tiny"
-                icon={isMaximised ? <Minimize /> : <Maximize />}
-                onClick={toggleMaximise}
+                icon={<Maximize />}
+                onClick={handleOpenInExplorer}
                 className="h-7 w-7 p-0"
               />
             </ShortcutTooltip>
@@ -218,43 +222,14 @@ export const AIAssistantHeader = ({
         </div>
       </div>
 
-      {showMetadataWarning && (
-        <Admonition
-          type="default"
-          title={
-            !updatedOptInSinceMCP
-              ? 'The Assistant has just been updated to help you better!'
-              : isHipaaProjectDisallowed
-                ? 'Project metadata is not shared due to HIPAA'
-                : aiOptInLevel === 'disabled'
-                  ? 'Project metadata is currently not shared'
-                  : 'Limited metadata is shared to the Assistant'
-          }
-          description={
-            !updatedOptInSinceMCP
-              ? 'You may now opt-in to share schema metadata and even logs for better results'
-              : isHipaaProjectDisallowed
-                ? 'Your organization has the HIPAA addon and will not send project metadata with your prompts for projects marked as HIPAA.'
-                : aiOptInLevel === 'disabled'
-                  ? 'The Assistant can provide better answers if you opt-in to share schema metadata.'
-                  : aiOptInLevel === 'schema'
-                    ? 'Sharing query data in addition to schema can further improve responses. Update AI settings to enable this.'
-                    : ''
-          }
-          className="border-0 border-b rounded-none bg-background"
-        >
-          {!isHipaaProjectDisallowed && (
-            <Button
-              variant="default"
-              className="w-fit mt-4"
-              onClick={() => setIsOptInModalOpen(true)}
-            >
-              Permission settings
-            </Button>
-          )}
-        </Admonition>
-      )}
-      <AIOptInModal visible={isOptInModalOpen} onCancel={() => setIsOptInModalOpen(false)} />
+      <AIAssistantMetadataWarning
+        visible={isOptInModalOpen}
+        onVisibleChange={setIsOptInModalOpen}
+        showMetadataWarning={showMetadataWarning}
+        updatedOptInSinceMCP={updatedOptInSinceMCP}
+        isHipaaProjectDisallowed={isHipaaProjectDisallowed}
+        aiOptInLevel={aiOptInLevel}
+      />
     </div>
   )
 }

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistantMetadataWarning.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistantMetadataWarning.tsx
@@ -1,0 +1,58 @@
+import { Button } from 'ui'
+import { Admonition } from 'ui-patterns/Admonition'
+
+import { AIOptInModal } from './AIOptInModal'
+
+interface AIAssistantMetadataWarningProps {
+  visible: boolean
+  onVisibleChange: (visible: boolean) => void
+  showMetadataWarning: boolean
+  updatedOptInSinceMCP: boolean
+  isHipaaProjectDisallowed: boolean
+  aiOptInLevel: 'disabled' | 'schema' | 'full' | string | undefined
+}
+
+export const AIAssistantMetadataWarning = ({
+  visible,
+  onVisibleChange,
+  showMetadataWarning,
+  updatedOptInSinceMCP,
+  isHipaaProjectDisallowed,
+  aiOptInLevel,
+}: AIAssistantMetadataWarningProps) => (
+  <>
+    {showMetadataWarning && (
+      <Admonition
+        type="default"
+        title={
+          !updatedOptInSinceMCP
+            ? 'The Assistant has just been updated to help you better!'
+            : isHipaaProjectDisallowed
+              ? 'Project metadata is not shared due to HIPAA'
+              : aiOptInLevel === 'disabled'
+                ? 'Project metadata is currently not shared'
+                : 'Limited metadata is shared to the Assistant'
+        }
+        description={
+          !updatedOptInSinceMCP
+            ? 'You may now opt-in to share schema metadata and even logs for better results'
+            : isHipaaProjectDisallowed
+              ? 'Your organization has the HIPAA addon and will not send project metadata with your prompts for projects marked as HIPAA.'
+              : aiOptInLevel === 'disabled'
+                ? 'The Assistant can provide better answers if you opt-in to share schema metadata.'
+                : aiOptInLevel === 'schema'
+                  ? 'Sharing query data in addition to schema can further improve responses. Update AI settings to enable this.'
+                  : ''
+        }
+        className="border-0 border-b rounded-none bg-background"
+      >
+        {!isHipaaProjectDisallowed && (
+          <Button variant="default" className="w-fit mt-4" onClick={() => onVisibleChange(true)}>
+            Permission settings
+          </Button>
+        )}
+      </Admonition>
+    )}
+    <AIOptInModal visible={visible} onCancel={() => onVisibleChange(false)} />
+  </>
+)

--- a/apps/studio/components/ui/EntityTypeIcon.tsx
+++ b/apps/studio/components/ui/EntityTypeIcon.tsx
@@ -1,4 +1,4 @@
-import { Eye, GitBranch, NotebookText, ScrollText, Table2 } from 'lucide-react'
+import { Eye, GitBranch, MessageSquare, NotebookText, ScrollText, Table2 } from 'lucide-react'
 import { cn, SQL_ICON } from 'ui'
 
 import type { SqlSnippetSource } from '@/components/interfaces/SQLEditor/querySource'
@@ -26,7 +26,7 @@ export const LogsSnippetIcon = ({
 )
 
 interface EntityTypeIconProps {
-  type: 'sql' | 'schema' | 'new' | 'r' | 'v' | 'm' | 'f' | 'p' | 'notebook'
+  type: 'sql' | 'schema' | 'new' | 'r' | 'v' | 'm' | 'f' | 'p' | 'notebook' | 'chat'
   size?: number
   strokeWidth?: number
   isActive?: boolean
@@ -105,6 +105,10 @@ export const EntityTypeIcon = ({
 
   if (type === 'notebook') {
     return <NotebookText size={size} strokeWidth={strokeWidth} className={''} />
+  }
+
+  if (type === 'chat') {
+    return <MessageSquare size={size} strokeWidth={strokeWidth} />
   }
 
   return (

--- a/apps/studio/pages/project/[ref]/explorer/chat/[id].tsx
+++ b/apps/studio/pages/project/[ref]/explorer/chat/[id].tsx
@@ -1,0 +1,14 @@
+import { ChatEditor } from '@/components/interfaces/Explorer/ChatEditor'
+import { DefaultLayout } from '@/components/layouts/DefaultLayout'
+import { ExplorerLayout } from '@/components/layouts/ExplorerLayout/ExplorerLayout'
+import type { NextPageWithLayout } from '@/types'
+
+const ChatPage: NextPageWithLayout = () => <ChatEditor />
+
+ChatPage.getLayout = (page) => (
+  <DefaultLayout>
+    <ExplorerLayout>{page}</ExplorerLayout>
+  </DefaultLayout>
+)
+
+export default ChatPage

--- a/apps/studio/routeTree.gen.ts
+++ b/apps/studio/routeTree.gen.ts
@@ -230,6 +230,7 @@ import { Route as ProjectRefFunctionsFunctionSlugInvocationsRouteImport } from '
 import { Route as ProjectRefFunctionsFunctionSlugDetailsRouteImport } from './routes/project/$ref/functions/$functionSlug/details'
 import { Route as ProjectRefFunctionsFunctionSlugCodeRouteImport } from './routes/project/$ref/functions/$functionSlug/code'
 import { Route as ProjectRefExplorerNotebookIdRouteImport } from './routes/project/$ref/explorer/notebook/$id'
+import { Route as ProjectRefExplorerChatIdRouteImport } from './routes/project/$ref/explorer/chat/$id'
 import { Route as ProjectRefDatabaseTriggersEventRouteImport } from './routes/project/$ref/database/triggers/event'
 import { Route as ProjectRefDatabaseTriggersDataRouteImport } from './routes/project/$ref/database/triggers/data'
 import { Route as ProjectRefDatabaseTablesIdRouteImport } from './routes/project/$ref/database/tables/$id'
@@ -1522,6 +1523,12 @@ const ProjectRefExplorerNotebookIdRoute =
     path: '/notebook/$id',
     getParentRoute: () => ProjectRefExplorerRoute,
   } as any)
+const ProjectRefExplorerChatIdRoute =
+  ProjectRefExplorerChatIdRouteImport.update({
+    id: '/chat/$id',
+    path: '/chat/$id',
+    getParentRoute: () => ProjectRefExplorerRoute,
+  } as any)
 const ProjectRefDatabaseTriggersEventRoute =
   ProjectRefDatabaseTriggersEventRouteImport.update({
     id: '/event',
@@ -2282,6 +2289,7 @@ export interface FileRoutesByFullPath {
   '/project/$ref/database/tables/$id': typeof ProjectRefDatabaseTablesIdRoute
   '/project/$ref/database/triggers/data': typeof ProjectRefDatabaseTriggersDataRoute
   '/project/$ref/database/triggers/event': typeof ProjectRefDatabaseTriggersEventRoute
+  '/project/$ref/explorer/chat/$id': typeof ProjectRefExplorerChatIdRoute
   '/project/$ref/explorer/notebook/$id': typeof ProjectRefExplorerNotebookIdRoute
   '/project/$ref/functions/$functionSlug/code': typeof ProjectRefFunctionsFunctionSlugCodeRoute
   '/project/$ref/functions/$functionSlug/details': typeof ProjectRefFunctionsFunctionSlugDetailsRoute
@@ -2579,6 +2587,7 @@ export interface FileRoutesByTo {
   '/project/$ref/database/tables/$id': typeof ProjectRefDatabaseTablesIdRoute
   '/project/$ref/database/triggers/data': typeof ProjectRefDatabaseTriggersDataRoute
   '/project/$ref/database/triggers/event': typeof ProjectRefDatabaseTriggersEventRoute
+  '/project/$ref/explorer/chat/$id': typeof ProjectRefExplorerChatIdRoute
   '/project/$ref/explorer/notebook/$id': typeof ProjectRefExplorerNotebookIdRoute
   '/project/$ref/functions/$functionSlug/code': typeof ProjectRefFunctionsFunctionSlugCodeRoute
   '/project/$ref/functions/$functionSlug/details': typeof ProjectRefFunctionsFunctionSlugDetailsRoute
@@ -2892,6 +2901,7 @@ export interface FileRoutesById {
   '/project/$ref/database/tables/$id': typeof ProjectRefDatabaseTablesIdRoute
   '/project/$ref/database/triggers/data': typeof ProjectRefDatabaseTriggersDataRoute
   '/project/$ref/database/triggers/event': typeof ProjectRefDatabaseTriggersEventRoute
+  '/project/$ref/explorer/chat/$id': typeof ProjectRefExplorerChatIdRoute
   '/project/$ref/explorer/notebook/$id': typeof ProjectRefExplorerNotebookIdRoute
   '/project/$ref/functions/$functionSlug/code': typeof ProjectRefFunctionsFunctionSlugCodeRoute
   '/project/$ref/functions/$functionSlug/details': typeof ProjectRefFunctionsFunctionSlugDetailsRoute
@@ -3204,6 +3214,7 @@ export interface FileRouteTypes {
     | '/project/$ref/database/tables/$id'
     | '/project/$ref/database/triggers/data'
     | '/project/$ref/database/triggers/event'
+    | '/project/$ref/explorer/chat/$id'
     | '/project/$ref/explorer/notebook/$id'
     | '/project/$ref/functions/$functionSlug/code'
     | '/project/$ref/functions/$functionSlug/details'
@@ -3501,6 +3512,7 @@ export interface FileRouteTypes {
     | '/project/$ref/database/tables/$id'
     | '/project/$ref/database/triggers/data'
     | '/project/$ref/database/triggers/event'
+    | '/project/$ref/explorer/chat/$id'
     | '/project/$ref/explorer/notebook/$id'
     | '/project/$ref/functions/$functionSlug/code'
     | '/project/$ref/functions/$functionSlug/details'
@@ -3813,6 +3825,7 @@ export interface FileRouteTypes {
     | '/project/$ref/database/tables/$id'
     | '/project/$ref/database/triggers/data'
     | '/project/$ref/database/triggers/event'
+    | '/project/$ref/explorer/chat/$id'
     | '/project/$ref/explorer/notebook/$id'
     | '/project/$ref/functions/$functionSlug/code'
     | '/project/$ref/functions/$functionSlug/details'
@@ -5568,6 +5581,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProjectRefExplorerNotebookIdRouteImport
       parentRoute: typeof ProjectRefExplorerRoute
     }
+    '/project/$ref/explorer/chat/$id': {
+      id: '/project/$ref/explorer/chat/$id'
+      path: '/chat/$id'
+      fullPath: '/project/$ref/explorer/chat/$id'
+      preLoaderRoute: typeof ProjectRefExplorerChatIdRouteImport
+      parentRoute: typeof ProjectRefExplorerRoute
+    }
     '/project/$ref/database/triggers/event': {
       id: '/project/$ref/database/triggers/event'
       path: '/event'
@@ -6516,11 +6536,13 @@ const ProjectRefEditorRouteWithChildren =
 
 interface ProjectRefExplorerRouteChildren {
   ProjectRefExplorerIndexRoute: typeof ProjectRefExplorerIndexRoute
+  ProjectRefExplorerChatIdRoute: typeof ProjectRefExplorerChatIdRoute
   ProjectRefExplorerNotebookIdRoute: typeof ProjectRefExplorerNotebookIdRoute
 }
 
 const ProjectRefExplorerRouteChildren: ProjectRefExplorerRouteChildren = {
   ProjectRefExplorerIndexRoute: ProjectRefExplorerIndexRoute,
+  ProjectRefExplorerChatIdRoute: ProjectRefExplorerChatIdRoute,
   ProjectRefExplorerNotebookIdRoute: ProjectRefExplorerNotebookIdRoute,
 }
 

--- a/apps/studio/routes/project/$ref/explorer/chat/$id.tsx
+++ b/apps/studio/routes/project/$ref/explorer/chat/$id.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { ChatEditor } from '@/components/interfaces/Explorer/ChatEditor'
+
+export const Route = createFileRoute('/project/$ref/explorer/chat/$id')({
+  component: ProjectExplorerChatRoute,
+})
+
+function ProjectExplorerChatRoute() {
+  return <ChatEditor />
+}

--- a/apps/studio/state/ai-assistant-state.tsx
+++ b/apps/studio/state/ai-assistant-state.tsx
@@ -3,7 +3,14 @@ import { DefaultChatTransport, lastAssistantMessageIsCompleteWithApprovalRespons
 import { LOCAL_STORAGE_KEYS, safeLocalStorage } from 'common'
 import { DBSchema, IDBPDatabase, openDB } from 'idb'
 import { debounce } from 'lodash'
-import { createContext, PropsWithChildren, useContext, useEffect, useState } from 'react'
+import {
+  createContext,
+  PropsWithChildren,
+  useContext,
+  useEffect,
+  useReducer,
+  useState,
+} from 'react'
 import { v4 as uuidv4 } from 'uuid'
 import { proxy, ref, snapshot, subscribe, useSnapshot } from 'valtio'
 
@@ -375,6 +382,7 @@ export const createAiAssistantState = (): AiAssistantState => {
     chatInstances: {},
     pendingSpanIds: {},
     messageSpanIds: {},
+    isInitialized: false,
 
     setContext: (context: Partial<AiAssistantContext>) => {
       state.context = { ...state.context, ...context }
@@ -382,6 +390,7 @@ export const createAiAssistantState = (): AiAssistantState => {
 
     resetAiAssistantPanel: () => {
       Object.assign(state, createInitialAiAssistantData())
+      state.isInitialized = false
     },
 
     setModel: (model: AssistantModel) => {
@@ -666,6 +675,7 @@ export type AiAssistantState = AiAssistantData & {
   chatInstances: Record<string, Chat<MessageType>>
   pendingSpanIds: Record<string, string>
   messageSpanIds: Record<string, string>
+  isInitialized: boolean
   setContext: (context: Partial<AiAssistantContext>) => void
   setModel: (model: AssistantModel) => void
   createChat: (options?: CreateChatOptions) => string
@@ -696,6 +706,7 @@ export const AiAssistantStateContextProvider = ({ children }: PropsWithChildren)
   // Effect to load state from IndexedDB on mount or projectRef change
   useEffect(() => {
     let isMounted = true
+    state.isInitialized = false
 
     async function loadAndInitializeState() {
       if (!project?.ref || typeof window === 'undefined') {
@@ -724,6 +735,7 @@ export const AiAssistantStateContextProvider = ({ children }: PropsWithChildren)
 
       // 4. Ensure an active chat exists and handle URL overrides
       ensureActiveChatOrInitialize(state)
+      state.isInitialized = true
     }
 
     loadAndInitializeState()
@@ -781,6 +793,13 @@ export const AiAssistantStateContextProvider = ({ children }: PropsWithChildren)
 export const useAiAssistantStateSnapshot = (options?: Parameters<typeof useSnapshot>[1]) => {
   const state = useContext(AiAssistantStateContext)
   return useSnapshot(state, options)
+}
+
+export const useAiAssistantChatList = (): ChatSession[] => {
+  const state = useContext(AiAssistantStateContext)
+  const [, rerender] = useReducer((count) => count + 1, 0)
+  useEffect(() => subscribe(state.chats, rerender), [state])
+  return Object.values(state.chats)
 }
 
 export const useAiAssistantState = () => {

--- a/apps/studio/state/shortcuts/registry.ts
+++ b/apps/studio/state/shortcuts/registry.ts
@@ -266,7 +266,7 @@ export const SHORTCUT_DEFINITIONS: Record<ShortcutId, ShortcutDefinition> = {
   },
   [SHORTCUT_IDS.AI_ASSISTANT_MAXIMIZE]: {
     id: SHORTCUT_IDS.AI_ASSISTANT_MAXIMIZE,
-    label: 'Maximize assistant',
+    label: 'Open chat in Explorer',
     sequence: ['A', '='],
     showInSettings: false,
   },

--- a/apps/studio/state/tabs.test.ts
+++ b/apps/studio/state/tabs.test.ts
@@ -1,7 +1,7 @@
 import type { NextRouter } from 'next/router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { createTabsState, type Tab } from './tabs'
+import { createTabId, createTabsState, type Tab } from './tabs'
 import { ENTITY_TYPE } from '@/data/entity-types/entity-type-constants'
 
 const fakeRouter = () => ({ query: { ref: 'default' }, push: vi.fn() }) as unknown as NextRouter
@@ -12,6 +12,52 @@ const sqlTab = (id: string): Tab => ({
   label: id,
   isPreview: false,
   metadata: { sqlId: id },
+})
+
+describe('Explorer chat tabs', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('creates stable chat tab ids and navigates to the chat route', () => {
+    const store = createTabsState('default')
+    const router = fakeRouter()
+    const id = createTabId('chat', { id: 'assistant-chat-id' })
+
+    store.addTab({
+      id,
+      type: 'chat',
+      label: 'Investigate errors',
+      metadata: { chatId: 'assistant-chat-id' },
+      isPreview: false,
+    })
+    store.handleTabNavigation(id, router)
+
+    expect(id).toBe('chat-assistant-chat-id')
+    expect(router.push).toHaveBeenCalledWith('/project/default/explorer/chat/assistant-chat-id')
+  })
+
+  it('returns to Explorer home when the final chat tab closes', () => {
+    const store = createTabsState('default')
+    const router = fakeRouter()
+    const id = createTabId('chat', { id: 'assistant-chat-id' })
+
+    store.addTab({
+      id,
+      type: 'chat',
+      label: 'Investigate errors',
+      metadata: { chatId: 'assistant-chat-id' },
+      isPreview: false,
+    })
+    store.handleTabClose({
+      id,
+      router,
+      editor: 'explorer',
+      onClearDashboardHistory: () => {},
+    })
+
+    expect(router.push).toHaveBeenCalledWith('/project/default/explorer')
+  })
 })
 
 describe('tabs recent items', () => {

--- a/apps/studio/state/tabs.tsx
+++ b/apps/studio/state/tabs.tsx
@@ -19,10 +19,10 @@ import type { ENTITY_TYPE } from '@/data/entity-types/entity-type-constants'
 export const editorEntityTypes = {
   table: ['r', 'v', 'm', 'f', 'p'],
   sql: ['sql'],
-  explorer: ['notebook'],
+  explorer: ['notebook', 'chat'],
 }
 
-export type TabType = ENTITY_TYPE | 'sql' | 'notebook'
+export type TabType = ENTITY_TYPE | 'sql' | 'notebook' | 'chat'
 
 type CreateTabIdParams = {
   r: { id: number }
@@ -32,6 +32,7 @@ type CreateTabIdParams = {
   p: { id: number }
   sql: { id: string }
   notebook: { id: string }
+  chat: { id: string }
   schema: { schema: string }
   view: never
   function: never
@@ -48,6 +49,7 @@ export interface Tab {
     tableId?: number
     sqlId?: string
     notebookId?: string
+    chatId?: string
     scrollTop?: number
     /**
      * For SQL tabs, which backend the snippet queries (`'database'` | `'logs'`),
@@ -111,6 +113,8 @@ export interface RecentItem {
     name?: string
     tableId?: number
     sqlId?: string
+    notebookId?: string
+    chatId?: string
     sqlSource?: SqlSnippetSource
   }
 }
@@ -391,6 +395,9 @@ export function createTabsState(projectRef: string) {
         case 'notebook':
           router.push(`/project/${router.query.ref}/explorer/notebook/${tab.metadata?.notebookId}`)
           break
+        case 'chat':
+          router.push(`/project/${router.query.ref}/explorer/chat/${tab.metadata?.chatId}`)
+          break
         case 'r':
         case 'v':
         case 'm':
@@ -525,6 +532,7 @@ export function createTabsState(projectRef: string) {
               router.push(`/project/${router.query.ref}/sql`)
               break
             case 'notebook':
+            case 'chat':
               router.push(`/project/${router.query.ref}/explorer`)
               break
             case 'r':
@@ -647,7 +655,9 @@ export function createTabId<T extends TabType>(type: T, params: CreateTabIdParam
     case 'sql':
       return `sql-${(params as CreateTabIdParams['sql']).id}`
     case 'notebook':
-      return `notebook-${(params as CreateTabIdParams['sql']).id}`
+      return `notebook-${(params as CreateTabIdParams['notebook']).id}`
+    case 'chat':
+      return `chat-${(params as CreateTabIdParams['chat']).id}`
     default:
       return ''
   }


### PR DESCRIPTION
## Summary

- add routed Explorer chat tabs backed by an explicit chat ID
- add an Explorer-specific chat toolbar without sidebar history or new-chat controls
- create and branch Explorer chats without changing sidebar selection
- list searchable non-support chats in Explorer with safe rehydrated-date sorting
- clean up orphaned chat tabs after assistant state hydration and show a useful missing-chat state
- add chat tab/recent-item routing and make the sidebar expand action open the active chat in Explorer
- leave placeholder notebook/SQL actions and sidebar maximize-state cleanup out of scope

This is PR 2 of 2 and is stacked on #48970. Review #48970 first; this PR contains only the Explorer feature when compared against its base branch.

## Test plan

- `mise exec node@22 -- pnpm --dir apps/studio exec tsc --noEmit`
- focused Vitest suite: 7 files / 29 tests covering assistant store isolation, chat editor routing/deletion, creation hook, nav filtering/sorting, tabs, recent items, and sidebar handoff
- ESLint on changed files
- Prettier check on changed files