### PR TITLE
docs: add update step to agent skills docs page

### DIFF
--- a/apps/docs/content/guides/ai-tools/ai-skills.mdx
+++ b/apps/docs/content/guides/ai-tools/ai-skills.mdx
@@ -24,6 +24,20 @@ Add skills for all detected agents at the same time by passing `--all`. See the 
 
 You can also install the agent skills together with the Supabase MCP server using the [Supabase Plugin for AI Coding Agents](/docs/guides/ai-tools/plugins) for a combined one-step setup.
 
+## Upgrading skills
+
+<Admonition type="note">
+
+We update our agent skills frequently, so be sure to check for updates and upgrade regularly to get the latest improvements.
+
+</Admonition>
+
+```bash
+npx skills update
+```
+
+This upgrades all skills you have installed. To upgrade specific skills instead, pass their names to the command, e.g. `npx skills update SKILL_NAME`. See the [`skills update` docs](https://github.com/vercel-labs/skills#skills-update) for more options.
+
 ## Available skills
 
 <AiSkillsIndex />

--- a/apps/docs/content/guides/ai-tools/ai-skills.mdx
+++ b/apps/docs/content/guides/ai-tools/ai-skills.mdx
@@ -24,11 +24,11 @@ Add skills for all detected agents at the same time by passing `--all`. See the 
 
 You can also install the agent skills together with the Supabase MCP server using the [Supabase Plugin for AI Coding Agents](/docs/guides/ai-tools/plugins) for a combined one-step setup.
 
-## Upgrading skills
+## Updating skills
 
 <Admonition type="note">
 
-We update our agent skills frequently, so be sure to check for updates and upgrade regularly to get the latest improvements.
+We update our agent skills frequently, so be sure to check for and install updates regularly to get the latest improvements.
 
 </Admonition>
 
@@ -36,7 +36,7 @@ We update our agent skills frequently, so be sure to check for updates and upgra
 npx skills update
 ```
 
-This upgrades all skills you have installed. To upgrade specific skills instead, pass their names to the command, e.g. `npx skills update SKILL_NAME`. See the [`skills update` docs](https://github.com/vercel-labs/skills#skills-update) for more options.
+This updates all skills you have installed. To update specific skills instead, pass their names to the command, e.g. `npx skills update SKILL_NAME`. See the [`skills update` docs](https://github.com/vercel-labs/skills#skills-update) for more options.
 
 ## Available skills
 


### PR DESCRIPTION
The agent skills docs page covered installing skills but not upgrading them, and skill fixes/features (like the debugging skill, only available from v0.1.8) can go unnoticed if users never re-run the CLI. Adds an **Upgrading skills** section with the `npx skills update` command and a link to the [`skills update` docs](https://github.com/vercel-labs/skills#skills-update).

### Preview

<img width="813" height="611" alt="image" src="https://github.com/user-attachments/assets/c4b96316-f2d1-4b8a-b7bd-a868156447d5" />



[source](https://docs-git-docs-add-update-agent-skills-step-to-docs-supabase.vercel.app/docs/guides/ai-tools/ai-skills)

Closes [AI-1066](https://linear.app/supabase/issue/AI-1066/add-agent-skills-upgrade-step-to-docs-page).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an “Upgrading skills” guide explaining how to update all or selected installed skills.
  * Included links to additional documentation for more details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->