### PR TITLE
docs: mention MCP debugging tools and Supabase agent skill in debugging docs

### DIFF
--- a/apps/docs/content/guides/ai-tools/mcp.mdx
+++ b/apps/docs/content/guides/ai-tools/mcp.mdx
@@ -57,6 +57,7 @@ The Supabase MCP server provides tools organized into feature groups. All groups
 ### Debugging
 
 - `get_logs` - Retrieve service logs (API, Postgres, Edge Functions, Auth, Storage, Realtime)
+- `query_logs` - Run a read-only SQL query against the project's logs to filter, aggregate, or join across log fields
 - `get_advisors` - Get security and performance advisors
 
 ### Development

--- a/apps/docs/content/guides/monitoring-and-debugging.mdx
+++ b/apps/docs/content/guides/monitoring-and-debugging.mdx
@@ -4,6 +4,8 @@ title: Monitoring and Debugging
 
 Monitor your project, debug errors, and understand what's happening across the Supabase stack.
 
+Debugging with an AI agent? See [Debug with AI tools](/docs/guides/monitoring-and-debugging/debugging#debug-with-ai-tools) for the MCP tools and agent skill that let it read your logs and advisors.
+
 <ContentListings id="telemetry-debugging" />
 
 <ContentListings id="telemetry-monitoring" />

--- a/apps/docs/content/guides/monitoring-and-debugging/debugging.mdx
+++ b/apps/docs/content/guides/monitoring-and-debugging/debugging.mdx
@@ -10,7 +10,9 @@ Debug by evidence, not by guessing. A Supabase error almost always surfaces at o
 
 An AI agent can work through this loop for you, but only if it can read your project's evidence instead of guessing from the error message.
 
-- The [Supabase MCP server](/docs/guides/ai-tools/mcp) provides the tools this guide relies on: `query_logs` to run read-only SQL against your logs for filtering and aggregation, `get_advisors` for security and performance findings, and `execute_sql` to inspect your schema and policies.
+Debugging with an agent needs two things:
+
+- The [Supabase MCP server](/docs/guides/ai-tools/mcp) provides the tools this guide relies on: `get_logs` for a per-service log dump, `query_logs` to run read-only SQL against your logs for filtering and aggregation, `get_advisors` for security and performance findings, and `execute_sql` to inspect your schema and policies.
 - The [Supabase agent skill](/docs/guides/ai-tools/ai-skills) teaches the agent this workflow: locate the failing layer, gather evidence from the matching log source, and verify the fix by re-running the operation that failed.
 
 Install both in one step with the [Supabase plugin for AI coding agents](/docs/guides/ai-tools/plugins). Connecting an agent to your project carries security risks, so read the [MCP security best practices](/docs/guides/ai-tools/mcp#security-risks) first.

--- a/apps/docs/content/guides/monitoring-and-debugging/debugging.mdx
+++ b/apps/docs/content/guides/monitoring-and-debugging/debugging.mdx
@@ -6,6 +6,15 @@ description: 'Isolate and fix Supabase issues by reading the error, isolating th
 
 Debug by evidence, not by guessing. A Supabase error almost always surfaces at one layer but originates at another, so the fastest path to a fix is finding _where_ the problem is, not pattern-matching the symptom. Retrying a failed request rarely helps; isolating the layer does.
 
+## Debug with AI tools
+
+An AI agent can work through this loop for you, but only if it can read your project's evidence instead of guessing from the error message.
+
+- The [Supabase MCP server](/docs/guides/ai-tools/mcp) provides the tools this guide relies on: `query_logs` to run read-only SQL against your logs for filtering and aggregation, `get_advisors` for security and performance findings, and `execute_sql` to inspect your schema and policies.
+- The [Supabase agent skill](/docs/guides/ai-tools/ai-skills) teaches the agent this workflow: locate the failing layer, gather evidence from the matching log source, and verify the fix by re-running the operation that failed.
+
+Install both in one step with the [Supabase plugin for AI coding agents](/docs/guides/ai-tools/plugins). Connecting an agent to your project carries security risks, so read the [MCP security best practices](/docs/guides/ai-tools/mcp#security-risks) first.
+
 ## Follow these debugging steps
 
 Work through these steps in order, skipping straight to a fix before you have evidence for the cause is the most common way to waste time on a bug.

--- a/apps/docs/content/guides/monitoring-and-debugging/debugging.mdx
+++ b/apps/docs/content/guides/monitoring-and-debugging/debugging.mdx
@@ -6,6 +6,15 @@ description: 'Isolate and fix Supabase issues by reading the error, isolating th
 
 Debug by evidence, not by guessing. A Supabase error almost always surfaces at one layer but originates at another, so the fastest path to a fix is finding _where_ the problem is, not pattern-matching the symptom. Retrying a failed request rarely helps; isolating the layer does.
 
+## Debug with AI tools
+
+An AI agent can work through this loop for you, but only if it can read your project's evidence instead of guessing from the error message.
+
+- The [Supabase MCP server](/docs/guides/ai-tools/mcp) provides the tools this guide relies on: `get_logs` for a per-service log dump, `query_logs` to run read-only SQL against your logs for filtering and aggregation, `get_advisors` for security and performance findings, and `execute_sql` to inspect your schema and policies.
+- The [Supabase agent skill](/docs/guides/ai-tools/ai-skills) teaches the agent this workflow: locate the failing layer, gather evidence from the matching log source, and verify the fix by re-running the operation that failed.
+
+Install both in one step with the [Supabase plugin for AI coding agents](/docs/guides/ai-tools/plugins). Connecting an agent to your project carries security risks, so read the [MCP security best practices](/docs/guides/ai-tools/mcp#security-risks) first.
+
 ## Follow these debugging steps
 
 Work through these steps in order, skipping straight to a fix before you have evidence for the cause is the most common way to waste time on a bug.


### PR DESCRIPTION
## What

- Adds a **Debug with AI tools** section to the debugging guide, covering the MCP debugging tools (`get_logs`, `query_logs`, `get_advisors`, `execute_sql`), the Supabase agent skill, and the combined plugin install, with a pointer to the MCP security best practices.
- Adds a one-line pointer to it from the Monitoring and Debugging overview.
- Adds the missing `query_logs` entry to the MCP server's Debugging tool group.

Note: `pnpm lint:mdx` couldn't run locally (Node version), Prettier passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for debugging with AI tools, including MCP tools and the Supabase agent skill for reading logs and advisors.
  * Documented plugin installation and security considerations when connecting AI agents through MCP.
  * Added links from monitoring and debugging guidance to the new AI tools documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->