### PR TITLE
(fix): clarify re-enabling data api section of no exposed schemas troubleshooting guide

### DIFF
--- a/apps/docs/content/troubleshooting/schema-pg_pgrst_no_exposed_schemas-does-not-exist.mdx
+++ b/apps/docs/content/troubleshooting/schema-pg_pgrst_no_exposed_schemas-does-not-exist.mdx
@@ -40,9 +40,11 @@ To stop the missing-schema log entries:
 
 PostgREST now exposes an empty schema, which stops the missing-schema errors.
 
-## Re-enable the Data API
+## Re-enabling the Data API in the future
 
-Before you re-enable the data API:
+You may decide that you wish to re-enable the Data API in the future.
+
+If you do so, to reverse the workaround, you can run the following statements before re-enabling the Data API:
 
 1. Open the SQL Editor.
 2. Run the following statements:


### PR DESCRIPTION

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?


## What is the new behavior?


## Additional context

Add any other context or screenshots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded troubleshooting guidance for re-enabling the Data API after applying the schema exposure workaround.
  * Clarified the steps and context for reversing the workaround.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->