### PR TITLE
chore: add Matt Robinson to humans.txt

### DIFF
--- a/apps/docs/public/humans.txt
+++ b/apps/docs/public/humans.txt
@@ -202,6 +202,7 @@ Márton Boros
 Matthew Hambright
 Matt Hudson
 Matt Johnston
+Matt Robinson
 Matt Rossman
 Matt Smiley
 Matthias Luft


### PR DESCRIPTION
## What kind of change does this PR introduce?

Chore — adds Matt Robinson to `apps/docs/public/humans.txt`, inserted in alphabetical order (between Matt Johnston and Matt Rossman).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Matt Robinson to the Supabase team listing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->