### PR TITLE
fix(studio): honor POSTGRES_HOST in self-hosted direct connection string

### DIFF
--- a/apps/studio/components/grid/components/header/ExportDialog.tsx
+++ b/apps/studio/components/grid/components/header/ExportDialog.tsx
@@ -22,6 +22,7 @@ import { Filter, Sort, SupaTable } from '@/components/grid/types'
 import { getConnectionStrings } from '@/components/interfaces/Connect/DatabaseSettings.utils'
 import { useReadReplicasQuery } from '@/data/read-replicas/replicas-query'
 import { getAllTableRowsSql } from '@/data/table-rows/table-rows-query'
+import { IS_PLATFORM } from '@/lib/constants'
 import { pluckObjectFields } from '@/lib/helpers'
 import { RoleImpersonationState, wrapWithRoleImpersonation } from '@/lib/role-impersonation'
 import { useRoleImpersonationStateSnapshot } from '@/state/role-impersonation-state'
@@ -52,10 +53,16 @@ export const ExportDialog = ({
   const { data: databases } = useReadReplicasQuery({ projectRef })
   const primaryDatabase = (databases ?? []).find((db) => db.identifier === projectRef)
   const DB_FIELDS = ['db_host', 'db_name', 'db_port', 'db_user', 'inserted_at']
+  // Self-hosted advertises a separate direct-connection host (POSTGRES_HOST);
+  // keep the platform connectionInfo shape untouched.
+  if (!IS_PLATFORM) DB_FIELDS.push('db_host_direct')
   const emptyState = { db_user: '', db_host: '', db_port: '', db_name: '' }
 
   const connectionInfo = pluckObjectFields(primaryDatabase || emptyState, DB_FIELDS)
   const { db_host, db_port, db_user, db_name } = connectionInfo
+  // pg_dump connects directly to Postgres, which the operator can host
+  // elsewhere on self-hosted; db_host stays the gateway host.
+  const directHost = connectionInfo.db_host_direct || db_host
 
   const connectionStrings = getConnectionStrings({
     connectionInfo,
@@ -81,7 +88,7 @@ export const ExportDialog = ({
 ${connectionStrings.direct.psql} -c "COPY (${query}) TO STDOUT WITH CSV HEADER DELIMITER ',';" > ${outputName}.csv`.trim()
 
   const sqlExportCommand = `
-pg_dump -h ${db_host} -p ${db_port} -d ${db_name} -U ${db_user} --table="${table?.schema}.${table?.name}" --data-only --column-inserts > ${outputName}.sql
+pg_dump -h ${directHost} -p ${db_port} -d ${db_name} -U ${db_user} --table="${table?.schema}.${table?.name}" --data-only --column-inserts > ${outputName}.sql
   `.trim()
 
   return (

--- a/apps/studio/components/interfaces/Connect/DatabaseSettings.utils.test.ts
+++ b/apps/studio/components/interfaces/Connect/DatabaseSettings.utils.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'vitest'
+
+import { getConnectionStrings } from './DatabaseSettings.utils'
+
+const baseConnectionInfo = {
+  db_user: 'postgres',
+  db_port: 5432,
+  db_host: 'gateway.example.com',
+  db_name: 'postgres',
+}
+
+const noPooler = { connectionString: '', db_user: '', db_port: 0, db_host: '', db_name: '' }
+
+describe('getConnectionStrings — direct host resolution', () => {
+  test('uses db_host_direct for direct strings when provided', () => {
+    const { direct } = getConnectionStrings({
+      connectionInfo: { ...baseConnectionInfo, db_host_direct: 'mydb.internal' },
+      poolingInfo: noPooler,
+      metadata: {},
+    })
+
+    expect(direct.uri).toBe('postgresql://postgres:[YOUR-PASSWORD]@mydb.internal:5432/postgres')
+    expect(direct.psql).toContain('-h mydb.internal')
+    expect(direct.jdbc).toContain('mydb.internal:5432')
+    // The gateway host must not leak into any direct string
+    expect(direct.uri).not.toContain('gateway.example.com')
+  })
+
+  test('falls back to db_host when db_host_direct is unset', () => {
+    const { direct } = getConnectionStrings({
+      connectionInfo: baseConnectionInfo,
+      poolingInfo: noPooler,
+      metadata: {},
+    })
+
+    expect(direct.uri).toBe(
+      'postgresql://postgres:[YOUR-PASSWORD]@gateway.example.com:5432/postgres'
+    )
+    expect(direct.psql).toContain('-h gateway.example.com')
+  })
+})

--- a/apps/studio/components/interfaces/Connect/DatabaseSettings.utils.ts
+++ b/apps/studio/components/interfaces/Connect/DatabaseSettings.utils.ts
@@ -20,6 +20,9 @@ export const getConnectionStrings = ({
     db_port: number
     db_host: string
     db_name: string
+    // Self-hosted only: direct-connection host, distinct from db_host (the
+    // gateway host used for the pooler). Falls back to db_host when unset.
+    db_host_direct?: string
   }
   poolingInfo?: {
     connectionString: string
@@ -43,7 +46,7 @@ export const getConnectionStrings = ({
   // Direct connection variables
   const directUser = connectionInfo.db_user
   const directPort = connectionInfo.db_port
-  const directHost = connectionInfo.db_host
+  const directHost = connectionInfo.db_host_direct || connectionInfo.db_host
   const directName = connectionInfo.db_name
 
   // Pooler connection variables

--- a/apps/studio/components/interfaces/ConnectSheet/ConnectStepsSection.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/ConnectStepsSection.tsx
@@ -72,10 +72,13 @@ function useConnectionStringPooler(deploymentMode: DeploymentMode): ConnectionSt
   // render and invalidate the final useMemo on each tick (and ripple through
   // every consumer that lists ConnectionStringPooler in their own deps).
   const connectionInfo = useMemo(() => {
-    const DB_FIELDS = ['db_host', 'db_host_direct', 'db_name', 'db_port', 'db_user', 'inserted_at']
+    const DB_FIELDS = ['db_host', 'db_name', 'db_port', 'db_user', 'inserted_at']
+    // Only self-hosted advertises a separate direct-connection host; keep the
+    // platform connectionInfo shape untouched.
+    if (deploymentMode.isSelfHosted) DB_FIELDS.push('db_host_direct')
     const emptyState = { db_user: '', db_host: '', db_port: '', db_name: '' }
     return pluckObjectFields(settings || emptyState, DB_FIELDS)
-  }, [settings])
+  }, [settings, deploymentMode.isSelfHosted])
 
   const poolingConfigurationShared = supavisorConfig?.find((x) => x.database_type === 'PRIMARY')
   const poolingConfigurationDedicated = allowPgBouncerSelection ? pgbouncerConfig : undefined

--- a/apps/studio/components/interfaces/ConnectSheet/ConnectStepsSection.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/ConnectStepsSection.tsx
@@ -72,7 +72,7 @@ function useConnectionStringPooler(deploymentMode: DeploymentMode): ConnectionSt
   // render and invalidate the final useMemo on each tick (and ripple through
   // every consumer that lists ConnectionStringPooler in their own deps).
   const connectionInfo = useMemo(() => {
-    const DB_FIELDS = ['db_host', 'db_name', 'db_port', 'db_user', 'inserted_at']
+    const DB_FIELDS = ['db_host', 'db_host_direct', 'db_name', 'db_port', 'db_user', 'inserted_at']
     const emptyState = { db_user: '', db_host: '', db_port: '', db_name: '' }
     return pluckObjectFields(settings || emptyState, DB_FIELDS)
   }, [settings])

--- a/apps/studio/components/interfaces/ConnectSheet/DatabaseSettings.utils.ts
+++ b/apps/studio/components/interfaces/ConnectSheet/DatabaseSettings.utils.ts
@@ -248,7 +248,7 @@ export const buildConnectionStringPooler = ({
   isHighAvailability,
 }: {
   deploymentMode: DeploymentMode
-  connectionInfo: { db_host: string; db_port: number | string }
+  connectionInfo: { db_host: string; db_port: number | string; db_host_direct?: string }
   connectionStringsShared: { direct: ConnectionStrings; pooler: ConnectionStrings }
   connectionStringsDedicated?: { direct: ConnectionStrings; pooler: ConnectionStrings }
   ipv4Addon: boolean
@@ -257,9 +257,12 @@ export const buildConnectionStringPooler = ({
   if (deploymentMode.isSelfHosted) {
     const dbHost = connectionInfo.db_host
     const dbPort = connectionInfo.db_port || 5432
+    // Pooler (Supavisor) is exposed at the gateway host; the direct connection
+    // points at Postgres itself, which the operator can host elsewhere.
+    const directHost = connectionInfo.db_host_direct || dbHost
     const sessionPool = getSelfHostedPoolerStrings(dbHost, dbPort)
     const transactionPool = getSelfHostedPoolerStrings(dbHost, 6543)
-    const directConn = getSelfHostedDirectStrings(dbHost, dbPort)
+    const directConn = getSelfHostedDirectStrings(directHost, dbPort)
     return {
       transactionShared: transactionPool.uri,
       sessionShared: sessionPool.uri,

--- a/apps/studio/components/interfaces/ConnectSheet/__tests__/DatabaseSettings.utils.test.ts
+++ b/apps/studio/components/interfaces/ConnectSheet/__tests__/DatabaseSettings.utils.test.ts
@@ -167,6 +167,42 @@ describe('buildConnectionStringPooler', () => {
     expect(result.ipv4SupportedForDedicatedPooler).toBe(false)
   })
 
+  test('self-hosted: direct uses db_host_direct while pooler stays on db_host', () => {
+    const result = buildConnectionStringPooler({
+      deploymentMode: selfHosted,
+      // Postgres runs elsewhere (e.g. a managed host), Supavisor at the gateway
+      connectionInfo: {
+        db_host: 'supabase.example.com',
+        db_host_direct: 'mydb.example.com',
+        db_port: 5432,
+      },
+      connectionStringsShared: sharedPlatform,
+      ipv4Addon: false,
+      isHighAvailability: false,
+    })
+
+    // Pooler strings keep the gateway host
+    expect(result.transactionShared).toContain('@supabase.example.com:6543/postgres')
+    expect(result.sessionShared).toContain('@supabase.example.com:5432/postgres')
+    // Direct string points at the Postgres host
+    expect(result.direct).toBe(
+      'postgresql://postgres:[YOUR-PASSWORD]@mydb.example.com:5432/postgres'
+    )
+  })
+
+  test('self-hosted: direct falls back to db_host when db_host_direct is unset', () => {
+    const result = buildConnectionStringPooler({
+      deploymentMode: selfHosted,
+      connectionInfo: { db_host: 'supabase.example.com', db_port: 5432 },
+      connectionStringsShared: sharedPlatform,
+      ipv4Addon: false,
+      isHighAvailability: false,
+    })
+    expect(result.direct).toBe(
+      'postgresql://postgres:[YOUR-PASSWORD]@supabase.example.com:5432/postgres'
+    )
+  })
+
   test('self-hosted: falls back to port 5432 when db_port is unset', () => {
     const result = buildConnectionStringPooler({
       deploymentMode: selfHosted,

--- a/apps/studio/components/interfaces/ConnectSheet/content/steps/direct-connection/content.test.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/content/steps/direct-connection/content.test.tsx
@@ -1,0 +1,148 @@
+import { waitFor } from '@testing-library/react'
+import { components, paths } from 'api-types'
+import { HttpResponse } from 'msw'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import DirectConnectionContent from './content'
+import type {
+  ConnectionStringPooler,
+  ConnectState,
+  DeploymentMode,
+  ProjectKeys,
+} from '@/components/interfaces/ConnectSheet/Connect.types'
+import { customRender } from '@/tests/lib/custom-render'
+import { addAPIMock } from '@/tests/lib/msw'
+
+type DatabaseDetailResponse = components['schemas']['DatabaseDetailResponse']
+// Self-hosted endpoint augments the response with the direct-connection host.
+type DatabaseMock = DatabaseDetailResponse & { db_host_direct?: string }
+type ProjectDetail =
+  paths['/platform/projects/{ref}']['get']['responses']['200']['content']['application/json']
+
+// IS_PLATFORM=false disables the pgbouncer/supavisor/addons queries (they're
+// gated on it), so /databases is the only network call the component makes.
+vi.mock('@/lib/constants', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/constants')>()),
+  IS_PLATFORM: false,
+}))
+
+// Entitlements/HA fan out to org + project queries; stub the two hooks/misc
+// consumers so the component only depends on the databases mock below.
+vi.mock('@/hooks/misc/useCheckEntitlements', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/hooks/misc/useCheckEntitlements')>()),
+  useCheckEntitlements: () => ({
+    hasAccess: false,
+    isLoading: false,
+    isSuccess: true,
+    getEntitlementNumericValue: () => undefined,
+    isEntitlementUnlimited: () => false,
+    getEntitlementSetValues: () => [],
+    getEntitlementMax: () => undefined,
+  }),
+}))
+vi.mock('@/hooks/misc/useSelectedProject', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/hooks/misc/useSelectedProject')>()),
+  useIsHighAvailability: () => false,
+}))
+
+const GATEWAY_HOST = 'gateway.example.com'
+
+// A project-detail fetch fires from the render tree (unrelated to the direct
+// string); mock it so there are no unhandled requests.
+function mockProjectDetail() {
+  addAPIMock({
+    method: 'get',
+    path: '/platform/projects/:ref',
+    response: () =>
+      HttpResponse.json<ProjectDetail>({
+        ref: 'default',
+        status: 'ACTIVE_HEALTHY',
+      } as ProjectDetail),
+  })
+}
+
+function mockDatabases({ dbHostDirect }: { dbHostDirect?: string }) {
+  addAPIMock({
+    method: 'get',
+    path: '/platform/projects/:ref/databases',
+    response: () =>
+      HttpResponse.json<DatabaseMock[]>([
+        {
+          cloud_provider: 'AWS',
+          connectionString: '',
+          db_host: GATEWAY_HOST,
+          // Self-hosted only: advertised direct-connection host
+          ...(dbHostDirect ? { db_host_direct: dbHostDirect } : {}),
+          db_name: 'postgres',
+          db_port: 5432,
+          db_user: 'postgres',
+          identifier: 'default',
+          inserted_at: '',
+          region: 'local',
+          restUrl: '',
+          size: '',
+          status: 'ACTIVE_HEALTHY',
+        },
+      ]),
+  })
+}
+
+const selfHosted: DeploymentMode = { isPlatform: false, isCli: false, isSelfHosted: true }
+const projectKeys: ProjectKeys = { apiUrl: null, anonKey: null, publishableKey: null }
+const state: ConnectState = {
+  mode: 'direct',
+  connectionSource: 'default',
+  connectionType: 'uri',
+  connectionMethod: 'direct',
+  useSharedPooler: true,
+}
+
+function renderDirect() {
+  return customRender(
+    <DirectConnectionContent
+      state={state}
+      projectKeys={projectKeys}
+      connectionStringPooler={{} as ConnectionStringPooler}
+      deploymentMode={selfHosted}
+    />
+  )
+}
+
+// The redacted connection string is mirrored verbatim on this attribute,
+// avoiding CodeBlock's syntax-highlighting span splitting.
+const getCopyValue = (container: HTMLElement) =>
+  container.querySelector('[data-connect-copy-value]')?.getAttribute('data-connect-copy-value')
+
+describe('DirectConnectionContent (self-hosted)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('advertises db_host_direct in the direct connection string', async () => {
+    mockProjectDetail()
+    mockDatabases({ dbHostDirect: 'mydb.internal' })
+
+    const { container } = renderDirect()
+
+    await waitFor(() => {
+      expect(getCopyValue(container)).toBe(
+        'postgresql://postgres:[YOUR-PASSWORD]@mydb.internal:5432/postgres'
+      )
+    })
+    // The public gateway host must not leak into the direct string
+    expect(getCopyValue(container)).not.toContain(GATEWAY_HOST)
+  })
+
+  it('falls back to db_host when db_host_direct is absent', async () => {
+    mockProjectDetail()
+    mockDatabases({})
+
+    const { container } = renderDirect()
+
+    await waitFor(() => {
+      expect(getCopyValue(container)).toBe(
+        `postgresql://postgres:[YOUR-PASSWORD]@${GATEWAY_HOST}:5432/postgres`
+      )
+    })
+  })
+})

--- a/apps/studio/components/interfaces/ConnectSheet/content/steps/direct-connection/content.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/content/steps/direct-connection/content.tsx
@@ -71,6 +71,9 @@ const useConnectionStringDatabases = (deploymentMode: DeploymentMode) => {
   // render and ripple through the resolveConnectionString useMemo below.
   return useMemo(() => {
     const DB_FIELDS = ['db_host', 'db_name', 'db_port', 'db_user', 'inserted_at']
+    // Only self-hosted advertises a separate direct-connection host; keep the
+    // platform connectionInfo shape untouched.
+    if (deploymentMode.isSelfHosted) DB_FIELDS.push('db_host_direct')
     const emptyState = { db_user: '', db_host: '', db_port: '', db_name: '' }
 
     return Object.fromEntries(

--- a/apps/studio/data/config/project-settings-v2-query.ts
+++ b/apps/studio/data/config/project-settings-v2-query.ts
@@ -15,6 +15,9 @@ type ProjectAppConfig = components['schemas']['ProjectSettingsResponse']['app_co
 }
 export type ProjectSettings = components['schemas']['ProjectSettingsResponse'] & {
   app_config?: ProjectAppConfig
+  // Self-hosted only: host for the direct connection string, which can differ
+  // from db_host (the public gateway) when Postgres runs elsewhere.
+  db_host_direct?: string
 }
 
 export async function getProjectSettings(

--- a/apps/studio/lib/api/self-hosted/settings.test.ts
+++ b/apps/studio/lib/api/self-hosted/settings.test.ts
@@ -10,6 +10,7 @@ vi.mock('@/lib/constants/api', () => ({
   PROJECT_ENDPOINT: 'localhost:8000',
   PROJECT_ENDPOINT_PROTOCOL: 'http',
   PROJECT_DB_HOST: 'localhost',
+  PROJECT_DB_HOST_DIRECT: 'localhost',
 }))
 
 describe('api/self-hosted/settings', () => {
@@ -47,7 +48,8 @@ describe('api/self-hosted/settings', () => {
 
       expect(settings.cloud_provider).toBe('AWS')
       expect(settings.db_host).toBe('localhost')
-      // POSTGRES_HOST unset → internal default `db` → falls back to db_host
+      // Passed through from PROJECT_DB_HOST_DIRECT (resolution unit-tested in
+      // lib/constants/api.test.ts)
       expect(settings.db_host_direct).toBe('localhost')
       expect(settings.db_name).toBe('postgres')
       expect(settings.db_port).toBe(5432)
@@ -115,19 +117,6 @@ describe('api/self-hosted/settings', () => {
       const settings = getSettings()
 
       expect(settings.name).toBe('Default Project')
-    })
-
-    it('should advertise POSTGRES_HOST in db_host_direct when set to a real host', async () => {
-      vi.stubEnv('POSTGRES_HOST', 'mydb.example.com')
-
-      // Re-import so ./constants picks up the stubbed env
-      vi.resetModules()
-      const { getProjectSettings: getSettings } = await import('./settings')
-      const settings = getSettings()
-
-      // Direct connection points at Postgres; db_host stays the gateway host
-      expect(settings.db_host_direct).toBe('mydb.example.com')
-      expect(settings.db_host).toBe('localhost')
     })
 
     it('should have correct db_ip_addr_config', () => {

--- a/apps/studio/lib/api/self-hosted/settings.test.ts
+++ b/apps/studio/lib/api/self-hosted/settings.test.ts
@@ -47,6 +47,8 @@ describe('api/self-hosted/settings', () => {
 
       expect(settings.cloud_provider).toBe('AWS')
       expect(settings.db_host).toBe('localhost')
+      // POSTGRES_HOST unset → internal default `db` → falls back to db_host
+      expect(settings.db_host_direct).toBe('localhost')
       expect(settings.db_name).toBe('postgres')
       expect(settings.db_port).toBe(5432)
       expect(settings.db_user).toBe('postgres')
@@ -113,6 +115,19 @@ describe('api/self-hosted/settings', () => {
       const settings = getSettings()
 
       expect(settings.name).toBe('Default Project')
+    })
+
+    it('should advertise POSTGRES_HOST in db_host_direct when set to a real host', async () => {
+      vi.stubEnv('POSTGRES_HOST', 'mydb.example.com')
+
+      // Re-import so ./constants picks up the stubbed env
+      vi.resetModules()
+      const { getProjectSettings: getSettings } = await import('./settings')
+      const settings = getSettings()
+
+      // Direct connection points at Postgres; db_host stays the gateway host
+      expect(settings.db_host_direct).toBe('mydb.example.com')
+      expect(settings.db_host).toBe('localhost')
     })
 
     it('should have correct db_ip_addr_config', () => {

--- a/apps/studio/lib/api/self-hosted/settings.ts
+++ b/apps/studio/lib/api/self-hosted/settings.ts
@@ -1,6 +1,6 @@
 import { components } from 'api-types'
 
-import { AUTH_JWT_SECRET, POSTGRES_PORT } from './constants'
+import { AUTH_JWT_SECRET, POSTGRES_HOST, POSTGRES_PORT } from './constants'
 import { assertSelfHosted } from './util'
 import { PROJECT_DB_HOST, PROJECT_ENDPOINT, PROJECT_ENDPOINT_PROTOCOL } from '@/lib/constants/api'
 
@@ -10,6 +10,10 @@ type ProjectAppConfig = components['schemas']['ProjectSettingsResponse']['app_co
 
 export type ProjectSettings = components['schemas']['ProjectSettingsResponse'] & {
   app_config?: ProjectAppConfig
+  // Host advertised in the direct connection string. Distinct from `db_host`
+  // (the public gateway host, where Supavisor is exposed): the operator can run
+  // Postgres elsewhere (managed PG, a separate container) via POSTGRES_HOST.
+  db_host_direct?: string
 }
 
 /**
@@ -31,6 +35,11 @@ export function getProjectSettings() {
     cloud_provider: 'AWS',
     db_dns_name: '-',
     db_host: PROJECT_DB_HOST,
+    // POSTGRES_HOST is where the backend reaches Postgres; surface it in the
+    // direct string when the operator points it at a real host. The default
+    // `db` is the compose-internal service name (unreachable by external
+    // clients), so fall back to the public gateway host as before.
+    db_host_direct: POSTGRES_HOST && POSTGRES_HOST !== 'db' ? POSTGRES_HOST : PROJECT_DB_HOST,
     db_ip_addr_config: 'legacy' as const,
     db_name: 'postgres',
     db_port: POSTGRES_PORT,

--- a/apps/studio/lib/api/self-hosted/settings.ts
+++ b/apps/studio/lib/api/self-hosted/settings.ts
@@ -1,8 +1,13 @@
 import { components } from 'api-types'
 
-import { AUTH_JWT_SECRET, POSTGRES_HOST, POSTGRES_PORT } from './constants'
+import { AUTH_JWT_SECRET, POSTGRES_PORT } from './constants'
 import { assertSelfHosted } from './util'
-import { PROJECT_DB_HOST, PROJECT_ENDPOINT, PROJECT_ENDPOINT_PROTOCOL } from '@/lib/constants/api'
+import {
+  PROJECT_DB_HOST,
+  PROJECT_DB_HOST_DIRECT,
+  PROJECT_ENDPOINT,
+  PROJECT_ENDPOINT_PROTOCOL,
+} from '@/lib/constants/api'
 
 type ProjectAppConfig = components['schemas']['ProjectSettingsResponse']['app_config'] & {
   protocol?: string
@@ -35,11 +40,7 @@ export function getProjectSettings() {
     cloud_provider: 'AWS',
     db_dns_name: '-',
     db_host: PROJECT_DB_HOST,
-    // POSTGRES_HOST is where the backend reaches Postgres; surface it in the
-    // direct string when the operator points it at a real host. The default
-    // `db` is the compose-internal service name (unreachable by external
-    // clients), so fall back to the public gateway host as before.
-    db_host_direct: POSTGRES_HOST && POSTGRES_HOST !== 'db' ? POSTGRES_HOST : PROJECT_DB_HOST,
+    db_host_direct: PROJECT_DB_HOST_DIRECT,
     db_ip_addr_config: 'legacy' as const,
     db_name: 'postgres',
     db_port: POSTGRES_PORT,

--- a/apps/studio/lib/constants/api.test.ts
+++ b/apps/studio/lib/constants/api.test.ts
@@ -61,6 +61,58 @@ describe('constants/api', () => {
     })
   })
 
+  describe('resolveDirectDbHost', () => {
+    it('passes a real POSTGRES_HOST through', async () => {
+      const { resolveDirectDbHost } = await import('./api')
+      expect(resolveDirectDbHost('mydb.example.com', 'gateway.example.com')).toBe(
+        'mydb.example.com'
+      )
+    })
+
+    it('passes an IP address through', async () => {
+      const { resolveDirectDbHost } = await import('./api')
+      expect(resolveDirectDbHost('10.0.0.5', 'gateway.example.com')).toBe('10.0.0.5')
+    })
+
+    it('falls back to the gateway host for the compose-internal default `db`', async () => {
+      const { resolveDirectDbHost } = await import('./api')
+      expect(resolveDirectDbHost('db', 'gateway.example.com')).toBe('gateway.example.com')
+    })
+
+    it('falls back to the gateway host when POSTGRES_HOST is undefined', async () => {
+      const { resolveDirectDbHost } = await import('./api')
+      expect(resolveDirectDbHost(undefined, 'gateway.example.com')).toBe('gateway.example.com')
+    })
+
+    it('falls back to the gateway host when POSTGRES_HOST is empty', async () => {
+      const { resolveDirectDbHost } = await import('./api')
+      expect(resolveDirectDbHost('', 'gateway.example.com')).toBe('gateway.example.com')
+    })
+  })
+
+  describe('PROJECT_DB_HOST_DIRECT', () => {
+    it('advertises POSTGRES_HOST when set to a real host', async () => {
+      vi.stubEnv('SUPABASE_PUBLIC_URL', 'https://gateway.example.com')
+      vi.stubEnv('POSTGRES_HOST', 'mydb.example.com')
+      const { PROJECT_DB_HOST_DIRECT } = await import('./api')
+      expect(PROJECT_DB_HOST_DIRECT).toBe('mydb.example.com')
+    })
+
+    it('falls back to the public URL host when POSTGRES_HOST is the default `db`', async () => {
+      vi.stubEnv('SUPABASE_PUBLIC_URL', 'https://gateway.example.com')
+      vi.stubEnv('POSTGRES_HOST', 'db')
+      const { PROJECT_DB_HOST_DIRECT } = await import('./api')
+      expect(PROJECT_DB_HOST_DIRECT).toBe('gateway.example.com')
+    })
+
+    it('falls back to the public URL host when POSTGRES_HOST is unset', async () => {
+      vi.stubEnv('SUPABASE_PUBLIC_URL', 'https://gateway.example.com')
+      vi.stubEnv('POSTGRES_HOST', '')
+      const { PROJECT_DB_HOST_DIRECT } = await import('./api')
+      expect(PROJECT_DB_HOST_DIRECT).toBe('gateway.example.com')
+    })
+  })
+
   describe('DEFAULT_PROJECT', () => {
     it('should have correct default values', async () => {
       vi.stubEnv('DEFAULT_PROJECT_NAME', '')

--- a/apps/studio/lib/constants/api.ts
+++ b/apps/studio/lib/constants/api.ts
@@ -10,6 +10,22 @@ export const PROJECT_ENDPOINT = PUBLIC_URL.host
 export const PROJECT_ENDPOINT_PROTOCOL = PUBLIC_URL.protocol.replace(':', '')
 export const PROJECT_DB_HOST = PUBLIC_URL.hostname
 
+/**
+ * Host advertised in the self-hosted direct connection string. `POSTGRES_HOST`
+ * points at Postgres itself (which the operator can run outside the compose
+ * network); its default `db` is the internal service name, unreachable by
+ * external clients, so fall back to the public gateway host in that case.
+ */
+export const resolveDirectDbHost = (
+  postgresHost: string | undefined,
+  gatewayHost: string
+): string => (postgresHost && postgresHost !== 'db' ? postgresHost : gatewayHost)
+
+export const PROJECT_DB_HOST_DIRECT = resolveDirectDbHost(
+  process.env.POSTGRES_HOST,
+  PROJECT_DB_HOST
+)
+
 export const DEFAULT_PROJECT = {
   id: 1,
   ref: 'default',

--- a/apps/studio/pages/api/platform/projects/[ref]/databases.ts
+++ b/apps/studio/pages/api/platform/projects/[ref]/databases.ts
@@ -3,7 +3,7 @@ import { NextApiRequest, NextApiResponse } from 'next'
 
 import { apiWrapper } from '@/lib/api/apiWrapper'
 import { POSTGRES_PORT } from '@/lib/api/self-hosted/constants'
-import { PROJECT_DB_HOST, PROJECT_REST_URL } from '@/lib/constants/api'
+import { PROJECT_DB_HOST, PROJECT_DB_HOST_DIRECT, PROJECT_REST_URL } from '@/lib/constants/api'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)
 
@@ -23,12 +23,16 @@ type ResponseData =
   paths['/platform/projects/{ref}/databases']['get']['responses']['200']['content']['application/json']
 
 const handleGet = async (_req: NextApiRequest, res: NextApiResponse<ResponseData>) => {
-  return res.status(200).json([
+  // db_host stays the public gateway host (where Supavisor is exposed); the
+  // direct connection points at Postgres itself, which the operator can host
+  // elsewhere via POSTGRES_HOST — see PROJECT_DB_HOST_DIRECT.
+  const databases: (ResponseData[number] & { db_host_direct?: string })[] = [
     {
       cloud_provider: 'localhost' as any,
       connectionString: '',
       connection_string_read_only: '',
       db_host: PROJECT_DB_HOST,
+      db_host_direct: PROJECT_DB_HOST_DIRECT,
       db_name: 'postgres',
       db_port: POSTGRES_PORT,
       db_user: 'postgres',
@@ -39,5 +43,7 @@ const handleGet = async (_req: NextApiRequest, res: NextApiResponse<ResponseData
       size: '',
       status: 'ACTIVE_HEALTHY',
     },
-  ])
+  ]
+
+  return res.status(200).json(databases)
 }

--- a/docker/CONFIG.md
+++ b/docker/CONFIG.md
@@ -87,7 +87,7 @@ The image tags below are pinned in `docker-compose.yml` at the time of this docu
 | `DEFAULT_PROJECT_NAME` | string | Self-hosted | Name shown for the single default project on the dashboard. | Mapped from `STUDIO_DEFAULT_PROJECT` in `.env.example`. Default: `Default Project`. |
 | `HOSTNAME` | string | Both | Network interface Next.js binds to inside the container. | Set to `0.0.0.0` so the container is reachable from outside. |
 | `POSTGRES_DB` | string | Self-hosted | Postgres database name used for Studio's internal connections. | Default: `postgres`. |
-| `POSTGRES_HOST` | string | Self-hosted | Postgres host (service name in compose network). | Default: `db`. |
+| `POSTGRES_HOST` | string | Self-hosted | Postgres host used for Studio's internal connections. When set to a value other than the default `db`, it's also advertised in the direct connection string shown in the dashboard (for running Postgres outside the compose network). | Default: `db` (compose service name). |
 | `POSTGRES_PASSWORD` | string | Both | Postgres password for the `POSTGRES_USER_READ_WRITE` role. | Supports `_FILE` suffix for Docker secrets. |
 | `POSTGRES_PORT` | integer | Self-hosted | Postgres TCP port. | Default: `5432`. |
 | `POSTGRES_USER_READ_ONLY` | string | | Postgres role used by the local MCP server when running in read-only mode. | Default: `supabase_read_only_user`. This role has no password by default, so read-only MCP will fail to connect. To enable, assign a password matching `POSTGRES_PASSWORD`. |


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

In self-hosted Studio, direct connection strings are derived from `SUPABASE_PUBLIC_URL`'s hostname (`PROJECT_DB_HOST`), which assumes Postgres is reachable at the same host as the public HTTP gateway. That breaks when Postgres runs elsewhere (e.g. a separate container or managed instance).

### Changed

Advertise `POSTGRES_HOST` in the direct connection strings only. A shared helper resolves the direct host (`POSTGRES_HOST` when set to a value other than the default `db`, otherwise the existing gateway host), exposed as `db_host_direct` from the self-hosted `settings` and `databases` endpoints.

For self-hosted, this covers:
- Connect sheet - Direct tab, plus the Framework/ORM/etc. tabs
- Table editor > Export (the `pg_dump` and `psql` commands)

When `POSTGRES_HOST` is the default `db` (compose-internal service name), behavior is unchanged. Platform behavior is untouched (the field is only plucked when self-hosted).

### Not implemented
- The pooler (Supavisor/Pgbouncer) strings keep pointing at the main instance

### Tests
- Unit coverage for the host resolution + a component test for the self-hosted Direct tab.
