### PR TITLE
[DEMO] Database health score on the project homepage

### DIFF
--- a/apps/studio/components/interfaces/ProjectHome/DATABASE_HEALTH.md
+++ b/apps/studio/components/interfaces/ProjectHome/DATABASE_HEALTH.md
@@ -1,0 +1,95 @@
+# Database health score (demo)
+
+A query-only, point-in-time health snapshot for the selected project's Postgres,
+rendered as a sortable section on the project homepage. No scheduled jobs, no
+persisted scores, no metrics service.
+
+## Files
+
+| File                                                          | Contents                                             |
+| ------------------------------------------------------------- | ---------------------------------------------------- |
+| `data/database/database-health-query.ts`                      | The five diagnostic queries and the React Query hook |
+| `data/database/database-health-score.ts`                      | `DATABASE_HEALTH_CONFIG`, metric schemas, all checks |
+| `data/database/database-health-score.test.ts`                 | Unit tests for the scoring model                     |
+| `components/interfaces/ProjectHome/DatabaseHealthSection.tsx` | The homepage section                                 |
+
+## Formula
+
+Each category starts at 100 and loses points for every check that crosses its
+threshold. Category scores are combined as a weighted average over the
+categories that were actually collected:
+
+```
+score = round(Σ(category.score × category.weight) / Σ(category.weight))
+```
+
+| Category                | Weight |
+| ----------------------- | ------ |
+| Connections             | 20%    |
+| Vacuum and table health | 25%    |
+| Locks                   | 15%    |
+| Transaction safety      | 20%    |
+| Performance             | 20%    |
+
+Status: `healthy` at 80+, `needs_attention` at 50–79, `critical` below 50.
+
+Three conditions cap the overall score at 30 and force `critical`:
+
+- `autovacuum = off`
+- `track_counts = off`
+- Transaction ID age at or past the 1.6 billion failsafe threshold
+
+Every threshold, weight, and penalty lives in `DATABASE_HEALTH_CONFIG`. Nothing
+is hardcoded in the check bodies except the copy.
+
+## Queries
+
+Five grouped queries, one per category, all run in parallel through the existing
+`executeSql` helper. Each is prefixed with
+`set local statement_timeout = '5s'` so a health check can never become the
+expensive query on someone's database.
+
+| Category           | Sources                                                      |
+| ------------------ | ------------------------------------------------------------ |
+| Connections        | `pg_stat_activity`, `pg_settings`                            |
+| Vacuum             | `pg_stat_user_tables`, `pg_class`, `current_setting()`       |
+| Locks              | `pg_stat_activity`, `pg_locks`                               |
+| Transaction safety | `pg_database`, `pg_class`, `pg_settings`, `pg_stat_activity` |
+| Performance        | `pg_stat_database`, `pg_stat_user_tables`, `pg_settings`     |
+
+Results are parsed with zod (`z.coerce.number()`, since Postgres returns
+`bigint` and `numeric` as strings over the wire) before scoring.
+
+## Missing data
+
+Missing data never counts as healthy:
+
+- A query that fails or times out marks its category `unavailable`. The category
+  is excluded from the weighted average and called out in the UI.
+- A check that cannot be evaluated (too few block reads for a meaningful cache
+  hit ratio, too few updates for a HOT ratio) is recorded as a skipped check and
+  listed under the findings rather than scored.
+- If every query fails, the whole result is `unavailable` and no score is shown.
+
+In development, an expandable panel dumps the full result object — per-category
+scores, findings, deductions, and skipped checks.
+
+## Current limitations
+
+- **Not calibrated.** Weights and penalties are first-pass guesses. Calibration
+  against real projects is follow-up work.
+- **Global autovacuum settings only.** The autovacuum-threshold check compares
+  against `autovacuum_vacuum_threshold` and
+  `autovacuum_vacuum_scale_factor` at the cluster level, so per-table storage
+  parameter overrides produce false positives.
+- **Dead-tuple ratio, not bloat.** Exact bloat estimation is deliberately out of
+  scope; `n_dead_tup / (n_live_tup + n_dead_tup)` from
+  `pg_stat_user_tables` is an approximation that misses index bloat entirely.
+- **Statistics are cumulative.** Cache hit ratio and HOT update ratio come from
+  counters that reset only on `pg_stat_reset()`, so they describe the lifetime of
+  the statistics, not the last few minutes.
+- **Snapshot only.** Connections, locks, and long transactions are read once. A
+  transient spike between refreshes is invisible; a spike at refresh time looks
+  permanent.
+- **Database scope only.** No CPU, memory, disk, or Auth/Storage/Realtime/Edge
+  Function health.

--- a/apps/studio/components/interfaces/ProjectHome/DatabaseHealthSection.test.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/DatabaseHealthSection.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { DatabaseHealthReport } from './DatabaseHealthSection'
+import {
+  calculateDatabaseHealth,
+  type DatabaseHealthCollection,
+} from '@/data/database/database-health-score'
+
+const COLLECTED_AT = '2026-08-12T10:30:00.000Z'
+
+const collection = (): DatabaseHealthCollection => ({
+  connections: {
+    status: 'collected',
+    metrics: {
+      max_connections: 100,
+      total_connections: 95,
+      idle_in_transaction_sessions: 0,
+      long_running_transactions: 0,
+    },
+  },
+  vacuum: {
+    status: 'collected',
+    metrics: {
+      table_count: 10,
+      dead_tuple_tables: 0,
+      tables_past_autovacuum_threshold: 0,
+      stale_statistics_tables: 0,
+      autovacuum_disabled_tables: 0,
+    },
+  },
+  locks: { status: 'unavailable', error: 'canceling statement due to statement timeout' },
+  transactions: {
+    status: 'collected',
+    metrics: {
+      max_database_xid_age: 1_000_000,
+      max_relation_xid_age: 1_000_000,
+      autovacuum: 'on',
+      track_counts: 'on',
+      autovacuum_freeze_max_age: 200_000_000,
+      oldest_transaction_seconds: 0,
+    },
+  },
+  performance: {
+    status: 'collected',
+    metrics: {
+      cache_hit_ratio: 0.999,
+      total_blocks_accessed: 5_000_000,
+      track_io_timing: 'on',
+      hot_update_ratio: 0.9,
+      total_updates: 50_000,
+    },
+  },
+})
+
+describe('DatabaseHealthReport', () => {
+  it('shows each finding with an explanation and a suggested action', () => {
+    const result = calculateDatabaseHealth(collection())
+
+    render(<DatabaseHealthReport result={result} collectedAt={COLLECTED_AT} />)
+
+    expect(screen.getByText('Connection pool is close to its limit')).toBeInTheDocument()
+    expect(screen.getByText(/95 of 100 connections are in use/)).toBeInTheDocument()
+    expect(
+      screen.getByText('Route clients through a connection pooler or reduce your pool size')
+    ).toBeInTheDocument()
+  })
+
+  it('calls out categories that could not be checked', () => {
+    const result = calculateDatabaseHealth(collection())
+
+    render(<DatabaseHealthReport result={result} collectedAt={COLLECTED_AT} />)
+
+    expect(screen.getByText('Some categories could not be checked')).toBeInTheDocument()
+    expect(screen.getByText(/Locks were excluded from the score/)).toBeInTheDocument()
+  })
+
+  it('explains the score cap when a critical condition is present', () => {
+    const withAutovacuumOff = collection()
+    withAutovacuumOff.transactions = {
+      status: 'collected',
+      metrics: {
+        max_database_xid_age: 1_000_000,
+        max_relation_xid_age: 1_000_000,
+        autovacuum: 'off',
+        track_counts: 'on',
+        autovacuum_freeze_max_age: 200_000_000,
+        oldest_transaction_seconds: 0,
+      },
+    }
+    const result = calculateDatabaseHealth(withAutovacuumOff)
+
+    render(<DatabaseHealthReport result={result} collectedAt={COLLECTED_AT} />)
+
+    expect(screen.getByText('Score capped at 30 by a critical condition')).toBeInTheDocument()
+    expect(screen.getByText('Critical')).toBeInTheDocument()
+  })
+
+  it('reports an unavailable snapshot when no query returned', () => {
+    const result = calculateDatabaseHealth({
+      connections: { status: 'unavailable', error: 'failed' },
+      vacuum: { status: 'unavailable', error: 'failed' },
+      locks: { status: 'unavailable', error: 'failed' },
+      transactions: { status: 'unavailable', error: 'failed' },
+      performance: { status: 'unavailable', error: 'failed' },
+    })
+
+    render(<DatabaseHealthReport result={result} collectedAt={COLLECTED_AT} />)
+
+    expect(screen.getByText('Unable to read database health')).toBeInTheDocument()
+  })
+})

--- a/apps/studio/components/interfaces/ProjectHome/DatabaseHealthSection.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/DatabaseHealthSection.tsx
@@ -1,0 +1,254 @@
+import dayjs from 'dayjs'
+import { Activity, AlertTriangle, Info, RefreshCw } from 'lucide-react'
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  cn,
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from 'ui'
+import { Admonition } from 'ui-patterns/Admonition'
+import { Row } from 'ui-patterns/Row'
+import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
+
+import { useDatabaseHealthQuery } from '@/data/database/database-health-query'
+import {
+  DATABASE_HEALTH_STATUS_LABELS,
+  type DatabaseHealthCategory,
+  type DatabaseHealthFinding,
+  type DatabaseHealthResult,
+  type DatabaseHealthSeverity,
+} from '@/data/database/database-health-score'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+
+const STATUS_BADGE_VARIANTS: Record<
+  DatabaseHealthResult['status'],
+  'success' | 'warning' | 'destructive' | 'default'
+> = {
+  healthy: 'success',
+  needs_attention: 'warning',
+  critical: 'destructive',
+  unavailable: 'default',
+}
+
+const SEVERITY_BADGE_VARIANTS: Record<
+  DatabaseHealthSeverity,
+  'warning' | 'destructive' | 'default'
+> = {
+  high: 'destructive',
+  medium: 'warning',
+  low: 'default',
+}
+
+const SEVERITY_LABELS: Record<DatabaseHealthSeverity, string> = {
+  high: 'High',
+  medium: 'Medium',
+  low: 'Low',
+}
+
+const scoreColorClass = (score: number) => {
+  if (score >= 80) return 'text-brand-600'
+  if (score >= 50) return 'text-warning-600'
+  return 'text-destructive-600'
+}
+
+export const DatabaseHealthSection = () => {
+  const { data: project } = useSelectedProjectQuery()
+
+  const { data, error, isPending, isError, isFetching, refetch } = useDatabaseHealthQuery({
+    projectRef: project?.ref,
+    connectionString: project?.connectionString,
+  })
+
+  return (
+    <div>
+      <div className="flex justify-between items-center mb-2 gap-4">
+        <h2>Database health</h2>
+        <Button
+          variant="default"
+          icon={<RefreshCw className={cn(isFetching && 'animate-spin')} />}
+          loading={isFetching}
+          onClick={() => refetch()}
+        >
+          Refresh
+        </Button>
+      </div>
+      <p className="text-sm text-foreground-light mb-6">
+        A live snapshot of PostgreSQL statistics, taken when you loaded this page. It does not cover
+        Auth, Storage, Realtime or Edge Functions.
+      </p>
+
+      {isPending && (
+        <div className="flex flex-col gap-2">
+          <ShimmeringLoader className="h-24" />
+          <ShimmeringLoader className="w-3/4" />
+          <ShimmeringLoader className="w-1/2" />
+        </div>
+      )}
+
+      {isError && (
+        <Admonition
+          type="default"
+          title="Unable to read database health"
+          description={error.message}
+        />
+      )}
+
+      {!isPending && !isError && (
+        <DatabaseHealthReport result={data.result} collectedAt={data.collectedAt} />
+      )}
+    </div>
+  )
+}
+
+export const DatabaseHealthReport = ({
+  result,
+  collectedAt,
+}: {
+  result: DatabaseHealthResult
+  collectedAt: string
+}) => {
+  const unavailableCategories = result.categories.filter(
+    (category) => category.status === 'unavailable'
+  )
+
+  if (result.status === 'unavailable') {
+    return (
+      <Admonition
+        type="default"
+        title="Unable to read database health"
+        description="None of the diagnostic queries returned. The database may be unreachable or under load."
+      />
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Card>
+        <CardContent className="flex flex-col md:flex-row md:items-center gap-6 p-6">
+          <div className="flex items-baseline gap-3 min-w-48">
+            <span className={cn('text-5xl font-medium', scoreColorClass(result.score ?? 0))}>
+              {result.score}
+            </span>
+            <span className="text-sm text-foreground-light">/ 100</span>
+            <Badge variant={STATUS_BADGE_VARIANTS[result.status]}>
+              {DATABASE_HEALTH_STATUS_LABELS[result.status]}
+            </Badge>
+          </div>
+          <div className="flex flex-col gap-1 text-sm text-foreground-light">
+            <p>
+              {result.findings.length === 0
+                ? 'No checks lost points.'
+                : `${result.findings.length} ${result.findings.length === 1 ? 'check' : 'checks'} lost points.`}
+            </p>
+            <p>Collected {dayjs(collectedAt).format('HH:mm:ss')}</p>
+          </div>
+        </CardContent>
+      </Card>
+
+      {result.criticalConditions.length > 0 && (
+        <Admonition
+          type="destructive"
+          title="Score capped at 30 by a critical condition"
+          description={result.criticalConditions.join('. ')}
+        />
+      )}
+
+      <Row maxColumns={5} minWidth={180}>
+        {result.categories.map((category) => (
+          <CategoryCard key={category.id} category={category} />
+        ))}
+      </Row>
+
+      {unavailableCategories.length > 0 && (
+        <Admonition
+          type="warning"
+          title="Some categories could not be checked"
+          description={`${unavailableCategories
+            .map((category) => category.label)
+            .join(', ')} were excluded from the score rather than counted as healthy.`}
+        />
+      )}
+
+      {result.findings.length > 0 && (
+        <div className="flex flex-col gap-2">
+          {result.findings.map((finding) => (
+            <FindingCard key={finding.id} finding={finding} />
+          ))}
+        </div>
+      )}
+
+      {result.skippedChecks.length > 0 && (
+        <div className="flex flex-col gap-1 text-xs text-foreground-lighter">
+          <p className="flex items-center gap-1.5">
+            <Info size={12} /> Checks skipped for insufficient data
+          </p>
+          {result.skippedChecks.map((check) => (
+            <p key={check.id} className="pl-5">
+              {check.id}: {check.reason}
+            </p>
+          ))}
+        </div>
+      )}
+
+      {process.env.NODE_ENV === 'development' && (
+        <Collapsible>
+          <CollapsibleTrigger className="text-xs text-foreground-lighter">
+            Show raw metrics and penalties
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <pre className="text-xs bg-surface-100 border rounded p-4 overflow-auto max-h-96">
+              {JSON.stringify(result, null, 2)}
+            </pre>
+          </CollapsibleContent>
+        </Collapsible>
+      )}
+    </div>
+  )
+}
+
+const CategoryCard = ({ category }: { category: DatabaseHealthCategory }) => (
+  <Card className="min-h-full">
+    <CardHeader className="border-b-0 pb-0">
+      <CardTitle className="text-foreground-light">{category.label}</CardTitle>
+    </CardHeader>
+    <CardContent className="pt-2">
+      {category.status === 'unavailable' ? (
+        <div className="flex items-center gap-2 text-sm text-foreground-lighter">
+          <AlertTriangle size={14} /> Unavailable
+        </div>
+      ) : (
+        <div className="flex items-baseline gap-2">
+          <span className={cn('text-2xl font-medium', scoreColorClass(category.score))}>
+            {category.score}
+          </span>
+          <span className="text-xs text-foreground-lighter">{category.weight}% of score</span>
+        </div>
+      )}
+    </CardContent>
+  </Card>
+)
+
+const FindingCard = ({ finding }: { finding: DatabaseHealthFinding }) => (
+  <Card>
+    <CardContent className="flex flex-col md:flex-row md:items-start gap-4 p-4">
+      <Activity size={16} strokeWidth={1.5} className="text-foreground-light mt-0.5 shrink-0" />
+      <div className="flex flex-col gap-1 flex-1">
+        <div className="flex items-center gap-2 flex-wrap">
+          <h3 className="text-sm">{finding.title}</h3>
+          <Badge variant={SEVERITY_BADGE_VARIANTS[finding.severity]}>
+            {SEVERITY_LABELS[finding.severity]}
+          </Badge>
+          <span className="text-xs text-foreground-lighter">-{finding.deduction} points</span>
+        </div>
+        <p className="text-sm text-foreground-light">{finding.description}</p>
+        <p className="text-sm text-foreground">{finding.action}</p>
+      </div>
+    </CardContent>
+  </Card>
+)

--- a/apps/studio/components/interfaces/ProjectHome/Home.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/Home.tsx
@@ -20,6 +20,7 @@ import { cn } from 'ui'
 import { AdvisorSection } from './AdvisorSection'
 import { ConnectSection } from './ConnectSection'
 import { CustomReportSection } from './CustomReportSection'
+import { DatabaseHealthSection } from './DatabaseHealthSection'
 import { DEFAULT_SECTION_ORDER, mergeSectionOrder } from './Home.utils'
 import { ProjectUsageSection } from './ProjectUsageSection'
 import { ProjectUsageSectionDeltas } from './ProjectUsageSectionDeltas'
@@ -146,6 +147,18 @@ export const ProjectHome = () => {
                         >
                           <SortableSection gripClassName={SORT_GRIP_CLASS} id={id}>
                             <AdvisorSection showEmptyState={isComingUp} />
+                          </SortableSection>
+                        </div>
+                      )
+                    }
+                    if (id === 'database-health') {
+                      return (
+                        <div
+                          key={id}
+                          className={cn(isComingUp && 'opacity-60 pointer-events-none')}
+                        >
+                          <SortableSection gripClassName={SORT_GRIP_CLASS} id={id}>
+                            <DatabaseHealthSection />
                           </SortableSection>
                         </div>
                       )

--- a/apps/studio/components/interfaces/ProjectHome/Home.utils.test.ts
+++ b/apps/studio/components/interfaces/ProjectHome/Home.utils.test.ts
@@ -4,15 +4,16 @@ import { mergeSectionOrder } from './Home.utils'
 
 describe('mergeSectionOrder', () => {
   it('returns stored order unchanged when it matches defaults', () => {
-    const stored = ['connect', 'usage', 'advisor', 'custom-report']
+    const stored = ['connect', 'usage', 'advisor', 'database-health', 'custom-report']
     expect(mergeSectionOrder(stored)).toBe(stored)
   })
 
   it('inserts missing sections at their default-relative position', () => {
-    expect(mergeSectionOrder(['usage', 'advisor', 'custom-report'])).toEqual([
+    expect(mergeSectionOrder(['usage', 'advisor', 'database-health', 'custom-report'])).toEqual([
       'connect',
       'usage',
       'advisor',
+      'database-health',
       'custom-report',
     ])
   })
@@ -22,22 +23,27 @@ describe('mergeSectionOrder', () => {
       'advisor',
       'connect',
       'usage',
+      'database-health',
       'custom-report',
     ])
   })
 
   it('strips unknown sections from stored order', () => {
-    expect(mergeSectionOrder(['usage', 'deleted-section', 'advisor', 'custom-report'])).toEqual([
-      'connect',
-      'usage',
-      'advisor',
-      'custom-report',
-    ])
+    expect(
+      mergeSectionOrder(['usage', 'deleted-section', 'advisor', 'database-health', 'custom-report'])
+    ).toEqual(['connect', 'usage', 'advisor', 'database-health', 'custom-report'])
   })
 
   it('strips legacy getting-started from stored order', () => {
     expect(
-      mergeSectionOrder(['connect', 'getting-started', 'usage', 'advisor', 'custom-report'])
-    ).toEqual(['connect', 'usage', 'advisor', 'custom-report'])
+      mergeSectionOrder([
+        'connect',
+        'getting-started',
+        'usage',
+        'advisor',
+        'database-health',
+        'custom-report',
+      ])
+    ).toEqual(['connect', 'usage', 'advisor', 'database-health', 'custom-report'])
   })
 })

--- a/apps/studio/components/interfaces/ProjectHome/Home.utils.ts
+++ b/apps/studio/components/interfaces/ProjectHome/Home.utils.ts
@@ -1,4 +1,10 @@
-export const DEFAULT_SECTION_ORDER = ['connect', 'usage', 'advisor', 'custom-report']
+export const DEFAULT_SECTION_ORDER = [
+  'connect',
+  'usage',
+  'advisor',
+  'database-health',
+  'custom-report',
+]
 
 /**
  * Reconciles a stored section order with the canonical list.

--- a/apps/studio/data/database/database-health-query.ts
+++ b/apps/studio/data/database/database-health-query.ts
@@ -1,0 +1,217 @@
+import { literal, safeSql, type SafeSqlFragment } from '@supabase/pg-meta'
+import { useQuery } from '@tanstack/react-query'
+import { z } from 'zod'
+
+import {
+  calculateDatabaseHealth,
+  connectionsMetricsSchema,
+  DATABASE_HEALTH_CONFIG,
+  locksMetricsSchema,
+  performanceMetricsSchema,
+  transactionsMetricsSchema,
+  vacuumMetricsSchema,
+  type DatabaseHealthCategoryId,
+  type DatabaseHealthCollection,
+  type DatabaseHealthResult,
+} from './database-health-score'
+import { databaseKeys } from './keys'
+import { executeSql } from '@/data/sql/execute-sql-mutation'
+import { ResponseError, UseCustomQueryOptions } from '@/types'
+
+/**
+ * Every group runs with its own short statement timeout so a health check can
+ * never become the expensive query on someone's database.
+ */
+const {
+  statementTimeout,
+  idleInTransactionSeconds,
+  longTransactionSeconds,
+  deadTupleRatio,
+  deadTupleMinimumRows,
+  staleStatisticsDays,
+  staleStatisticsMinimumChanges,
+} = DATABASE_HEALTH_CONFIG.metrics
+
+const HEALTH_CHECK_STATEMENT_TIMEOUT = safeSql`set local statement_timeout = ${literal(statementTimeout)};`
+
+const connectionsSql = safeSql`
+  ${HEALTH_CHECK_STATEMENT_TIMEOUT}
+  select
+    (select setting::int from pg_settings where name = 'max_connections') as max_connections,
+    (select count(*)::int from pg_stat_activity) as total_connections,
+    (count(*) filter (
+      where state like 'idle in transaction%'
+        and state_change < now() - make_interval(secs => ${literal(idleInTransactionSeconds)})
+    ))::int as idle_in_transaction_sessions,
+    (count(*) filter (
+      where state <> 'idle'
+        and xact_start < now() - make_interval(secs => ${literal(longTransactionSeconds)})
+    ))::int as long_running_transactions
+  from pg_stat_activity
+  where datname = current_database();
+`
+
+const vacuumSql = safeSql`
+  ${HEALTH_CHECK_STATEMENT_TIMEOUT}
+  select
+    count(*)::int as table_count,
+    (count(*) filter (
+      where t.n_live_tup + t.n_dead_tup >= ${literal(deadTupleMinimumRows)}
+        and t.n_dead_tup::numeric / nullif(t.n_live_tup + t.n_dead_tup, 0) > ${literal(deadTupleRatio)}
+    ))::int as dead_tuple_tables,
+    (count(*) filter (
+      where t.n_dead_tup >
+        current_setting('autovacuum_vacuum_threshold')::numeric
+        + current_setting('autovacuum_vacuum_scale_factor')::numeric * greatest(c.reltuples, 0)::numeric
+    ))::int as tables_past_autovacuum_threshold,
+    (count(*) filter (
+      where t.n_mod_since_analyze >= ${literal(staleStatisticsMinimumChanges)}
+        and coalesce(greatest(t.last_analyze, t.last_autoanalyze), '-infinity'::timestamptz)
+            < now() - make_interval(days => ${literal(staleStatisticsDays)})
+    ))::int as stale_statistics_tables,
+    (count(*) filter (
+      where c.reloptions && array['autovacuum_enabled=false', 'autovacuum_enabled=off']
+    ))::int as autovacuum_disabled_tables
+  from pg_stat_user_tables t
+  join pg_class c on c.oid = t.relid;
+`
+
+const locksSql = safeSql`
+  ${HEALTH_CHECK_STATEMENT_TIMEOUT}
+  select
+    (select count(*)::int from pg_locks where not granted) as ungranted_locks,
+    (count(*) filter (where wait_event_type = 'Lock'))::int as sessions_waiting_on_locks,
+    coalesce(
+      max(extract(epoch from now() - state_change)) filter (where wait_event_type = 'Lock'),
+      0
+    )::int as longest_lock_wait_seconds
+  from pg_stat_activity
+  where datname = current_database();
+`
+
+const transactionsSql = safeSql`
+  ${HEALTH_CHECK_STATEMENT_TIMEOUT}
+  select
+    (select max(age(datfrozenxid))::bigint from pg_database) as max_database_xid_age,
+    (
+      select coalesce(max(age(relfrozenxid)), 0)::bigint
+      from pg_class
+      where relkind in ('r', 'm', 't') and relfrozenxid <> 0
+    ) as max_relation_xid_age,
+    (select setting from pg_settings where name = 'autovacuum') as autovacuum,
+    (select setting from pg_settings where name = 'track_counts') as track_counts,
+    (
+      select setting::bigint
+      from pg_settings
+      where name = 'autovacuum_freeze_max_age'
+    ) as autovacuum_freeze_max_age,
+    (
+      select coalesce(max(extract(epoch from now() - xact_start)), 0)::int
+      from pg_stat_activity
+      where state <> 'idle' and xact_start is not null
+    ) as oldest_transaction_seconds;
+`
+
+const performanceSql = safeSql`
+  ${HEALTH_CHECK_STATEMENT_TIMEOUT}
+  select
+    (
+      select sum(blks_hit)::numeric / nullif(sum(blks_hit + blks_read), 0)
+      from pg_stat_database
+      where datname = current_database()
+    )::float8 as cache_hit_ratio,
+    (
+      select coalesce(sum(blks_hit + blks_read), 0)::bigint
+      from pg_stat_database
+      where datname = current_database()
+    ) as total_blocks_accessed,
+    (select setting from pg_settings where name = 'track_io_timing') as track_io_timing,
+    (
+      select sum(n_tup_hot_upd)::numeric / nullif(sum(n_tup_upd), 0)
+      from pg_stat_user_tables
+    )::float8 as hot_update_ratio,
+    (select coalesce(sum(n_tup_upd), 0)::bigint from pg_stat_user_tables) as total_updates;
+`
+
+const HEALTH_CHECK_GROUPS = [
+  { id: 'connections', sql: connectionsSql, schema: connectionsMetricsSchema },
+  { id: 'vacuum', sql: vacuumSql, schema: vacuumMetricsSchema },
+  { id: 'locks', sql: locksSql, schema: locksMetricsSchema },
+  { id: 'transactions', sql: transactionsSql, schema: transactionsMetricsSchema },
+  { id: 'performance', sql: performanceSql, schema: performanceMetricsSchema },
+] satisfies { id: DatabaseHealthCategoryId; sql: SafeSqlFragment; schema: z.ZodTypeAny }[]
+
+export type DatabaseHealthVariables = {
+  projectRef?: string
+  connectionString?: string | null
+}
+
+async function collectHealthGroup(
+  group: (typeof HEALTH_CHECK_GROUPS)[number],
+  { projectRef, connectionString }: DatabaseHealthVariables,
+  signal?: AbortSignal
+) {
+  const { result } = await executeSql(
+    {
+      projectRef,
+      connectionString,
+      sql: group.sql,
+      queryKey: ['database-health', group.id],
+      handleError: (error) => {
+        throw error
+      },
+    },
+    signal
+  )
+
+  const parsed = group.schema.safeParse(result?.[0])
+  if (!parsed.success) throw new Error(`Unexpected shape for ${group.id} metrics`)
+
+  return parsed.data
+}
+
+export async function getDatabaseHealth(
+  variables: DatabaseHealthVariables,
+  signal?: AbortSignal
+): Promise<{ result: DatabaseHealthResult; collectedAt: string }> {
+  const outcomes = await Promise.allSettled(
+    HEALTH_CHECK_GROUPS.map((group) => collectHealthGroup(group, variables, signal))
+  )
+
+  const collection = Object.fromEntries(
+    HEALTH_CHECK_GROUPS.map((group, index) => {
+      const outcome = outcomes[index]
+      if (outcome.status === 'fulfilled') {
+        return [group.id, { status: 'collected', metrics: outcome.value }]
+      }
+      return [
+        group.id,
+        {
+          status: 'unavailable',
+          error: outcome.reason instanceof Error ? outcome.reason.message : 'Query failed',
+        },
+      ]
+    })
+  ) as DatabaseHealthCollection
+
+  return { result: calculateDatabaseHealth(collection), collectedAt: new Date().toISOString() }
+}
+
+export type DatabaseHealthData = Awaited<ReturnType<typeof getDatabaseHealth>>
+export type DatabaseHealthError = ResponseError
+
+export const useDatabaseHealthQuery = <TData = DatabaseHealthData,>(
+  { projectRef, connectionString }: DatabaseHealthVariables,
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<DatabaseHealthData, DatabaseHealthError, TData> = {}
+) =>
+  useQuery<DatabaseHealthData, DatabaseHealthError, TData>({
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps -- connection string doesn't change the result of the query
+    queryKey: databaseKeys.databaseHealth(projectRef),
+    queryFn: ({ signal }) => getDatabaseHealth({ projectRef, connectionString }, signal),
+    enabled: enabled && typeof projectRef !== 'undefined',
+    staleTime: 60 * 1000,
+    ...options,
+  })

--- a/apps/studio/data/database/database-health-query.ts
+++ b/apps/studio/data/database/database-health-query.ts
@@ -200,7 +200,7 @@ export async function getDatabaseHealth(
 export type DatabaseHealthData = Awaited<ReturnType<typeof getDatabaseHealth>>
 export type DatabaseHealthError = ResponseError
 
-export const useDatabaseHealthQuery = <TData = DatabaseHealthData,>(
+export const useDatabaseHealthQuery = <TData = DatabaseHealthData>(
   { projectRef, connectionString }: DatabaseHealthVariables,
   {
     enabled = true,

--- a/apps/studio/data/database/database-health-score.test.ts
+++ b/apps/studio/data/database/database-health-score.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  calculateDatabaseHealth,
+  DATABASE_HEALTH_CONFIG,
+  type DatabaseHealthCollection,
+  type TransactionsMetrics,
+} from './database-health-score'
+
+const healthyTransactionsMetrics = {
+  max_database_xid_age: 1_000_000,
+  max_relation_xid_age: 1_000_000,
+  autovacuum: 'on',
+  track_counts: 'on',
+  autovacuum_freeze_max_age: 200_000_000,
+  oldest_transaction_seconds: 2,
+} satisfies TransactionsMetrics
+
+const healthyCollection = (): DatabaseHealthCollection => ({
+  connections: {
+    status: 'collected',
+    metrics: {
+      max_connections: 100,
+      total_connections: 10,
+      idle_in_transaction_sessions: 0,
+      long_running_transactions: 0,
+    },
+  },
+  vacuum: {
+    status: 'collected',
+    metrics: {
+      table_count: 20,
+      dead_tuple_tables: 0,
+      tables_past_autovacuum_threshold: 0,
+      stale_statistics_tables: 0,
+      autovacuum_disabled_tables: 0,
+    },
+  },
+  locks: {
+    status: 'collected',
+    metrics: { sessions_waiting_on_locks: 0, ungranted_locks: 0, longest_lock_wait_seconds: 0 },
+  },
+  transactions: { status: 'collected', metrics: healthyTransactionsMetrics },
+  performance: {
+    status: 'collected',
+    metrics: {
+      cache_hit_ratio: 0.999,
+      total_blocks_accessed: 5_000_000,
+      track_io_timing: 'on',
+      hot_update_ratio: 0.8,
+      total_updates: 100_000,
+    },
+  },
+})
+
+describe('calculateDatabaseHealth', () => {
+  it('scores a healthy database at 100 with no findings', () => {
+    const result = calculateDatabaseHealth(healthyCollection())
+
+    expect(result.score).toBe(100)
+    expect(result.status).toBe('healthy')
+    expect(result.findings).toEqual([])
+  })
+
+  it('deducts per-table penalties up to the configured maximum', () => {
+    const collection = healthyCollection()
+    collection.vacuum = {
+      status: 'collected',
+      metrics: {
+        table_count: 100,
+        dead_tuple_tables: 100,
+        tables_past_autovacuum_threshold: 0,
+        stale_statistics_tables: 0,
+        autovacuum_disabled_tables: 0,
+      },
+    }
+
+    const result = calculateDatabaseHealth(collection)
+    const finding = result.findings.find((f) => f.id === 'dead-tuples')
+
+    expect(finding?.deduction).toBe(DATABASE_HEALTH_CONFIG.vacuum.deadTuples.maxDeduction)
+    expect(result.score).toBeLessThan(100)
+  })
+
+  it('caps the score at 30 when autovacuum is off', () => {
+    const collection = healthyCollection()
+    collection.transactions = {
+      status: 'collected',
+      metrics: { ...healthyTransactionsMetrics, autovacuum: 'off' },
+    }
+
+    const result = calculateDatabaseHealth(collection)
+
+    expect(result.score).toBeLessThanOrEqual(DATABASE_HEALTH_CONFIG.criticalScoreCap)
+    expect(result.status).toBe('critical')
+    expect(result.criticalConditions).toContain('Autovacuum is disabled')
+  })
+
+  it('caps the score at 30 when XID age reaches the failsafe threshold', () => {
+    const collection = healthyCollection()
+    collection.transactions = {
+      status: 'collected',
+      metrics: {
+        ...healthyTransactionsMetrics,
+        max_relation_xid_age: DATABASE_HEALTH_CONFIG.transactions.failsafeXidAge,
+      },
+    }
+
+    const result = calculateDatabaseHealth(collection)
+
+    expect(result.score).toBeLessThanOrEqual(DATABASE_HEALTH_CONFIG.criticalScoreCap)
+    expect(result.criticalConditions).toContain('Transaction ID wraparound is imminent')
+  })
+
+  it('excludes unavailable categories from the weighted average instead of scoring them', () => {
+    const collection = healthyCollection()
+    collection.locks = { status: 'unavailable', error: 'canceling statement due to timeout' }
+    collection.performance = { status: 'unavailable', error: 'permission denied' }
+
+    const result = calculateDatabaseHealth(collection)
+
+    expect(result.score).toBe(100)
+    expect(result.categories.filter((c) => c.status === 'unavailable')).toHaveLength(2)
+  })
+
+  it('reports unavailable when no category could be collected', () => {
+    const result = calculateDatabaseHealth({
+      connections: { status: 'unavailable', error: 'failed' },
+      vacuum: { status: 'unavailable', error: 'failed' },
+      locks: { status: 'unavailable', error: 'failed' },
+      transactions: { status: 'unavailable', error: 'failed' },
+      performance: { status: 'unavailable', error: 'failed' },
+    })
+
+    expect(result.score).toBeNull()
+    expect(result.status).toBe('unavailable')
+  })
+
+  it('skips checks with insufficient data rather than passing them', () => {
+    const collection = healthyCollection()
+    collection.performance = {
+      status: 'collected',
+      metrics: {
+        cache_hit_ratio: null,
+        total_blocks_accessed: 0,
+        track_io_timing: 'on',
+        hot_update_ratio: null,
+        total_updates: 0,
+      },
+    }
+
+    const result = calculateDatabaseHealth(collection)
+
+    expect(result.skippedChecks.map((check) => check.id)).toEqual([
+      'cache-hit-ratio',
+      'hot-update-ratio',
+    ])
+    expect(result.findings).toEqual([])
+  })
+
+  it('sorts findings by severity then deduction', () => {
+    const collection = healthyCollection()
+    collection.performance = {
+      status: 'collected',
+      metrics: {
+        cache_hit_ratio: 0.5,
+        total_blocks_accessed: 5_000_000,
+        track_io_timing: 'off',
+        hot_update_ratio: 0.8,
+        total_updates: 100_000,
+      },
+    }
+
+    const result = calculateDatabaseHealth(collection)
+
+    expect(result.findings.map((finding) => finding.severity)).toEqual(['high', 'low'])
+  })
+})

--- a/apps/studio/data/database/database-health-score.ts
+++ b/apps/studio/data/database/database-health-score.ts
@@ -1,0 +1,644 @@
+import { z } from 'zod'
+
+/**
+ * Point-in-time database health score, derived only from live PostgreSQL
+ * statistics. Every threshold and penalty lives in DATABASE_HEALTH_CONFIG so it
+ * can be reviewed and calibrated without touching the check logic.
+ */
+export const DATABASE_HEALTH_CONFIG = {
+  status: { healthy: 80, needsAttention: 50 },
+  /** Thresholds baked into the diagnostic queries themselves. */
+  metrics: {
+    statementTimeout: '5s',
+    idleInTransactionSeconds: 30,
+    longTransactionSeconds: 300,
+    deadTupleRatio: 0.2,
+    deadTupleMinimumRows: 1000,
+    staleStatisticsDays: 7,
+    staleStatisticsMinimumChanges: 1000,
+  },
+  criticalScoreCap: 30,
+  categories: {
+    connections: { label: 'Connections', weight: 20 },
+    vacuum: { label: 'Vacuum and table health', weight: 25 },
+    locks: { label: 'Locks', weight: 15 },
+    transactions: { label: 'Transaction safety', weight: 20 },
+    performance: { label: 'Performance', weight: 20 },
+  },
+  connections: {
+    usage: { warningRatio: 0.7, warningDeduction: 12, criticalRatio: 0.9, criticalDeduction: 35 },
+    idleInTransaction: { deductionPerSession: 6, maxDeduction: 24 },
+    longRunningTransactions: { deductionPerSession: 10, maxDeduction: 30 },
+  },
+  vacuum: {
+    deadTuples: { deductionPerTable: 5, maxDeduction: 30 },
+    pastAutovacuumThreshold: { deductionPerTable: 3, maxDeduction: 18 },
+    staleStatistics: { deductionPerTable: 3, maxDeduction: 15 },
+    autovacuumDisabled: { deductionPerTable: 12, maxDeduction: 36 },
+  },
+  locks: {
+    waitingSessions: { deductionPerSession: 10, maxDeduction: 30 },
+    ungrantedLocks: { deductionPerLock: 6, maxDeduction: 24 },
+    longWait: { seconds: 30, deduction: 25 },
+  },
+  transactions: {
+    xidAge: { warningDeduction: 25, criticalDeduction: 100 },
+    failsafeXidAge: 1_600_000_000,
+    mvccHorizon: { seconds: 600, deduction: 20 },
+  },
+  performance: {
+    cacheHit: {
+      minimumBlocks: 10_000,
+      warningRatio: 0.99,
+      warningDeduction: 12,
+      criticalRatio: 0.9,
+      criticalDeduction: 35,
+    },
+    trackIoTiming: { deduction: 5 },
+    hotUpdates: { minimumUpdates: 1_000, warningRatio: 0.3, deduction: 15 },
+  },
+} as const
+
+const onOff = z.enum(['on', 'off'])
+const count = z.coerce.number()
+const optionalRatio = z.coerce.number().nullable()
+
+export const connectionsMetricsSchema = z.object({
+  max_connections: count,
+  total_connections: count,
+  idle_in_transaction_sessions: count,
+  long_running_transactions: count,
+})
+
+export const vacuumMetricsSchema = z.object({
+  table_count: count,
+  dead_tuple_tables: count,
+  tables_past_autovacuum_threshold: count,
+  stale_statistics_tables: count,
+  autovacuum_disabled_tables: count,
+})
+
+export const locksMetricsSchema = z.object({
+  sessions_waiting_on_locks: count,
+  ungranted_locks: count,
+  longest_lock_wait_seconds: count,
+})
+
+export const transactionsMetricsSchema = z.object({
+  max_database_xid_age: count,
+  max_relation_xid_age: count,
+  autovacuum: onOff,
+  track_counts: onOff,
+  autovacuum_freeze_max_age: count,
+  oldest_transaction_seconds: count,
+})
+
+export const performanceMetricsSchema = z.object({
+  cache_hit_ratio: optionalRatio,
+  total_blocks_accessed: count,
+  track_io_timing: onOff,
+  hot_update_ratio: optionalRatio,
+  total_updates: count,
+})
+
+export type ConnectionsMetrics = z.infer<typeof connectionsMetricsSchema>
+export type VacuumMetrics = z.infer<typeof vacuumMetricsSchema>
+export type LocksMetrics = z.infer<typeof locksMetricsSchema>
+export type TransactionsMetrics = z.infer<typeof transactionsMetricsSchema>
+export type PerformanceMetrics = z.infer<typeof performanceMetricsSchema>
+
+export type DatabaseHealthCategoryId = keyof typeof DATABASE_HEALTH_CONFIG.categories
+
+export type DatabaseHealthMetricsByCategory = {
+  connections: ConnectionsMetrics
+  vacuum: VacuumMetrics
+  locks: LocksMetrics
+  transactions: TransactionsMetrics
+  performance: PerformanceMetrics
+}
+
+export type DatabaseHealthCollection = {
+  [Id in DatabaseHealthCategoryId]:
+    | { status: 'collected'; metrics: DatabaseHealthMetricsByCategory[Id] }
+    | { status: 'unavailable'; error: string }
+}
+
+export type DatabaseHealthSeverity = 'low' | 'medium' | 'high'
+
+export type DatabaseHealthFinding = {
+  id: string
+  category: DatabaseHealthCategoryId
+  severity: DatabaseHealthSeverity
+  title: string
+  description: string
+  deduction: number
+  action: string
+}
+
+export type DatabaseHealthSkippedCheck = { id: string; reason: string }
+
+export type DatabaseHealthCategory = {
+  id: DatabaseHealthCategoryId
+  label: string
+  weight: number
+} & (
+  | {
+      status: 'collected'
+      score: number
+      findings: DatabaseHealthFinding[]
+      skippedChecks: DatabaseHealthSkippedCheck[]
+    }
+  | { status: 'unavailable'; error: string }
+)
+
+export type DatabaseHealthResult = {
+  score: number | null
+  status: 'healthy' | 'needs_attention' | 'critical' | 'unavailable'
+  categories: DatabaseHealthCategory[]
+  findings: DatabaseHealthFinding[]
+  criticalConditions: string[]
+  skippedChecks: DatabaseHealthSkippedCheck[]
+}
+
+type CheckFinding = Omit<DatabaseHealthFinding, 'id' | 'category'>
+
+type CheckOutcome =
+  | { status: 'passed' }
+  | { status: 'insufficient_data'; reason: string }
+  | { status: 'failed'; finding: CheckFinding }
+
+type Check<TMetrics> = { id: string; run: (metrics: TMetrics) => CheckOutcome }
+
+const passed: CheckOutcome = { status: 'passed' }
+
+const insufficientData = (reason: string): CheckOutcome => ({ status: 'insufficient_data', reason })
+
+const failed = (finding: CheckFinding): CheckOutcome => ({ status: 'failed', finding })
+
+const cappedDeduction = (count: number, perItem: number, maxDeduction: number) =>
+  Math.min(count * perItem, maxDeduction)
+
+const pluralize = (count: number, singular: string, plural: string) =>
+  `${count} ${count === 1 ? singular : plural}`
+
+const asPercentage = (ratio: number) => `${(ratio * 100).toFixed(1)}%`
+
+const connectionsChecks: Check<ConnectionsMetrics>[] = [
+  {
+    id: 'connection-usage',
+    run: ({ total_connections, max_connections }) => {
+      if (max_connections === 0) return insufficientData('max_connections reported as 0')
+
+      const { usage } = DATABASE_HEALTH_CONFIG.connections
+      const ratio = total_connections / max_connections
+      if (ratio < usage.warningRatio) return passed
+
+      const isCritical = ratio >= usage.criticalRatio
+      return failed({
+        severity: isCritical ? 'high' : 'medium',
+        title: 'Connection pool is close to its limit',
+        description: `${total_connections} of ${max_connections} connections are in use (${asPercentage(ratio)}). New connections are refused once the limit is reached.`,
+        deduction: isCritical ? usage.criticalDeduction : usage.warningDeduction,
+        action: 'Route clients through a connection pooler or reduce your pool size',
+      })
+    },
+  },
+  {
+    id: 'idle-in-transaction',
+    run: ({ idle_in_transaction_sessions }) => {
+      if (idle_in_transaction_sessions === 0) return passed
+
+      const { idleInTransaction } = DATABASE_HEALTH_CONFIG.connections
+      return failed({
+        severity: 'medium',
+        title: 'Sessions are idle in transaction',
+        description: `${pluralize(idle_in_transaction_sessions, 'session has', 'sessions have')} been idle in a transaction for over 30 seconds. These sessions hold locks and block vacuum.`,
+        deduction: cappedDeduction(
+          idle_in_transaction_sessions,
+          idleInTransaction.deductionPerSession,
+          idleInTransaction.maxDeduction
+        ),
+        action: 'Find the idle sessions and commit or roll back their transactions',
+      })
+    },
+  },
+  {
+    id: 'long-running-transactions',
+    run: ({ long_running_transactions }) => {
+      if (long_running_transactions === 0) return passed
+
+      const { longRunningTransactions } = DATABASE_HEALTH_CONFIG.connections
+      return failed({
+        severity: 'medium',
+        title: 'Transactions have been running for over 5 minutes',
+        description: `${pluralize(long_running_transactions, 'transaction has', 'transactions have')} been open for more than 5 minutes.`,
+        deduction: cappedDeduction(
+          long_running_transactions,
+          longRunningTransactions.deductionPerSession,
+          longRunningTransactions.maxDeduction
+        ),
+        action: 'Review the long-running queries and add a statement timeout',
+      })
+    },
+  },
+]
+
+const vacuumChecks: Check<VacuumMetrics>[] = [
+  {
+    id: 'dead-tuples',
+    run: ({ table_count, dead_tuple_tables }) => {
+      if (table_count === 0) return insufficientData('No user tables to inspect')
+      if (dead_tuple_tables === 0) return passed
+
+      const { deadTuples } = DATABASE_HEALTH_CONFIG.vacuum
+      return failed({
+        severity: 'medium',
+        title: 'Tables are carrying too many dead rows',
+        description: `${pluralize(dead_tuple_tables, 'table has', 'tables have')} more than 20% dead rows. Dead rows slow down scans and waste disk.`,
+        deduction: cappedDeduction(
+          dead_tuple_tables,
+          deadTuples.deductionPerTable,
+          deadTuples.maxDeduction
+        ),
+        action: 'Run VACUUM on the affected tables',
+      })
+    },
+  },
+  {
+    id: 'past-autovacuum-threshold',
+    run: ({ table_count, tables_past_autovacuum_threshold }) => {
+      if (table_count === 0) return insufficientData('No user tables to inspect')
+      if (tables_past_autovacuum_threshold === 0) return passed
+
+      const { pastAutovacuumThreshold } = DATABASE_HEALTH_CONFIG.vacuum
+      return failed({
+        severity: 'medium',
+        title: 'Autovacuum is falling behind',
+        description: `${pluralize(tables_past_autovacuum_threshold, 'table has', 'tables have')} accumulated more dead rows than their autovacuum trigger.`,
+        deduction: cappedDeduction(
+          tables_past_autovacuum_threshold,
+          pastAutovacuumThreshold.deductionPerTable,
+          pastAutovacuumThreshold.maxDeduction
+        ),
+        action: 'Lower autovacuum_vacuum_scale_factor or vacuum the tables manually',
+      })
+    },
+  },
+  {
+    id: 'stale-statistics',
+    run: ({ table_count, stale_statistics_tables }) => {
+      if (table_count === 0) return insufficientData('No user tables to inspect')
+      if (stale_statistics_tables === 0) return passed
+
+      const { staleStatistics } = DATABASE_HEALTH_CONFIG.vacuum
+      return failed({
+        severity: 'low',
+        title: 'Planner statistics are stale',
+        description: `${pluralize(stale_statistics_tables, 'table has', 'tables have')} changed a lot since the last ANALYZE. The planner picks worse plans with stale statistics.`,
+        deduction: cappedDeduction(
+          stale_statistics_tables,
+          staleStatistics.deductionPerTable,
+          staleStatistics.maxDeduction
+        ),
+        action: 'Run ANALYZE on the affected tables',
+      })
+    },
+  },
+  {
+    id: 'autovacuum-disabled-tables',
+    run: ({ autovacuum_disabled_tables }) => {
+      if (autovacuum_disabled_tables === 0) return passed
+
+      const { autovacuumDisabled } = DATABASE_HEALTH_CONFIG.vacuum
+      return failed({
+        severity: 'high',
+        title: 'Autovacuum is disabled on some tables',
+        description: `${pluralize(autovacuum_disabled_tables, 'table has', 'tables have')} autovacuum_enabled set to false. These tables never get vacuumed automatically.`,
+        deduction: cappedDeduction(
+          autovacuum_disabled_tables,
+          autovacuumDisabled.deductionPerTable,
+          autovacuumDisabled.maxDeduction
+        ),
+        action: 'Re-enable autovacuum on the affected tables',
+      })
+    },
+  },
+]
+
+const locksChecks: Check<LocksMetrics>[] = [
+  {
+    id: 'sessions-waiting-on-locks',
+    run: ({ sessions_waiting_on_locks }) => {
+      if (sessions_waiting_on_locks === 0) return passed
+
+      const { waitingSessions } = DATABASE_HEALTH_CONFIG.locks
+      return failed({
+        severity: 'medium',
+        title: 'Sessions are waiting on locks',
+        description: `${pluralize(sessions_waiting_on_locks, 'session is', 'sessions are')} blocked waiting for a lock.`,
+        deduction: cappedDeduction(
+          sessions_waiting_on_locks,
+          waitingSessions.deductionPerSession,
+          waitingSessions.maxDeduction
+        ),
+        action: 'Identify the blocking session and end it if it is stuck',
+      })
+    },
+  },
+  {
+    id: 'ungranted-locks',
+    run: ({ ungranted_locks }) => {
+      if (ungranted_locks === 0) return passed
+
+      const { ungrantedLocks } = DATABASE_HEALTH_CONFIG.locks
+      return failed({
+        severity: 'medium',
+        title: 'Lock requests have not been granted',
+        description: `${pluralize(ungranted_locks, 'lock request is', 'lock requests are')} still pending. Pending locks queue behind each other and stall writes.`,
+        deduction: cappedDeduction(
+          ungranted_locks,
+          ungrantedLocks.deductionPerLock,
+          ungrantedLocks.maxDeduction
+        ),
+        action: 'Review the lock queue and retry the blocked statements',
+      })
+    },
+  },
+  {
+    id: 'long-lock-wait',
+    run: ({ longest_lock_wait_seconds }) => {
+      const { longWait } = DATABASE_HEALTH_CONFIG.locks
+      if (longest_lock_wait_seconds < longWait.seconds) return passed
+
+      return failed({
+        severity: 'high',
+        title: 'A session has been waiting on a lock for too long',
+        description: `The longest lock wait is ${Math.round(longest_lock_wait_seconds)} seconds. Waits this long usually mean a transaction is stuck.`,
+        deduction: longWait.deduction,
+        action: 'End the blocking transaction to release the lock',
+      })
+    },
+  },
+]
+
+const transactionsChecks: Check<TransactionsMetrics>[] = [
+  {
+    id: 'xid-age',
+    run: ({ max_database_xid_age, max_relation_xid_age, autovacuum_freeze_max_age }) => {
+      const { xidAge, failsafeXidAge } = DATABASE_HEALTH_CONFIG.transactions
+      const age = Math.max(max_database_xid_age, max_relation_xid_age)
+
+      if (age >= failsafeXidAge) {
+        return failed({
+          severity: 'high',
+          title: 'Transaction ID wraparound is imminent',
+          description: `The oldest transaction ID is ${age.toLocaleString()} transactions old, past the ${failsafeXidAge.toLocaleString()} failsafe. PostgreSQL stops accepting writes near 2 billion.`,
+          deduction: xidAge.criticalDeduction,
+          action: 'Run VACUUM FREEZE on the oldest tables now',
+        })
+      }
+
+      if (autovacuum_freeze_max_age === 0) {
+        return insufficientData('autovacuum_freeze_max_age reported as 0')
+      }
+
+      if (age < autovacuum_freeze_max_age) return passed
+
+      return failed({
+        severity: 'high',
+        title: 'Transaction ID age is past the freeze threshold',
+        description: `The oldest transaction ID is ${age.toLocaleString()} transactions old, past autovacuum_freeze_max_age of ${autovacuum_freeze_max_age.toLocaleString()}.`,
+        deduction: xidAge.warningDeduction,
+        action: 'Let the anti-wraparound vacuum finish, or run VACUUM FREEZE',
+      })
+    },
+  },
+  {
+    id: 'autovacuum-disabled',
+    run: ({ autovacuum }) => {
+      if (autovacuum === 'on') return passed
+
+      return failed({
+        severity: 'high',
+        title: 'Autovacuum is disabled',
+        description:
+          'Autovacuum is off for the whole database. Dead rows and transaction IDs accumulate until the database stops accepting writes.',
+        deduction: 100,
+        action: 'Set autovacuum back to on',
+      })
+    },
+  },
+  {
+    id: 'track-counts-disabled',
+    run: ({ track_counts }) => {
+      if (track_counts === 'on') return passed
+
+      return failed({
+        severity: 'high',
+        title: 'Statistics collection is disabled',
+        description:
+          'track_counts is off, so PostgreSQL cannot see which tables need vacuuming. Autovacuum stops working correctly.',
+        deduction: 100,
+        action: 'Set track_counts back to on',
+      })
+    },
+  },
+  {
+    id: 'mvcc-horizon',
+    run: ({ oldest_transaction_seconds }) => {
+      const { mvccHorizon } = DATABASE_HEALTH_CONFIG.transactions
+      if (oldest_transaction_seconds < mvccHorizon.seconds) return passed
+
+      return failed({
+        severity: 'medium',
+        title: 'An old transaction is holding back cleanup',
+        description: `The oldest open transaction started ${Math.round(oldest_transaction_seconds / 60)} minutes ago. Vacuum cannot remove rows newer than it.`,
+        deduction: mvccHorizon.deduction,
+        action: 'End the oldest transaction so vacuum can reclaim space',
+      })
+    },
+  },
+]
+
+const performanceChecks: Check<PerformanceMetrics>[] = [
+  {
+    id: 'cache-hit-ratio',
+    run: ({ cache_hit_ratio, total_blocks_accessed }) => {
+      const { cacheHit } = DATABASE_HEALTH_CONFIG.performance
+      if (cache_hit_ratio === null || total_blocks_accessed < cacheHit.minimumBlocks) {
+        return insufficientData(
+          `Fewer than ${cacheHit.minimumBlocks.toLocaleString()} blocks read since the last statistics reset`
+        )
+      }
+      if (cache_hit_ratio >= cacheHit.warningRatio) return passed
+
+      const isCritical = cache_hit_ratio < cacheHit.criticalRatio
+      return failed({
+        severity: isCritical ? 'high' : 'medium',
+        title: 'Cache hit ratio is low',
+        description: `${asPercentage(cache_hit_ratio)} of block reads are served from cache. Reads that miss cache go to disk.`,
+        deduction: isCritical ? cacheHit.criticalDeduction : cacheHit.warningDeduction,
+        action: 'Add indexes for the heaviest queries, or move to a larger compute add-on',
+      })
+    },
+  },
+  {
+    id: 'track-io-timing',
+    run: ({ track_io_timing }) => {
+      if (track_io_timing === 'on') return passed
+
+      return failed({
+        severity: 'low',
+        title: 'I/O timing is not tracked',
+        description:
+          'track_io_timing is off, so query plans and pg_stat_statements cannot show time spent reading from disk.',
+        deduction: DATABASE_HEALTH_CONFIG.performance.trackIoTiming.deduction,
+        action: 'Set track_io_timing to on',
+      })
+    },
+  },
+  {
+    id: 'hot-update-ratio',
+    run: ({ hot_update_ratio, total_updates }) => {
+      const { hotUpdates } = DATABASE_HEALTH_CONFIG.performance
+      if (hot_update_ratio === null || total_updates < hotUpdates.minimumUpdates) {
+        return insufficientData(
+          `Fewer than ${hotUpdates.minimumUpdates.toLocaleString()} updates since the last statistics reset`
+        )
+      }
+      if (hot_update_ratio >= hotUpdates.warningRatio) return passed
+
+      return failed({
+        severity: 'low',
+        title: 'Few updates are heap-only',
+        description: `Only ${asPercentage(hot_update_ratio)} of updates avoid rewriting index entries. Every other update writes to every index on the table.`,
+        deduction: hotUpdates.deduction,
+        action: 'Drop unused indexes on frequently updated tables',
+      })
+    },
+  },
+]
+
+const CHECKS_BY_CATEGORY = {
+  connections: connectionsChecks,
+  vacuum: vacuumChecks,
+  locks: locksChecks,
+  transactions: transactionsChecks,
+  performance: performanceChecks,
+}
+
+const CRITICAL_CHECK_IDS = new Set(['autovacuum-disabled', 'track-counts-disabled'])
+
+function evaluateCategory<Id extends DatabaseHealthCategoryId>(
+  id: Id,
+  metrics: DatabaseHealthMetricsByCategory[Id]
+) {
+  const findings: DatabaseHealthFinding[] = []
+  const skippedChecks: DatabaseHealthSkippedCheck[] = []
+
+  const checks = CHECKS_BY_CATEGORY[id] as Check<DatabaseHealthMetricsByCategory[Id]>[]
+  for (const check of checks) {
+    const outcome = check.run(metrics)
+    if (outcome.status === 'failed') {
+      findings.push({ id: check.id, category: id, ...outcome.finding })
+    }
+    if (outcome.status === 'insufficient_data') {
+      skippedChecks.push({ id: check.id, reason: outcome.reason })
+    }
+  }
+
+  const totalDeduction = findings.reduce((total, finding) => total + finding.deduction, 0)
+
+  return { score: Math.max(0, 100 - totalDeduction), findings, skippedChecks }
+}
+
+const SEVERITY_ORDER: Record<DatabaseHealthSeverity, number> = { high: 0, medium: 1, low: 2 }
+
+export function calculateDatabaseHealth(
+  collection: DatabaseHealthCollection
+): DatabaseHealthResult {
+  const categoryIds = Object.keys(DATABASE_HEALTH_CONFIG.categories) as DatabaseHealthCategoryId[]
+
+  const categories = categoryIds.map((id): DatabaseHealthCategory => {
+    const { label, weight } = DATABASE_HEALTH_CONFIG.categories[id]
+    const collected = collection[id]
+
+    if (collected.status === 'unavailable') {
+      return { id, label, weight, status: 'unavailable', error: collected.error }
+    }
+
+    return { id, label, weight, status: 'collected', ...evaluateCategory(id, collected.metrics) }
+  })
+
+  const collectedCategories = categories.filter((category) => category.status === 'collected')
+
+  const findings = collectedCategories
+    .flatMap((category) => category.findings)
+    .sort(
+      (a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity] || b.deduction - a.deduction
+    )
+
+  const criticalConditions = findings
+    .filter((finding) => CRITICAL_CHECK_IDS.has(finding.id))
+    .map((finding) => finding.title)
+
+  const transactionsCategory = categories.find((category) => category.id === 'transactions')
+  const hasFailsafeXidAge =
+    transactionsCategory?.status === 'collected' &&
+    collection.transactions.status === 'collected' &&
+    Math.max(
+      collection.transactions.metrics.max_database_xid_age,
+      collection.transactions.metrics.max_relation_xid_age
+    ) >= DATABASE_HEALTH_CONFIG.transactions.failsafeXidAge
+  if (hasFailsafeXidAge) criticalConditions.push('Transaction ID wraparound is imminent')
+
+  const skippedChecks = collectedCategories.flatMap((category) => category.skippedChecks)
+
+  if (collectedCategories.length === 0) {
+    return {
+      score: null,
+      status: 'unavailable',
+      categories,
+      findings,
+      criticalConditions,
+      skippedChecks,
+    }
+  }
+
+  const totalWeight = collectedCategories.reduce((total, category) => total + category.weight, 0)
+  const weightedScore = collectedCategories.reduce(
+    (total, category) => total + category.score * category.weight,
+    0
+  )
+
+  const score =
+    criticalConditions.length > 0
+      ? Math.min(Math.round(weightedScore / totalWeight), DATABASE_HEALTH_CONFIG.criticalScoreCap)
+      : Math.round(weightedScore / totalWeight)
+
+  return {
+    score,
+    status: getDatabaseHealthStatus(score, criticalConditions),
+    categories,
+    findings,
+    criticalConditions,
+    skippedChecks,
+  }
+}
+
+function getDatabaseHealthStatus(
+  score: number,
+  criticalConditions: string[]
+): DatabaseHealthResult['status'] {
+  if (criticalConditions.length > 0) return 'critical'
+  if (score >= DATABASE_HEALTH_CONFIG.status.healthy) return 'healthy'
+  if (score >= DATABASE_HEALTH_CONFIG.status.needsAttention) return 'needs_attention'
+  return 'critical'
+}
+
+export const DATABASE_HEALTH_STATUS_LABELS: Record<DatabaseHealthResult['status'], string> = {
+  healthy: 'Healthy',
+  needs_attention: 'Needs attention',
+  critical: 'Critical',
+  unavailable: 'Unavailable',
+}

--- a/apps/studio/data/database/keys.ts
+++ b/apps/studio/data/database/keys.ts
@@ -49,6 +49,8 @@ export const databaseKeys = {
     ['projects', projectRef, 'database-size'] as const,
   maxConnections: (projectRef: string | undefined) =>
     ['projects', projectRef, 'max-connections'] as const,
+  databaseHealth: (projectRef: string | undefined) =>
+    ['projects', projectRef, 'database-health'] as const,
   pgbouncerStatus: (projectRef: string | undefined) =>
     ['projects', projectRef, 'pgbouncer', 'status'] as const,
   pgbouncerConfig: (projectRef: string | undefined) =>


### PR DESCRIPTION
Prototype exploring whether we can give a useful Postgres health snapshot from live queries alone, with no new monitoring infrastructure. Adds a "Database health" section to the project homepage.

## What it does

- Runs five grouped diagnostic queries in parallel against the selected project (connections, vacuum and table health, locks, transaction safety, performance).
- Each query carries a 5s statement timeout so a health check can't become the expensive query on someone's database.
- Scores 0–100 in the app layer as a weighted average of the categories that were actually collected.
- Shows the overall score and status, per-category scores, and every check that lost points with an explanation and a suggested next step.
- Refresh button re-runs the snapshot. In development, an expandable panel dumps the raw metrics and per-finding deductions.

## Notes for review

- All thresholds, weights, and penalties live in one `DATABASE_HEALTH_CONFIG` object so they're easy to argue with.
- Missing data never counts as healthy: a failed query marks its category unavailable and drops it from the average; a check without enough data is listed as skipped.
- `autovacuum = off`, `track_counts = off`, and XID age past the failsafe threshold cap the score at 30.
- Formula, query sources, and current limitations are written up in `apps/studio/components/interfaces/ProjectHome/DATABASE_HEALTH.md`.
- Queries were verified against a local Postgres 14, including the dead-tuple and disabled-autovacuum branches. Thresholds are not calibrated yet.

Nothing is persisted and no scheduled jobs are added.
