### PR TITLE
chore: add Pierre Frances to humans.txt

### DIFF
--- a/apps/docs/public/humans.txt
+++ b/apps/docs/public/humans.txt
@@ -238,6 +238,7 @@ Pedro Rodrigues
 Peter Lyn
 Peter Soderberg
 Pierre Ducroquet
+Pierre Frances
 Qiao Han
 Quintin Willison
 Rafael Chacón


### PR DESCRIPTION
## What kind of change does this PR introduce?

Chore — adds Pierre Frances to `apps/docs/public/humans.txt`, inserted in alphabetical order (after Pierre Ducroquet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Pierre Frances to the team information listed on the documentation site.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->