### PR TITLE
chore: Update API types

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/DowngradeModal.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/DowngradeModal.tsx
@@ -170,12 +170,6 @@ export const DowngradeModal = ({
               </div>
             </li>
           </ul>
-
-          {subscription?.billing_via_partner === true && subscription.billing_partner === 'fly' && (
-            <p className="mt-4 text-sm">
-              Your organization will be downgraded at the end of your current billing cycle.
-            </p>
-          )}
         </div>
         <DialogFooter>
           <Button variant={'default'} onClick={onClose}>

--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/SubscriptionPlanUpdateDialog.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/SubscriptionPlanUpdateDialog.tsx
@@ -378,14 +378,6 @@ export const SubscriptionPlanUpdateDialog = ({
                         <>You will be charged by them directly.</>
                       )}
                     </p>
-                    {billingViaPartner &&
-                      billingPartner === 'fly' &&
-                      subscriptionPreview?.plan_change_type === 'downgrade' && (
-                        <p className="text-sm">
-                          Your organization will be downgraded at the end of your current billing
-                          cycle.
-                        </p>
-                      )}
                   </div>
                 )}
               </div>

--- a/apps/studio/components/interfaces/Settings/Database/JitDatabaseAccess/JitDbAccess.utils.test.ts
+++ b/apps/studio/components/interfaces/Settings/Database/JitDatabaseAccess/JitDbAccess.utils.test.ts
@@ -121,6 +121,7 @@ describe('getJitMemberOptions', () => {
     const organizationMembers: OrganizationMembersData = [
       {
         gotrue_id: 'de305d54-75b4-431b-adb2-eb6b9e546014',
+        avatar_url: null,
         primary_email: 'active@example.com',
         username: 'Active User',
         is_sso_user: false,
@@ -130,6 +131,7 @@ describe('getJitMemberOptions', () => {
       },
       {
         gotrue_id: '',
+        avatar_url: null,
         invited_id: 123,
         invited_at: '2026-03-01T00:00:00.000Z',
         primary_email: 'expired-invite@example.com',

--- a/apps/studio/components/interfaces/Settings/Database/JitDatabaseAccess/JitDbAccessConfiguration.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/JitDatabaseAccess/JitDbAccessConfiguration.tsx
@@ -162,14 +162,9 @@ export const JitDbAccessConfiguration = () => {
       ? jitDbAccessConfiguration?.appliedSuccessfully
       : false
   const isJitDbAccessUnavailable = jitDbAccessConfiguration?.state === 'unavailable'
-  const unavailableReason = (
-    isJitDbAccessUnavailable ? jitDbAccessConfiguration.unavailableReason : undefined
-  ) as
-    | 'postgres_upgrade_required'
-    | 'ssl_enforcement_required'
-    | 'manual_migration_required'
-    | 'temporarily_unavailable'
-    | undefined
+  const unavailableReason = isJitDbAccessUnavailable
+    ? jitDbAccessConfiguration.unavailableReason
+    : undefined
 
   const roleOptions = useMemo(() => getAssignableJitRoleOptions(databaseRoles), [databaseRoles])
 
@@ -323,19 +318,15 @@ export const JitDbAccessConfiguration = () => {
   const unavailableTitle =
     unavailableReason === 'postgres_upgrade_required'
       ? 'Postgres upgrade required'
-      : unavailableReason === 'manual_migration_required'
-        ? 'Migration required'
-        : unavailableReason === 'ssl_enforcement_required'
-          ? 'SSL enforcement required'
-          : 'Temporary access unavailable'
+      : unavailableReason === 'ssl_enforcement_required'
+        ? 'SSL enforcement required'
+        : 'Temporary access unavailable'
   const unavailableDescription =
     unavailableReason === 'postgres_upgrade_required'
       ? 'must be upgraded to Postgres 17 or later before temporary access can be enabled.'
-      : unavailableReason === 'manual_migration_required'
-        ? 'must be migrated before temporary access can be enabled. Contact support to migrate this project.'
-        : unavailableReason === 'ssl_enforcement_required'
-          ? 'must have SSL enforcement enabled before temporary access can be enabled.'
-          : 'This feature is currently unavailable for this project. Contact support if you need help enabling it.'
+      : unavailableReason === 'ssl_enforcement_required'
+        ? 'must have SSL enforcement enabled before temporary access can be enabled.'
+        : 'This feature is currently unavailable for this project. Contact support if you need help enabling it.'
 
   useEffect(() => {
     if (!isLoadingConfiguration && jitDbAccessConfiguration) {

--- a/apps/studio/components/interfaces/Settings/Database/JitDatabaseAccess/JitDbAccessConfiguration.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/JitDatabaseAccess/JitDbAccessConfiguration.tsx
@@ -162,9 +162,14 @@ export const JitDbAccessConfiguration = () => {
       ? jitDbAccessConfiguration?.appliedSuccessfully
       : false
   const isJitDbAccessUnavailable = jitDbAccessConfiguration?.state === 'unavailable'
-  const unavailableReason = isJitDbAccessUnavailable
-    ? jitDbAccessConfiguration.unavailableReason
-    : undefined
+  const unavailableReason = (
+    isJitDbAccessUnavailable ? jitDbAccessConfiguration.unavailableReason : undefined
+  ) as
+    | 'postgres_upgrade_required'
+    | 'ssl_enforcement_required'
+    | 'manual_migration_required'
+    | 'temporarily_unavailable'
+    | undefined
 
   const roleOptions = useMemo(() => getAssignableJitRoleOptions(databaseRoles), [databaseRoles])
 

--- a/apps/studio/components/interfaces/Settings/Database/JitDatabaseAccess/JitDbAccessConfiguration.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/JitDatabaseAccess/JitDbAccessConfiguration.tsx
@@ -382,12 +382,13 @@ export const JitDbAccessConfiguration = () => {
               layout="responsive"
               title={unavailableTitle}
               description={
-                unavailableReason === 'temporarily_unavailable' ? (
-                  unavailableDescription
-                ) : (
+                unavailableReason === 'postgres_upgrade_required' ||
+                unavailableReason === 'ssl_enforcement_required' ? (
                   <>
                     {projectReference} {unavailableDescription}
                   </>
+                ) : (
+                  unavailableDescription
                 )
               }
               actions={

--- a/apps/studio/data/api-keys/api-key-create-mutation.ts
+++ b/apps/studio/data/api-keys/api-key-create-mutation.ts
@@ -18,7 +18,7 @@ export async function createAPIKey(payload: APIKeyCreateVariables) {
     params: {
       path: { ref: payload.projectRef },
       query: {
-        reveal: false,
+        reveal: 'false',
       },
     },
     body: {
@@ -29,7 +29,7 @@ export async function createAPIKey(payload: APIKeyCreateVariables) {
               role: 'service_role',
             },
           }
-        : name),
+        : {}),
 
       type: payload.type,
       name: payload.name,

--- a/apps/studio/data/api-keys/api-key-delete-mutation.ts
+++ b/apps/studio/data/api-keys/api-key-delete-mutation.ts
@@ -16,7 +16,7 @@ export async function deleteAPIKey(payload: APIKeyDeleteVariables) {
   const { data, error } = await del('/v1/projects/{ref}/api-keys/{id}', {
     params: {
       path: { ref: payload.projectRef, id: payload.id },
-      query: { reveal: false },
+      query: { reveal: 'false' },
     },
   })
 

--- a/apps/studio/data/api-keys/api-key-id-query.ts
+++ b/apps/studio/data/api-keys/api-key-id-query.ts
@@ -16,7 +16,7 @@ export async function getAPIKeysById(
   const { data, error } = await get('/v1/projects/{ref}/api-keys/{id}', {
     params: {
       path: { ref: projectRef, id },
-      query: { reveal },
+      query: { reveal: reveal ? 'true' : 'false' },
     },
     signal,
   })

--- a/apps/studio/data/api-keys/api-keys-query.ts
+++ b/apps/studio/data/api-keys/api-keys-query.ts
@@ -55,7 +55,7 @@ async function getAPIKeys({ projectRef, reveal }: APIKeysVariables, signal?: Abo
   if (!projectRef) throw new Error('projectRef is required')
 
   const { data, error } = await get(`/v1/projects/{ref}/api-keys`, {
-    params: { path: { ref: projectRef }, query: { reveal } },
+    params: { path: { ref: projectRef }, query: { reveal: reveal ? 'true' : 'false' } },
     signal,
   })
 

--- a/apps/studio/data/api-keys/legacy-api-key-toggle-mutation.ts
+++ b/apps/studio/data/api-keys/legacy-api-key-toggle-mutation.ts
@@ -16,7 +16,7 @@ export async function toggleLegacyAPIKeys(payload: ToggleLegacyAPIKeysVariables)
   const { data, error } = await put('/v1/projects/{ref}/api-keys/legacy', {
     params: {
       path: { ref: payload.projectRef },
-      query: { enabled: payload.enabled },
+      query: { enabled: payload.enabled ? 'true' : 'false' },
     },
   })
 

--- a/apps/studio/data/branches/branch-diff-query.ts
+++ b/apps/studio/data/branches/branch-diff-query.ts
@@ -24,10 +24,7 @@ export async function getBranchDiff({
   const { data: diffData, error } = await get('/v1/branches/{branch_id_or_ref}/diff', {
     params: {
       path: { branch_id_or_ref: branchRef },
-      query:
-        Object.keys(query).length > 0
-          ? (query as { included_schemas?: string; pgdelta?: boolean })
-          : undefined,
+      query: Object.keys(query).length > 0 ? query : undefined,
     },
     headers: {
       Accept: 'text/plain',

--- a/apps/studio/data/content/sql-snippets-query.ts
+++ b/apps/studio/data/content/sql-snippets-query.ts
@@ -40,7 +40,7 @@ export async function getSqlSnippets(
         type,
         cursor,
         visibility,
-        favorite,
+        favorite: typeof favorite === 'boolean' ? (favorite ? 'true' : 'false') : undefined,
         name,
         limit: SNIPPET_PAGE_LIMIT.toString(),
         sort_by: sort,

--- a/apps/studio/data/content/sql-snippets-query.ts
+++ b/apps/studio/data/content/sql-snippets-query.ts
@@ -40,7 +40,7 @@ export async function getSqlSnippets(
         type,
         cursor,
         visibility,
-        favorite: typeof favorite === 'boolean' ? (favorite ? 'true' : 'false') : undefined,
+        favorite: favorite?.toString(),
         name,
         limit: SNIPPET_PAGE_LIMIT.toString(),
         sort_by: sort,

--- a/apps/studio/data/custom-domains/custom-domains-delete-mutation.ts
+++ b/apps/studio/data/custom-domains/custom-domains-delete-mutation.ts
@@ -18,7 +18,7 @@ export async function deleteCustomDomain({
   const { data, error } = await del(`/v1/projects/{ref}/custom-hostname`, {
     params: {
       path: { ref: projectRef },
-      query: { remove_addon: removeAddon },
+      query: { remove_addon: removeAddon ? 'true' : 'false' },
     },
   })
 

--- a/apps/studio/data/organizations/organization-available-regions-query.ts
+++ b/apps/studio/data/organizations/organization-available-regions-query.ts
@@ -10,7 +10,7 @@ export type DesiredInstanceSizeForAvailableRegions =
 
 export type OrganizationAvailableRegionsVariables = {
   slug?: string
-  cloudProvider: 'AWS' | 'FLY' | 'AWS_K8S' | 'AWS_NIMBUS'
+  cloudProvider: 'AWS' | 'AWS_K8S' | 'AWS_NIMBUS'
   desiredInstanceSize?: DesiredInstanceSizeForAvailableRegions
 }
 

--- a/apps/studio/data/storage/iceberg-namespace-table-delete-mutation.ts
+++ b/apps/studio/data/storage/iceberg-namespace-table-delete-mutation.ts
@@ -25,7 +25,7 @@ async function deleteIcebergNamespaceTable({
     {
       params: {
         path: { ref: projectRef, id: warehouse, namespace, table },
-        query: { purge: true },
+        query: { purge: 'true' },
       },
     }
   )

--- a/apps/studio/lib/api/self-hosted/signing-keys.test.ts
+++ b/apps/studio/lib/api/self-hosted/signing-keys.test.ts
@@ -30,6 +30,7 @@ describe('api/self-hosted/signing-keys', () => {
       expect(key).toEqual({
         id: '00000000-0000-0000-0000-000000000000',
         algorithm: 'HS256',
+        public_jwk: '',
         status: 'in_use',
         created_at: '1970-01-01T00:00:00.000Z',
         updated_at: '1970-01-01T00:00:00.000Z',

--- a/apps/studio/lib/api/self-hosted/signing-keys.ts
+++ b/apps/studio/lib/api/self-hosted/signing-keys.ts
@@ -24,6 +24,7 @@ export function getLegacySigningKey(): SigningKeyResponse {
   return {
     id: LEGACY_KEY_ID,
     algorithm: 'HS256',
+    public_jwk: '',
     status: 'in_use',
     created_at: LEGACY_KEY_CREATED_AT,
     updated_at: LEGACY_KEY_CREATED_AT,

--- a/apps/studio/pages/api/platform/organizations/[slug]/billing/subscription.ts
+++ b/apps/studio/pages/api/platform/organizations/[slug]/billing/subscription.ts
@@ -35,7 +35,7 @@ const handleGet = async (_req: NextApiRequest, res: NextApiResponse<ResponseData
     project_addons: [],
     payment_method_type: '',
     billing_via_partner: false,
-    billing_partner: 'fly',
+    billing_partner: 'aws_marketplace',
     scheduled_plan_change: null,
     customer_balance: 0,
   }

--- a/apps/studio/tests/components/Organization/TeamSettings/InviteMemberButton.network.test.tsx
+++ b/apps/studio/tests/components/Organization/TeamSettings/InviteMemberButton.network.test.tsx
@@ -67,6 +67,7 @@ const buildRole = (id: number, name: string): OrganizationRoleResponse['org_scop
 
 const buildMember = (overrides: Partial<Member>): Member => ({
   gotrue_id: 'gotrue-test',
+  avatar_url: null,
   is_sso_user: false,
   metadata: {},
   mfa_enabled: false,

--- a/apps/studio/tests/components/Organization/TeamSettings/UpdateRolesPanel.network.test.tsx
+++ b/apps/studio/tests/components/Organization/TeamSettings/UpdateRolesPanel.network.test.tsx
@@ -83,6 +83,7 @@ const buildPermission = (resource: string): AccessControlPermission => ({
 
 const MEMBER: OrganizationMember = {
   gotrue_id: 'gotrue-member',
+  avatar_url: null,
   is_sso_user: false,
   metadata: {},
   mfa_enabled: false,

--- a/packages/api-types/types/api.d.ts
+++ b/packages/api-types/types/api.d.ts
@@ -3348,52 +3348,28 @@ export interface components {
       }
     }
     JitListAccessResponse: {
-      items: (
-        | {
-            expires_at: null
-            invite_id: null
-            primary_email: string | null
-            /** Format: uuid */
-            user_id: string
-            user_roles: {
-              allowed_networks?: {
-                allowed_cidrs?: {
-                  /** Format: cidrv4 */
-                  cidr: string
-                }[]
-                allowed_cidrs_v6?: {
-                  /** Format: cidrv6 */
-                  cidr: string
-                }[]
-              }
-              branches_only?: boolean
-              expires_at?: number
-              role: string
+      items: {
+        expires_at: null
+        invite_id: null
+        primary_email: string | null
+        /** Format: uuid */
+        user_id: string
+        user_roles: {
+          allowed_networks?: {
+            allowed_cidrs?: {
+              /** Format: cidrv4 */
+              cidr: string
+            }[]
+            allowed_cidrs_v6?: {
+              /** Format: cidrv6 */
+              cidr: string
             }[]
           }
-        | {
-            expires_at: string
-            /** Format: uuid */
-            invite_id: string
-            primary_email: string
-            user_id: null
-            user_roles: {
-              allowed_networks?: {
-                allowed_cidrs?: {
-                  /** Format: cidrv4 */
-                  cidr: string
-                }[]
-                allowed_cidrs_v6?: {
-                  /** Format: cidrv6 */
-                  cidr: string
-                }[]
-              }
-              branches_only?: boolean
-              expires_at?: number
-              role: string
-            }[]
-          }
-      )[]
+          branches_only?: boolean
+          expires_at?: number
+          role: string
+        }[]
+      }[]
     }
     LegacyApiKeysResponse: {
       enabled: boolean

--- a/packages/api-types/types/api.d.ts
+++ b/packages/api-types/types/api.d.ts
@@ -521,6 +521,35 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/v1/projects/{ref}/analytics/endpoints/logs': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Gets all project's logs in a single log stream
+     * @description Executes an SQL or LQL query on the project's unified logs stream.
+     *
+     *     Either the `iso_timestamp_start` and `iso_timestamp_end` parameters must be provided.
+     *     If both are not provided, only the last 1 minute of logs will be queried.
+     *     The timestamp range must be no more than 24 hours and is rounded to the nearest minute. If the range is more than 24 hours, a validation error will be thrown.
+     *
+     *     Filter by the `source` column to specify specific log sources, such as edge_logs, postgres_logs, etc.
+     *
+     *     Note: SQL must be written in **ClickHouse SQL dialect**.
+     *
+     */
+    get: operations['v1-get-project-logs']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/v1/projects/{ref}/analytics/endpoints/logs.all': {
     parameters: {
       query?: never
@@ -530,6 +559,7 @@ export interface paths {
     }
     /**
      * Gets project's logs
+     * @deprecated
      * @description Executes a SQL query on the project's logs.
      *
      *     Either the `iso_timestamp_start` and `iso_timestamp_end` parameters must be provided.
@@ -539,7 +569,27 @@ export interface paths {
      *     Note: Unless the `sql` parameter is provided, only edge_logs will be queried. See the [log query docs](/docs/guides/telemetry/logs?queryGroups=product&product=postgres&queryGroups=source&source=edge_logs#querying-with-the-logs-explorer:~:text=logs%20from%20the-,Sources,-drop%2Ddown%3A) for all available sources.
      *
      */
-    get: operations['v1-get-project-logs']
+    get: operations['v1-get-project-logs-all']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/v1/projects/{ref}/analytics/endpoints/metrics': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Scrape a project's metrics
+     * @description Prometheus scrape endpoint. Returns metrics of a customer project in the Prometheus open exposition format.
+     */
+    get: operations['v1-scrape-project-metrics']
     put?: never
     post?: never
     delete?: never
@@ -1315,6 +1365,66 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/v1/projects/{ref}/database/jit/invite': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * Invites an external user to a database for JIT access
+     * @description Invites the external user and sets initial roles that can be assumed and for how long
+     */
+    post: operations['v1-invite-external-jit-access']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/v1/projects/{ref}/database/jit/invite/{invite_id}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    post?: never
+    /**
+     * Deletes the invite for an external user to a database for JIT access
+     * @description Revokes and deletes the invitation
+     */
+    delete: operations['v1-delete-invite-external-jit-access']
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/v1/projects/{ref}/database/jit/invite/accept': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * Accepts invitation for JIT database access
+     * @description Accepts the invitation to JIT database access
+     */
+    post: operations['v1-accept-invite-external-jit-access']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/v1/projects/{ref}/database/jit/list': {
     parameters: {
       query?: never
@@ -1342,25 +1452,13 @@ export interface paths {
       path?: never
       cookie?: never
     }
-    /**
-     * List applied migration versions
-     * @description Only available to selected partner OAuth apps
-     */
+    /** List applied migration versions */
     get: operations['v1-list-migration-history']
-    /**
-     * Upsert a database migration without applying
-     * @description Only available to selected partner OAuth apps
-     */
+    /** Upsert a database migration without applying */
     put: operations['v1-upsert-a-migration']
-    /**
-     * Apply a database migration
-     * @description Only available to selected partner OAuth apps
-     */
+    /** Apply a database migration */
     post: operations['v1-apply-a-migration']
-    /**
-     * Rollback database migrations and remove them from history table
-     * @description Only available to selected partner OAuth apps
-     */
+    /** Rollback database migrations and remove them from history table */
     delete: operations['v1-rollback-migrations']
     options?: never
     head?: never
@@ -1374,20 +1472,14 @@ export interface paths {
       path?: never
       cookie?: never
     }
-    /**
-     * Fetch an existing entry from migration history
-     * @description Only available to selected partner OAuth apps
-     */
+    /** Fetch an existing entry from migration history */
     get: operations['v1-get-a-migration']
     put?: never
     post?: never
     delete?: never
     options?: never
     head?: never
-    /**
-     * Patch an existing entry in migration history
-     * @description Only available to selected partner OAuth apps
-     */
+    /** Patch an existing entry in migration history */
     patch: operations['v1-patch-a-migration']
     trace?: never
   }
@@ -2114,6 +2206,15 @@ export interface paths {
 export type webhooks = Record<string, never>
 export interface components {
   schemas: {
+    /** @example {
+     *       "email": "external-user@somedomain.xyz",
+     *       "token": ""
+     *     } */
+    AcceptInviteExternalUserJitAccessBody: {
+      /** Format: email */
+      email: string
+      token: string
+    }
     ActionRunResponse: {
       branch_id: string
       check_run_id: number | null
@@ -2749,7 +2850,6 @@ export interface components {
       domains?: {
         created_at?: string
         domain?: string
-        id: string
         updated_at?: string
       }[]
       id: string
@@ -2765,7 +2865,6 @@ export interface components {
           }
         }
         entity_id: string
-        id: string
         metadata_url?: string
         metadata_xml?: string
         /** @enum {string} */
@@ -2932,7 +3031,6 @@ export interface components {
       domains?: {
         created_at?: string
         domain?: string
-        id: string
         updated_at?: string
       }[]
       id: string
@@ -2948,7 +3046,6 @@ export interface components {
           }
         }
         entity_id: string
-        id: string
         metadata_url?: string
         metadata_xml?: string
         /** @enum {string} */
@@ -3053,7 +3150,7 @@ export interface components {
      *       }
      *     } */
     FunctionDeployBody: {
-      file?: string[]
+      file: string[]
       metadata: {
         entrypoint_path: string
         import_map_path?: string
@@ -3122,7 +3219,6 @@ export interface components {
       domains?: {
         created_at?: string
         domain?: string
-        id: string
         updated_at?: string
       }[]
       id: string
@@ -3138,7 +3234,6 @@ export interface components {
           }
         }
         entity_id: string
-        id: string
         metadata_url?: string
         metadata_xml?: string
         /** @enum {string} */
@@ -3151,6 +3246,63 @@ export interface components {
       updated_at?: string
     }
     /** @example {
+     *       "email": "external-user@somedomain.xyz",
+     *       "roles": [
+     *         {
+     *           "role": "postgres",
+     *           "expires_at": 1740787200,
+     *           "allowed_networks": {
+     *             "allowed_cidrs": [
+     *               {
+     *                 "cidr": "203.0.113.0/24"
+     *               }
+     *             ]
+     *           },
+     *           "branches_only": false
+     *         }
+     *       ]
+     *     } */
+    InviteExternalUserJitAccessBody: {
+      /** Format: email */
+      email: string
+      roles: {
+        allowed_networks?: {
+          allowed_cidrs?: {
+            /** Format: cidrv4 */
+            cidr: string
+          }[]
+          allowed_cidrs_v6?: {
+            /** Format: cidrv6 */
+            cidr: string
+          }[]
+        }
+        branches_only?: boolean
+        expires_at?: number
+        role: string
+      }[]
+    }
+    InviteExternalUserJitResponse: {
+      /** Format: email */
+      email: string
+      /** Format: uuid */
+      invite_id: string
+      user_roles: {
+        allowed_networks?: {
+          allowed_cidrs?: {
+            /** Format: cidrv4 */
+            cidr: string
+          }[]
+          allowed_cidrs_v6?: {
+            /** Format: cidrv6 */
+            cidr: string
+          }[]
+        }
+        branches_only?: boolean
+        expires_at?: number
+        role: string
+      }[]
+    }
+    /** @example {
      *       "state": "enabled"
      *     } */
     JitAccessRequestRequest: {
@@ -3159,13 +3311,15 @@ export interface components {
     }
     JitAccessResponse: {
       /** Format: uuid */
-      user_id: string
+      user_id?: string
       user_roles: {
         allowed_networks?: {
           allowed_cidrs?: {
+            /** Format: cidrv4 */
             cidr: string
           }[]
           allowed_cidrs_v6?: {
+            /** Format: cidrv6 */
             cidr: string
           }[]
         }
@@ -3180,9 +3334,11 @@ export interface components {
       user_role: {
         allowed_networks?: {
           allowed_cidrs?: {
+            /** Format: cidrv4 */
             cidr: string
           }[]
           allowed_cidrs_v6?: {
+            /** Format: cidrv6 */
             cidr: string
           }[]
         }
@@ -3192,40 +3348,53 @@ export interface components {
       }
     }
     JitListAccessResponse: {
-      items: {
-        /** Format: uuid */
-        user_id: string
-        user_roles: {
-          allowed_networks?: {
-            allowed_cidrs?: {
-              cidr: string
-            }[]
-            allowed_cidrs_v6?: {
-              cidr: string
+      items: (
+        | {
+            expires_at: null
+            invite_id: null
+            primary_email: string | null
+            /** Format: uuid */
+            user_id: string
+            user_roles: {
+              allowed_networks?: {
+                allowed_cidrs?: {
+                  /** Format: cidrv4 */
+                  cidr: string
+                }[]
+                allowed_cidrs_v6?: {
+                  /** Format: cidrv6 */
+                  cidr: string
+                }[]
+              }
+              branches_only?: boolean
+              expires_at?: number
+              role: string
             }[]
           }
-          branches_only?: boolean
-          expires_at?: number
-          role: string
-        }[]
-      }[]
+        | {
+            expires_at: string
+            /** Format: uuid */
+            invite_id: string
+            primary_email: string
+            user_id: null
+            user_roles: {
+              allowed_networks?: {
+                allowed_cidrs?: {
+                  /** Format: cidrv4 */
+                  cidr: string
+                }[]
+                allowed_cidrs_v6?: {
+                  /** Format: cidrv6 */
+                  cidr: string
+                }[]
+              }
+              branches_only?: boolean
+              expires_at?: number
+              role: string
+            }[]
+          }
+      )[]
     }
-    JitStateResponse:
-      | {
-          appliedSuccessfully?: boolean
-          /** @enum {string} */
-          state: 'enabled' | 'disabled'
-        }
-      | {
-          /** @enum {string} */
-          state: 'unavailable'
-          /** @enum {string} */
-          unavailableReason:
-            | 'manual_migration_required'
-            | 'postgres_upgrade_required'
-            | 'ssl_enforcement_required'
-            | 'temporarily_unavailable'
-        }
     LegacyApiKeysResponse: {
       enabled: boolean
     }
@@ -3288,8 +3457,7 @@ export interface components {
             | 'auth_mfa_web_authn_default'
             | 'log_drain_default'
             | 'etl_pipeline_default'
-          /** @description Any JSON-serializable value */
-          meta?: unknown
+          meta?: components['schemas']['ListProjectAddonsResponseJsonValue']
           name: string
           price: {
             amount: number
@@ -3341,8 +3509,7 @@ export interface components {
             | 'auth_mfa_web_authn_default'
             | 'log_drain_default'
             | 'etl_pipeline_default'
-          /** @description Any JSON-serializable value */
-          meta?: unknown
+          meta?: components['schemas']['ListProjectAddonsResponseJsonValue']
           name: string
           price: {
             amount: number
@@ -3355,13 +3522,19 @@ export interface components {
         }
       }[]
     }
+    /** @description Any JSON-serializable value */
+    ListProjectAddonsResponseJsonValue:
+      | ((string | number | boolean) | null)
+      | components['schemas']['ListProjectAddonsResponseJsonValue'][]
+      | {
+          [key: string]: components['schemas']['ListProjectAddonsResponseJsonValue']
+        }
     ListProvidersResponse: {
       items: {
         created_at?: string
         domains?: {
           created_at?: string
           domain?: string
-          id: string
           updated_at?: string
         }[]
         id: string
@@ -3377,7 +3550,6 @@ export interface components {
             }
           }
           entity_id: string
-          id: string
           metadata_url?: string
           metadata_xml?: string
           /** @enum {string} */
@@ -3437,7 +3609,17 @@ export interface components {
     NetworkRestrictionsResponse: {
       /** Format: date-time */
       applied_at?: string
-      /** @description At any given point in time, this is the config that the user has requested be applied to their project. The `status` field indicates if it has been applied to the project, or is pending. When an updated config is received, the applied config is moved to `old_config`. */
+      /**
+       * @description At any given point in time, this is the config that the user has requested be applied to their project. The `status` field indicates if it has been applied to the project, or is pending. When an updated config is received, the applied config is moved to `old_config`.
+       * @example {
+       *       "dbAllowedCidrs": [
+       *         "203.0.113.0/24"
+       *       ],
+       *       "dbAllowedCidrsV6": [
+       *         "2001:db8::/32"
+       *       ]
+       *     }
+       */
       config: {
         dbAllowedCidrs?: string[]
         dbAllowedCidrsV6?: string[]
@@ -3669,8 +3851,28 @@ export interface components {
        */
       slug: string
     }
+    /** @example {
+     *       "root_key": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+     *     } */
     PgsodiumConfigResponse: {
+      /** @description The pgsodium root key: 32 bytes, hex-encoded (64 characters). */
       root_key: string
+    }
+    PlanGateErrorBody: {
+      /** @description Present on entitlement denials. Other errors with this status code (validation, billing state) carry only message. */
+      error?: {
+        /**
+         * @description Machine-readable marker for plan-gated denials
+         * @enum {string}
+         */
+        code: 'entitlement_required'
+        /** @description Entitlement feature key that failed the check */
+        feature: string
+        /** @description Billing page URL for the organization, present when the org is resolvable */
+        upgrade_url?: string
+      }
+      /** @description Human-readable explanation of the plan gate */
+      message: string
     }
     PostgresConfigResponse: {
       /** @description Default unit: s */
@@ -3694,6 +3896,7 @@ export interface components {
       maintenance_work_mem?: string
       max_connections?: number
       max_locks_per_transaction?: number
+      max_logical_replication_workers?: number
       max_parallel_maintenance_workers?: number
       max_parallel_workers?: number
       max_parallel_workers_per_gather?: number
@@ -3701,6 +3904,7 @@ export interface components {
       max_slot_wal_keep_size?: string
       max_standby_archive_delay?: string
       max_standby_streaming_delay?: string
+      max_sync_workers_per_subscription?: number
       max_wal_senders?: number
       max_wal_size?: string
       max_worker_processes?: number
@@ -3720,6 +3924,8 @@ export interface components {
       db_extra_search_path: string
       /** @description If `null`, the value is automatically configured based on compute size. */
       db_pool: number | null
+      /** @description If `null`, the value is automatically configured to 10. */
+      db_pool_acquisition_timeout: number | null
       db_schema: string
       jwt_secret?: string
       max_rows: number
@@ -3807,7 +4013,6 @@ export interface components {
           }
         | {
             obj_name: string
-            /** @enum {string} */
             obj_type: 'table' | 'function'
             schema_name: string
             /** @enum {string} */
@@ -3906,7 +4111,7 @@ export interface components {
             | 'sa-east-1'
           name: string
           /** @enum {string} */
-          provider: 'AWS' | 'FLY' | 'AWS_K8S' | 'AWS_NIMBUS'
+          provider: 'AWS' | 'AWS_K8S' | 'AWS_NIMBUS'
           /** @enum {string} */
           status?: 'capacity' | 'other'
           /** @enum {string} */
@@ -3944,7 +4149,7 @@ export interface components {
             | 'sa-east-1'
           name: string
           /** @enum {string} */
-          provider: 'AWS' | 'FLY' | 'AWS_K8S' | 'AWS_NIMBUS'
+          provider: 'AWS' | 'AWS_K8S' | 'AWS_NIMBUS'
           /** @enum {string} */
           status?: 'capacity' | 'other'
           /** @enum {string} */
@@ -4014,7 +4219,7 @@ export interface components {
       created_at: string
       /** Format: uuid */
       id: string
-      public_jwk?: unknown
+      public_jwk: unknown
       /** @enum {string} */
       status: 'in_use' | 'previously_used' | 'revoked' | 'standby'
       /** Format: date-time */
@@ -4028,7 +4233,7 @@ export interface components {
         created_at: string
         /** Format: uuid */
         id: string
-        public_jwk?: unknown
+        public_jwk: unknown
         /** @enum {string} */
         status: 'in_use' | 'previously_used' | 'revoked' | 'standby'
         /** Format: date-time */
@@ -4129,6 +4334,9 @@ export interface components {
           maxTables: number
         }
         imageTransformation: {
+          enabled: boolean
+        }
+        purgeCache: {
           enabled: boolean
         }
         s3Protocol: {
@@ -4483,8 +4691,8 @@ export interface components {
     UpdateCustomHostnameResponse: {
       custom_hostname: string
       data: {
-        errors: unknown[]
-        messages: unknown[]
+        errors: components['schemas']['UpdateCustomHostnameResponseJsonValue'][]
+        messages: components['schemas']['UpdateCustomHostnameResponseJsonValue'][]
         result: {
           custom_origin_server: string
           hostname: string
@@ -4517,6 +4725,13 @@ export interface components {
         | '4_origin_setup_completed'
         | '5_services_reconfigured'
     }
+    /** @description Any JSON-serializable value */
+    UpdateCustomHostnameResponseJsonValue:
+      | ((string | number | boolean) | null)
+      | components['schemas']['UpdateCustomHostnameResponseJsonValue'][]
+      | {
+          [key: string]: components['schemas']['UpdateCustomHostnameResponseJsonValue']
+        }
     /** @example {
      *       "user_id": "55555555-5555-4555-8555-555555555555",
      *       "roles": [
@@ -4538,9 +4753,11 @@ export interface components {
       roles: {
         allowed_networks?: {
           allowed_cidrs?: {
+            /** Format: cidrv4 */
             cidr: string
           }[]
           allowed_cidrs_v6?: {
+            /** Format: cidrv6 */
             cidr: string
           }[]
         }
@@ -4552,9 +4769,10 @@ export interface components {
       user_id: string
     }
     /** @example {
-     *       "root_key": "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY="
+     *       "root_key": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
      *     } */
     UpdatePgsodiumConfigBody: {
+      /** @description The pgsodium root key: 32 bytes, hex-encoded (64 characters). */
       root_key: string
     }
     /** @example {
@@ -4585,6 +4803,7 @@ export interface components {
       maintenance_work_mem?: string
       max_connections?: number
       max_locks_per_transaction?: number
+      max_logical_replication_workers?: number
       max_parallel_maintenance_workers?: number
       max_parallel_workers?: number
       max_parallel_workers_per_gather?: number
@@ -4592,6 +4811,7 @@ export interface components {
       max_slot_wal_keep_size?: string
       max_standby_archive_delay?: string
       max_standby_streaming_delay?: string
+      max_sync_workers_per_subscription?: number
       max_wal_senders?: number
       max_wal_size?: string
       max_worker_processes?: number
@@ -4641,7 +4861,6 @@ export interface components {
       domains?: {
         created_at?: string
         domain?: string
-        id: string
         updated_at?: string
       }[]
       id: string
@@ -4657,7 +4876,6 @@ export interface components {
           }
         }
         entity_id: string
-        id: string
         metadata_url?: string
         metadata_xml?: string
         /** @enum {string} */
@@ -4752,6 +4970,9 @@ export interface components {
           maxTables: number
         }
         imageTransformation?: {
+          enabled: boolean
+        }
+        purgeCache?: {
           enabled: boolean
         }
         s3Protocol?: {
@@ -4875,6 +5096,8 @@ export interface components {
         | '48xlarge_optimized_memory'
         | '48xlarge_optimized_cpu'
         | '48xlarge_high_memory'
+      /** @description [Experimental] Whether to enable high availability for the project. */
+      high_availability?: boolean
       /**
        * @deprecated
        * @description This field is deprecated and is ignored in this request
@@ -4898,6 +5121,8 @@ export interface components {
        * @enum {string}
        */
       plan?: 'free' | 'pro'
+      /** @deprecated */
+      postgres_engine?: null
       /**
        * @deprecated
        * @description Region you want your server to reside in. Use region_selection instead.
@@ -4960,6 +5185,8 @@ export interface components {
             /** @enum {string} */
             type: 'smartGroup'
           }
+      /** @deprecated */
+      release_channel?: null
       /**
        * Format: uri
        * @description Template URL used to create the project from the CLI.
@@ -5047,6 +5274,7 @@ export interface components {
             | 'storage.image_transformations'
             | 'storage.vector_buckets'
             | 'storage.iceberg_catalog'
+            | 'storage.purge_cache'
             | 'security.audit_logs_days'
             | 'security.questionnaire'
             | 'security.soc2_report'
@@ -5096,6 +5324,8 @@ export interface components {
             | 'integrations.github_connections'
             | 'dedicated_pooler'
             | 'observability.dashboard_advanced_metrics'
+            | 'api.members.invitations'
+            | 'api.members.roles'
           /** @enum {string} */
           type: 'boolean' | 'numeric' | 'set'
         }
@@ -5109,6 +5339,7 @@ export interface components {
       version: string
     }[]
     V1OrganizationMemberResponse: {
+      avatar_url: string | null
       email?: string
       mfa_enabled: boolean
       role_name: string
@@ -5151,6 +5382,8 @@ export interface components {
       db_extra_search_path: string
       /** @description If `null`, the value is automatically configured based on compute size. */
       db_pool: number | null
+      /** @description If `null`, the value is automatically configured to 10. */
+      db_pool_acquisition_timeout: number | null
       db_schema: string
       max_rows: number
     }
@@ -5451,6 +5684,7 @@ export interface components {
     V1UpdatePostgrestConfigBody: {
       db_extra_search_path?: string
       db_pool?: number
+      db_pool_acquisition_timeout?: number
       db_schema?: string
       max_rows?: number
     }
@@ -5523,7 +5757,7 @@ export interface operations {
     parameters: {
       query?: {
         /** @description If set to false, schedule deletion with 1-hour grace period (only when soft deletion is enabled). */
-        force?: boolean
+        force?: string
       }
       header?: never
       path: {
@@ -5588,8 +5822,13 @@ export interface operations {
     parameters: {
       query?: {
         included_schemas?: string
-        /** @description Use pg-delta instead of Migra for diffing when true */
-        pgdelta?: boolean
+        /** @description Use pg-delta instead of Migra for diffing when true.
+         *     Boolean string.
+         *
+         *     Truthy values: `true`, `1`, `yes`, `on`, `y`, `enabled`
+         *
+         *     Falsy values: `false`, `0`, `no`, `off`, `n`, `disabled` */
+        pgdelta?: string
       }
       header?: never
       path: {
@@ -5760,6 +5999,7 @@ export interface operations {
         response_type: 'code' | 'token' | 'id_token token'
         scope?: string
         state?: string
+        target_flow?: string
       }
       header?: never
       path?: never
@@ -6908,6 +7148,13 @@ export interface operations {
         }
         content?: never
       }
+      /** @description Usage exceeded. Enable additional usage to continue querying */
+      402: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
       /** @description Forbidden action */
       403: {
         headers: {
@@ -6917,6 +7164,113 @@ export interface operations {
       }
       /** @description Rate limit exceeded */
       429: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  'v1-get-project-logs-all': {
+    parameters: {
+      query?: {
+        iso_timestamp_end?: string
+        iso_timestamp_start?: string
+        /** @description Custom SQL query to execute on the logs. See [querying logs](/docs/guides/telemetry/logs?queryGroups=product&product=postgres&queryGroups=source&source=edge_logs#querying-with-the-logs-explorer) for more details. */
+        sql?: string
+      }
+      header?: never
+      path: {
+        /** @description Project ref */
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['AnalyticsResponse']
+        }
+      }
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Usage exceeded. Enable additional usage to continue querying */
+      402: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Forbidden action */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Rate limit exceeded */
+      429: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  'v1-scrape-project-metrics': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description Project ref */
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Prometheus / OpenMetrics text exposition */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/openmetrics-text': string
+          'text/plain': string
+        }
+      }
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Forbidden action */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Rate limit exceeded */
+      429: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Failed to fetch project's metrics */
+      500: {
         headers: {
           [name: string]: unknown
         }
@@ -7029,8 +7383,12 @@ export interface operations {
   'v1-get-project-api-keys': {
     parameters: {
       query?: {
-        /** @description Boolean string, true or false */
-        reveal?: boolean
+        /** @description Boolean string.
+         *
+         *     Truthy values: `true`, `1`, `yes`, `on`, `y`, `enabled`
+         *
+         *     Falsy values: `false`, `0`, `no`, `off`, `n`, `disabled` */
+        reveal?: string
       }
       header?: never
       path: {
@@ -7075,8 +7433,12 @@ export interface operations {
   'v1-create-project-api-key': {
     parameters: {
       query?: {
-        /** @description Boolean string, true or false */
-        reveal?: boolean
+        /** @description Boolean string.
+         *
+         *     Truthy values: `true`, `1`, `yes`, `on`, `y`, `enabled`
+         *
+         *     Falsy values: `false`, `0`, `no`, `off`, `n`, `disabled` */
+        reveal?: string
       }
       header?: never
       path: {
@@ -7125,8 +7487,12 @@ export interface operations {
   'v1-get-project-api-key': {
     parameters: {
       query?: {
-        /** @description Boolean string, true or false */
-        reveal?: boolean
+        /** @description Boolean string.
+         *
+         *     Truthy values: `true`, `1`, `yes`, `on`, `y`, `enabled`
+         *
+         *     Falsy values: `false`, `0`, `no`, `off`, `n`, `disabled` */
+        reveal?: string
       }
       header?: never
       path: {
@@ -7174,9 +7540,9 @@ export interface operations {
       query?: {
         reason?: string
         /** @description Boolean string, true or false */
-        reveal?: boolean
+        reveal?: string
         /** @description Boolean string, true or false */
-        was_compromised?: boolean
+        was_compromised?: string
       }
       header?: never
       path: {
@@ -7222,8 +7588,12 @@ export interface operations {
   'v1-update-project-api-key': {
     parameters: {
       query?: {
-        /** @description Boolean string, true or false */
-        reveal?: boolean
+        /** @description Boolean string.
+         *
+         *     Truthy values: `true`, `1`, `yes`, `on`, `y`, `enabled`
+         *
+         *     Falsy values: `false`, `0`, `no`, `off`, `n`, `disabled` */
+        reveal?: string
       }
       header?: never
       path: {
@@ -7316,8 +7686,12 @@ export interface operations {
   'v1-update-project-legacy-api-keys': {
     parameters: {
       query: {
-        /** @description Boolean string, true or false */
-        enabled: boolean
+        /** @description Boolean string.
+         *
+         *     Truthy values: `true`, `1`, `yes`, `on`, `y`, `enabled`
+         *
+         *     Falsy values: `false`, `0`, `no`, `off`, `n`, `disabled` */
+        enabled: string
       }
       header?: never
       path: {
@@ -9513,7 +9887,7 @@ export interface operations {
     parameters: {
       query?: {
         /** @description If true, also removes the custom domain add-on from the project subscription. */
-        remove_addon?: boolean
+        remove_addon?: string
       }
       header?: never
       path: {
@@ -9985,7 +10359,9 @@ export interface operations {
         headers: {
           [name: string]: unknown
         }
-        content?: never
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
       }
       /** @description Forbidden action */
       403: {
@@ -10060,7 +10436,9 @@ export interface operations {
         headers: {
           [name: string]: unknown
         }
-        content?: never
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
       }
       /** @description Forbidden action */
       403: {
@@ -10275,7 +10653,7 @@ export interface operations {
         }
         content?: never
       }
-      /** @description Failed to upsert database migration */
+      /** @description Failed to update JIT access */
       500: {
         headers: {
           [name: string]: unknown
@@ -10379,6 +10757,142 @@ export interface operations {
         content?: never
       }
       /** @description Failed to remove JIT access */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  'v1-invite-external-jit-access': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description Project ref */
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['InviteExternalUserJitAccessBody']
+      }
+    }
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['InviteExternalUserJitResponse']
+        }
+      }
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Forbidden action */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Rate limit exceeded */
+      429: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Failed to invite external user */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  'v1-delete-invite-external-jit-access': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        invite_id: string
+        /** @description Project ref */
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Forbidden action */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Rate limit exceeded */
+      429: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Failed to revoke invite for external user */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  'v1-accept-invite-external-jit-access': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description Project ref */
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['AcceptInviteExternalUserJitAccessBody']
+      }
+    }
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['JitAccessResponse']
+        }
+      }
+      /** @description Failed to accept invitation */
       500: {
         headers: {
           [name: string]: unknown
@@ -11127,13 +11641,11 @@ export interface operations {
       query?: {
         entrypoint_path?: string
         ezbr_sha256?: string
-        /** @description Boolean string, true or false */
-        import_map?: boolean
+        import_map?: string
         import_map_path?: string
         name?: string
         slug?: string
-        /** @description Boolean string, true or false */
-        verify_jwt?: boolean
+        verify_jwt?: string
       }
       header?: never
       path: {
@@ -11301,13 +11813,11 @@ export interface operations {
       query?: {
         entrypoint_path?: string
         ezbr_sha256?: string
-        /** @description Boolean string, true or false */
-        import_map?: boolean
+        import_map?: string
         import_map_path?: string
         name?: string
         slug?: string
-        /** @description Boolean string, true or false */
-        verify_jwt?: boolean
+        verify_jwt?: string
       }
       header?: never
       path: {
@@ -11418,8 +11928,7 @@ export interface operations {
   'v1-deploy-a-function': {
     parameters: {
       query?: {
-        /** @description Boolean string, true or false */
-        bundleOnly?: boolean
+        bundleOnly?: string
         slug?: string
       }
       header?: never
@@ -11483,16 +11992,19 @@ export interface operations {
   'v1-get-services-health': {
     parameters: {
       query: {
-        services: (
-          | 'auth'
-          | 'db'
-          | 'db_postgres_user'
-          | 'pooler'
-          | 'realtime'
-          | 'rest'
-          | 'storage'
-          | 'pg_bouncer'
-        )[]
+        /** @description Comma-separated list of enums or array of enums. */
+        services:
+          | string
+          | (
+              | 'auth'
+              | 'db'
+              | 'db_postgres_user'
+              | 'pooler'
+              | 'realtime'
+              | 'rest'
+              | 'storage'
+              | 'pg_bouncer'
+            )[]
         timeout_ms?: number
       }
       header?: never
@@ -11559,7 +12071,21 @@ export interface operations {
           [name: string]: unknown
         }
         content: {
-          'application/json': components['schemas']['JitStateResponse']
+          'application/json':
+            | {
+                appliedSuccessfully?: boolean
+                /** @enum {string} */
+                state: 'enabled' | 'disabled'
+              }
+            | {
+                /** @constant */
+                state: 'unavailable'
+                /** @enum {string} */
+                unavailableReason:
+                  | 'postgres_upgrade_required'
+                  | 'ssl_enforcement_required'
+                  | 'temporarily_unavailable'
+              }
         }
       }
       /** @description Unauthorized */
@@ -11613,7 +12139,21 @@ export interface operations {
           [name: string]: unknown
         }
         content: {
-          'application/json': components['schemas']['JitStateResponse']
+          'application/json':
+            | {
+                appliedSuccessfully?: boolean
+                /** @enum {string} */
+                state: 'enabled' | 'disabled'
+              }
+            | {
+                /** @constant */
+                state: 'unavailable'
+                /** @enum {string} */
+                unavailableReason:
+                  | 'postgres_upgrade_required'
+                  | 'ssl_enforcement_required'
+                  | 'temporarily_unavailable'
+              }
         }
       }
       /** @description Unauthorized */
@@ -12291,7 +12831,9 @@ export interface operations {
         headers: {
           [name: string]: unknown
         }
-        content?: never
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
       }
       /** @description Forbidden action */
       403: {
@@ -13121,7 +13663,9 @@ export interface operations {
         headers: {
           [name: string]: unknown
         }
-        content?: never
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
       }
       /** @description Unauthorized */
       401: {
@@ -13230,7 +13774,9 @@ export interface operations {
         headers: {
           [name: string]: unknown
         }
-        content?: never
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
       }
       /** @description Unauthorized */
       401: {
@@ -13291,7 +13837,9 @@ export interface operations {
         headers: {
           [name: string]: unknown
         }
-        content?: never
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
       }
       /** @description Unauthorized */
       401: {

--- a/packages/api-types/types/platform.d.ts
+++ b/packages/api-types/types/platform.d.ts
@@ -520,23 +520,6 @@ export interface paths {
     patch?: never
     trace?: never
   }
-  '/platform/feedback/docs': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Send feedback on docs */
-    post: operations['SendFeedbackController_sendDocsFeedback']
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
   '/platform/feedback/downgrade': {
     parameters: {
       query?: never
@@ -681,6 +664,26 @@ export interface paths {
     head?: never
     /** Updates a GitHub connection for a supabase project */
     patch: operations['GitHubConnectionsController_updateGitHubConnection']
+    trace?: never
+  }
+  '/platform/integrations/github/connections/{connection_id}/config': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Gets the Supabase config of a connected GitHub repository
+     * @description Reads `supabase/config.toml` from the workdir of the connected repository and returns it as JSON.
+     */
+    get: operations['GitHubConnectionsController_getGitHubConnectionConfig']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
     trace?: never
   }
   '/platform/integrations/github/repositories': {
@@ -1984,11 +1987,9 @@ export interface paths {
     }
     /** Gets the given organization's tax ID */
     get: operations['TaxIdsController_getTaxId']
-    /** Creates or updates a tax ID for the given organization */
-    put: operations['TaxIdsController_updateTaxId']
+    put?: never
     post?: never
-    /** Delete the tax ID with the given ID */
-    delete: operations['TaxIdsController_deleteTaxId']
+    delete?: never
     options?: never
     head?: never
     patch?: never
@@ -2592,6 +2593,24 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/platform/projects/{ref}/analytics/endpoints/logs': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Gets project's logs from the unified logs stream */
+    get: operations['LogsController_getProjectLogsViaGetNew']
+    put?: never
+    /** Gets project's logs from the unified logs stream */
+    post: operations['LogsController_getProjectLogsViaPostNew']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/platform/projects/{ref}/analytics/endpoints/logs.all': {
     parameters: {
       query?: never
@@ -2599,10 +2618,16 @@ export interface paths {
       path?: never
       cookie?: never
     }
-    /** Gets project's logs */
+    /**
+     * Gets project's logs from legacy logs tables
+     * @deprecated
+     */
     get: operations['LogsController_getProjectLogsViaGet']
     put?: never
-    /** Gets project's logs */
+    /**
+     * Gets project's logs from legacy logs tables
+     * @deprecated
+     */
     post: operations['LogsController_getProjectLogsViaPost']
     delete?: never
     options?: never
@@ -2617,10 +2642,16 @@ export interface paths {
       path?: never
       cookie?: never
     }
-    /** Gets project's logs from the ClickHouse-backed endpoint */
+    /**
+     * Gets project's logs from the unified logs stream
+     * @deprecated
+     */
     get: operations['LogsController_getProjectLogsOtelViaGet']
     put?: never
-    /** Gets project's logs from the ClickHouse-backed endpoint */
+    /**
+     * Gets project's logs from the unified logs stream
+     * @deprecated
+     */
     post: operations['LogsController_getProjectLogsOtelViaPost']
     delete?: never
     options?: never
@@ -2761,6 +2792,26 @@ export interface paths {
     put?: never
     /** Test a log drain connection */
     post: operations['LogDrainController_testLogDrain']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/platform/projects/{ref}/analytics/metrics': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Scrape a project's metrics
+     * @description Prometheus scrape endpoint. Returns metrics of a customer project in the Prometheus open exposition format. Replaces `/customer/v1/privileged/metrics`.
+     */
+    get: operations['scrape-project-metrics']
+    put?: never
+    post?: never
     delete?: never
     options?: never
     head?: never
@@ -3394,9 +3445,29 @@ export interface paths {
     post?: never
     /**
      * Remove AWS account from PrivateLink share for the project
-     * @description Removes an AWS account from the project's PrivateLink configuration. Cleans up associated AWS resources.
+     * @description Removes an AWS account from the project's PrivateLink configuration (targeting the primary database). Cleans up associated AWS resources.
      */
     delete: operations['ProjectPrivateLinkController_removeAwsAccountFromPrivateLink']
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/platform/projects/{ref}/privatelink/associations/aws-account/{aws_account_id}/database/{database_identifier}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    post?: never
+    /**
+     * Remove AWS account from a specific database PrivateLink share for the project
+     * @description Removes an AWS account from the project's PrivateLink configuration for the given read replica. Cleans up associated AWS resources.
+     */
+    delete: operations['ProjectPrivateLinkController_removeAwsAccountFromPrivateLinkForDatabase']
     options?: never
     head?: never
     patch?: never
@@ -3496,57 +3567,6 @@ export interface paths {
     }
     /** Run project lints */
     get: operations['ProjectRunLintsController_runProjectLints']
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  '/platform/projects/{ref}/run-lints/{name}': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Run project lint by name */
-    get: operations['ProjectRunLintsController_runLintByName']
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  '/platform/projects/{ref}/run-lints/leaked-service-key': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Run project leaked service key lint */
-    get: operations['ProjectRunLintsController_runLeakedServiceKeyLint']
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  '/platform/projects/{ref}/run-lints/no-backup-admin': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Run project backup admin lint */
-    get: operations['ProjectRunLintsController_runAuthBackupAdminLint']
     put?: never
     post?: never
     delete?: never
@@ -4104,7 +4124,7 @@ export interface paths {
     }
     /**
      * Estimate replication cost for a publication
-     * @description Estimate the cost of replicating a publication's tables. Returns the flat per-pipeline fee, a per-table breakdown of the one-time initial-copy cost derived from the tables’ on-disk size, and the usage-based streaming rate. Requires bearer auth and an active, healthy project.
+     * @description Estimate the cost of replicating a publication's tables. Returns the hourly (and projected monthly) per-pipeline fee, a per-table breakdown of the one-time initial-copy cost derived from the tables’ on-disk size, and the usage-based streaming rate. Requires bearer auth and an active, healthy project.
      */
     get: operations['ReplicationSourcesController_getCostEstimate']
     put?: never
@@ -4539,6 +4559,40 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/platform/storage/{ref}/cdn/purge-bucket': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Purges CDN cache for an entire bucket */
+    post: operations['StorageCdnController_purgeBucketCache']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/platform/storage/{ref}/cdn/purge-object': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Purges CDN cache for a single object */
+    post: operations['StorageCdnController_purgeObjectCache']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/platform/storage/{ref}/credentials': {
     parameters: {
       query?: never
@@ -4903,6 +4957,134 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/platform/warehouse/{ref}/catalog': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get Warehouse catalog access
+     * @description Return whether external Warehouse catalog access is enabled and credentials when enabled.
+     */
+    get: operations['WarehouseController_getCatalog']
+    put?: never
+    /**
+     * Update Warehouse catalog access
+     * @description Enable or disable external Warehouse catalog access for the project.
+     */
+    post: operations['WarehouseController_updateCatalog']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/platform/warehouse/{ref}/refresh-schema': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * Refresh the Warehouse foreign schema
+     * @description Reinstall the project Warehouse FDW schema asynchronously without restarting replication or waiting for a table copy.
+     */
+    post: operations['WarehouseController_refreshSchema']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/platform/warehouse/{ref}/setup-status': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get Warehouse setup status
+     * @description Return the async Warehouse setup status for the project. Overall completion follows the replication pipeline and table copy state; project database FDW markers are informational.
+     */
+    get: operations['WarehouseController_getSetupStatus']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/platform/warehouse/{ref}/tables': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * List Warehouse linked tables
+     * @description List tables copied to Warehouse for the project. Requires bearer auth and an active, healthy project.
+     */
+    get: operations['WarehouseController_getTables']
+    put?: never
+    /**
+     * Copy a table to Warehouse
+     * @description Ensure the project Warehouse pipeline exists, add the table to its publication, and start syncing. Warehouse FDW installation is opt-in.
+     */
+    post: operations['WarehouseController_linkTable']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/platform/warehouse/{ref}/tables/{schema}/{name}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    post?: never
+    /**
+     * Detach a table from Warehouse
+     * @description Remove the table from the Warehouse publication so it stops syncing. Existing DuckLake data is left in place.
+     */
+    delete: operations['WarehouseController_detachTable']
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/platform/warehouse/{ref}/tables/{schema}/{name}/snapshots': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * List Warehouse snapshots for a table
+     * @description Return available DuckLake snapshots for a Warehouse-linked table. The snapshots are read from the Warehouse FDW in the project database.
+     */
+    get: operations['WarehouseController_getTableSnapshots']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/platform/workflow-runs': {
     parameters: {
       query?: never
@@ -4987,6 +5169,8 @@ export interface components {
     AddAwsAccountToPrivateLinkBody: {
       account_name?: string
       aws_account_id: string
+      /** @description Identifier of the read replica this PrivateLink share should target. Omit to target the primary database. */
+      database_identifier?: string
     }
     AnalyticsResponse: {
       error?:
@@ -5020,6 +5204,9 @@ export interface components {
           }
           method: string
           name: string
+          params?: {
+            [key: string]: unknown
+          }
           route: string
           status: number
         }
@@ -5027,10 +5214,24 @@ export interface components {
           app_id?: string
           app_name?: string
           email?: string
+          /** @description Only present when token_type=app */
+          installation_id?: string
           ip?: string
+          /** @description JWT issuer. Only present for branching service JWTs */
+          jwt_issuer?: string
+          /** @description JWT subject. Only present for branching service JWTs */
+          jwt_subject?: string
           oauth_app_id?: string
           oauth_app_name?: string
+          /** @description Organization whose grant was used. Only present when token_type=oauth */
+          organization_id?: string
+          /** @description GoTrue login session. Only present when token_type=jwt */
+          session_id?: string
+          /** @description Access token alias, as shown in the dashboard. Only present when token_type=v0, token_type=v1 or token_type=scoped_pat */
+          token_alias?: string
           token_hash?: string
+          /** @description Only present when token_type=scoped_pat */
+          token_scope?: string
           token_type: string
           user_id?: string
         }
@@ -5040,60 +5241,6 @@ export interface components {
         timestamp: number
       }[]
       retention_period: number
-    }
-    AuthBackupAdminLintResponse: {
-      lints: {
-        cache_key: string
-        categories: ('PERFORMANCE' | 'SECURITY')[]
-        description: string
-        detail: string
-        /** @enum {string} */
-        facing: 'EXTERNAL'
-        /** @enum {string} */
-        level: 'ERROR' | 'WARN' | 'INFO'
-        metadata?: {
-          entity?: string
-          fkey_columns?: number[]
-          fkey_name?: string
-          name?: string
-          schema?: string
-          /** @enum {string} */
-          type?: 'table' | 'view' | 'auth' | 'function' | 'extension' | 'compliance'
-        }
-        /** @enum {string} */
-        name:
-          | 'unindexed_foreign_keys'
-          | 'auth_users_exposed'
-          | 'auth_rls_initplan'
-          | 'no_primary_key'
-          | 'unused_index'
-          | 'multiple_permissive_policies'
-          | 'policy_exists_rls_disabled'
-          | 'rls_enabled_no_policy'
-          | 'duplicate_index'
-          | 'security_definer_view'
-          | 'function_search_path_mutable'
-          | 'rls_disabled_in_public'
-          | 'extension_in_public'
-          | 'rls_references_user_metadata'
-          | 'materialized_view_in_api'
-          | 'foreign_table_in_api'
-          | 'unsupported_reg_types'
-          | 'auth_otp_long_expiry'
-          | 'auth_otp_short_length'
-          | 'ssl_not_enforced'
-          | 'network_restrictions_not_set'
-          | 'password_requirements_min_length'
-          | 'pitr_not_enabled'
-          | 'auth_leaked_password_protection'
-          | 'auth_insufficient_mfa_options'
-          | 'auth_password_policy_missing'
-          | 'leaked_service_key'
-          | 'no_backup_admin'
-          | 'vulnerable_postgres_version'
-        remediation: string
-        title: string
-      }[]
     }
     BackendConnectionTest: {
       'connected?': boolean
@@ -5131,7 +5278,7 @@ export interface components {
       clear_tax_id?: true
       dry_run?: boolean
       tax_id?: {
-        country?: string
+        country: string
         type: string
         value: string
       }
@@ -5219,6 +5366,81 @@ export interface components {
     }
     CopyObjectResponse: {
       path: string
+    }
+    CostEstimateResponse: {
+      /**
+       * @description Currency of all amounts
+       * @example usd
+       * @enum {string}
+       */
+      currency: 'usd'
+      /** @description Recurring per-pipeline cost */
+      pipeline: {
+        /**
+         * @description Hourly rate charged per active pipeline
+         * @example 0.053
+         */
+        hourly_cost: number
+        /**
+         * @description Projected monthly cost for an active pipeline, based on an average 730-hour month. Pipelines are billed hourly, so this is an estimate, not a metered amount.
+         * @example 38.69
+         */
+        monthly_cost: number
+      }
+      /** @description Usage-based streaming cost, expressed as a rate */
+      streaming: {
+        /**
+         * @description Usage-based streaming rate per GB. Actual cost depends on the change volume.
+         * @example 3
+         */
+        rate_per_gb: number
+      }
+      /** @description One-time cost for the initial table copy */
+      table_copy: {
+        /**
+         * @description One-time initial-copy rate per GB
+         * @example 0.6
+         */
+        rate_per_gb: number
+        /** @description Per-table initial-copy cost estimate */
+        tables: {
+          /**
+           * @description Estimated on-disk size of the table in bytes
+           * @example 10960896
+           */
+          estimated_bytes: number
+          /**
+           * @description Estimated one-time initial-copy cost for the table, in the response currency
+           * @example 0.01
+           */
+          estimated_cost: number
+          /**
+           * @description Whether this table has a row filter. The estimate does not account for how many rows the filter excludes, so the actual replicated volume may be lower than shown.
+           * @example false
+           */
+          is_row_filtered: boolean
+          /**
+           * @description Table name
+           * @example orders
+           */
+          name: string
+          /**
+           * @description Table schema
+           * @example public
+           */
+          schema: string
+        }[]
+        /**
+         * @description Total estimated bytes across all tables
+         * @example 11911168
+         */
+        total_bytes: number
+        /**
+         * @description Total estimated one-time initial-copy cost
+         * @example 0.01
+         */
+        total_cost: number
+      }
     }
     CreateAccessTokenBody: {
       /** Format: date-time */
@@ -5389,24 +5611,11 @@ export interface components {
       workdir: string
     }
     CreateInvitationBody: {
-      /**
-       * Format: email
-       * @deprecated
-       */
-      email?: string
-      emails?: string[]
+      emails: string[]
       require_sso?: boolean
       role_id: number
       role_scoped_projects?: string[]
     }
-    CreateInvitationResponse: {
-      failed: {
-        /** Format: email */
-        email: string
-        error: string
-      }[]
-      succeeded: string[]
-    } | null
     CreateNamespaceBody: {
       namespace: string
     }
@@ -5566,7 +5775,7 @@ export interface components {
       payment_method?: string
       size?: string
       tax_id?: {
-        country?: string
+        country: string
         type: string
         value: string
       }
@@ -5579,37 +5788,6 @@ export interface components {
         | 'tier_enterprise'
         | 'tier_platform'
     }
-    CreateOrganizationResponse:
-      | {
-          pending_payment_intent_secret: string | null
-        }
-      | {
-          billing_email: string | null
-          /** @enum {string|null} */
-          billing_partner: 'fly' | 'aws_marketplace' | 'vercel_marketplace' | null
-          id: number
-          integration_source: string | null
-          is_owner: boolean
-          name: string
-          opt_in_tags: string[]
-          organization_missing_address: boolean
-          organization_missing_tax_id: boolean
-          organization_requires_mfa: boolean
-          plan: {
-            /** @enum {string} */
-            id: 'free' | 'pro' | 'team' | 'enterprise' | 'platform'
-            name: string
-          }
-          restriction_data: {
-            [key: string]: string
-          } | null
-          /** @enum {string|null} */
-          restriction_status: 'grace_period' | 'grace_period_over' | 'restricted' | null
-          slug: string
-          stripe_customer_id: string | null
-          subscription_id: string | null
-          usage_billing_enabled: boolean
-        }
     CreatePipelineResponse: {
       /**
        * @description Pipeline id
@@ -5631,6 +5809,8 @@ export interface components {
         | 'members_write'
         | 'organization_projects_read'
         | 'organization_projects_create'
+        | 'platform_webhooks_organization_read'
+        | 'platform_webhooks_organization_write'
         | 'project_admin_read'
         | 'project_admin_write'
         | 'action_runs_read'
@@ -5700,6 +5880,8 @@ export interface components {
         | 'storage_config_write'
         | 'vanity_subdomain_read'
         | 'vanity_subdomain_write'
+        | 'platform_webhooks_projects_read'
+        | 'platform_webhooks_projects_write'
       )[]
     }
     CreatePlatformAppResponse: {
@@ -5728,9 +5910,9 @@ export interface components {
     CreateProjectBody: {
       auth_site_url?: string
       /** @enum {string} */
-      cloud_provider: 'AWS' | 'FLY' | 'AWS_K8S' | 'AWS_NIMBUS'
+      cloud_provider: 'AWS' | 'AWS_K8S' | 'AWS_NIMBUS'
       custom_supabase_internal_requests?: {
-        ami: {
+        ami?: {
           /**
            * @description Exact AWS instance type to provision (e.g. `t3.nano`, `t4g.nano`). Hard pin — no ODCR fallback. Only for internal use; rejected for user-facing requests in production.
            * @enum {string}
@@ -5740,16 +5922,67 @@ export interface components {
             | 't3a.nano'
             | 't3.nano'
             | 't4g.micro'
+            | 't3a.micro'
+            | 't3.micro'
             | 't4g.small'
+            | 't3a.small'
+            | 't3.small'
             | 't4g.medium'
+            | 't3a.medium'
+            | 't3.medium'
             | 'm6g.medium'
+            | 'm7g.medium'
+            | 'm8g.medium'
+            | 'm9g.medium'
             | 'm6g.large'
+            | 'm6a.large'
+            | 'm6i.large'
+            | 'm7i.large'
+            | 'm8i.large'
+            | 'm7a.large'
+            | 'm8a.large'
             | 'm6g.xlarge'
+            | 'm6a.xlarge'
+            | 'm6i.xlarge'
+            | 'm7i.xlarge'
+            | 'm8i.xlarge'
+            | 'm7a.xlarge'
+            | 'm8a.xlarge'
             | 'm6g.2xlarge'
+            | 'm6a.2xlarge'
+            | 'm6i.2xlarge'
+            | 'm7i.2xlarge'
+            | 'm8i.2xlarge'
+            | 'm7a.2xlarge'
+            | 'm8a.2xlarge'
             | 'm6g.4xlarge'
+            | 'm6a.4xlarge'
+            | 'm6i.4xlarge'
+            | 'm7i.4xlarge'
+            | 'm8i.4xlarge'
+            | 'm7a.4xlarge'
+            | 'm8a.4xlarge'
             | 'm6g.8xlarge'
+            | 'm6a.8xlarge'
+            | 'm6i.8xlarge'
+            | 'm7i.8xlarge'
+            | 'm8i.8xlarge'
+            | 'm7a.8xlarge'
+            | 'm8a.8xlarge'
             | 'm6g.12xlarge'
+            | 'm6a.12xlarge'
+            | 'm6i.12xlarge'
+            | 'm7i.12xlarge'
+            | 'm8i.12xlarge'
+            | 'm7a.12xlarge'
+            | 'm8a.12xlarge'
             | 'm6g.16xlarge'
+            | 'm6a.16xlarge'
+            | 'm6i.16xlarge'
+            | 'm7i.16xlarge'
+            | 'm8i.16xlarge'
+            | 'm7a.16xlarge'
+            | 'm8a.16xlarge'
             | 'm8g.24xlarge'
             | 'c8g.24xlarge'
             | 'r8g.24xlarge'
@@ -5766,6 +5999,26 @@ export interface components {
           search_tags?: {
             [key: string]: string
           }
+        }
+        warehouse_fdw?: {
+          /** @description AWS ACM Private CA ARN used by the worker to issue per-project warehouse FDW client certificates. Defaults to the worker environment configuration when omitted. */
+          client_certificate_authority_arn?: string
+          /** @description Optional URI SAN to place in the issued client certificate. Defaults to spiffe://supabase/<environment>/postgres/<project-ref>/<database-identifier>. */
+          client_certificate_identity_uri?: string
+          client_certificate_ttl_days?: number
+          connect_timeout_ms?: number
+          enabled?: boolean
+          endpoint: string
+          jwt_audience?: string
+          jwt_issuer?: string
+          jwt_kid: string
+          jwt_ttl_secs?: number
+          request_timeout_ms?: number
+          /** @description Optional legacy input. The platform derives the runtime AWS Secrets Manager prefix from the project ref as warehouse-fdw/<project-ref>. */
+          secret_prefix?: string
+          secret_region?: string
+          stream_idle_timeout_ms?: number
+          tls_domain_name?: string
         }
       }
       data_api_exposed_schemas?: string[]
@@ -5815,7 +6068,29 @@ export interface components {
       /** @description Provider region selection. Only one of db_region or region_selection can be specified. */
       region_selection?:
         | {
-            code: string
+            /**
+             * @description The selected region code must be valid for the specified cloud provider.
+             * @enum {string}
+             */
+            code:
+              | 'us-east-1'
+              | 'us-east-2'
+              | 'us-west-1'
+              | 'us-west-2'
+              | 'ap-east-1'
+              | 'ap-southeast-1'
+              | 'ap-northeast-1'
+              | 'ap-northeast-2'
+              | 'ap-southeast-2'
+              | 'eu-west-1'
+              | 'eu-west-2'
+              | 'eu-west-3'
+              | 'eu-north-1'
+              | 'eu-central-1'
+              | 'eu-central-2'
+              | 'ca-central-1'
+              | 'ap-south-1'
+              | 'sa-east-1'
             /** @enum {string} */
             type: 'specific'
           }
@@ -6167,7 +6442,7 @@ export interface components {
               private_key_passphrase?: string | null
               /**
                * @description Optional Snowflake role
-               * @example ETL_ROLE
+               * @example PIPELINES_ROLE
                */
               role?: string | null
               /**
@@ -6177,7 +6452,7 @@ export interface components {
               schema: string
               /**
                * @description Snowflake user configured for key-pair authentication
-               * @example ETL_USER
+               * @example PIPELINES_USER
                */
               user: string
             }
@@ -6479,7 +6754,7 @@ export interface components {
               private_key_passphrase?: string | null
               /**
                * @description Optional Snowflake role
-               * @example ETL_ROLE
+               * @example PIPELINES_ROLE
                */
               role?: string | null
               /**
@@ -6489,7 +6764,7 @@ export interface components {
               schema: string
               /**
                * @description Snowflake user configured for key-pair authentication
-               * @example ETL_USER
+               * @example PIPELINES_USER
                */
               user: string
             }
@@ -6530,7 +6805,7 @@ export interface components {
          * @example info
          * @enum {string|null}
          */
-        log_level?: 'debug' | 'error' | 'info' | 'trace' | 'warn' | null
+        log_level?: 'trace' | 'debug' | 'info' | 'warn' | 'error' | null
         /** @description Maximum number of copy connections per table */
         max_copy_connections_per_table?: number | null
         /** @description Maximum number of table sync workers */
@@ -6605,7 +6880,7 @@ export interface components {
               /** @enum {string} */
               type: 'skip_tables'
             }
-          | (never | null)
+          | never
       }
       /**
        * @description Source id
@@ -6645,7 +6920,7 @@ export interface components {
          * @example info
          * @enum {string|null}
          */
-        log_level?: 'debug' | 'error' | 'info' | 'trace' | 'warn' | null
+        log_level?: 'trace' | 'debug' | 'info' | 'warn' | 'error' | null
         /** @description Maximum number of copy connections per table */
         max_copy_connections_per_table?: number | null
         /** @description Maximum number of table sync workers */
@@ -6720,7 +6995,7 @@ export interface components {
               /** @enum {string} */
               type: 'skip_tables'
             }
-          | (never | null)
+          | never
       }
       /**
        * @description Destination id
@@ -6769,6 +7044,8 @@ export interface components {
         | 'members_write'
         | 'organization_projects_read'
         | 'organization_projects_create'
+        | 'platform_webhooks_organization_read'
+        | 'platform_webhooks_organization_write'
         | 'project_admin_read'
         | 'project_admin_write'
         | 'action_runs_read'
@@ -6838,6 +7115,8 @@ export interface components {
         | 'storage_config_write'
         | 'vanity_subdomain_read'
         | 'vanity_subdomain_write'
+        | 'platform_webhooks_projects_read'
+        | 'platform_webhooks_projects_write'
       )[]
       project_refs?: string[]
     }
@@ -6857,80 +7136,13 @@ export interface components {
       /** @description Source ID */
       id: number
     }
-    CreateSSOProviderBody:
-      | {
-          /** @default [] */
-          domains?: string[]
-          email_mapping: string[]
-          enabled: boolean
-          first_name_mapping?: string[]
-          /** Format: uri */
-          idjag_issuer_url?: string | null
-          join_org_on_signup_enabled: boolean
-          /** @enum {string} */
-          join_org_on_signup_role?: 'Administrator' | 'Developer' | 'Owner' | 'Read-only'
-          last_name_mapping?: string[]
-          metadata_xml_file: string
-          /** Format: uri */
-          metadata_xml_url?: string
-          user_name_mapping?: string[]
-        }
-      | {
-          /** @default [] */
-          domains?: string[]
-          email_mapping: string[]
-          enabled: boolean
-          first_name_mapping?: string[]
-          /** Format: uri */
-          idjag_issuer_url?: string | null
-          join_org_on_signup_enabled: boolean
-          /** @enum {string} */
-          join_org_on_signup_role?: 'Administrator' | 'Developer' | 'Owner' | 'Read-only'
-          last_name_mapping?: string[]
-          metadata_xml_file?: string
-          metadata_xml_url: string
-          user_name_mapping?: string[]
-        }
-    CreateSSOProviderResponse:
-      | {
-          /** @default [] */
-          domains?: string[]
-          email_mapping: string[]
-          enabled: boolean
-          first_name_mapping?: string[]
-          /** Format: uri */
-          idjag_issuer_url?: string | null
-          join_org_on_signup_enabled: boolean
-          /** @enum {string} */
-          join_org_on_signup_role?: 'Administrator' | 'Developer' | 'Owner' | 'Read-only'
-          last_name_mapping?: string[]
-          metadata_xml_file: string
-          /** Format: uri */
-          metadata_xml_url?: string
-          user_name_mapping?: string[]
-        }
-      | {
-          /** @default [] */
-          domains?: string[]
-          email_mapping: string[]
-          enabled: boolean
-          first_name_mapping?: string[]
-          /** Format: uri */
-          idjag_issuer_url?: string | null
-          join_org_on_signup_enabled: boolean
-          /** @enum {string} */
-          join_org_on_signup_role?: 'Administrator' | 'Developer' | 'Owner' | 'Read-only'
-          last_name_mapping?: string[]
-          metadata_xml_file?: string
-          metadata_xml_url: string
-          user_name_mapping?: string[]
-        }
     CreateStorageAnalyticsBucketBody: {
       bucketName: string
     }
     CreateStorageBucketBody: {
       allowed_mime_types?: string[]
       file_size_limit?: number
+      /** @description Storage bucket id */
       id: string
       public: boolean
       /** @enum {string} */
@@ -6947,11 +7159,6 @@ export interface components {
     }
     CreateStorageVectorBucketBody: {
       bucketName: string
-    }
-    CreateTaxIdBody: {
-      country?: string
-      type: string
-      value: string
     }
     CreateTenantSourceResponse: {
       /**
@@ -6977,7 +7184,7 @@ export interface components {
       parent_id?: string | null
       project_id: number
     }
-    CreateUserReponse: {
+    CreateUserResponse: {
       aud?: string
       banned_until?: string
       confirmation_sent_at?: string
@@ -7055,7 +7262,6 @@ export interface components {
     }
     CreditRedemptionResponse: {
       amount_cents: number
-      /** Format: date-time */
       credits_expire_at: string | null
     }
     CreditsTopUpRequest: {
@@ -7112,7 +7318,7 @@ export interface components {
     }
     DatabaseDetailResponse: {
       /** @enum {string} */
-      cloud_provider: 'AWS' | 'FLY' | 'AWS_K8S' | 'AWS_NIMBUS'
+      cloud_provider: 'AWS' | 'AWS_K8S' | 'AWS_NIMBUS'
       /** @default null */
       connection_string_read_only?: string | null
       /** @default null */
@@ -7325,7 +7531,6 @@ export interface components {
       logo_uri?: string
       redirect_uris: string[]
       response_types?: string[]
-      /** @default organizations:read projects:read projects:write database:write database:read analytics:read secrets:read edge_functions:read edge_functions:write environment:read environment:write storage:read */
       scope?: string
       token_endpoint_auth_method?: string
     }
@@ -7346,70 +7551,25 @@ export interface components {
       private: number
       shared: number
     }
+    GetGitHubConnectionConfigResponse: {
+      /** @description JSON representation of the parsed `supabase/config.toml`. Its shape is owned by the Supabase CLI and is passed through as-is. */
+      config: {
+        [key: string]: unknown
+      }
+      /** @description Path of the config file within the connected repository, relative to its root. */
+      path: string
+      /** @description Git ref the config was read from, or `null` when the default branch of the connected repository was used. */
+      ref: string | null
+      /** @description Blob SHA of the config file, to detect changes between requests. */
+      sha: string
+    }
     GetJwtSecretUpdateStatus: {
       update_status: {
         change_tracking_id: string
-        /** @enum {number} */
         error?: 0 | 1 | 2 | 3 | 4 | 5
-        /** @enum {number} */
         progress: 0 | 1 | 2 | 3 | 4 | 5
-        /** @enum {number} */
         status: 0 | 1 | 2
       } | null
-    }
-    GetLeakedServiceKeyLintResponse: {
-      lints: {
-        cache_key: string
-        categories: ('PERFORMANCE' | 'SECURITY')[]
-        description: string
-        detail: string
-        /** @enum {string} */
-        facing: 'EXTERNAL'
-        /** @enum {string} */
-        level: 'ERROR' | 'WARN' | 'INFO'
-        metadata?: {
-          entity?: string
-          fkey_columns?: number[]
-          fkey_name?: string
-          name?: string
-          schema?: string
-          /** @enum {string} */
-          type?: 'table' | 'view' | 'auth' | 'function' | 'extension' | 'compliance'
-        }
-        /** @enum {string} */
-        name:
-          | 'unindexed_foreign_keys'
-          | 'auth_users_exposed'
-          | 'auth_rls_initplan'
-          | 'no_primary_key'
-          | 'unused_index'
-          | 'multiple_permissive_policies'
-          | 'policy_exists_rls_disabled'
-          | 'rls_enabled_no_policy'
-          | 'duplicate_index'
-          | 'security_definer_view'
-          | 'function_search_path_mutable'
-          | 'rls_disabled_in_public'
-          | 'extension_in_public'
-          | 'rls_references_user_metadata'
-          | 'materialized_view_in_api'
-          | 'foreign_table_in_api'
-          | 'unsupported_reg_types'
-          | 'auth_otp_long_expiry'
-          | 'auth_otp_short_length'
-          | 'ssl_not_enforced'
-          | 'network_restrictions_not_set'
-          | 'password_requirements_min_length'
-          | 'pitr_not_enabled'
-          | 'auth_leaked_password_protection'
-          | 'auth_insufficient_mfa_options'
-          | 'auth_password_policy_missing'
-          | 'leaked_service_key'
-          | 'no_backup_admin'
-          | 'vulnerable_postgres_version'
-        remediation: string
-        title: string
-      }[]
     }
     GetOAuthAuthorizationResponse: {
       approved_at?: string
@@ -7495,13 +7655,19 @@ export interface components {
       integration: {
         name: string
       }
-      /** @description Any JSON-serializable value */
-      metadata: unknown
+      metadata: components['schemas']['GetOrganizationIntegrationResponseJsonValue']
       organization: {
         slug: string
       }
       updated_at: string
     }
+    /** @description Any JSON-serializable value */
+    GetOrganizationIntegrationResponseJsonValue:
+      | ((string | number | boolean) | null)
+      | components['schemas']['GetOrganizationIntegrationResponseJsonValue'][]
+      | {
+          [key: string]: components['schemas']['GetOrganizationIntegrationResponseJsonValue']
+        }
     GetPlatformAppInstallationResponse: {
       /** Format: uuid */
       app_id: string
@@ -7541,6 +7707,13 @@ export interface components {
       private_link_associations: {
         account_name?: string
         aws_account_id: string
+        /** @description Identifier of the database this PrivateLink share targets - the project ref for the primary, or the read replica identifier. */
+        database_identifier: string
+        /**
+         * @description Whether this PrivateLink share targets the primary database or a read replica.
+         * @enum {string}
+         */
+        database_type: 'PRIMARY' | 'READ_REPLICA'
         /**
          * Format: date-time
          * @description The time and date at which the AWS Resource Share Association was requested from Supabase. `null` means that the association was not yet requested while the PrivateLink Association is pending.
@@ -7750,40 +7923,6 @@ export interface components {
       }
       path: string[]
     }
-    GetSSOProviderResponse:
-      | {
-          /** @default [] */
-          domains?: string[]
-          email_mapping: string[]
-          enabled: boolean
-          first_name_mapping?: string[]
-          /** Format: uri */
-          idjag_issuer_url?: string | null
-          join_org_on_signup_enabled: boolean
-          /** @enum {string} */
-          join_org_on_signup_role?: 'Administrator' | 'Developer' | 'Owner' | 'Read-only'
-          last_name_mapping?: string[]
-          metadata_xml_file: string
-          /** Format: uri */
-          metadata_xml_url?: string
-          user_name_mapping?: string[]
-        }
-      | {
-          /** @default [] */
-          domains?: string[]
-          email_mapping: string[]
-          enabled: boolean
-          first_name_mapping?: string[]
-          /** Format: uri */
-          idjag_issuer_url?: string | null
-          join_org_on_signup_enabled: boolean
-          /** @enum {string} */
-          join_org_on_signup_role?: 'Administrator' | 'Developer' | 'Owner' | 'Read-only'
-          last_name_mapping?: string[]
-          metadata_xml_file?: string
-          metadata_xml_url: string
-          user_name_mapping?: string[]
-        }
     GetStorageCredentialsResponse: {
       data: {
         created_at: string
@@ -7799,7 +7938,7 @@ export interface components {
       }[]
       billing_cycle_anchor: number
       /** @enum {string} */
-      billing_partner?: 'fly' | 'aws_marketplace' | 'vercel_marketplace'
+      billing_partner?: 'aws_marketplace' | 'vercel_marketplace'
       billing_via_partner: boolean
       current_period_end: number
       current_period_start: number
@@ -7854,8 +7993,7 @@ export interface components {
               | 'auth_mfa_web_authn_default'
               | 'log_drain_default'
               | 'etl_pipeline_default'
-            /** @description Any JSON-serializable value */
-            meta?: unknown
+            meta?: components['schemas']['GetSubscriptionResponseJsonValue']
             name: string
             price: number
             price_description: string
@@ -7869,7 +8007,6 @@ export interface components {
         ref: string
       }[]
       scheduled_plan_change: {
-        /** Format: date-time */
         at: string
         /** @enum {string} */
         target_plan: 'free' | 'pro' | 'team' | 'enterprise' | 'platform'
@@ -7877,6 +8014,13 @@ export interface components {
       } | null
       usage_billing_enabled: boolean
     }
+    /** @description Any JSON-serializable value */
+    GetSubscriptionResponseJsonValue:
+      | ((string | number | boolean) | null)
+      | components['schemas']['GetSubscriptionResponseJsonValue'][]
+      | {
+          [key: string]: components['schemas']['GetSubscriptionResponseJsonValue']
+        }
     GetUserContentByIdResponse: {
       content: {
         [key: string]: unknown
@@ -7964,13 +8108,19 @@ export interface components {
       integration: {
         name: string
       }
-      /** @description Any JSON-serializable value */
-      metadata: unknown
+      metadata: components['schemas']['GetUserOrganizationIntegrationResponseJsonValue']
       organization: {
         slug: string
       }
       updated_at: string
     }
+    /** @description Any JSON-serializable value */
+    GetUserOrganizationIntegrationResponseJsonValue:
+      | ((string | number | boolean) | null)
+      | components['schemas']['GetUserOrganizationIntegrationResponseJsonValue'][]
+      | {
+          [key: string]: components['schemas']['GetUserOrganizationIntegrationResponseJsonValue']
+        }
     GetVercelProjectsResponse: {
       pagination: {
         count: number
@@ -8380,14 +8530,14 @@ export interface components {
             tls?: boolean
           }
       description?: string
-      id: number
-      metadata: {
+      readonly id: number
+      readonly metadata: {
         project_ref: string
         /** @enum {string} */
         type: 'log-drain'
       } | null
       name: string
-      token: string
+      readonly token: string
       /** @enum {string} */
       type:
         | 'postgres'
@@ -8402,7 +8552,7 @@ export interface components {
         | 'last9'
         | 'otlp'
         | 'syslog'
-      user_id: number
+      readonly user_id: number
     }
     LinkClazarBuyerBody: {
       buyer_id: string
@@ -8437,6 +8587,7 @@ export interface components {
             | 'storage.image_transformations'
             | 'storage.vector_buckets'
             | 'storage.iceberg_catalog'
+            | 'storage.purge_cache'
             | 'security.audit_logs_days'
             | 'security.questionnaire'
             | 'security.soc2_report'
@@ -8486,6 +8637,8 @@ export interface components {
             | 'integrations.github_connections'
             | 'dedicated_pooler'
             | 'observability.dashboard_advanced_metrics'
+            | 'api.members.invitations'
+            | 'api.members.roles'
           /** @enum {string} */
           type: 'boolean' | 'numeric' | 'set'
         }
@@ -8678,6 +8831,7 @@ export interface components {
       is_sensitive: boolean
     }
     Member: {
+      avatar_url: string | null
       gotrue_id: string
       is_sso_user: boolean | null
       metadata: {
@@ -8736,18 +8890,23 @@ export interface components {
       'table-uuid'?: string
     }
     NotificationResponse: {
-      /** @description Any JSON-serializable value */
-      data: unknown
+      data: components['schemas']['NotificationResponseJsonValue']
       id: string
       inserted_at: string
-      /** @description Any JSON-serializable value */
-      meta: unknown
+      meta: components['schemas']['NotificationResponseJsonValue']
       name: string
       /** @enum {string} */
       priority: 'Critical' | 'Warning' | 'Info'
       /** @enum {string} */
       status: 'new' | 'seen' | 'archived'
     }
+    /** @description Any JSON-serializable value */
+    NotificationResponseJsonValue:
+      | ((string | number | boolean) | null)
+      | components['schemas']['NotificationResponseJsonValue'][]
+      | {
+          [key: string]: components['schemas']['NotificationResponseJsonValue']
+        }
     NotificationsSummary: {
       has_critical: boolean
       has_warning: boolean
@@ -8887,7 +9046,7 @@ export interface components {
     OrganizationResponse: {
       billing_email: string | null
       /** @enum {string|null} */
-      billing_partner: 'fly' | 'aws_marketplace' | 'vercel_marketplace' | null
+      billing_partner: 'aws_marketplace' | 'vercel_marketplace' | null
       id: number
       integration_source: string | null
       is_owner: boolean
@@ -8943,7 +9102,7 @@ export interface components {
     }
     OrganizationSlugAvailableVersionsBody: {
       /** @enum {string} */
-      provider: 'AWS' | 'FLY' | 'AWS_K8S' | 'AWS_NIMBUS'
+      provider: 'AWS' | 'AWS_K8S' | 'AWS_NIMBUS'
       region: string
     }
     OrganizationSlugAvailableVersionsResponse: {
@@ -8958,7 +9117,7 @@ export interface components {
     OrganizationSlugResponse: {
       billing_email: string | null
       /** @enum {string|null} */
-      billing_partner: 'fly' | 'aws_marketplace' | 'vercel_marketplace' | null
+      billing_partner: 'aws_marketplace' | 'vercel_marketplace' | null
       has_oriole_project: boolean
       id: number
       integration_source: string | null
@@ -8988,6 +9147,7 @@ export interface components {
           egress_storage: number
           egress_supavisor: number
         } | null
+        /** Format: date */
         date: string
         /** @enum {string} */
         metric:
@@ -9037,6 +9197,8 @@ export interface components {
           | 'IPV4'
           | 'LOG_DRAIN'
           | 'ETL_PIPELINE'
+          | 'ETL_REPLICATED_DATA'
+          | 'ETL_COPY_BACKFILL_DATA'
           | 'LOG_INGESTION'
           | 'LOG_QUERYING'
           | 'LOG_STORAGE'
@@ -9102,6 +9264,8 @@ export interface components {
           | 'IPV4'
           | 'LOG_DRAIN'
           | 'ETL_PIPELINE'
+          | 'ETL_REPLICATED_DATA'
+          | 'ETL_COPY_BACKFILL_DATA'
           | 'LOG_INGESTION'
           | 'LOG_QUERYING'
           | 'LOG_STORAGE'
@@ -9240,6 +9404,22 @@ export interface components {
           type: 'boolean' | 'numeric' | 'set'
         }
       }
+    }
+    PlanGateErrorBody: {
+      /** @description Present on entitlement denials. Other errors with this status code (validation, billing state) carry only message. */
+      error?: {
+        /**
+         * @description Machine-readable marker for plan-gated denials
+         * @enum {string}
+         */
+        code: 'entitlement_required'
+        /** @description Entitlement feature key that failed the check */
+        feature: string
+        /** @description Billing page URL for the organization, present when the org is resolvable */
+        upgrade_url?: string
+      }
+      /** @description Human-readable explanation of the plan gate */
+      message: string
     }
     PlansResponse: {
       plans: {
@@ -9507,7 +9687,7 @@ export interface components {
         state?: string | null
       }
       tax_id?: {
-        country?: string
+        country: string
         type: string
         value: string
       }
@@ -9682,23 +9862,7 @@ export interface components {
     }
     ProfileResponse: {
       auth0_id: string
-      disabled_features: (
-        | 'organizations:create'
-        | 'organizations:delete'
-        | 'organization_members:create'
-        | 'organization_members:delete'
-        | 'projects:create'
-        | 'projects:transfer'
-        | 'project_auth:all'
-        | 'project_storage:all'
-        | 'project_edge_function:all'
-        | 'profile:update'
-        | 'billing:account_data'
-        | 'billing:credits'
-        | 'billing:invoices'
-        | 'billing:payment_methods'
-        | 'realtime:all'
-      )[]
+      disabled_features: string[]
       first_name: string | null
       free_project_limit: number | null
       gotrue_id: string
@@ -9753,8 +9917,7 @@ export interface components {
             | 'auth_mfa_web_authn_default'
             | 'log_drain_default'
             | 'etl_pipeline_default'
-          /** @description Any JSON-serializable value */
-          meta?: unknown
+          meta?: components['schemas']['ProjectAddonsResponseJsonValue']
           name: string
           price: number
           price_description: string
@@ -9806,8 +9969,7 @@ export interface components {
             | 'auth_mfa_web_authn_default'
             | 'log_drain_default'
             | 'etl_pipeline_default'
-          /** @description Any JSON-serializable value */
-          meta?: unknown
+          meta?: components['schemas']['ProjectAddonsResponseJsonValue']
           name: string
           price: number
           price_description: string
@@ -9818,6 +9980,13 @@ export interface components {
         }
       }[]
     }
+    /** @description Any JSON-serializable value */
+    ProjectAddonsResponseJsonValue:
+      | ((string | number | boolean) | null)
+      | components['schemas']['ProjectAddonsResponseJsonValue'][]
+      | {
+          [key: string]: components['schemas']['ProjectAddonsResponseJsonValue']
+        }
     ProjectClonedResponse: {
       source_project_ref: string
       target_disk_size_gb: number
@@ -9992,6 +10161,15 @@ export interface components {
     PublicUrlResponse: {
       publicUrl: string
     }
+    PurgeBucketCacheBody: {
+      /** @description Storage bucket id */
+      bucket_id: string
+    }
+    PurgeObjectCacheBody: {
+      /** @description Storage bucket id */
+      bucket_id: string
+      path: string
+    }
     PutOAuthAppResponse: {
       client_id: string
       created_at: string
@@ -10057,7 +10235,7 @@ export interface components {
             | 'sa-east-1'
           name: string
           /** @enum {string} */
-          provider: 'AWS' | 'FLY' | 'AWS_K8S' | 'AWS_NIMBUS'
+          provider: 'AWS' | 'AWS_K8S' | 'AWS_NIMBUS'
           /** @enum {string} */
           status?: 'capacity' | 'other'
           /** @enum {string} */
@@ -10095,7 +10273,7 @@ export interface components {
             | 'sa-east-1'
           name: string
           /** @enum {string} */
-          provider: 'AWS' | 'FLY' | 'AWS_K8S' | 'AWS_NIMBUS'
+          provider: 'AWS' | 'AWS_K8S' | 'AWS_NIMBUS'
           /** @enum {string} */
           status?: 'capacity' | 'other'
           /** @enum {string} */
@@ -10267,7 +10445,7 @@ export interface components {
               database: string
               /**
                * @description Optional Snowflake role
-               * @example ETL_ROLE
+               * @example PIPELINES_ROLE
                */
               role?: string
               /**
@@ -10277,7 +10455,7 @@ export interface components {
               schema: string
               /**
                * @description Snowflake user configured for key-pair authentication
-               * @example ETL_USER
+               * @example PIPELINES_USER
                */
               user: string
             }
@@ -10456,7 +10634,7 @@ export interface components {
                 database: string
                 /**
                  * @description Optional Snowflake role
-                 * @example ETL_ROLE
+                 * @example PIPELINES_ROLE
                  */
                 role?: string
                 /**
@@ -10466,7 +10644,7 @@ export interface components {
                 schema: string
                 /**
                  * @description Snowflake user configured for key-pair authentication
-                 * @example ETL_USER
+                 * @example PIPELINES_USER
                  */
                 user: string
               }
@@ -10526,7 +10704,7 @@ export interface components {
          * @example reserved
          * @enum {string}
          */
-        wal_status?: 'extended' | 'lost' | 'reserved' | 'unknown' | 'unreserved'
+        wal_status?: 'reserved' | 'extended' | 'unreserved' | 'lost' | 'unknown'
         /**
          * @description Write lag expressed in milliseconds.
          * @example 1500
@@ -10646,7 +10824,7 @@ export interface components {
            * @example reserved
            * @enum {string}
            */
-          wal_status?: 'extended' | 'lost' | 'reserved' | 'unknown' | 'unreserved'
+          wal_status?: 'reserved' | 'extended' | 'unreserved' | 'lost' | 'unknown'
           /**
            * @description Write lag expressed in milliseconds.
            * @example 1500
@@ -10688,7 +10866,7 @@ export interface components {
          * @example info
          * @enum {string}
          */
-        log_level?: 'debug' | 'error' | 'info' | 'trace' | 'warn'
+        log_level?: 'trace' | 'debug' | 'info' | 'warn' | 'error'
         /** @description Maximum number of copy connections per table */
         max_copy_connections_per_table?: number
         /** @description Maximum number of table sync workers */
@@ -10834,7 +11012,7 @@ export interface components {
            * @example info
            * @enum {string}
            */
-          log_level?: 'debug' | 'error' | 'info' | 'trace' | 'warn'
+          log_level?: 'trace' | 'debug' | 'info' | 'warn' | 'error'
           /** @description Maximum number of copy connections per table */
           max_copy_connections_per_table?: number
           /** @description Maximum number of table sync workers */
@@ -10993,81 +11171,6 @@ export interface components {
          * @example v0.3.0
          */
         name: string
-      }
-    }
-    CostEstimateResponse: {
-      /**
-       * @description Currency of all amounts
-       * @example usd
-       * @enum {string}
-       */
-      currency: 'usd'
-      /** @description Recurring per-pipeline cost */
-      pipeline: {
-        /**
-         * @description Hourly rate charged per active pipeline
-         * @example 0.053
-         */
-        hourly_cost: number
-        /**
-         * @description Projected monthly cost for an active pipeline, based on an average 730-hour month. Pipelines are billed hourly, so this is an estimate, not a metered amount.
-         * @example 38.69
-         */
-        monthly_cost: number
-      }
-      /** @description Usage-based streaming cost, expressed as a rate */
-      streaming: {
-        /**
-         * @description Usage-based streaming rate per GB. Actual cost depends on the change volume.
-         * @example 3
-         */
-        rate_per_gb: number
-      }
-      /** @description One-time cost for the initial table copy */
-      table_copy: {
-        /**
-         * @description One-time initial-copy rate per GB
-         * @example 0.6
-         */
-        rate_per_gb: number
-        /** @description Per-table initial-copy cost estimate */
-        tables: {
-          /**
-           * @description Estimated on-disk size of the table in bytes
-           * @example 10960896
-           */
-          estimated_bytes: number
-          /**
-           * @description Estimated one-time initial-copy cost for the table, in the response currency
-           * @example 0.01
-           */
-          estimated_cost: number
-          /**
-           * @description Whether this table has a row filter. The estimate does not account for how many rows the filter excludes, so the actual replicated volume may be lower than shown.
-           * @example false
-           */
-          is_row_filtered: boolean
-          /**
-           * @description Table name
-           * @example orders
-           */
-          name: string
-          /**
-           * @description Table schema
-           * @example public
-           */
-          schema: string
-        }[]
-        /**
-         * @description Total estimated bytes across all tables
-         * @example 11911168
-         */
-        total_bytes: number
-        /**
-         * @description Total estimated one-time initial-copy cost
-         * @example 0.01
-         */
-        total_cost: number
       }
     }
     ReplicationPublicationsResponse: {
@@ -11308,72 +11411,11 @@ export interface components {
         table_id: number
       }[]
     }
-    RunLintByNameResponse: {
-      lints: {
-        cache_key: string
-        categories: ('PERFORMANCE' | 'SECURITY')[]
-        description: string
-        detail: string
-        /** @enum {string} */
-        facing: 'EXTERNAL'
-        /** @enum {string} */
-        level: 'ERROR' | 'WARN' | 'INFO'
-        metadata?: {
-          entity?: string
-          fkey_columns?: number[]
-          fkey_name?: string
-          name?: string
-          schema?: string
-          /** @enum {string} */
-          type?: 'table' | 'view' | 'auth' | 'function' | 'extension' | 'compliance'
-        }
-        /** @enum {string} */
-        name:
-          | 'unindexed_foreign_keys'
-          | 'auth_users_exposed'
-          | 'auth_rls_initplan'
-          | 'no_primary_key'
-          | 'unused_index'
-          | 'multiple_permissive_policies'
-          | 'policy_exists_rls_disabled'
-          | 'rls_enabled_no_policy'
-          | 'duplicate_index'
-          | 'security_definer_view'
-          | 'function_search_path_mutable'
-          | 'rls_disabled_in_public'
-          | 'extension_in_public'
-          | 'rls_references_user_metadata'
-          | 'materialized_view_in_api'
-          | 'foreign_table_in_api'
-          | 'unsupported_reg_types'
-          | 'auth_otp_long_expiry'
-          | 'auth_otp_short_length'
-          | 'ssl_not_enforced'
-          | 'network_restrictions_not_set'
-          | 'password_requirements_min_length'
-          | 'pitr_not_enabled'
-          | 'auth_leaked_password_protection'
-          | 'auth_insufficient_mfa_options'
-          | 'auth_password_policy_missing'
-          | 'leaked_service_key'
-          | 'no_backup_admin'
-          | 'vulnerable_postgres_version'
-        remediation: string
-        title: string
-      }[]
-    }
     RunQueryBody: {
       /** @default false */
       disable_statement_timeout?: boolean
       parameters?: unknown[]
       query: string
-    }
-    SendDocsFeedbackBody: {
-      feedback?: string
-      isHelpful: boolean
-      page: string
-      team?: string
-      title: string
     }
     SendExitSurveyBody: {
       additionalFeedback?: string
@@ -11492,6 +11534,9 @@ export interface components {
           maxTables: number
         }
         imageTransformation: {
+          enabled: boolean
+        }
+        purgeCache: {
           enabled: boolean
         }
         s3Protocol: {
@@ -11654,7 +11699,7 @@ export interface components {
     }
     TelemetryFeatureFlagBody: {
       feature_flag_name: string
-      feature_flag_value?: unknown
+      feature_flag_value: unknown
     }
     TelemetryGroupsIdentityBody: {
       organization_slug?: string
@@ -11710,9 +11755,7 @@ export interface components {
     UpcomingInvoice: {
       amount_projected?: number
       amount_total: number
-      /** Format: date-time */
       billing_cycle_end: string
-      /** Format: date-time */
       billing_cycle_start: string
       currency: string
       customer_balance: number
@@ -11773,9 +11816,7 @@ export interface components {
           is_read_replica?: boolean
         }
         period?: {
-          /** Format: date-time */
           end: string
-          /** Format: date-time */
           start: string
         }
         proration: boolean
@@ -11831,6 +11872,8 @@ export interface components {
           | 'IPV4'
           | 'LOG_DRAIN'
           | 'ETL_PIPELINE'
+          | 'ETL_REPLICATED_DATA'
+          | 'ETL_COPY_BACKFILL_DATA'
           | 'LOG_INGESTION'
           | 'LOG_QUERYING'
           | 'LOG_STORAGE'
@@ -12367,6 +12410,8 @@ export interface components {
         | 'members_write'
         | 'organization_projects_read'
         | 'organization_projects_create'
+        | 'platform_webhooks_organization_read'
+        | 'platform_webhooks_organization_write'
         | 'project_admin_read'
         | 'project_admin_write'
         | 'action_runs_read'
@@ -12436,6 +12481,8 @@ export interface components {
         | 'storage_config_write'
         | 'vanity_subdomain_read'
         | 'vanity_subdomain_write'
+        | 'platform_webhooks_projects_read'
+        | 'platform_webhooks_projects_write'
       )[]
     }
     UpdatePlatformAppInstallationResponse: {
@@ -12471,6 +12518,7 @@ export interface components {
     UpdatePostgrestConfigBody: {
       db_extra_search_path?: string
       db_pool?: number
+      db_pool_acquisition_timeout?: number
       db_schema?: string
       max_rows?: number
     }
@@ -12478,6 +12526,8 @@ export interface components {
       db_extra_search_path: string
       /** @description If `null`, the value is automatically configured based on compute size. */
       db_pool: number | null
+      /** @description If `null`, the value is automatically configured to 10. */
+      db_pool_acquisition_timeout: number | null
       db_schema: string
       max_rows: number
     }
@@ -12807,7 +12857,7 @@ export interface components {
               private_key_passphrase?: string | null
               /**
                * @description Optional Snowflake role
-               * @example ETL_ROLE
+               * @example PIPELINES_ROLE
                */
               role?: string | null
               /**
@@ -12817,7 +12867,7 @@ export interface components {
               schema?: string | null
               /**
                * @description Snowflake user configured for key-pair authentication
-               * @example ETL_USER
+               * @example PIPELINES_USER
                */
               user?: string | null
             }
@@ -13115,7 +13165,7 @@ export interface components {
               private_key_passphrase?: string | null
               /**
                * @description Optional Snowflake role
-               * @example ETL_ROLE
+               * @example PIPELINES_ROLE
                */
               role?: string | null
               /**
@@ -13125,7 +13175,7 @@ export interface components {
               schema?: string | null
               /**
                * @description Snowflake user configured for key-pair authentication
-               * @example ETL_USER
+               * @example PIPELINES_USER
                */
               user?: string | null
             }
@@ -13166,7 +13216,7 @@ export interface components {
          * @example info
          * @enum {string|null}
          */
-        log_level?: 'debug' | 'error' | 'info' | 'trace' | 'warn' | null
+        log_level?: 'trace' | 'debug' | 'info' | 'warn' | 'error' | null
         /** @description Maximum number of copy connections per table */
         max_copy_connections_per_table?: number | null
         /** @description Maximum number of table sync workers */
@@ -13190,7 +13240,7 @@ export interface components {
          */
         memory_refresh_interval_ms?: number | null
         /**
-         * @description Publication name. Omission preserves the stored value; ETL rejects clearing it with `null`.
+         * @description Publication name. Omission preserves the stored value; Pipelines rejects clearing it with `null`.
          * @example pub_orders
          */
         publication_name?: string | null
@@ -13241,7 +13291,7 @@ export interface components {
               /** @enum {string} */
               type: 'skip_tables'
             }
-          | (never | null)
+          | never
       }
       /**
        * @description Source id
@@ -13281,7 +13331,7 @@ export interface components {
          * @example info
          * @enum {string|null}
          */
-        log_level?: 'debug' | 'error' | 'info' | 'trace' | 'warn' | null
+        log_level?: 'trace' | 'debug' | 'info' | 'warn' | 'error' | null
         /** @description Maximum number of copy connections per table */
         max_copy_connections_per_table?: number | null
         /** @description Maximum number of table sync workers */
@@ -13305,7 +13355,7 @@ export interface components {
          */
         memory_refresh_interval_ms?: number | null
         /**
-         * @description Publication name. Omission preserves the stored value; ETL rejects clearing it with `null`.
+         * @description Publication name. Omission preserves the stored value; Pipelines rejects clearing it with `null`.
          * @example pub_orders
          */
         publication_name?: string | null
@@ -13356,7 +13406,7 @@ export interface components {
               /** @enum {string} */
               type: 'skip_tables'
             }
-          | (never | null)
+          | never
       }
       /**
        * @description Destination id
@@ -13398,74 +13448,6 @@ export interface components {
     UpdateSecretsResponse: {
       message: string
     }
-    UpdateSSOProviderBody:
-      | {
-          /** @default [] */
-          domains?: string[]
-          email_mapping: string[]
-          enabled: boolean
-          first_name_mapping?: string[]
-          /** Format: uri */
-          idjag_issuer_url?: string | null
-          join_org_on_signup_enabled: boolean
-          /** @enum {string} */
-          join_org_on_signup_role?: 'Administrator' | 'Developer' | 'Owner' | 'Read-only'
-          last_name_mapping?: string[]
-          metadata_xml_file: string
-          /** Format: uri */
-          metadata_xml_url?: string
-          user_name_mapping?: string[]
-        }
-      | {
-          /** @default [] */
-          domains?: string[]
-          email_mapping: string[]
-          enabled: boolean
-          first_name_mapping?: string[]
-          /** Format: uri */
-          idjag_issuer_url?: string | null
-          join_org_on_signup_enabled: boolean
-          /** @enum {string} */
-          join_org_on_signup_role?: 'Administrator' | 'Developer' | 'Owner' | 'Read-only'
-          last_name_mapping?: string[]
-          metadata_xml_file?: string
-          metadata_xml_url: string
-          user_name_mapping?: string[]
-        }
-    UpdateSSOProviderResponse:
-      | {
-          /** @default [] */
-          domains?: string[]
-          email_mapping: string[]
-          enabled: boolean
-          first_name_mapping?: string[]
-          /** Format: uri */
-          idjag_issuer_url?: string | null
-          join_org_on_signup_enabled: boolean
-          /** @enum {string} */
-          join_org_on_signup_role?: 'Administrator' | 'Developer' | 'Owner' | 'Read-only'
-          last_name_mapping?: string[]
-          metadata_xml_file: string
-          /** Format: uri */
-          metadata_xml_url?: string
-          user_name_mapping?: string[]
-        }
-      | {
-          /** @default [] */
-          domains?: string[]
-          email_mapping: string[]
-          enabled: boolean
-          first_name_mapping?: string[]
-          /** Format: uri */
-          idjag_issuer_url?: string | null
-          join_org_on_signup_enabled: boolean
-          /** @enum {string} */
-          join_org_on_signup_role?: 'Administrator' | 'Developer' | 'Owner' | 'Read-only'
-          last_name_mapping?: string[]
-          metadata_xml_file?: string
-          metadata_xml_url: string
-          user_name_mapping?: string[]
-        }
     UpdateStorageBucketBody: {
       allowed_mime_types?: string[] | null
       file_size_limit?: number | null
@@ -13492,6 +13474,9 @@ export interface components {
           maxTables: number
         }
         imageTransformation?: {
+          enabled: boolean
+        }
+        purgeCache?: {
           enabled: boolean
         }
         s3Protocol?: {
@@ -13537,7 +13522,7 @@ export interface components {
     UpdateUserBody: {
       ban_duration?: string
     }
-    UpdateUserReponse: {
+    UpdateUserResponse: {
       aud?: string
       banned_until?: string
       confirmation_sent_at?: string
@@ -13584,6 +13569,10 @@ export interface components {
       env_sync_targets?: ('production' | 'preview' | 'development')[]
       public_env_var_prefix?: string
     }
+    UpdateWarehouseCatalogBody: {
+      /** @description Whether external catalog access should be enabled */
+      enabled: boolean
+    }
     UpsertContentBody: {
       content?: {
         [key: string]: unknown
@@ -13594,8 +13583,7 @@ export interface components {
        * @default false
        */
       favorite?: boolean
-      /** Format: uuid */
-      folder_id?: (null | (string | null)) | null
+      folder_id?: (string | null)[]
       id?: string
       name: string
       owner_id?: number
@@ -13613,6 +13601,9 @@ export interface components {
           }
           method: string
           name: string
+          params?: {
+            [key: string]: unknown
+          }
           route: string
           status: number
         }
@@ -13620,10 +13611,24 @@ export interface components {
           app_id?: string
           app_name?: string
           email?: string
+          /** @description Only present when token_type=app */
+          installation_id?: string
           ip?: string
+          /** @description JWT issuer. Only present for branching service JWTs */
+          jwt_issuer?: string
+          /** @description JWT subject. Only present for branching service JWTs */
+          jwt_subject?: string
           oauth_app_id?: string
           oauth_app_name?: string
+          /** @description Organization whose grant was used. Only present when token_type=oauth */
+          organization_id?: string
+          /** @description GoTrue login session. Only present when token_type=jwt */
+          session_id?: string
+          /** @description Access token alias, as shown in the dashboard. Only present when token_type=v0, token_type=v1 or token_type=scoped_pat */
+          token_alias?: string
           token_hash?: string
+          /** @description Only present when token_type=scoped_pat */
+          token_scope?: string
           token_type: string
           user_id?: string
         }
@@ -14010,7 +14015,7 @@ export interface components {
               private_key_passphrase?: string | null
               /**
                * @description Optional Snowflake role
-               * @example ETL_ROLE
+               * @example PIPELINES_ROLE
                */
               role?: string | null
               /**
@@ -14020,7 +14025,7 @@ export interface components {
               schema: string
               /**
                * @description Snowflake user configured for key-pair authentication
-               * @example ETL_USER
+               * @example PIPELINES_USER
                */
               user: string
             }
@@ -14056,7 +14061,7 @@ export interface components {
          * @example info
          * @enum {string|null}
          */
-        log_level?: 'debug' | 'error' | 'info' | 'trace' | 'warn' | null
+        log_level?: 'trace' | 'debug' | 'info' | 'warn' | 'error' | null
         /** @description Maximum number of copy connections per table */
         max_copy_connections_per_table?: number | null
         /** @description Maximum number of table sync workers */
@@ -14131,7 +14136,7 @@ export interface components {
               /** @enum {string} */
               type: 'skip_tables'
             }
-          | (never | null)
+          | never
       }
       /**
        * @description Source id
@@ -14171,7 +14176,7 @@ export interface components {
          * @example info
          * @enum {string|null}
          */
-        log_level?: 'debug' | 'error' | 'info' | 'trace' | 'warn' | null
+        log_level?: 'trace' | 'debug' | 'info' | 'warn' | 'error' | null
         /** @description Maximum number of copy connections per table */
         max_copy_connections_per_table?: number | null
         /** @description Maximum number of table sync workers */
@@ -14246,7 +14251,7 @@ export interface components {
               /** @enum {string} */
               type: 'skip_tables'
             }
-          | (never | null)
+          | never
       }
       /**
        * @description Source id
@@ -14274,6 +14279,277 @@ export interface components {
     VerifyEmailResponse: {
       /** @enum {string} */
       result: 'success'
+    }
+    WarehouseCatalogResponse: {
+      /** @description External catalog credentials. Present only when enabled. */
+      credentials?: {
+        /**
+         * @description DuckLake catalog Postgres URL
+         * @example postgres://postgres:<pwd>@db.example.supabase.co:5432/postgres
+         */
+        catalog_url: string
+        /**
+         * @description DuckLake object storage path
+         * @example s3://warehouse/
+         */
+        data_path: string
+        /**
+         * @description DuckLake metadata schema in the catalog database
+         * @example ducklake
+         */
+        metadata_schema: string
+        /** @description S3 access key id */
+        s3_access_key_id: string
+        /**
+         * @description S3-compatible storage endpoint without protocol
+         * @example abcjuqabhgwjjutfvtpa.storage.supabase.co/storage/v1/s3
+         */
+        s3_endpoint: string
+        /**
+         * @description S3-compatible storage region
+         * @example us-east-1
+         */
+        s3_region: string
+        /** @description S3 secret access key */
+        s3_secret_access_key: string
+      }
+      /** @description Whether external catalog access is enabled */
+      enabled: boolean
+    }
+    WarehouseLinkedTable: {
+      /**
+       * @description Warehouse-facing table name
+       * @example warehouse.orders
+       */
+      copy_name: string
+      /**
+       * @description Replication lag in milliseconds, when available
+       * @example 12000
+       */
+      lag_ms?: number
+      /**
+       * Format: date-time
+       * @description Last sync timestamp, when available
+       * @example 2026-06-23T17:48:00Z
+       */
+      last_synced_at?: string
+      /**
+       * @description Postgres table name
+       * @example orders
+       */
+      name: string
+      /**
+       * @description Postgres schema name
+       * @example public
+       */
+      schema: string
+      /**
+       * @description Warehouse copy sync state derived from replication status
+       * @example live
+       * @enum {string}
+       */
+      state: 'syncing' | 'live' | 'error'
+      /**
+       * @description Warehouse table size in bytes, when available
+       * @example 197912092672
+       */
+      warehouse_size_bytes?: number
+    }
+    WarehouseLinkTableBody: {
+      /**
+       * @description Whether to configure and install the Warehouse FDW in the project database. Defaults to false.
+       * @example false
+       */
+      install_fdw?: boolean
+      /**
+       * @description Postgres table name
+       * @example orders
+       */
+      name: string
+      /**
+       * @description Postgres schema name
+       * @example public
+       */
+      schema: string
+    }
+    WarehouseSetupStatusResponse: {
+      /** @description Project database FDW setup markers used to derive the Warehouse FDW phase */
+      fdw_status: {
+        /**
+         * @description Whether fdw_warehouse is available to install on the project database instance
+         * @example true
+         */
+        extension_available: boolean
+        /**
+         * @description Whether the fdw_warehouse extension exists in the project database
+         * @example true
+         */
+        extension_installed: boolean
+        /**
+         * @description Whether the Warehouse foreign schema import has exposed the Warehouse snapshots table
+         * @example true
+         */
+        foreign_schema_imported: boolean
+        /**
+         * @description Whether the local Warehouse schema exists in the project database
+         * @example true
+         */
+        schema_created: boolean
+        /**
+         * @description Whether the Warehouse foreign server exists in the project database
+         * @example true
+         */
+        server_configured: boolean
+        /**
+         * @description Whether the Warehouse foreign data wrapper exists in the project database
+         * @example true
+         */
+        wrapper_installed: boolean
+      }
+      /**
+       * @description Warehouse replication pipeline id when it exists
+       * @example 101
+       */
+      pipeline_id?: number
+      /**
+       * @description Overall Warehouse setup status derived from replication state
+       * @example copying
+       * @enum {string}
+       */
+      setup_status: 'not_started' | 'setting_up' | 'copying' | 'complete' | 'error'
+      /** @description Warehouse setup phases in execution order */
+      steps: {
+        /**
+         * @description Best-effort progress or error message derived from Warehouse state
+         * @example Pending initial copy: public.orders:copying_table
+         */
+        message?: string
+        /**
+         * @description Observable Warehouse setup phase
+         * @example warehouse_copy
+         * @enum {string}
+         */
+        name: 'warehouse_pipeline' | 'warehouse_copy' | 'warehouse_fdw'
+        /**
+         * @description Derived Warehouse setup step status
+         * @example running
+         * @enum {string}
+         */
+        status: 'waiting' | 'running' | 'completed' | 'skipped' | 'error'
+      }[]
+      /** @description Warehouse linked tables and replication-derived sync state */
+      tables: {
+        /**
+         * @description Warehouse-facing table name
+         * @example warehouse.orders
+         */
+        copy_name: string
+        /**
+         * @description Replication lag in milliseconds, when available
+         * @example 12000
+         */
+        lag_ms?: number
+        /**
+         * Format: date-time
+         * @description Last sync timestamp, when available
+         * @example 2026-06-23T17:48:00Z
+         */
+        last_synced_at?: string
+        /**
+         * @description Postgres table name
+         * @example orders
+         */
+        name: string
+        /**
+         * @description Postgres schema name
+         * @example public
+         */
+        schema: string
+        /**
+         * @description Warehouse copy sync state derived from replication status
+         * @example live
+         * @enum {string}
+         */
+        state: 'syncing' | 'live' | 'error'
+        /**
+         * @description Warehouse table size in bytes, when available
+         * @example 197912092672
+         */
+        warehouse_size_bytes?: number
+      }[]
+    }
+    WarehouseTableSnapshotsResponse: {
+      /** @description Available Warehouse snapshots for the project catalog. */
+      snapshots: {
+        /**
+         * @description Snapshot author, when available.
+         * @example postgres
+         */
+        author: string | null
+        /** @description Snapshot change metadata returned by the Warehouse FDW. */
+        changes: string | null
+        /** @description Additional snapshot commit metadata returned by the Warehouse FDW. */
+        commit_extra_info: string | null
+        /** @description Snapshot commit message, when available. */
+        commit_message: string | null
+        /**
+         * @description DuckLake schema version. Returned as a string because the source value is bigint.
+         * @example 7
+         */
+        schema_version: string | null
+        /**
+         * @description DuckLake snapshot id. Returned as a string because the source value is bigint.
+         * @example 42
+         */
+        snapshot_id: string
+        /**
+         * @description Snapshot timestamp returned by the Warehouse FDW.
+         * @example 2026-06-24 08:00:00+00
+         */
+        snapshot_time: string | null
+      }[]
+    }
+    WarehouseTablesResponse: {
+      /** @description Tables with Warehouse copies */
+      tables: {
+        /**
+         * @description Warehouse-facing table name
+         * @example warehouse.orders
+         */
+        copy_name: string
+        /**
+         * @description Replication lag in milliseconds, when available
+         * @example 12000
+         */
+        lag_ms?: number
+        /**
+         * Format: date-time
+         * @description Last sync timestamp, when available
+         * @example 2026-06-23T17:48:00Z
+         */
+        last_synced_at?: string
+        /**
+         * @description Postgres table name
+         * @example orders
+         */
+        name: string
+        /**
+         * @description Postgres schema name
+         * @example public
+         */
+        schema: string
+        /**
+         * @description Warehouse copy sync state derived from replication status
+         * @example live
+         * @enum {string}
+         */
+        state: 'syncing' | 'live' | 'error'
+        /**
+         * @description Warehouse table size in bytes, when available
+         * @example 197912092672
+         */
+        warehouse_size_bytes?: number
+      }[]
     }
     WorkflowRunResponse: {
       branch_id: string
@@ -14791,7 +15067,7 @@ export interface operations {
           [name: string]: unknown
         }
         content: {
-          'application/json': components['schemas']['CreateUserReponse']
+          'application/json': components['schemas']['CreateUserResponse']
         }
       }
       /** @description Unauthorized */
@@ -14827,8 +15103,12 @@ export interface operations {
   UsersController_deleteUserById: {
     parameters: {
       query?: {
-        /** @description Boolean string, true or false */
-        soft_delete?: boolean
+        /** @description Boolean string.
+         *
+         *     Truthy values: `true`, `1`, `yes`, `on`, `y`, `enabled`
+         *
+         *     Falsy values: `false`, `0`, `no`, `off`, `n`, `disabled` */
+        soft_delete?: string
       }
       header?: never
       path: {
@@ -14898,7 +15178,7 @@ export interface operations {
           [name: string]: unknown
         }
         content: {
-          'application/json': components['schemas']['UpdateUserReponse']
+          'application/json': components['schemas']['UpdateUserResponse']
         }
       }
       /** @description Unauthorized */
@@ -15587,7 +15867,9 @@ export interface operations {
         headers: {
           [name: string]: unknown
         }
-        content?: never
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
       }
       /** @description Forbidden action */
       403: {
@@ -15853,36 +16135,6 @@ export interface operations {
       }
     }
   }
-  SendFeedbackController_sendDocsFeedback: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['SendDocsFeedbackBody']
-      }
-    }
-    responses: {
-      201: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': components['schemas']['SendFeedbackResponse']
-        }
-      }
-      /** @description Failed to send feedback for docs */
-      500: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-    }
-  }
   SendFeedbackController_sendExitSurvey: {
     parameters: {
       query?: never
@@ -16137,6 +16389,7 @@ export interface operations {
     parameters: {
       query: {
         organization_id: number
+        project_ref?: string
       }
       header?: never
       path?: never
@@ -16239,6 +16492,58 @@ export interface operations {
         content?: never
       }
       /** @description Failed to update GitHub connection */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  GitHubConnectionsController_getGitHubConnectionConfig: {
+    parameters: {
+      query?: {
+        /** @description Git branch, tag or commit SHA to read the config from. Defaults to the default branch of the connected repository. */
+        ref?: string
+      }
+      header?: never
+      path: {
+        connection_id: number
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['GetGitHubConnectionConfigResponse']
+        }
+      }
+      /** @description Not allowed to read the config of this connection */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description GitHub connection not found, or the repository has no config file */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description The config file could not be parsed as TOML */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Failed to get the Supabase config of the connected GitHub repository */
       500: {
         headers: {
           [name: string]: unknown
@@ -16522,7 +16827,9 @@ export interface operations {
         headers: {
           [name: string]: unknown
         }
-        content?: never
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
       }
       /** @description Forbidden action */
       403: {
@@ -16582,7 +16889,9 @@ export interface operations {
         headers: {
           [name: string]: unknown
         }
-        content?: never
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
       }
       /** @description Forbidden action */
       403: {
@@ -17004,7 +17313,35 @@ export interface operations {
           [name: string]: unknown
         }
         content: {
-          'application/json': components['schemas']['CreateOrganizationResponse']
+          'application/json':
+            | {
+                pending_payment_intent_secret: string | null
+              }
+            | {
+                billing_email: string | null
+                billing_partner: ('aws_marketplace' | 'vercel_marketplace') | null
+                id: number
+                integration_source: string | null
+                is_owner: boolean
+                name: string
+                opt_in_tags: string[]
+                organization_missing_address: boolean
+                organization_missing_tax_id: boolean
+                organization_requires_mfa: boolean
+                plan: {
+                  /** @enum {string} */
+                  id: 'free' | 'pro' | 'team' | 'enterprise' | 'platform'
+                  name: string
+                }
+                restriction_data: {
+                  [key: string]: string
+                } | null
+                restriction_status: ('grace_period' | 'grace_period_over' | 'restricted') | null
+                slug: string
+                stripe_customer_id: string | null
+                subscription_id: string | null
+                usage_billing_enabled: boolean
+              }
         }
       }
       /** @description Unexpected error creating an organization */
@@ -17247,7 +17584,9 @@ export interface operations {
         headers: {
           [name: string]: unknown
         }
-        content?: never
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
       }
       /** @description Forbidden action */
       403: {
@@ -19333,7 +19672,9 @@ export interface operations {
         headers: {
           [name: string]: unknown
         }
-        content?: never
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
       }
       /** @description Unauthorized */
       401: {
@@ -19383,7 +19724,9 @@ export interface operations {
         headers: {
           [name: string]: unknown
         }
-        content?: never
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
       }
       /** @description Unauthorized */
       401: {
@@ -19433,7 +19776,9 @@ export interface operations {
         headers: {
           [name: string]: unknown
         }
-        content?: never
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
       }
       /** @description Unauthorized */
       401: {
@@ -19808,7 +20153,14 @@ export interface operations {
           [name: string]: unknown
         }
         content: {
-          'application/json': components['schemas']['CreateInvitationResponse']
+          'application/json': {
+            failed: {
+              /** Format: email */
+              email: string
+              error: string
+            }[]
+            succeeded: string[]
+          } | null
         }
       }
       /** @description Unauthorized */
@@ -20036,7 +20388,9 @@ export interface operations {
         headers: {
           [name: string]: unknown
         }
-        content?: never
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
       }
       /** @description Forbidden action */
       403: {
@@ -20873,7 +21227,38 @@ export interface operations {
           [name: string]: unknown
         }
         content: {
-          'application/json': components['schemas']['GetSSOProviderResponse']
+          'application/json':
+            | {
+                /** @default [] */
+                domains: string[]
+                email_mapping: string[]
+                enabled: boolean
+                first_name_mapping?: string[]
+                idjag_issuer_url?: string | null
+                join_org_on_signup_enabled: boolean
+                /** @enum {string} */
+                join_org_on_signup_role?: 'Administrator' | 'Developer' | 'Owner' | 'Read-only'
+                last_name_mapping?: string[]
+                metadata_xml_file: string
+                /** Format: uri */
+                metadata_xml_url?: string
+                user_name_mapping?: string[]
+              }
+            | {
+                /** @default [] */
+                domains: string[]
+                email_mapping: string[]
+                enabled: boolean
+                first_name_mapping?: string[]
+                idjag_issuer_url?: string | null
+                join_org_on_signup_enabled: boolean
+                /** @enum {string} */
+                join_org_on_signup_role?: 'Administrator' | 'Developer' | 'Owner' | 'Read-only'
+                last_name_mapping?: string[]
+                metadata_xml_file?: string
+                metadata_xml_url: string
+                user_name_mapping?: string[]
+              }
         }
       }
       /** @description Unauthorized */
@@ -20909,18 +21294,45 @@ export interface operations {
       }
       cookie?: never
     }
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['UpdateSSOProviderBody']
-      }
-    }
+    requestBody?: never
     responses: {
       200: {
         headers: {
           [name: string]: unknown
         }
         content: {
-          'application/json': components['schemas']['UpdateSSOProviderResponse']
+          'application/json':
+            | {
+                /** @default [] */
+                domains: string[]
+                email_mapping: string[]
+                enabled: boolean
+                first_name_mapping?: string[]
+                idjag_issuer_url?: string | null
+                join_org_on_signup_enabled: boolean
+                /** @enum {string} */
+                join_org_on_signup_role?: 'Administrator' | 'Developer' | 'Owner' | 'Read-only'
+                last_name_mapping?: string[]
+                metadata_xml_file: string
+                /** Format: uri */
+                metadata_xml_url?: string
+                user_name_mapping?: string[]
+              }
+            | {
+                /** @default [] */
+                domains: string[]
+                email_mapping: string[]
+                enabled: boolean
+                first_name_mapping?: string[]
+                idjag_issuer_url?: string | null
+                join_org_on_signup_enabled: boolean
+                /** @enum {string} */
+                join_org_on_signup_role?: 'Administrator' | 'Developer' | 'Owner' | 'Read-only'
+                last_name_mapping?: string[]
+                metadata_xml_file?: string
+                metadata_xml_url: string
+                user_name_mapping?: string[]
+              }
         }
       }
       /** @description Unauthorized */
@@ -20956,18 +21368,45 @@ export interface operations {
       }
       cookie?: never
     }
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['CreateSSOProviderBody']
-      }
-    }
+    requestBody?: never
     responses: {
       201: {
         headers: {
           [name: string]: unknown
         }
         content: {
-          'application/json': components['schemas']['CreateSSOProviderResponse']
+          'application/json':
+            | {
+                /** @default [] */
+                domains: string[]
+                email_mapping: string[]
+                enabled: boolean
+                first_name_mapping?: string[]
+                idjag_issuer_url?: string | null
+                join_org_on_signup_enabled: boolean
+                /** @enum {string} */
+                join_org_on_signup_role?: 'Administrator' | 'Developer' | 'Owner' | 'Read-only'
+                last_name_mapping?: string[]
+                metadata_xml_file: string
+                /** Format: uri */
+                metadata_xml_url?: string
+                user_name_mapping?: string[]
+              }
+            | {
+                /** @default [] */
+                domains: string[]
+                email_mapping: string[]
+                enabled: boolean
+                first_name_mapping?: string[]
+                idjag_issuer_url?: string | null
+                join_org_on_signup_enabled: boolean
+                /** @enum {string} */
+                join_org_on_signup_role?: 'Administrator' | 'Developer' | 'Owner' | 'Read-only'
+                last_name_mapping?: string[]
+                metadata_xml_file?: string
+                metadata_xml_url: string
+                user_name_mapping?: string[]
+              }
         }
       }
       /** @description Unauthorized */
@@ -20982,7 +21421,9 @@ export interface operations {
         headers: {
           [name: string]: unknown
         }
-        content?: never
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
       }
       /** @description Forbidden action */
       403: {
@@ -21083,108 +21524,6 @@ export interface operations {
         content?: never
       }
       /** @description Failed to retrieve the organization's tax ID */
-      500: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-    }
-  }
-  TaxIdsController_updateTaxId: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        /** @description Organization slug */
-        slug: string
-      }
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['CreateTaxIdBody']
-      }
-    }
-    responses: {
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': components['schemas']['TaxIdResponse']
-        }
-      }
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Forbidden action */
-      403: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Rate limit exceeded */
-      429: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Failed to create the tax ID */
-      500: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-    }
-  }
-  TaxIdsController_deleteTaxId: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        /** @description Organization slug */
-        slug: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      204: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Forbidden action */
-      403: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Rate limit exceeded */
-      429: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Failed to delete the tax ID */
       500: {
         headers: {
           [name: string]: unknown
@@ -21351,7 +21690,35 @@ export interface operations {
           [name: string]: unknown
         }
         content: {
-          'application/json': components['schemas']['CreateOrganizationResponse']
+          'application/json':
+            | {
+                pending_payment_intent_secret: string | null
+              }
+            | {
+                billing_email: string | null
+                billing_partner: ('aws_marketplace' | 'vercel_marketplace') | null
+                id: number
+                integration_source: string | null
+                is_owner: boolean
+                name: string
+                opt_in_tags: string[]
+                organization_missing_address: boolean
+                organization_missing_tax_id: boolean
+                organization_requires_mfa: boolean
+                plan: {
+                  /** @enum {string} */
+                  id: 'free' | 'pro' | 'team' | 'enterprise' | 'platform'
+                  name: string
+                }
+                restriction_data: {
+                  [key: string]: string
+                } | null
+                restriction_status: ('grace_period' | 'grace_period_over' | 'restricted') | null
+                slug: string
+                stripe_customer_id: string | null
+                subscription_id: string | null
+                usage_billing_enabled: boolean
+              }
         }
       }
       202: {
@@ -22064,6 +22431,7 @@ export interface operations {
           | 'storage.image_transformations'
           | 'storage.vector_buckets'
           | 'storage.iceberg_catalog'
+          | 'storage.purge_cache'
           | 'security.audit_logs_days'
           | 'security.questionnaire'
           | 'security.soc2_report'
@@ -22113,6 +22481,8 @@ export interface operations {
           | 'integrations.github_connections'
           | 'dedicated_pooler'
           | 'observability.dashboard_advanced_metrics'
+          | 'api.members.invitations'
+          | 'api.members.roles'
       }
       header?: never
       path?: never
@@ -22726,9 +23096,9 @@ export interface operations {
   ApiKeysLastUsedController_getApiKeysLastUsed: {
     parameters: {
       query?: {
-        iso_timestamp_start?: string
-        iso_timestamp_end?: string
         days?: string
+        iso_timestamp_end?: string
+        iso_timestamp_start?: string
       }
       header?: never
       path: {
@@ -22980,6 +23350,115 @@ export interface operations {
         content?: never
       }
       /** @description Failed to get project's function resource usage */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  LogsController_getProjectLogsViaGetNew: {
+    parameters: {
+      query?: {
+        iso_timestamp_end?: string
+        iso_timestamp_start?: string
+        lql?: string
+        sql?: string
+      }
+      header?: never
+      path: {
+        /** @description Project ref */
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['AnalyticsResponse']
+        }
+      }
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Forbidden action */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Rate limit exceeded */
+      429: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Failed to get project's logs */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  LogsController_getProjectLogsViaPostNew: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description Project ref */
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['GetProjectLogsBody']
+      }
+    }
+    responses: {
+      201: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['AnalyticsResponse']
+        }
+      }
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Forbidden action */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Rate limit exceeded */
+      429: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Failed to get project's logs */
       500: {
         headers: {
           [name: string]: unknown
@@ -23554,7 +24033,9 @@ export interface operations {
         headers: {
           [name: string]: unknown
         }
-        content?: never
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
       }
       /** @description Forbidden action */
       403: {
@@ -23785,6 +24266,61 @@ export interface operations {
         content?: never
       }
       /** @description Failed to test log drain */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  'scrape-project-metrics': {
+    parameters: {
+      query?: {
+        /** @description Project service to include in the scrape. Valid values are `database`. Defaults to `database`. */
+        services?: string
+      }
+      header?: never
+      path: {
+        /** @description Project ref */
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Prometheus / OpenMetrics text exposition */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/openmetrics-text': string
+          'text/plain': string
+        }
+      }
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Forbidden action */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Rate limit exceeded */
+      429: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Failed to fetch project's metrics */
       500: {
         headers: {
           [name: string]: unknown
@@ -24778,8 +25314,12 @@ export interface operations {
     parameters: {
       query?: {
         cursor?: string
-        /** @description Boolean string, true or false */
-        favorite?: boolean
+        /** @description Boolean string.
+         *
+         *     Truthy values: `true`, `1`, `yes`, `on`, `y`, `enabled`
+         *
+         *     Falsy values: `false`, `0`, `no`, `off`, `n`, `disabled` */
+        favorite?: string
         limit?: string
         name?: string
         sort_by?: 'name' | 'inserted_at'
@@ -25847,65 +26387,68 @@ export interface operations {
           | 'physical_replication_lag_physical_replication_lag_seconds'
           | 'pg_stat_database_num_backends'
           | 'max_db_connections'
-        attributes?: (
-          | 'cpu_usage'
-          | 'cpu_usage_busy_system'
-          | 'cpu_usage_busy_user'
-          | 'cpu_usage_busy_iowait'
-          | 'cpu_usage_busy_irqs'
-          | 'cpu_usage_busy_other'
-          | 'cpu_usage_busy_idle'
-          | 'max_cpu_usage'
-          | 'avg_cpu_usage'
-          | 'ram_usage'
-          | 'ram_usage_total'
-          | 'ram_usage_available'
-          | 'ram_usage_used'
-          | 'ram_usage_free'
-          | 'ram_usage_cache_and_buffers'
-          | 'ram_usage_swap'
-          | 'ram_commit_used'
-          | 'ram_commit_limit'
-          | 'swap_usage'
-          | 'client_connections_pgbouncer'
-          | 'network_receive_bytes'
-          | 'network_transmit_bytes'
-          | 'pgbouncer_pools_client_active_connections'
-          | 'supavisor_connections_active'
-          | 'client_connections_postgres'
-          | 'client_connections_authenticator'
-          | 'client_connections_supabase_auth_admin'
-          | 'client_connections_supabase_storage_admin'
-          | 'client_connections_supabase_admin'
-          | 'client_connections_other'
-          | 'realtime_connections_connected'
-          | 'realtime_channel_joins'
-          | 'realtime_channel_events'
-          | 'realtime_channel_presence_events'
-          | 'realtime_channel_db_events'
-          | 'realtime_authorization_rls_execution_time'
-          | 'realtime_read_authorization_rls_execution_time'
-          | 'realtime_write_authorization_rls_execution_time'
-          | 'realtime_payload_size'
-          | 'realtime_replication_connection_lag'
-          | 'realtime_sum_connections_connected'
-          | 'disk_io_budget'
-          | 'disk_io_consumption'
-          | 'disk_io_usage'
-          | 'disk_iops_read'
-          | 'disk_iops_write'
-          | 'disk_bytes_read'
-          | 'disk_bytes_written'
-          | 'pg_database_size'
-          | 'disk_fs_size'
-          | 'disk_fs_avail'
-          | 'disk_fs_used'
-          | 'disk_fs_used_wal'
-          | 'disk_fs_used_system'
-          | 'physical_replication_lag_physical_replication_lag_seconds'
-          | 'pg_stat_database_num_backends'
-          | 'max_db_connections'
-        )[]
+        /** @description Comma-separated list of enums or array of enums. */
+        attributes?:
+          | string
+          | (
+              | 'cpu_usage'
+              | 'cpu_usage_busy_system'
+              | 'cpu_usage_busy_user'
+              | 'cpu_usage_busy_iowait'
+              | 'cpu_usage_busy_irqs'
+              | 'cpu_usage_busy_other'
+              | 'cpu_usage_busy_idle'
+              | 'max_cpu_usage'
+              | 'avg_cpu_usage'
+              | 'ram_usage'
+              | 'ram_usage_total'
+              | 'ram_usage_available'
+              | 'ram_usage_used'
+              | 'ram_usage_free'
+              | 'ram_usage_cache_and_buffers'
+              | 'ram_usage_swap'
+              | 'ram_commit_used'
+              | 'ram_commit_limit'
+              | 'swap_usage'
+              | 'client_connections_pgbouncer'
+              | 'network_receive_bytes'
+              | 'network_transmit_bytes'
+              | 'pgbouncer_pools_client_active_connections'
+              | 'supavisor_connections_active'
+              | 'client_connections_postgres'
+              | 'client_connections_authenticator'
+              | 'client_connections_supabase_auth_admin'
+              | 'client_connections_supabase_storage_admin'
+              | 'client_connections_supabase_admin'
+              | 'client_connections_other'
+              | 'realtime_connections_connected'
+              | 'realtime_channel_joins'
+              | 'realtime_channel_events'
+              | 'realtime_channel_presence_events'
+              | 'realtime_channel_db_events'
+              | 'realtime_authorization_rls_execution_time'
+              | 'realtime_read_authorization_rls_execution_time'
+              | 'realtime_write_authorization_rls_execution_time'
+              | 'realtime_payload_size'
+              | 'realtime_replication_connection_lag'
+              | 'realtime_sum_connections_connected'
+              | 'disk_io_budget'
+              | 'disk_io_consumption'
+              | 'disk_io_usage'
+              | 'disk_iops_read'
+              | 'disk_iops_write'
+              | 'disk_bytes_read'
+              | 'disk_bytes_written'
+              | 'pg_database_size'
+              | 'disk_fs_size'
+              | 'disk_fs_avail'
+              | 'disk_fs_used'
+              | 'disk_fs_used_wal'
+              | 'disk_fs_used_system'
+              | 'physical_replication_lag_physical_replication_lag_seconds'
+              | 'pg_stat_database_num_backends'
+              | 'max_db_connections'
+            )[]
         databaseIdentifier?: string
         endDate: string
         interval?: '1m' | '5m' | '10m' | '30m' | '1h' | '1d'
@@ -26432,7 +26975,9 @@ export interface operations {
         headers: {
           [name: string]: unknown
         }
-        content?: never
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
       }
       /** @description Forbidden action */
       403: {
@@ -26463,6 +27008,64 @@ export interface operations {
       header?: never
       path: {
         aws_account_id: string
+        /** @description Project ref */
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Scheduled AWS PrivateLink resources to be removed. */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Invalid AWS account ID format or association does not have a valid status for deletion. */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Forbidden action */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Rate limit exceeded */
+      429: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Failed to remove AWS account from PrivateLink share */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  ProjectPrivateLinkController_removeAwsAccountFromPrivateLinkForDatabase: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        aws_account_id: string
+        database_identifier: string
         /** @description Project ref */
         ref: string
       }
@@ -26548,7 +27151,9 @@ export interface operations {
         headers: {
           [name: string]: unknown
         }
-        content?: never
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
       }
       /** @description Forbidden action */
       403: {
@@ -26799,165 +27404,6 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['GetProjectLintsResponse']
-        }
-      }
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Forbidden action */
-      403: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Rate limit exceeded */
-      429: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-    }
-  }
-  ProjectRunLintsController_runLintByName: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        name:
-          | 'unindexed_foreign_keys'
-          | 'auth_users_exposed'
-          | 'auth_rls_initplan'
-          | 'no_primary_key'
-          | 'unused_index'
-          | 'multiple_permissive_policies'
-          | 'policy_exists_rls_disabled'
-          | 'rls_enabled_no_policy'
-          | 'duplicate_index'
-          | 'security_definer_view'
-          | 'function_search_path_mutable'
-          | 'rls_disabled_in_public'
-          | 'extension_in_public'
-          | 'rls_references_user_metadata'
-          | 'materialized_view_in_api'
-          | 'foreign_table_in_api'
-          | 'unsupported_reg_types'
-          | 'auth_otp_long_expiry'
-          | 'auth_otp_short_length'
-          | 'ssl_not_enforced'
-          | 'network_restrictions_not_set'
-          | 'password_requirements_min_length'
-          | 'pitr_not_enabled'
-          | 'auth_leaked_password_protection'
-          | 'auth_insufficient_mfa_options'
-          | 'auth_password_policy_missing'
-          | 'leaked_service_key'
-          | 'no_backup_admin'
-          | 'vulnerable_postgres_version'
-        /** @description Project ref */
-        ref: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': components['schemas']['RunLintByNameResponse']
-        }
-      }
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Forbidden action */
-      403: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Rate limit exceeded */
-      429: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-    }
-  }
-  ProjectRunLintsController_runLeakedServiceKeyLint: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        /** @description Project ref */
-        ref: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': components['schemas']['GetLeakedServiceKeyLintResponse']
-        }
-      }
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Forbidden action */
-      403: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Rate limit exceeded */
-      429: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-    }
-  }
-  ProjectRunLintsController_runAuthBackupAdminLint: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        /** @description Project ref */
-        ref: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': components['schemas']['AuthBackupAdminLintResponse']
         }
       }
       /** @description Unauthorized */
@@ -27316,7 +27762,7 @@ export interface operations {
   ProjectsController_getRegions: {
     parameters: {
       query: {
-        cloud_provider: 'AWS' | 'FLY' | 'AWS_K8S' | 'AWS_NIMBUS'
+        cloud_provider: 'AWS' | 'AWS_K8S' | 'AWS_NIMBUS'
         desired_instance_size?:
           | 'micro'
           | 'small'
@@ -27437,6 +27883,15 @@ export interface operations {
         }
         content?: never
       }
+      /** @description This feature requires the Pro, Team, or Enterprise organization plan. */
+      402: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
+      }
       /** @description Forbidden action */
       403: {
         headers: {
@@ -27491,6 +27946,15 @@ export interface operations {
           [name: string]: unknown
         }
         content?: never
+      }
+      /** @description This feature requires the Pro, Team, or Enterprise organization plan. */
+      402: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
       }
       /** @description Forbidden action */
       403: {
@@ -27549,6 +28013,15 @@ export interface operations {
         }
         content?: never
       }
+      /** @description This feature requires the Pro, Team, or Enterprise organization plan. */
+      402: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
+      }
       /** @description Forbidden action */
       403: {
         headers: {
@@ -27603,6 +28076,15 @@ export interface operations {
           [name: string]: unknown
         }
         content?: never
+      }
+      /** @description This feature requires the Pro, Team, or Enterprise organization plan. */
+      402: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
       }
       /** @description Forbidden action */
       403: {
@@ -27726,6 +28208,15 @@ export interface operations {
         }
         content?: never
       }
+      /** @description This feature requires the Pro, Team, or Enterprise organization plan. */
+      402: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
+      }
       /** @description Forbidden action */
       403: {
         headers: {
@@ -27776,6 +28267,15 @@ export interface operations {
           [name: string]: unknown
         }
         content?: never
+      }
+      /** @description This feature requires the Pro, Team, or Enterprise organization plan. */
+      402: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
       }
       /** @description Forbidden action */
       403: {
@@ -27952,6 +28452,15 @@ export interface operations {
         }
         content?: never
       }
+      /** @description This feature requires the Pro, Team, or Enterprise organization plan. */
+      402: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
+      }
       /** @description Forbidden action */
       403: {
         headers: {
@@ -28060,6 +28569,15 @@ export interface operations {
         }
         content?: never
       }
+      /** @description This feature requires the Pro, Team, or Enterprise organization plan. */
+      402: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
+      }
       /** @description Forbidden action */
       403: {
         headers: {
@@ -28110,6 +28628,15 @@ export interface operations {
           [name: string]: unknown
         }
         content?: never
+      }
+      /** @description This feature requires the Pro, Team, or Enterprise organization plan. */
+      402: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
       }
       /** @description Forbidden action */
       403: {
@@ -28201,6 +28728,73 @@ export interface operations {
       }
     }
   }
+  ReplicationPipelinesController_restartPipeline: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description Pipeline id */
+        pipeline_id: number
+        /** @description Project ref */
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Pipeline restart accepted. */
+      202: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description This feature requires the Pro, Team, or Enterprise organization plan. */
+      402: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
+      }
+      /** @description Forbidden action */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Pipeline is not running. */
+      409: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Rate limit exceeded */
+      429: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Unexpected error while restarting pipeline. */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
   ReplicationPipelinesController_rollbackTables: {
     parameters: {
       query?: never
@@ -28234,6 +28828,15 @@ export interface operations {
           [name: string]: unknown
         }
         content?: never
+      }
+      /** @description This feature requires the Pro, Team, or Enterprise organization plan. */
+      402: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
       }
       /** @description Forbidden action */
       403: {
@@ -28286,6 +28889,15 @@ export interface operations {
         }
         content?: never
       }
+      /** @description This feature requires the Pro, Team, or Enterprise organization plan. */
+      402: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
+      }
       /** @description Forbidden action */
       403: {
         headers: {
@@ -28301,64 +28913,6 @@ export interface operations {
         content?: never
       }
       /** @description Unexpected error while starting pipeline. */
-      500: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-    }
-  }
-  ReplicationPipelinesController_restartPipeline: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        /** @description Pipeline id */
-        pipeline_id: number
-        /** @description Project ref */
-        ref: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Pipeline restart accepted. */
-      202: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Forbidden action */
-      403: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Pipeline is not running. */
-      409: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Rate limit exceeded */
-      429: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Unexpected error while restarting pipeline. */
       500: {
         headers: {
           [name: string]: unknown
@@ -28447,6 +29001,15 @@ export interface operations {
           [name: string]: unknown
         }
         content?: never
+      }
+      /** @description This feature requires the Pro, Team, or Enterprise organization plan. */
+      402: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
       }
       /** @description Forbidden action */
       403: {
@@ -28555,6 +29118,15 @@ export interface operations {
           [name: string]: unknown
         }
         content?: never
+      }
+      /** @description This feature requires the Pro, Team, or Enterprise organization plan. */
+      402: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
       }
       /** @description Forbidden action */
       403: {
@@ -28718,7 +29290,9 @@ export interface operations {
         headers: {
           [name: string]: unknown
         }
-        content?: never
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
       }
       /** @description Forbidden action */
       403: {
@@ -28796,61 +29370,6 @@ export interface operations {
       }
     }
   }
-  ReplicationSourcesController_getCostEstimate: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        /** @description Publication name */
-        publication_name: string
-        /** @description Project ref */
-        ref: string
-        /** @description Source id */
-        source_id: number
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Cost estimate for replicating the publication. */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': components['schemas']['CostEstimateResponse']
-        }
-      }
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Forbidden action */
-      403: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Rate limit exceeded */
-      429: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Unexpected error while estimating replication cost. */
-      500: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-    }
-  }
   ReplicationSourcesController_createPublication: {
     parameters: {
       query?: never
@@ -28882,6 +29401,15 @@ export interface operations {
           [name: string]: unknown
         }
         content?: never
+      }
+      /** @description This feature requires the Pro, Team, or Enterprise organization plan. */
+      402: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
       }
       /** @description Forbidden action */
       403: {
@@ -28940,6 +29468,15 @@ export interface operations {
         }
         content?: never
       }
+      /** @description This feature requires the Pro, Team, or Enterprise organization plan. */
+      402: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
+      }
       /** @description Forbidden action */
       403: {
         headers: {
@@ -28993,6 +29530,15 @@ export interface operations {
         }
         content?: never
       }
+      /** @description This feature requires the Pro, Team, or Enterprise organization plan. */
+      402: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
+      }
       /** @description Forbidden action */
       403: {
         headers: {
@@ -29015,6 +29561,61 @@ export interface operations {
         content?: never
       }
       /** @description Unexpected error while deleting publication. */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  ReplicationSourcesController_getCostEstimate: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description Publication name */
+        publication_name: string
+        /** @description Project ref */
+        ref: string
+        /** @description Source id */
+        source_id: number
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Cost estimate for replicating the publication. */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['CostEstimateResponse']
+        }
+      }
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Forbidden action */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Rate limit exceeded */
+      429: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Unexpected error while estimating replication cost. */
       500: {
         headers: {
           [name: string]: unknown
@@ -29102,6 +29703,15 @@ export interface operations {
         }
         content?: never
       }
+      /** @description This feature requires the Pro, Team, or Enterprise organization plan. */
+      402: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
+      }
       /** @description Forbidden action */
       403: {
         headers: {
@@ -29172,7 +29782,9 @@ export interface operations {
         headers: {
           [name: string]: unknown
         }
-        content?: never
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
       }
       /** @description Forbidden action */
       403: {
@@ -29383,7 +29995,7 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        /** @description Analytics Bucket ID */
+        /** @description Storage bucket id */
         id: string
         /** @description Project ref */
         ref: string
@@ -29435,7 +30047,7 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        /** @description Analytics Bucket ID */
+        /** @description Storage bucket id */
         id: string
         /** @description Project ref */
         ref: string
@@ -29487,7 +30099,7 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        /** @description Analytics Bucket ID */
+        /** @description Storage bucket id */
         id: string
         /** @description Project ref */
         ref: string
@@ -29700,8 +30312,12 @@ export interface operations {
   StorageAnalyticsBucketNamespaceTableController_dropTable: {
     parameters: {
       query?: {
-        /** @description Boolean string, true or false */
-        purge?: boolean
+        /** @description Boolean string.
+         *
+         *     Truthy values: `true`, `1`, `yes`, `on`, `y`, `enabled`
+         *
+         *     Falsy values: `false`, `0`, `no`, `off`, `n`, `disabled` */
+        purge?: string
       }
       header?: never
       path: {
@@ -30608,6 +31224,128 @@ export interface operations {
       }
     }
   }
+  StorageCdnController_purgeBucketCache: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description Project ref */
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['PurgeBucketCacheBody']
+      }
+    }
+    responses: {
+      201: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description This feature requires the Pro, Team, or Enterprise organization plan. */
+      402: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
+      }
+      /** @description Forbidden action */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Rate limit exceeded */
+      429: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Failed to purge CDN cache for bucket */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  StorageCdnController_purgeObjectCache: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description Project ref */
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['PurgeObjectCacheBody']
+      }
+    }
+    responses: {
+      201: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description This feature requires the Pro, Team, or Enterprise organization plan. */
+      402: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
+      }
+      /** @description Forbidden action */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Rate limit exceeded */
+      429: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Failed to purge CDN cache for object */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
   StorageS3CredentialsController_getAllCredentials: {
     parameters: {
       query?: never
@@ -31492,6 +32230,465 @@ export interface operations {
         }
       }
       /** @description Failed to get Vercel redirect url */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  WarehouseController_getCatalog: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description Project ref */
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Warehouse catalog access. */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['WarehouseCatalogResponse']
+        }
+      }
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Forbidden action */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Rate limit exceeded */
+      429: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Unexpected error while retrieving Warehouse catalog. */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  WarehouseController_updateCatalog: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description Project ref */
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['UpdateWarehouseCatalogBody']
+      }
+    }
+    responses: {
+      /** @description Warehouse catalog access updated. */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['WarehouseCatalogResponse']
+        }
+      }
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description This feature requires the Pro, Team, or Enterprise organization plan. */
+      402: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
+      }
+      /** @description Forbidden action */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Rate limit exceeded */
+      429: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Unexpected error while updating Warehouse catalog. */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  WarehouseController_refreshSchema: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description Project ref */
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Warehouse foreign schema refresh accepted. */
+      202: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description This feature requires the Pro, Team, or Enterprise organization plan. */
+      402: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
+      }
+      /** @description Forbidden action */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Rate limit exceeded */
+      429: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Unexpected error while refreshing the Warehouse foreign schema. */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  WarehouseController_getSetupStatus: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description Project ref */
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Warehouse setup status. */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['WarehouseSetupStatusResponse']
+        }
+      }
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Forbidden action */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Rate limit exceeded */
+      429: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Unexpected error while retrieving Warehouse setup status. */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  WarehouseController_getTables: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description Project ref */
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Warehouse linked tables. */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['WarehouseTablesResponse']
+        }
+      }
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Forbidden action */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Rate limit exceeded */
+      429: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Unexpected error while listing Warehouse tables. */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  WarehouseController_linkTable: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description Project ref */
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['WarehouseLinkTableBody']
+      }
+    }
+    responses: {
+      /** @description Warehouse table link accepted. */
+      202: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['WarehouseLinkedTable']
+        }
+      }
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description This feature requires the Pro, Team, or Enterprise organization plan. */
+      402: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
+      }
+      /** @description Forbidden action */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Rate limit exceeded */
+      429: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Unexpected error while linking Warehouse table. */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  WarehouseController_detachTable: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description Postgres table name */
+        name: string
+        /** @description Project ref */
+        ref: string
+        /** @description Postgres schema name */
+        schema: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Warehouse table detached. */
+      204: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description This feature requires the Pro, Team, or Enterprise organization plan. */
+      402: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
+      }
+      /** @description Forbidden action */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Rate limit exceeded */
+      429: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Unexpected error while detaching Warehouse table. */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  WarehouseController_getTableSnapshots: {
+    parameters: {
+      query?: {
+        /** @description Maximum number of snapshots to return. */
+        limit?: number
+      }
+      header?: never
+      path: {
+        /** @description Postgres table name */
+        name: string
+        /** @description Project ref */
+        ref: string
+        /** @description Postgres schema name */
+        schema: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Warehouse snapshots. */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['WarehouseTableSnapshotsResponse']
+        }
+      }
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Forbidden action */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Rate limit exceeded */
+      429: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Unexpected error while listing Warehouse snapshots. */
       500: {
         headers: {
           [name: string]: unknown

--- a/packages/api-types/types/platform.d.ts
+++ b/packages/api-types/types/platform.d.ts
@@ -5616,6 +5616,14 @@ export interface components {
       role_id: number
       role_scoped_projects?: string[]
     }
+    CreateInvitationResponse: {
+      failed: {
+        /** Format: email */
+        email: string
+        error: string
+      }[]
+      succeeded: string[]
+    } | null
     CreateNamespaceBody: {
       namespace: string
     }
@@ -7136,6 +7144,40 @@ export interface components {
       /** @description Source ID */
       id: number
     }
+    CreateSSOProviderBody:
+      | {
+          /** @default [] */
+          domains?: string[]
+          email_mapping: string[]
+          enabled: boolean
+          first_name_mapping?: string[]
+          /** Format: uri */
+          idjag_issuer_url?: string | null
+          join_org_on_signup_enabled: boolean
+          /** @enum {string} */
+          join_org_on_signup_role?: 'Administrator' | 'Developer' | 'Owner' | 'Read-only'
+          last_name_mapping?: string[]
+          metadata_xml_file: string
+          /** Format: uri */
+          metadata_xml_url?: string
+          user_name_mapping?: string[]
+        }
+      | {
+          /** @default [] */
+          domains?: string[]
+          email_mapping: string[]
+          enabled: boolean
+          first_name_mapping?: string[]
+          /** Format: uri */
+          idjag_issuer_url?: string | null
+          join_org_on_signup_enabled: boolean
+          /** @enum {string} */
+          join_org_on_signup_role?: 'Administrator' | 'Developer' | 'Owner' | 'Read-only'
+          last_name_mapping?: string[]
+          metadata_xml_file?: string
+          metadata_xml_url: string
+          user_name_mapping?: string[]
+        }
     CreateStorageAnalyticsBucketBody: {
       bucketName: string
     }
@@ -13448,6 +13490,40 @@ export interface components {
     UpdateSecretsResponse: {
       message: string
     }
+    UpdateSSOProviderBody:
+      | {
+          /** @default [] */
+          domains?: string[]
+          email_mapping: string[]
+          enabled: boolean
+          first_name_mapping?: string[]
+          /** Format: uri */
+          idjag_issuer_url?: string | null
+          join_org_on_signup_enabled: boolean
+          /** @enum {string} */
+          join_org_on_signup_role?: 'Administrator' | 'Developer' | 'Owner' | 'Read-only'
+          last_name_mapping?: string[]
+          metadata_xml_file: string
+          /** Format: uri */
+          metadata_xml_url?: string
+          user_name_mapping?: string[]
+        }
+      | {
+          /** @default [] */
+          domains?: string[]
+          email_mapping: string[]
+          enabled: boolean
+          first_name_mapping?: string[]
+          /** Format: uri */
+          idjag_issuer_url?: string | null
+          join_org_on_signup_enabled: boolean
+          /** @enum {string} */
+          join_org_on_signup_role?: 'Administrator' | 'Developer' | 'Owner' | 'Read-only'
+          last_name_mapping?: string[]
+          metadata_xml_file?: string
+          metadata_xml_url: string
+          user_name_mapping?: string[]
+        }
     UpdateStorageBucketBody: {
       allowed_mime_types?: string[] | null
       file_size_limit?: number | null
@@ -13583,7 +13659,7 @@ export interface components {
        * @default false
        */
       favorite?: boolean
-      folder_id?: (string | null)[]
+      folder_id?: (null | (string | null)) | null
       id?: string
       name: string
       owner_id?: number
@@ -21294,7 +21370,11 @@ export interface operations {
       }
       cookie?: never
     }
-    requestBody?: never
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['UpdateSSOProviderBody']
+      }
+    }
     responses: {
       200: {
         headers: {
@@ -21368,7 +21448,11 @@ export interface operations {
       }
       cookie?: never
     }
-    requestBody?: never
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['CreateSSOProviderBody']
+      }
+    }
     responses: {
       201: {
         headers: {


### PR DESCRIPTION
Update the API types by running `api:codegen`. Some of the changes are fixed in code, some of the type changes had to be reverted (JIT Access, SSO features).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Billing**
  * Updated subscription messaging to reflect AWS Marketplace billing.
  * Removed outdated partner-billing downgrade notices.

* **Bug Fixes**
  * Improved request handling for API keys, custom domains, SQL snippets, branches, and storage operations.
  * Improved legacy signing-key compatibility.
  * Refined temporary database access availability messaging.

* **Updates**
  * Removed Fly as an available cloud provider for region selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->