### PR TITLE
docs(auth): clarify session timebox and inactivity timeout are in hours

### DIFF
--- a/apps/docs/content/guides/auth/sessions.mdx
+++ b/apps/docs/content/guides/auth/sessions.mdx
@@ -59,6 +59,16 @@ To make sure that users are required to re-authenticate periodically, you can se
 
 To make sure that sessions expire after a period of inactivity, you can set a positive duration for the **Inactivity timeout** option in the [Auth settings](/dashboard/project/_/auth/sessions).
 
+Both **Time-box user sessions** and **Inactivity timeout** are measured in hours. Fractional values are allowed, so `0.5` is 30 minutes. Set a value to `0` to turn that limit off.
+
+<Admonition type="caution">
+
+The `sessions_timebox` and `sessions_inactivity_timeout` properties of the [Management API](/docs/reference/api/v1-update-auth-service-config) are also measured in hours, not seconds. Send `sessions_inactivity_timeout: 4` for a four-hour timeout. Sending `14400` sets a timeout of 14,400 hours, or around 1.6 years, so sessions appear to never time out.
+
+</Admonition>
+
+With the Supabase CLI, set `auth.sessions.timebox` and `auth.sessions.inactivity_timeout` in `config.toml` using duration strings such as `"4h"` or `"50m"`.
+
 You can also enforce only one active session per user per device or browser. When this is enabled, the session from the most recent sign in will remain active, while the rest are terminated. Enable this via the _Single session per user_ option in the [Auth settings](/dashboard/project/_/auth/sessions).
 
 Sessions are not proactively destroyed when you change these settings, but rather the check is enforced whenever a session is refreshed next. This can confuse developers because the actual duration of a session is the configured timeout plus the JWT expiration time. For single session per user, the effect will only be noticed at intervals of the JWT expiration time. Make sure you adjust this setting depending on your needs. We do not recommend going below 5 minutes for the JWT expiration time.

--- a/apps/docs/content/guides/auth/sessions.mdx
+++ b/apps/docs/content/guides/auth/sessions.mdx
@@ -63,7 +63,7 @@ Both **Time-box user sessions** and **Inactivity timeout** are measured in hours
 
 <Admonition type="caution">
 
-The `sessions_timebox` and `sessions_inactivity_timeout` properties of the [Management API](/docs/reference/api/v1-update-auth-service-config) are also measured in hours, not seconds. Send `sessions_inactivity_timeout: 4` for a four-hour timeout. Sending `14400` sets a timeout of 14,400 hours, or around 1.6 years, so sessions appear to never time out.
+The `sessions_timebox` and `sessions_inactivity_timeout` properties of the [Management API](/docs/reference/api/v1-update-auth-service-config) are also measured in hours, not seconds. Send `{"sessions_inactivity_timeout": 4}` for a four-hour timeout. Sending `14400` sets a timeout of 14,400 hours, or around 1.6 years, so sessions appear to never time out.
 
 </Admonition>
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update.

## What is the current behavior?

Closes #48910.

The Auth sessions guide tells you to set **Time-box user sessions** and **Inactivity timeout**, but never says what unit those values are in. The Management API spec doesn't either — `sessions_timebox` and `sessions_inactivity_timeout` are both typed as a bare `number` with no description.

Both are in **hours**. The CLI's conversion into that same endpoint makes this explicit:

```go
// supabase/cli — apps/cli-go/pkg/config/auth.go
body.SessionsTimebox = nullable.NewNullableWithValue(float32(s.Timebox.Hours()))
body.SessionsInactivityTimeout = nullable.NewNullableWithValue(float32(s.InactivityTimeout.Hours()))
```

Without that documented, seconds is a natural assumption. In #48910 the reporter sent `sessions_inactivity_timeout: 14400` intending 4 hours — that's 14,400 hours, about 1.6 years — and concluded the timeout wasn't being enforced at `POST /auth/v1/token?grant_type=refresh_token`.

It is enforced, synchronously, on every refresh: [`Session.CheckValidity`](https://github.com/supabase/auth/blob/master/internal/models/sessions.go) rejects the session, and the refresh grant in `internal/tokens/service.go` maps that to `session_expired` / `Invalid Refresh Token: Session Expired (Inactivity)`. The configured value simply hadn't elapsed.

## What is the new behavior?

Three sentences added to `apps/docs/content/guides/auth/sessions.mdx`, after the existing description of the two options:

- The dashboard fields are in hours, fractional values work (`0.5` = 30 minutes), and `0` disables the limit.
- A caution that the `sessions_timebox` / `sessions_inactivity_timeout` Management API properties are in hours too, calling out the `14400` case directly.
- A pointer to the CLI equivalents, which take duration strings (`"4h"`, `"50m"`).

I left the OpenAPI spec files alone since `docs-mgmt-api-update.yml` regenerates them from the API; adding descriptions there would need to happen upstream.

## Additional context

`supa-mdx-lint` and Prettier both pass on the changed file. The one warning `supa-mdx-lint` reports for `sessions.mdx` is pre-existing on line 7 and untouched by this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that session timebox and inactivity timeout settings use hours and support fractional values.
  * Documented how to disable these timeouts using `0`.
  * Added guidance on Management API units and CLI duration-string configuration examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->