### PR TITLE
fix(www): redirect the two legacy svg customer logos to on-light

### DIFF
--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -10,6 +10,18 @@ module.exports = [
     source: '/images/customers/logos/:slug((?!dreambase-mark\\.png)[^/.]+).png',
     destination: '/images/customers/logos/on-light/:slug.png',
   },
+  // The two svg wordmarks that moved with them. Listed individually so the
+  // `{slug}-icon.svg` chips, which stayed at the logos/ root, keep resolving.
+  {
+    permanent: true,
+    source: '/images/customers/logos/accenture.svg',
+    destination: '/images/customers/logos/on-light/accenture.svg',
+  },
+  {
+    permanent: true,
+    source: '/images/customers/logos/stigg.svg',
+    destination: '/images/customers/logos/on-light/stigg.svg',
+  },
   {
     permanent: true,
     source: '/blog/pricing',

--- a/apps/www/next.config.test.ts
+++ b/apps/www/next.config.test.ts
@@ -90,4 +90,25 @@ describe('next.config.mjs', () => {
       slug: 'dreambase-marketing',
     })
   })
+
+  it('redirects legacy svg wordmarks while leaving icon chips at the logos root', async () => {
+    const { default: config } = (await import('./next.config.mjs')) as { default: NextConfig }
+    const redirects = (await config.redirects?.()) || []
+
+    const logoRedirects = redirects.filter((redirect) =>
+      redirect.source.startsWith('/images/customers/logos')
+    )
+    const isRedirected = (url: string) =>
+      logoRedirects.some((redirect) => getPathMatch(redirect.source)(url) !== false)
+
+    // Wordmarks that moved from logos/ to logos/on-light/ have to keep resolving.
+    expect(isRedirected('/images/customers/logos/accenture.svg')).toBe(true)
+    expect(isRedirected('/images/customers/logos/stigg.svg')).toBe(true)
+    // hyper.svg moved out of logos/light/, which the :path* rule already covers.
+    expect(isRedirected('/images/customers/logos/light/hyper.svg')).toBe(true)
+
+    // Icon chips and dreambase-mark.png deliberately stayed put, so they must not redirect.
+    expect(isRedirected('/images/customers/logos/chatbase-icon.svg')).toBe(false)
+    expect(isRedirected('/images/customers/logos/dreambase-mark.png')).toBe(false)
+  })
 })

--- a/apps/www/next.config.test.ts
+++ b/apps/www/next.config.test.ts
@@ -98,17 +98,27 @@ describe('next.config.mjs', () => {
     const logoRedirects = redirects.filter((redirect) =>
       redirect.source.startsWith('/images/customers/logos')
     )
-    const isRedirected = (url: string) =>
-      logoRedirects.some((redirect) => getPathMatch(redirect.source)(url) !== false)
+    const redirectFor = (url: string) =>
+      logoRedirects.find((redirect) => getPathMatch(redirect.source)(url) !== false)
 
-    // Wordmarks that moved from logos/ to logos/on-light/ have to keep resolving.
-    expect(isRedirected('/images/customers/logos/accenture.svg')).toBe(true)
-    expect(isRedirected('/images/customers/logos/stigg.svg')).toBe(true)
+    // Wordmarks that moved from logos/ to logos/on-light/ have to keep resolving, and
+    // land on the file's new home rather than merely matching some rule.
+    expect(redirectFor('/images/customers/logos/accenture.svg')).toMatchObject({
+      destination: '/images/customers/logos/on-light/accenture.svg',
+      permanent: true,
+    })
+    expect(redirectFor('/images/customers/logos/stigg.svg')).toMatchObject({
+      destination: '/images/customers/logos/on-light/stigg.svg',
+      permanent: true,
+    })
     // hyper.svg moved out of logos/light/, which the :path* rule already covers.
-    expect(isRedirected('/images/customers/logos/light/hyper.svg')).toBe(true)
+    expect(redirectFor('/images/customers/logos/light/hyper.svg')).toMatchObject({
+      destination: '/images/customers/logos/on-dark/:path*',
+      permanent: true,
+    })
 
     // Icon chips and dreambase-mark.png deliberately stayed put, so they must not redirect.
-    expect(isRedirected('/images/customers/logos/chatbase-icon.svg')).toBe(false)
-    expect(isRedirected('/images/customers/logos/dreambase-mark.png')).toBe(false)
+    expect(redirectFor('/images/customers/logos/chatbase-icon.svg')).toBeUndefined()
+    expect(redirectFor('/images/customers/logos/dreambase-mark.png')).toBeUndefined()
   })
 })


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix. Two legacy customer logo URLs 404 instead of redirecting.

## What is the current behavior?

#48962 moved the customer logos into `on-light/` and `on-dark/` and added legacy redirects so the old URLs keep working. The rule for the old root wordmarks is:

```js
source: '/images/customers/logos/:slug((?!dreambase-mark\\.png)[^/.]+).png',
destination: '/images/customers/logos/on-light/:slug.png',
```

It ends in a literal `.png`. Three of the files that moved in that same commit are svg, not png:

| moved file | covered by an existing redirect? |
| --- | --- |
| `logos/accenture.svg` to `on-light/accenture.svg` | no |
| `logos/stigg.svg` to `on-light/stigg.svg` | no |
| `logos/light/hyper.svg` to `on-dark/hyper.svg` | yes, the `logos/light/:path*` rule uses `:path*` so it matches any extension |

So `/images/customers/logos/accenture.svg` and `/images/customers/logos/stigg.svg` now 404, while every png that moved alongside them redirects. Confirmed against production:

| URL | status |
| --- | --- |
| `logos/resend.png` (png wordmark, moved) | 200, redirects |
| `logos/accenture.svg` (svg wordmark, moved) | **404** |
| `logos/stigg.svg` (svg wordmark, moved) | **404** |
| `logos/on-light/accenture.svg` | 200 |
| `logos/light/hyper.svg` (svg, moved out of `light/`) | 200, redirects |
| `logos/mobbin-icon.svg` (icon chip, stayed) | 200 |

Nothing inside the repo still points at those two paths, I checked all 99 `/images/customers/logos/...` references and they all resolve. The impact is on anything outside the repo holding the old URL, which is the same case the png redirects in #48962 were added to handle.

## What is the new behavior?

Two redirects, one per file, pointing at where the files actually live.

I listed them individually instead of widening the existing rule to also accept `.svg`. The `{slug}-icon.svg` chips deliberately stayed at the logos root (`chatbase-icon.svg`, `e2b-icon.svg`, `firecrawl-icon.svg`, `hyper-icon.svg`, `markprompt-icon.svg`, `mobbin-icon.svg`, `rally-icon.svg`, `resend-icon.svg`), so a general `.svg` rule would need a second negative lookahead to skip them. For exactly two files that seemed like more regex than the problem deserves. Happy to switch it to a generalized rule with a `(?!.*-icon\.svg)` lookahead if you would rather it cover future svg moves.

`hyper.svg` needs nothing, and I added an assertion pinning that so it does not silently regress.

## Additional context

Test first, then the fix. This is added to `next.config.test.ts` next to the existing legacy-logo test and it fails on current master:

```
× redirects legacy svg wordmarks while leaving icon chips at the logos root
AssertionError: expected false to be true
```

It reuses `getPathMatch` the way your existing test does, but asks the broader question "does any logo redirect match this URL" rather than naming one rule, so it stays valid whichever way you implement the coverage. It also asserts the icon chips and `dreambase-mark.png` are still NOT redirected, so it fails if a future widening catches them by accident.

How I found it: I diffed the rename commit's file moves and compared each old path against the redirects that were added, which is also how I confirmed `hyper.svg` was already fine and that `dreambase-mark.png` is correctly excluded.

While I was in there I also checked the rest of the rename and found nothing else wrong, so this is the only thing in this PR:

- all 99 in-repo logo references resolve to files that exist
- every `on-light` variant is black ink and every `on-dark` variant is white ink across all 51 pairs, including `phoenix-energy.png`, whose two variants were swapped relative to the other logos in the rename. That looked like a mistake until I measured the pixels, and it is actually a correction of a pre-existing mislabel

Gates on this branch: `test:prettier` passes repo wide, `typecheck --filter=www --force` passes 8/8, and the www vitest suite passes (6 files, 76 tests). I did not run `pnpm build`, which cannot finish in my environment because the docs `build:federated-content` step needs `DOCS_GITHUB_APP_PRIVATE_KEY`.

Freshman contributor. Put this together with Claude Code's help, and I verified the file moves, the redirect matching, and the failing test myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added permanent redirects for legacy Accenture and Stigg logo wordmark URLs.
  * Preserved direct access to root-level icon assets and `dreambase-mark.png`.
  * Added coverage to verify redirect and non-redirect behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->