### PR TITLE
docs(database): close the RLS guide gaps the eval flagged

### DIFF
--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -428,18 +428,19 @@ A wrong policy fails quietly. Too permissive, and a query returns rows it should
 
 Supabase runs database tests with [pgTAP](/docs/guides/database/extensions/pgtap) through the CLI. Test files are `.sql` files under `supabase/tests/`.
 
-### How policy tests work
+### Anatomy of a policy test
 
-Switch role and identity between cases with `set local role` and `set local request.jwt.claim.sub`, so each assertion runs as the user it describes.
+Each case sets an identity, runs one statement as that identity, and asserts the outcome. Three things decide whether the assertion means anything.
 
-Match the assertion to the way the denial happens:
+**Identity.** Switch role and identity between cases with `set local role` and `set local request.jwt.claim.sub`, so each assertion runs as the user it describes. Without the switch, every case runs as the same role and proves nothing about access.
+
+**Denials.** A denied request doesn't always raise an error, so match the assertion to the way the denial happens:
 
 - A missing grant raises `42501`. Assert it with `throws_ok`.
 - A `with check` violation raises `42501`. Assert it with `throws_ok`.
-- A `using` clause that filters the target row out raises nothing. The update or delete matches zero rows instead. Assert that no row changed, not that an error was raised.
-- An allowed write needs an assertion on the resulting row. The absence of an error doesn't prove that anything changed.
+- A `using` clause that filters the target row out raises nothing. The update or delete matches zero rows instead. Assert that no row changed.
 
-Add `returning` to an allowed write so a single assertion proves the row changed. A denied write returns no rows, so the same shape asserts the denial.
+**Allowed writes.** The absence of an error doesn't prove that anything changed. Add `returning` to the statement so one assertion covers both directions. An allowed write returns the changed row, and a write the policy filters out returns nothing.
 
 ### Write and run the tests
 

--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -11,20 +11,23 @@ When you need granular authorization rules, nothing beats Postgres's [Row Level 
 
 <Admonition type="danger">
 
-Supabase allows convenient and secure data access from the browser, as long as you enable RLS.
+A table in an exposed schema without RLS is readable and writable by anyone with your publishable key. RLS _must_ always be enabled on any table stored in an exposed schema. By default, this is the `public` schema.
 
-RLS _must_ always be enabled on any tables stored in an exposed schema. By default, this is the `public` schema.
-
-RLS is enabled by default on tables created with the Table Editor in the dashboard. If you create one in raw SQL or with the SQL editor, remember to enable RLS yourself and grant only the permissions each Postgres role needs.
+RLS is enabled by default on tables created with the Table Editor in the dashboard. If you create a table in raw SQL or with the SQL editor, enable RLS yourself and leave each role only the privileges it needs:
 
 ```sql
-GRANT SELECT ON <schema_name>.<table_name> TO anon;
-GRANT SELECT, INSERT, UPDATE, DELETE ON <schema_name>.<table_name> TO authenticated;
-GRANT SELECT, INSERT, UPDATE, DELETE ON <schema_name>.<table_name> TO service_role;
+-- Take back the privileges granted automatically to client roles.
+revoke all on table <schema_name>.<table_name> from anon, authenticated;
+
+-- Grant back only what each role needs.
+grant select on table <schema_name>.<table_name> to anon, authenticated;
+grant insert, update, delete on table <schema_name>.<table_name> to authenticated;
 
 alter table <schema_name>.<table_name>
 enable row level security;
 ```
+
+Policies alone don't do this. See [Grants and policies](#grants-and-policies).
 
 </Admonition>
 
@@ -62,6 +65,38 @@ alter table "table_name" enable row level security;
 ```
 
 Once you have enabled RLS, no data will be accessible via the [API](/docs/guides/api) when using a publishable key, until you create policies.
+
+## Grants and policies
+
+Postgres runs two checks before a client touches a table. Grants decide whether a role can run an operation on the table at all. Policies decide which rows that operation applies to. Set both for every table you expose.
+
+On existing projects, a new table in `public` receives `select`, `insert`, `update`, and `delete` for `anon`, `authenticated`, and `service_role` automatically. Both client roles start out able to write to your table, and adding policies doesn't take those grants back. A table protected only by policies still hands `anon` an insert path if you never revoke the grant.
+
+Set the grants to match what each role does in your app:
+
+1. Revoke the automatic grants from both client roles.
+
+   ```sql
+   revoke all on table public.reports from anon, authenticated;
+   ```
+
+2. Grant back only the privileges the role needs.
+
+   ```sql
+   -- Signed-in users manage reports. Signed-out visitors get nothing.
+   grant select, insert, update, delete on table public.reports to authenticated;
+   ```
+
+3. Enable RLS on the table and write policies that decide which rows each role reaches.
+
+Data that clients read but never write, such as a feed a backend job populates, gets no write grant at all:
+
+```sql
+revoke all on table public.weather_readings from anon, authenticated;
+grant select on table public.weather_readings to anon, authenticated;
+```
+
+A missing grant raises a `42501` error before any policy runs, so check the grants first when a request fails that your policy should allow. To stop new tables from receiving the automatic grants, see [Revoke default privileges](/docs/guides/api/securing-your-api#revoke-default-privileges).
 
 ## Auto-enable RLS for new tables
 
@@ -369,6 +404,135 @@ alter role "role_name" with bypassrls;
 
 This can be useful for system-level access. You should _never_ share login credentials for any Postgres Role with this privilege.
 
+## Test your policies
+
+A wrong policy fails quietly. Too permissive, and a query returns rows it shouldn't. Too strict, and it returns nothing and raises no error. Test both directions before you ship a policy.
+
+Supabase runs database tests with [pgTAP](/docs/guides/database/extensions/pgtap) through the CLI. Test files are `.sql` files under `supabase/tests/`.
+
+1. Create the tests directory and a test file:
+
+   ```bash
+   mkdir -p supabase/tests
+   touch supabase/tests/profiles_rls.test.sql
+   ```
+
+2. Write the tests. Cover `select`, `insert`, `update`, and `delete` twice each, once for a request the policy allows and once for a request it denies. Cover `anon` as well as `authenticated`.
+
+3. Run the suite:
+
+   ```bash
+   supabase test db
+   ```
+
+Switch role and identity between cases with `set local role` and `set local request.jwt.claim.sub`, so each assertion runs as the user it describes.
+
+Match the assertion to the way the denial happens:
+
+- A missing grant raises `42501`. Assert it with `throws_ok`.
+- A `with check` violation raises `42501`. Assert it with `throws_ok`.
+- A `using` clause that filters the target row out raises nothing. The update or delete matches zero rows instead. Assert that no row changed, not that an error was raised.
+- An allowed write needs an assertion on the resulting row. The absence of an error doesn't prove that anything changed.
+
+Add `returning` to an allowed write so a single assertion proves the row changed. A denied write returns no rows, so the same shape asserts the denial.
+
+This example tests a `profiles` table where `authenticated` holds every privilege, `anon` holds none, and each user reads and writes only their own row:
+
+```sql supabase/tests/profiles_rls.test.sql
+begin;
+select plan(11);
+
+-- Seed two users. The rows come later, through the policies under test.
+insert into auth.users (id, email)
+values
+  ('11111111-1111-1111-1111-111111111111', 'owner@example.com'),
+  ('22222222-2222-2222-2222-222222222222', 'other@example.com');
+
+-- Signed-out visitors hold no grant, so the request stops before any policy runs.
+set local role anon;
+select throws_ok(
+  $$select * from profiles$$,
+  '42501',
+  null,
+  'anon cannot read profiles'
+);
+select throws_ok(
+  $$insert into profiles (id, user_id)
+    values (gen_random_uuid(), '11111111-1111-1111-1111-111111111111')$$,
+  '42501',
+  null,
+  'anon cannot insert a profile'
+);
+
+-- The owner reads and writes their own row.
+set local role authenticated;
+set local request.jwt.claim.sub = '11111111-1111-1111-1111-111111111111';
+select results_eq(
+  $$insert into profiles (id, user_id, avatar_url)
+    values (
+      gen_random_uuid(),
+      '11111111-1111-1111-1111-111111111111',
+      'owner.png'
+    )
+    returning avatar_url$$,
+  array['owner.png'],
+  'the owner creates their own profile'
+);
+select results_eq(
+  $$select avatar_url from profiles$$,
+  array['owner.png'],
+  'the owner reads their own profile'
+);
+select results_eq(
+  $$update profiles set avatar_url = 'updated.png' returning avatar_url$$,
+  array['updated.png'],
+  'the owner updates their own profile'
+);
+
+-- The with check clause rejects the row, which raises.
+select throws_ok(
+  $$insert into profiles (id, user_id)
+    values (gen_random_uuid(), '22222222-2222-2222-2222-222222222222')$$,
+  '42501',
+  null,
+  'the owner cannot create a profile for someone else'
+);
+
+-- A signed-in stranger holds the grant, so the policy is what stops them. The
+-- using clause filters the row out, so these match nothing and raise nothing.
+set local request.jwt.claim.sub = '22222222-2222-2222-2222-222222222222';
+select is_empty(
+  $$select * from profiles$$,
+  'another user reads no profiles'
+);
+select is_empty(
+  $$update profiles set avatar_url = 'stolen.png' returning avatar_url$$,
+  'another user updates no profiles'
+);
+select is_empty(
+  $$delete from profiles returning id$$,
+  'another user deletes no profiles'
+);
+
+-- The row is still there, still holding the owner's value.
+set local request.jwt.claim.sub = '11111111-1111-1111-1111-111111111111';
+select results_eq(
+  $$select avatar_url from profiles$$,
+  array['updated.png'],
+  'the other user changed nothing'
+);
+select results_eq(
+  $$delete from profiles returning avatar_url$$,
+  array['updated.png'],
+  'the owner deletes their own profile'
+);
+
+select * from finish();
+rollback;
+```
+
+For CLI setup and more pgTAP helpers, see [Testing your database](/docs/guides/database/testing).
+
 ## RLS performance recommendations
 
 Every authorization system has an impact on performance. While row level security is powerful, the performance impact is important to keep in mind. This is especially true for queries that scan every row in a table - like many `select` operations, including those using limit, offset, and ordering.
@@ -377,7 +541,7 @@ Based on a series of [tests](https://github.com/GaryAustin1/RLS-Performance), we
 
 ### Add indexes
 
-Make sure you've added [indexes](/docs/guides/database/postgres/indexes) on any columns used within the Policies which are not already indexed (or primary keys). For a Policy like this:
+Add an [index](/docs/guides/database/postgres/indexes) on every column your policies filter on. Postgres evaluates the policy against each candidate row, so an unindexed filter column turns a read into a sequential scan. For a policy like this:
 
 ```sql
 create policy "rls_test_select" on test_table
@@ -390,6 +554,21 @@ You can add an index like:
 ```sql
 create index userid
 on test_table
+using btree (user_id);
+```
+
+A column counts as indexed only when it comes first in a `btree` index. Postgres can't use a multi-column index to filter on a column that isn't the leading one, so a composite primary key indexes its first column and no others. A membership table keyed on `(team_id, user_id)` has no index on `user_id`:
+
+```sql
+create table team_members (
+  team_id uuid references teams (id),
+  user_id uuid references auth.users (id),
+  primary key (team_id, user_id)
+);
+
+-- The primary key covers team_id. A policy filtering on user_id needs its own index.
+create index team_members_user_id_idx
+on team_members
 using btree (user_id);
 ```
 

--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -70,7 +70,15 @@ Once you have enabled RLS, no data will be accessible via the [API](/docs/guides
 
 Postgres runs two checks before a client touches a table. Grants decide whether a role can run an operation on the table at all. Policies decide which rows that operation applies to. Set both for every table you expose.
 
-On existing projects, a new table in `public` receives `select`, `insert`, `update`, and `delete` for `anon`, `authenticated`, and `service_role` automatically. Both client roles start out able to write to your table, and adding policies doesn't take those grants back. A table protected only by policies still hands `anon` an insert path if you never revoke the grant.
+On existing projects, a new table in `public` starts with every privilege already granted to all three roles:
+
+| Role            | Granted automatically                  | What it should keep                                     |
+| --------------- | -------------------------------------- | ------------------------------------------------------- |
+| `anon`          | `select`, `insert`, `update`, `delete` | Only what signed-out visitors are meant to read         |
+| `authenticated` | `select`, `insert`, `update`, `delete` | Only the operations your app exposes to signed-in users |
+| `service_role`  | `select`, `insert`, `update`, `delete` | Full access. It bypasses RLS, so keep it server-side    |
+
+Adding policies doesn't take those grants back. A table protected only by policies still hands `anon` an insert path if you never revoke the grant.
 
 A missing grant raises a `42501` error before any policy runs. When a request fails that your policy should allow, check the grants before you change the policy.
 

--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -76,6 +76,8 @@ A missing grant raises a `42501` error before any policy runs. When a request fa
 
 ### Set the grants for a table
 
+Run these statements in the [SQL Editor](/dashboard/project/_/sql/new) for a one-off change, or in a [migration](/docs/guides/deployment/database-migrations) to keep the change reproducible across environments. Grants and RLS belong in the same migration.
+
 Set the grants to match what each role does in your app:
 
 1. Revoke the automatic grants from both client roles.

--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -11,7 +11,7 @@ When you need granular authorization rules, nothing beats Postgres's [Row Level 
 
 <Admonition type="danger">
 
-A table in an exposed schema without RLS is readable and writable by anyone with your publishable key. RLS _must_ always be enabled on any table stored in an exposed schema. By default, this is the `public` schema.
+A table in an exposed schema without RLS is readable and writable by anyone with your publishable key. RLS must always be enabled on any table stored in an exposed schema. By default, this is the `public` schema.
 
 RLS is enabled by default on tables created with the Table Editor in the dashboard. If you create a table in raw SQL or with the SQL editor, enable RLS yourself and leave each role only the privileges it needs:
 

--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -104,6 +104,8 @@ grant select on table public.weather_readings to anon, authenticated;
 
 To stop new tables from receiving the automatic grants in the first place, see [Revoke default privileges](/docs/guides/api/securing-your-api#revoke-default-privileges).
 
+Write the tests for this table in the same change. See [Test your policies](#test-your-policies).
+
 ## Auto-enable RLS for new tables
 
 If you want RLS enabled automatically for new tables, you can create an event trigger that runs after table creation. This uses a Postgres [event trigger](/docs/guides/database/postgres/event-triggers) to call `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` on each newly created table.
@@ -412,7 +414,9 @@ This can be useful for system-level access. You should _never_ share login crede
 
 ## Test your policies
 
-A wrong policy fails quietly. Too permissive, and a query returns rows it shouldn't. Too strict, and it returns nothing and raises no error. Test both directions before you ship a policy.
+We recommend writing tests for every policy, in the same change that sets the grants and creates the policies. Treat the tests as part of securing the table, not as a follow-up.
+
+A wrong policy fails quietly. Too permissive, and a query returns rows it shouldn't. Too strict, and it returns nothing and raises no error. Neither case surfaces as an error, so tests are how you find out.
 
 Supabase runs database tests with [pgTAP](/docs/guides/database/extensions/pgtap) through the CLI. Test files are `.sql` files under `supabase/tests/`.
 

--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -72,6 +72,10 @@ Postgres runs two checks before a client touches a table. Grants decide whether 
 
 On existing projects, a new table in `public` receives `select`, `insert`, `update`, and `delete` for `anon`, `authenticated`, and `service_role` automatically. Both client roles start out able to write to your table, and adding policies doesn't take those grants back. A table protected only by policies still hands `anon` an insert path if you never revoke the grant.
 
+A missing grant raises a `42501` error before any policy runs. When a request fails that your policy should allow, check the grants before you change the policy.
+
+### Set the grants for a table
+
 Set the grants to match what each role does in your app:
 
 1. Revoke the automatic grants from both client roles.
@@ -89,14 +93,14 @@ Set the grants to match what each role does in your app:
 
 3. Enable RLS on the table and write policies that decide which rows each role reaches.
 
-Data that clients read but never write, such as a feed a backend job populates, gets no write grant at all:
+For data that clients read but never write, such as a feed a backend job populates, grant no writes in step 2:
 
 ```sql
 revoke all on table public.weather_readings from anon, authenticated;
 grant select on table public.weather_readings to anon, authenticated;
 ```
 
-A missing grant raises a `42501` error before any policy runs, so check the grants first when a request fails that your policy should allow. To stop new tables from receiving the automatic grants, see [Revoke default privileges](/docs/guides/api/securing-your-api#revoke-default-privileges).
+To stop new tables from receiving the automatic grants in the first place, see [Revoke default privileges](/docs/guides/api/securing-your-api#revoke-default-privileges).
 
 ## Auto-enable RLS for new tables
 

--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -422,11 +422,26 @@ This can be useful for system-level access. You should _never_ share login crede
 
 ## Test your policies
 
-We recommend writing tests for every policy, in the same change that sets the grants and creates the policies. Treat the tests as part of securing the table, not as a follow-up.
+We recommend writing tests for every policy, in the same change that sets the grants and creates the policies. Tests are a fundamental part of a secure setup, and they give you a repeatable way to prove a policy behaves the way you intended.
 
 A wrong policy fails quietly. Too permissive, and a query returns rows it shouldn't. Too strict, and it returns nothing and raises no error. Neither case surfaces as an error, so tests are how you find out.
 
 Supabase runs database tests with [pgTAP](/docs/guides/database/extensions/pgtap) through the CLI. Test files are `.sql` files under `supabase/tests/`.
+
+### How policy tests work
+
+Switch role and identity between cases with `set local role` and `set local request.jwt.claim.sub`, so each assertion runs as the user it describes.
+
+Match the assertion to the way the denial happens:
+
+- A missing grant raises `42501`. Assert it with `throws_ok`.
+- A `with check` violation raises `42501`. Assert it with `throws_ok`.
+- A `using` clause that filters the target row out raises nothing. The update or delete matches zero rows instead. Assert that no row changed, not that an error was raised.
+- An allowed write needs an assertion on the resulting row. The absence of an error doesn't prove that anything changed.
+
+Add `returning` to an allowed write so a single assertion proves the row changed. A denied write returns no rows, so the same shape asserts the denial.
+
+### Write and run the tests
 
 1. Create the tests directory and a test file:
 
@@ -442,17 +457,6 @@ Supabase runs database tests with [pgTAP](/docs/guides/database/extensions/pgtap
    ```bash
    supabase test db
    ```
-
-Switch role and identity between cases with `set local role` and `set local request.jwt.claim.sub`, so each assertion runs as the user it describes.
-
-Match the assertion to the way the denial happens:
-
-- A missing grant raises `42501`. Assert it with `throws_ok`.
-- A `with check` violation raises `42501`. Assert it with `throws_ok`.
-- A `using` clause that filters the target row out raises nothing. The update or delete matches zero rows instead. Assert that no row changed, not that an error was raised.
-- An allowed write needs an assertion on the resulting row. The absence of an error doesn't prove that anything changed.
-
-Add `returning` to an allowed write so a single assertion proves the row changed. A denied write returns no rows, so the same shape asserts the denial.
 
 This example tests a `profiles` table where `authenticated` holds every privilege, `anon` holds none, and each user reads and writes only their own row:
 


### PR DESCRIPTION
Closes DOCS-1274

## Problem

The `build-docs-002-rls-guide` eval points an agent at the Row Level Security guide with a vibe-coder prompt that never says RLS, policy, role, or test. It failed 6 of 35 checks. Each failure traces to something the guide doesn't say.

- **Grants.** `anon` kept insert, update, and delete on all four to-do tables. Both client roles kept writes on the weather feed. 24 privileges untouched.
- **Indexes.** Missing on `list_members.user_id`. The agent indexed the other three, so it missed the composite-primary-key case specifically.
- **Tests.** No pgTAP files. `Result: NOTESTS`, so the coverage judge never ran.

## Solution

- **Add a `Grants and policies` section.**
- **Rewrite the opening danger admonition around revoke-then-grant.** It previously showed `grant` only, which reads as though privileges start from nothing. 
- **Drop the `(or primary keys)` carve-out from `Add indexes`.** A column counts as indexed only when it leads a `btree` index, shown with a composite-primary-key example.
- **Add a `Test your policies` section.** Covers file location under `supabase/tests/`, `supabase test db`, role and identity switching, which assertion matches which denial, and an 11-assertion example spanning allow and deny for all four operations across `anon` and `authenticated`.

Used the supacademy RLS course as a second reference. Its framing of grants running before RLS shaped the new section.

## Manual testing

1. Open the [Row Level Security guide](https://docs-git-docs-rls-revision-supabase.vercel.app/docs/guides/database/postgres/row-level-security) on the preview. `Grants and policies` and `Test your policies` appear in the table of contents.
2. Select the `Grants and policies` link at the end of the first admonition. It jumps to the new section.
3. Open the [markdown version](https://docs-git-docs-rls-revision-supabase.vercel.app/docs/guides/database/postgres/row-level-security.md), which is what agents fetch. Both new sections and the revised `Add indexes` text are present.
4. From `apps/docs`, run `pnpm lint:mdx`. The 4 warnings on this file match `master`, with no new ones.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation

* Clarified that exposed tables must enable row-level security.
* Explained the distinction between database grants and row-level security policies.
* Added least-privilege examples for client roles, including read-only access.
* Added pgTAP testing guidance with a complete `profiles` example.
* Clarified that composite indexes support policy filters only on their leading columns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->