### PR TITLE
fix: Update supabase test docs to use `_test.sql`

### DIFF
--- a/apps/docs/content/guides/database/testing.mdx
+++ b/apps/docs/content/guides/database/testing.mdx
@@ -27,14 +27,14 @@ mkdir -p ./supabase/tests/database
 Create a new file with the `.sql` extension which will contain the test.
 
 ```bash
-touch ./supabase/tests/database/hello_world.test.sql
+touch ./supabase/tests/database/hello_world_test.sql
 ```
 
 ### Writing tests
 
 All `sql` files use [pgTAP](/docs/guides/database/extensions/pgtap) as the test runner.
 
-Write a test to check that our `auth.users` table has an ID column. Open `hello_world.test.sql` and add the following code:
+Write a test to check that our `auth.users` table has an ID column. Open `hello_world_test.sql` and add the following code:
 
 ```sql
 begin;
@@ -63,7 +63,7 @@ This will produce the following output:
 
 ```bash
 $ supabase test db
-supabase/tests/database/hello_world.test.sql .. ok
+supabase/tests/database/hello_world_test.sql .. ok
 All tests successful.
 Files=1, Tests=1,  1 wallclock secs ( 0.01 usr  0.00 sys +  0.04 cusr  0.02 csys =  0.07 CPU)
 Result: PASS


### PR DESCRIPTION


## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

The database testing docs currently show test files using the `.test.sql` suffix, but `supabase test new` generates `_test.sql` files.

Both formats work, but the generator behavior matches the previous Go CLI implementation and existing test fixtures. Update the docs for consistency with the actual generated file naming.

Relevant context: [database testing docs](<https://supabase.com/docs/guides/database/testing>) and [CLI-1318](<https://linear.app/supabase/issue/CLI-1318/port-supabase-test-db-supabase-test-new>).

We might want to add `supabase test new` to the docs, but that's a separate change.

## What is the current behavior?

It reports `.test.sql`

## What is the new behavior?

it reports `_test.sql` inline with the generator

## Additional context

[slack thread](https://supabase.slack.com/archives/C07E5GFAHTM/p1786373594478619) - we can also add the test generator to the docs but I think that's a separate issue.