### PR TITLE
fix(studio): use SUPABASE_PUBLISHABLE_KEY in Flask connect panel

### DIFF
--- a/apps/studio/components/interfaces/ConnectSheet/content/flask/supabasepy/content.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/content/flask/supabasepy/content.tsx
@@ -9,7 +9,7 @@ const ContentFile = ({ projectKeys }: StepContentProps) => {
       language: 'bash',
       code: `
 SUPABASE_URL=${projectKeys.apiUrl ?? 'your-project-url'}
-SUPABASE_KEY=${projectKeys.publishableKey ?? projectKeys.anonKey ?? 'your-anon-key'}
+SUPABASE_PUBLISHABLE_KEY=${projectKeys.publishableKey ?? projectKeys.anonKey ?? 'your-anon-key'}
         `,
     },
     {
@@ -27,7 +27,7 @@ app = Flask(__name__)
 
 supabase: Client = create_client(
     os.environ.get("SUPABASE_URL"),
-    os.environ.get("SUPABASE_KEY")
+    os.environ.get("SUPABASE_PUBLISHABLE_KEY")
 )
 
 @app.route('/')


### PR DESCRIPTION
Closes #48826

The Flask quickstart docs tell you to set `SUPABASE_PUBLISHABLE_KEY` in `.env`, but the Connect panel's Flask snippet writes `SUPABASE_KEY` — while populating it from `projectKeys.publishableKey`. Following the docs and then copying from Connect leaves `os.environ.get("SUPABASE_KEY")` unset, and `create_client` raises `SupabaseException: supabase_key is required`.

This aligns the Connect panel snippet with the docs. No behaviour change — the value being emitted is already the publishable key; only the variable name was inconsistent.

Note: `astro`, `nuxt`, `refine`, `tanstack`, `ionicreact` and `exporeactnative` share the same `SUPABASE_KEY` naming in their Connect content. I kept this PR to Flask to match the issue — happy to open a follow-up for the rest if you'd like them aligned too.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Flask connection example to use `SUPABASE_PUBLISHABLE_KEY` in environment configuration and Python client setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->