### PR TITLE
docs: update database inspect page title DOCS-1300

### DIFF
--- a/apps/docs/content/guides/database/inspect.mdx
+++ b/apps/docs/content/guides/database/inspect.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Debugging and monitoring'
+title: 'Database debugging and monitoring'
 description: 'Inspecting your Postgres database for common issues around disk, query performance, index, locks, and more using the terminal.'
 ---
 


### PR DESCRIPTION
## Problem

The database debugging and monitoring guide had the generic title "Debugging and monitoring", which lacked product context and made it unclear in search results or breadcrumbs which area it covered.

## Fix

Changed the page title to "Database debugging and monitoring". The sidebar entry keeps its shorter "Debugging and monitoring" label since it already has database section context.

## How to test

- Navigate to the database debugging and monitoring guide in the docs
- Confirm the page H1 reads "Database debugging and monitoring"
- Confirm the sidebar entry still reads "Debugging and monitoring"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the guide title to “Database debugging and monitoring” for clearer navigation and context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->