### PR TITLE
docs: clarify sessions inactivity timeout is in hours

### DIFF
--- a/apps/design-system/registry/default/example/page-layout-settings.tsx
+++ b/apps/design-system/registry/default/example/page-layout-settings.tsx
@@ -218,7 +218,7 @@ export default function PageLayoutSettings() {
                         <FormItemLayout
                           layout="flex-row-reverse"
                           label="Time-box user sessions"
-                          description="The amount of time before a user is forced to sign in again. Use 0 for never."
+                          description="Hours before a user must sign in again. Checked on the next token refresh. Use 0 for never."
                         >
                           <div className="flex items-center">
                             <FormControl>
@@ -245,7 +245,7 @@ export default function PageLayoutSettings() {
                         <FormItemLayout
                           layout="flex-row-reverse"
                           label="Inactivity timeout"
-                          description="The amount of time a user needs to be inactive to be forced to sign in again. Use 0 for never."
+                          description="Hours without a session refresh before the user must sign in again. Checked on the next token refresh. Use 0 for never."
                         >
                           <div className="flex items-center">
                             <FormControl>

--- a/apps/docs/content/guides/auth/sessions.mdx
+++ b/apps/docs/content/guides/auth/sessions.mdx
@@ -59,11 +59,27 @@ To make sure that users are required to re-authenticate periodically, you can se
 
 To make sure that sessions expire after a period of inactivity, you can set a positive duration for the **Inactivity timeout** option in the [Auth settings](/dashboard/project/_/auth/sessions).
 
+Inactivity means the session has not been **refreshed** (no successful `grant_type=refresh_token` exchange). Other API calls that use a still-valid access token do not count as activity and do not reset the inactivity timer.
+
 You can also enforce only one active session per user per device or browser. When this is enabled, the session from the most recent sign in will remain active, while the rest are terminated. Enable this via the _Single session per user_ option in the [Auth settings](/dashboard/project/_/auth/sessions).
 
-Sessions are not proactively destroyed when you change these settings, but rather the check is enforced whenever a session is refreshed next. This can confuse developers because the actual duration of a session is the configured timeout plus the JWT expiration time. For single session per user, the effect will only be noticed at intervals of the JWT expiration time. Make sure you adjust this setting depending on your needs. We do not recommend going below 5 minutes for the JWT expiration time.
+Sessions are not proactively destroyed when you change these settings, but rather the check is enforced whenever a session is refreshed next. If inactivity (or the time-box) has been exceeded, Auth rejects the refresh with HTTP `400`, `error_code` `session_expired`, and a message such as `Invalid Refresh Token: Session Expired (Inactivity)`.
 
-Otherwise sessions are progressively deleted from the database 24 hours after they expire, which prevents you from causing a high load on your project by accident and allows you some freedom to undo changes without adversely affecting all users.
+This can confuse developers because the actual duration of a session is the configured timeout plus the JWT expiration time. For single session per user, the effect will only be noticed at intervals of the JWT expiration time. Make sure you adjust this setting depending on your needs. We do not recommend going below 5 minutes for the JWT expiration time.
+
+### Configuring session timeouts via the Management API
+
+The Dashboard **Time-box user sessions** and **Inactivity timeout** fields are measured in **hours** (including fractional hours such as `0.5`). The Management API fields `sessions_timebox` and `sessions_inactivity_timeout` use the same unit: **hours**, not seconds.
+
+Examples:
+
+- `4` → 4 hours
+- `0.5` → 30 minutes
+- `168` → 7 days
+
+Do not send values such as `14400` when you mean 4 hours; that configures 14400 hours. For self-hosted Auth, set Go duration strings instead, for example `GOTRUE_SESSIONS_INACTIVITY_TIMEOUT=4h`.
+
+Expired sessions are progressively deleted from the database about 24 hours after they expire. That avoids a sudden high load on your project and gives you time to tweak or roll back settings without immediately affecting every user.
 
 ## Frequently asked questions
 

--- a/apps/docs/spec/api_v1_openapi.json
+++ b/apps/docs/spec/api_v1_openapi.json
@@ -10421,10 +10421,18 @@
             "type": "boolean",
             "nullable": true
           },
-          "sessions_inactivity_timeout": { "type": "number", "nullable": true },
+          "sessions_inactivity_timeout": {
+            "type": "number",
+            "nullable": true,
+            "description": "Hours without a session refresh before the session is rejected on the next refresh. Use 0 for never. Same unit as the Dashboard Auth Sessions setting (not seconds)."
+          },
           "sessions_single_per_user": { "type": "boolean", "nullable": true },
           "sessions_tags": { "type": "string", "nullable": true },
-          "sessions_timebox": { "type": "number", "nullable": true },
+          "sessions_timebox": {
+            "type": "number",
+            "nullable": true,
+            "description": "Maximum session lifetime in hours from session creation. Use 0 for never. Same unit as the Dashboard Auth Sessions setting (not seconds)."
+          },
           "site_url": { "type": "string", "nullable": true },
           "sms_autoconfirm": { "type": "boolean", "nullable": true },
           "sms_max_frequency": {
@@ -10850,8 +10858,18 @@
             "nullable": true
           },
           "security_captcha_secret": { "type": "string", "nullable": true },
-          "sessions_timebox": { "type": "number", "minimum": 0, "nullable": true },
-          "sessions_inactivity_timeout": { "type": "number", "minimum": 0, "nullable": true },
+          "sessions_timebox": {
+            "type": "number",
+            "minimum": 0,
+            "nullable": true,
+            "description": "Maximum session lifetime in hours from session creation. Use 0 for never. Same unit as the Dashboard Auth Sessions setting (not seconds)."
+          },
+          "sessions_inactivity_timeout": {
+            "type": "number",
+            "minimum": 0,
+            "nullable": true,
+            "description": "Hours without a session refresh before the session is rejected on the next refresh. Use 0 for never. Same unit as the Dashboard Auth Sessions setting (not seconds)."
+          },
           "sessions_single_per_user": { "type": "boolean", "nullable": true },
           "sessions_tags": {
             "type": "string",

--- a/apps/docs/spec/cli_v1_config.yaml
+++ b/apps/docs/spec/cli_v1_config.yaml
@@ -1489,7 +1489,8 @@ parameters:
     required: false
     default: ''
     description: |
-      Force log out after the specified duration. Sample values include: '50m', '20h'.
+      Force log out after the specified duration from session creation. Sample values include: '50m', '20h'.
+      On hosted projects, the Dashboard and Management API configure this in hours (for example, 4 means 4 hours).
     links:
       - name: 'Auth Sessions'
         link: 'https://supabase.com/docs/guides/auth/sessions'
@@ -1500,7 +1501,8 @@ parameters:
     required: false
     default: ''
     description: |
-      Force log out if the user has been inactive longer than the specified duration. Sample values include: '50m', '20h'.
+      Force log out if the session has not been refreshed within the specified duration. Sample values include: '50m', '20h'.
+      Activity means a successful token refresh, not other API calls. On hosted projects, the Dashboard and Management API configure this in hours (for example, 4 means 4 hours).
     links:
       - name: 'Auth Sessions'
         link: 'https://supabase.com/docs/guides/auth/sessions'

--- a/apps/docs/spec/transforms/api_v1_openapi_deparsed.json
+++ b/apps/docs/spec/transforms/api_v1_openapi_deparsed.json
@@ -15237,7 +15237,8 @@
           },
           "sessions_inactivity_timeout": {
             "type": "number",
-            "nullable": true
+            "nullable": true,
+            "description": "Hours without a session refresh before the session is rejected on the next refresh. Use 0 for never. Same unit as the Dashboard Auth Sessions setting (not seconds)."
           },
           "sessions_single_per_user": {
             "type": "boolean",
@@ -15249,7 +15250,8 @@
           },
           "sessions_timebox": {
             "type": "number",
-            "nullable": true
+            "nullable": true,
+            "description": "Maximum session lifetime in hours from session creation. Use 0 for never. Same unit as the Dashboard Auth Sessions setting (not seconds)."
           },
           "site_url": {
             "type": "string",
@@ -15887,12 +15889,14 @@
           "sessions_timebox": {
             "type": "number",
             "minimum": 0,
-            "nullable": true
+            "nullable": true,
+            "description": "Maximum session lifetime in hours from session creation. Use 0 for never. Same unit as the Dashboard Auth Sessions setting (not seconds)."
           },
           "sessions_inactivity_timeout": {
             "type": "number",
             "minimum": 0,
-            "nullable": true
+            "nullable": true,
+            "description": "Hours without a session refresh before the session is rejected on the next refresh. Use 0 for never. Same unit as the Dashboard Auth Sessions setting (not seconds)."
           },
           "sessions_single_per_user": {
             "type": "boolean",

--- a/apps/studio/components/interfaces/Auth/SessionsAuthSettingsForm/SessionsAuthSettingsForm.tsx
+++ b/apps/studio/components/interfaces/Auth/SessionsAuthSettingsForm/SessionsAuthSettingsForm.tsx
@@ -282,7 +282,7 @@ export const SessionsAuthSettingsForm = () => {
                       <FormItemLayout
                         layout="flex-row-reverse"
                         label="Time-box user sessions"
-                        description="The amount of time before a user is forced to sign in again. Use 0 for never."
+                        description="Hours before a user must sign in again. Checked on the next token refresh. Use 0 for never."
                       >
                         <FormControl className="w-full">
                           <InputGroup>
@@ -312,7 +312,7 @@ export const SessionsAuthSettingsForm = () => {
                       <FormItemLayout
                         layout="flex-row-reverse"
                         label="Inactivity timeout"
-                        description="The amount of time a user needs to be inactive to be forced to sign in again. Use 0 for never."
+                        description="Hours without a session refresh before the user must sign in again. Checked on the next token refresh. Use 0 for never."
                       >
                         <FormControl className="w-full">
                           <InputGroup>

--- a/docker/CONFIG.md
+++ b/docker/CONFIG.md
@@ -660,10 +660,10 @@ The fields below are repeated for each provider. Substitute `<PROVIDER>` with on
 | Variable | Type | Set by | Description | Notes |
 |---|---|---|---|---|
 | `GOTRUE_SESSIONS_ALLOW_LOW_AAL` | string (duration) |  | Time during which a low-AAL session is still accepted. |  |
-| `GOTRUE_SESSIONS_INACTIVITY_TIMEOUT` | string (duration) |  | Session inactivity timeout. |  |
+| `GOTRUE_SESSIONS_INACTIVITY_TIMEOUT` | string (duration) |  | Session inactivity timeout (time since last successful token refresh). | Go duration, e.g. `4h`, `50m`. Dashboard / Management API use hours (e.g. `4`), which map to this duration. |
 | `GOTRUE_SESSIONS_SINGLE_PER_USER` | boolean |  | Allow only one active session per user. |  |
 | `GOTRUE_SESSIONS_TAGS` | string (CSV) |  | Tags attached to created sessions. |  |
-| `GOTRUE_SESSIONS_TIMEBOX` | string (duration) |  | Absolute session lifetime. |  |
+| `GOTRUE_SESSIONS_TIMEBOX` | string (duration) |  | Absolute session lifetime from creation. | Go duration, e.g. `24h`. Dashboard / Management API use hours (e.g. `24`), which map to this duration. |
 
 ### Web3
 


### PR DESCRIPTION
## Summary
- Document that Dashboard / Management API `sessions_timebox` and `sessions_inactivity_timeout` are in **hours**, not seconds
- Clarify that inactivity is measured by successful token refresh and enforced on the next refresh (`400` + `session_expired`)
- Tighten Studio (and design-system example) field descriptions to match
Clarifies https://github.com/supabase/supabase/issues/48910 (second-like values such as `14400` for a 4h timeout).
## Test plan
- [x] Read updated sessions guide — units and refresh behavior are clear
- [x] Open Auth → Sessions in Studio — inactivity/timebox descriptions mention hours + refresh
- [x] Spot-check OpenAPI descriptions for `sessions_inactivity_timeout` / `sessions_timebox`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that session timeouts are measured in hours for hosted configuration.
  * Explained that inactivity is based on the last successful token refresh and enforced during refresh.
  * Documented that `0` means no timeout and that timeboxing begins when a session is created.
  * Added configuration examples, duration syntax guidance, expiration behavior, and session cleanup details.
  * Updated dashboard, API, CLI, and configuration references for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->