### PR TITLE
perf(logs): drop log_attributes from the OTEL previewer list query

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/Logs.utils.otel.test.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.utils.otel.test.ts
@@ -2,12 +2,14 @@ import { describe, expect, it } from 'vitest'
 
 import { LogsTableName } from './Logs.constants'
 import {
+  genAttributeHydrationQueryOtel,
   genChartQueryOtel,
   genCountQueryOtel,
   genDefaultQueryOtel,
   genSingleLogQueryOtel,
   mapOtelPreviewRow,
   mapOtelSingleLogToLegacy,
+  otelListNeedsHydration,
   otelTimestampToMicros,
 } from './Logs.utils.otel'
 import type { OtelLogRow } from '@/data/logs/otel-inspection.utils'
@@ -17,17 +19,16 @@ import { formatSql } from '@/lib/formatSql'
 const fmt = (fragment: string) => formatSql(fragment)
 
 describe('genDefaultQueryOtel', () => {
-  it('targets the OTEL logs table by source and aliases postgres columns', () => {
+  // Reading any `log_attributes` key decompresses the whole map, so the list
+  // query must not reference it at all — the aliased columns move to
+  // `genAttributeHydrationQueryOtel`.
+  it('omits log_attributes entirely when the filters do not need it', () => {
     expect(fmt(genDefaultQueryOtel(LogsTableName.POSTGRES, {}, 100))).toMatchInlineSnapshot(`
       "-- Logs Preview Query (otel) ['postgres_logs']
       select
         id,
         timestamp,
-        event_message,
-        log_attributes['identifier'] as identifier,
-        log_attributes['parsed.error_severity'] as error_severity,
-        log_attributes['parsed.detail'] as detail,
-        log_attributes['parsed.hint'] as hint
+        event_message
       from
         logs
       where
@@ -39,18 +40,14 @@ describe('genDefaultQueryOtel', () => {
     `)
   })
 
-  it('aliases edge columns to the leaf names the api renderer reads', () => {
-    expect(fmt(genDefaultQueryOtel(LogsTableName.EDGE, {}, 50))).toMatchInlineSnapshot(`
+  it('omits log_attributes for edge logs too', () => {
+    const sql = fmt(genDefaultQueryOtel(LogsTableName.EDGE, {}, 50))
+    expect(sql).toMatchInlineSnapshot(`
       "-- Logs Preview Query (otel) ['edge_logs']
       select
         id,
         timestamp,
-        event_message,
-        log_attributes['identifier'] as identifier,
-        log_attributes['request.method'] as method,
-        log_attributes['request.path'] as path,
-        log_attributes['request.search'] as search,
-        log_attributes['response.status_code'] as status_code
+        event_message
       from
         logs
       where
@@ -60,6 +57,16 @@ describe('genDefaultQueryOtel', () => {
       limit
         50"
     `)
+    expect(sql).not.toContain('log_attributes')
+  })
+
+  // A filter that already reads the map makes the split pointless — the query
+  // pays for the map in WHERE regardless, so the columns stay inline and no
+  // second request is made.
+  it('keeps the aliased columns inline when a filter already reads the map', () => {
+    const sql = fmt(genDefaultQueryOtel(LogsTableName.EDGE, { 'status_code.error': true }))
+    expect(sql).toContain("log_attributes['request.method'] as method")
+    expect(otelListNeedsHydration(LogsTableName.EDGE, { 'status_code.error': true })).toBe(false)
   })
 
   it('maps pg_cron onto postgres_logs with the cron predicate', () => {
@@ -131,6 +138,8 @@ describe('genDefaultQueryOtel', () => {
     `)
   })
 
+  // Text search reads `event_message`, a real column — so it keeps the lean
+  // projection rather than falling back.
   it('translates a search_query filter to a case-insensitive event_message match', () => {
     expect(fmt(genDefaultQueryOtel(LogsTableName.POSTGRES, { search_query: 'deadlock' })))
       .toMatchInlineSnapshot(`
@@ -138,11 +147,7 @@ describe('genDefaultQueryOtel', () => {
       select
         id,
         timestamp,
-        event_message,
-        log_attributes['identifier'] as identifier,
-        log_attributes['parsed.error_severity'] as error_severity,
-        log_attributes['parsed.detail'] as detail,
-        log_attributes['parsed.hint'] as hint
+        event_message
       from
         logs
       where
@@ -531,6 +536,63 @@ describe('genChartQueryOtel', () => {
       order by
         timestamp asc"
     `)
+  })
+})
+
+describe('genAttributeHydrationQueryOtel', () => {
+  it('fetches the aliased columns for one page of ids, scoped to the source', () => {
+    expect(fmt(genAttributeHydrationQueryOtel(LogsTableName.EDGE, ['id-a', 'id-b'])!))
+      .toMatchInlineSnapshot(`
+      "-- Logs Attribute Hydration Query (otel) ['edge_logs']
+      select
+        id,
+        log_attributes['identifier'] as identifier,
+        log_attributes['request.method'] as method,
+        log_attributes['request.path'] as path,
+        log_attributes['request.search'] as search,
+        log_attributes['response.status_code'] as status_code
+      from
+        logs
+      where
+        source = 'edge_logs'
+        and id in ('id-a', 'id-b')
+      limit
+        2"
+    `)
+  })
+
+  it('escapes ids rather than interpolating them raw', () => {
+    const sql = genAttributeHydrationQueryOtel(LogsTableName.EDGE, ["a' or '1'='1"])!
+    expect(sql).toContain("'a'' or ''1''=''1'")
+  })
+
+  // Null lets the caller skip the request rather than send a query that can
+  // only return nothing.
+  it('returns null when there is nothing to fetch', () => {
+    expect(genAttributeHydrationQueryOtel(LogsTableName.EDGE, [])).toBeNull()
+    expect(genAttributeHydrationQueryOtel(LogsTableName.REALTIME, ['id-a'])).toBeNull()
+  })
+})
+
+describe('otelListNeedsHydration', () => {
+  it('is true for a table with attribute columns and map-free filters', () => {
+    expect(otelListNeedsHydration(LogsTableName.EDGE, {})).toBe(true)
+    expect(otelListNeedsHydration(LogsTableName.POSTGRES, { search_query: 'deadlock' })).toBe(true)
+  })
+
+  it('is false when a filter reads the map', () => {
+    expect(otelListNeedsHydration(LogsTableName.POSTGRES, { database: 'replica-1' })).toBe(false)
+    expect(otelListNeedsHydration(LogsTableName.EDGE, { 'method.get': true })).toBe(false)
+  })
+
+  // pg_cron's base condition reads `parsed.application_name`, so it pays for
+  // the map on every query regardless of user filters.
+  it('is false for pg_cron, whose base condition reads the map', () => {
+    expect(otelListNeedsHydration(LogsTableName.PG_CRON, {})).toBe(false)
+  })
+
+  it('is false for tables with no attribute columns to hydrate', () => {
+    expect(otelListNeedsHydration(LogsTableName.REALTIME, {})).toBe(false)
   })
 })
 

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.utils.otel.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.utils.otel.ts
@@ -259,17 +259,81 @@ const genOtelSelectColumns = (table: LogsTableName): SafeLogSqlFragment => {
   return joinSqlFragments(columns, ', ')
 }
 
+// The real columns every list row needs, with no `log_attributes` access.
+const LIST_COLUMNS: SafeLogSqlFragment = safeSql`id, timestamp, event_message`
+
+// `log_attributes` is a Map(String,String), stored as parallel key/value arrays,
+// so reading ANY key decompresses the whole map — one key costs what the entire
+// map costs. It dominates row size, which makes it the difference between a
+// cheap list query and one that can exhaust the server's memory while sorting.
+//
+// So the projection is all-or-nothing: dropping some keys saves nothing. A list
+// query either avoids the map entirely (and fetches attributes for the rendered
+// page separately, via `genAttributeHydrationQueryOtel`) or may as well keep
+// them inline.
+const touchesAttributes = (fragment: SafeLogSqlFragment): boolean =>
+  fragment.includes('log_attributes')
+
+/**
+ * True when the list query for this table/filter combination can use the lean
+ * projection, and therefore needs a follow-up hydration query to render its
+ * attribute-derived columns.
+ *
+ * False when the table has no attribute columns (nothing to hydrate), or when
+ * the WHERE clause already reads `log_attributes` — a status/method/path filter,
+ * the `database` filter, or the pg_cron base condition. Those queries pay the
+ * map's cost in WHERE no matter what, so splitting would add a round trip and
+ * save nothing.
+ */
+export const otelListNeedsHydration = (table: LogsTableName, filters: Filters): boolean => {
+  if ((OTEL_SOURCES[table].columns?.length ?? 0) === 0) return false
+  return !touchesAttributes(genOtelWhere(table, filters))
+}
+
 export const genDefaultQueryOtel = (
   table: LogsTableName,
   filters: Filters,
   limit: number = 100
 ): SafeLogSqlFragment => {
+  const columns = otelListNeedsHydration(table, filters)
+    ? LIST_COLUMNS
+    : genOtelSelectColumns(table)
+
   return safeSql`-- Logs Preview Query (otel) [${lit(table)}]
-SELECT ${genOtelSelectColumns(table)}
+SELECT ${columns}
 FROM logs
 ${genOtelWhere(table, filters)}
 ORDER BY timestamp DESC
 LIMIT ${lit(limit)}`
+}
+
+/**
+ * Fetches the attribute-derived columns for one already-rendered page of rows.
+ *
+ * The caller bounds this to the page's own timestamp span via the endpoint's
+ * `iso_timestamp_*` params — that bracket is what prunes the scan. `id` is not
+ * part of the table's sort key, so an `id IN (...)` lookup on its own would read
+ * the whole selected range and give back everything the lean projection saved.
+ *
+ * Returns null when there is nothing to fetch, so the caller can skip the
+ * request entirely.
+ */
+export const genAttributeHydrationQueryOtel = (
+  table: LogsTableName,
+  ids: string[]
+): SafeLogSqlFragment | null => {
+  const desc = OTEL_SOURCES[table]
+  if (!desc.columns?.length || ids.length === 0) return null
+
+  const idList = joinSqlFragments(
+    ids.map((id) => lit(id)),
+    ', '
+  )
+  return safeSql`-- Logs Attribute Hydration Query (otel) [${lit(table)}]
+SELECT id, ${joinSqlFragments(desc.columns, ', ')}
+FROM logs
+WHERE source = ${lit(desc.source)} AND id IN (${idList})
+LIMIT ${lit(ids.length)}`
 }
 
 export const genCountQueryOtel = (table: LogsTableName, filters: Filters): SafeLogSqlFragment => {

--- a/apps/studio/hooks/analytics/useLogsPreview.test.ts
+++ b/apps/studio/hooks/analytics/useLogsPreview.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+import { mergeOtelPageAttributes } from './useLogsPreview'
+import type { LogData } from '@/components/interfaces/Settings/Logs/Logs.types'
+
+const row = (id: string, timestamp: number): LogData => ({
+  id,
+  timestamp,
+  event_message: `message ${id}`,
+})
+
+describe('mergeOtelPageAttributes', () => {
+  it('merges attribute columns onto the matching row', () => {
+    const merged = mergeOtelPageAttributes(
+      [row('a', 1_000), row('b', 2_000)],
+      [
+        { id: 'a', method: 'GET', path: '/rest/v1/todos' },
+        { id: 'b', method: 'POST', path: '/auth/v1/token' },
+      ]
+    )
+
+    expect(merged[0]).toMatchObject({ id: 'a', method: 'GET', path: '/rest/v1/todos' })
+    expect(merged[1]).toMatchObject({ id: 'b', method: 'POST', path: '/auth/v1/token' })
+  })
+
+  // The list query normalizes `timestamp` to microseconds for the renderers and
+  // the pagination cursor; the attribute query doesn't select it. A merge that
+  // let the second response win here would silently break both.
+  it('never overwrites the row timestamp or event_message', () => {
+    const [merged] = mergeOtelPageAttributes(
+      [row('a', 1_755_000_000_000_000)],
+      [{ id: 'a', timestamp: 'clobbered', event_message: 'clobbered', method: 'GET' }]
+    )
+
+    expect(merged.timestamp).toBe(1_755_000_000_000_000)
+    expect(merged.event_message).toBe('message a')
+    expect(merged.method).toBe('GET')
+  })
+
+  it('passes through rows the attribute query did not return', () => {
+    const merged = mergeOtelPageAttributes(
+      [row('a', 1_000), row('b', 2_000)],
+      [{ id: 'a', method: 'GET' }]
+    )
+
+    expect(merged[0]).toMatchObject({ method: 'GET' })
+    expect(merged[1]).toEqual(row('b', 2_000))
+  })
+
+  it('returns the rows untouched when hydration produced nothing usable', () => {
+    const rows = [row('a', 1_000)]
+
+    expect(mergeOtelPageAttributes(rows, [])).toBe(rows)
+    expect(mergeOtelPageAttributes(rows, [{ method: 'GET' }])).toBe(rows)
+  })
+})

--- a/apps/studio/hooks/analytics/useLogsPreview.tsx
+++ b/apps/studio/hooks/analytics/useLogsPreview.tsx
@@ -26,13 +26,91 @@ import {
   genDefaultQuery,
 } from '@/components/interfaces/Settings/Logs/Logs.utils'
 import {
+  genAttributeHydrationQueryOtel,
   genChartQueryOtel,
   genCountQueryOtel,
   genDefaultQueryOtel,
   mapOtelPreviewRow,
+  otelListNeedsHydration,
 } from '@/components/interfaces/Settings/Logs/Logs.utils.otel'
 import { executeAnalyticsSql } from '@/data/logs/execute-analytics-sql'
 import { logsAllEndpointUrl, pickLogsQueryBuilder } from '@/data/logs/logs-endpoint'
+
+// Pads the page's timestamp bracket so a row sitting exactly on the boundary
+// isn't dropped by rounding on the way to an ISO string.
+const HYDRATION_PADDING_MS = 1000
+
+/**
+ * Fetches the attribute-derived columns for one page of already-fetched rows and
+ * merges them in, keeping the row shape the renderers already expect.
+ *
+ * Bounded to the page's own timestamp span — `id` is not in the logs table's
+ * sort key, so the time bracket is what keeps this cheap. Returns the rows
+ * unchanged if there is nothing to fetch.
+ */
+async function hydrateOtelPageAttributes({
+  rows,
+  table,
+  projectRef,
+  endpoint,
+  signal,
+}: {
+  rows: LogData[]
+  table: LogsTableName
+  projectRef: string
+  endpoint: ReturnType<typeof logsAllEndpointUrl>
+  signal?: AbortSignal
+}): Promise<LogData[]> {
+  const ids = rows
+    .map((row) => row.id)
+    .filter((id): id is string => typeof id === 'string' && id.length > 0)
+  const sql = genAttributeHydrationQueryOtel(table, ids)
+  if (sql === null) return rows
+
+  const timestamps = rows.map((row) => Number(row.timestamp)).filter((ts) => Number.isFinite(ts))
+  if (timestamps.length === 0) return rows
+
+  const data = await executeAnalyticsSql({
+    projectRef,
+    endpoint,
+    sql,
+    iso_timestamp_start: new Date(
+      Math.min(...timestamps) / 1000 - HYDRATION_PADDING_MS
+    ).toISOString(),
+    iso_timestamp_end: new Date(
+      Math.max(...timestamps) / 1000 + HYDRATION_PADDING_MS
+    ).toISOString(),
+    signal,
+  })
+
+  return mergeOtelPageAttributes(rows, (data as unknown as Logs)?.result ?? [])
+}
+
+/**
+ * Merges hydrated attribute columns onto their rows by id. Rows with no match
+ * (the attribute query returned fewer rows, or none at all) are passed through
+ * unchanged so the list still renders.
+ *
+ * The list row wins on any shared key. Today `id` is the only one the two
+ * projections have in common, but the list query is the one that normalizes
+ * `timestamp` to microseconds for the renderers and the pagination cursor — so
+ * its values take precedence rather than relying on the projections staying
+ * disjoint.
+ */
+export function mergeOtelPageAttributes(
+  rows: LogData[],
+  attributeRows: Array<Record<string, any>>
+): LogData[] {
+  const attributesById = new Map<string, Record<string, unknown>>(
+    attributeRows.filter((row) => typeof row?.id === 'string').map((row) => [row.id as string, row])
+  )
+  if (attributesById.size === 0) return rows
+
+  return rows.map((row) => {
+    const attributes = row.id ? attributesById.get(row.id) : undefined
+    return attributes ? ({ ...attributes, ...row } as LogData) : row
+  })
+}
 
 interface LogsPreviewHook {
   logData: LogData[]
@@ -102,6 +180,14 @@ function useLogsPreview({
     [useOtel, table, mergedFilters, limit]
   )
 
+  // When the list query uses the lean projection, its attribute-derived columns
+  // come from a second request scoped to the page just returned. See
+  // `otelListNeedsHydration` for when this applies.
+  const needsHydration = useMemo(
+    () => useOtel && otelListNeedsHydration(table, mergedFilters),
+    [useOtel, table, mergedFilters]
+  )
+
   const params: LogsEndpointParams = useMemo(
     () => ({
       iso_timestamp_start: timestampStart,
@@ -111,9 +197,18 @@ function useLogsPreview({
     [timestampStart, timestampEnd, defaultSql]
   )
 
+  // `table` and `needsHydration` are already implied by `defaultSql`, but the
+  // queryFn reads them directly, so they belong in the key.
   const queryKey = useMemo(
-    () => ['projects', projectRef, 'logs', params, defaultSql, { otel: useOtel }],
-    [projectRef, params, defaultSql, useOtel]
+    () => [
+      'projects',
+      projectRef,
+      'logs',
+      params,
+      defaultSql,
+      { otel: useOtel, table, needsHydration },
+    ],
+    [projectRef, params, defaultSql, useOtel, table, needsHydration]
   )
 
   const {
@@ -138,10 +233,26 @@ function useLogsPreview({
         signal,
       })
       const logs = data as unknown as Logs
-      if (useOtel && logs?.result) {
-        return { ...logs, result: logs.result.map(mapOtelPreviewRow) } as Logs
+      if (!useOtel || !logs?.result) return logs
+
+      const result = logs.result.map(mapOtelPreviewRow)
+      if (!needsHydration || result.length === 0) return { ...logs, result } as Logs
+
+      try {
+        const hydrated = await hydrateOtelPageAttributes({
+          rows: result,
+          table,
+          projectRef,
+          endpoint: logsAllEndpointUrl(useOtel),
+          signal,
+        })
+        return { ...logs, result: hydrated } as Logs
+      } catch (error) {
+        // Attribute columns are supplementary — the row still renders its
+        // timestamp and message without them. Don't fail the page over it.
+        console.error('Failed to fetch log attributes for page:', error)
+        return { ...logs, result } as Logs
       }
-      return logs
     },
     refetchOnWindowFocus: false,
     initialPageParam: undefined as string | undefined,


### PR DESCRIPTION
## What

Splits the Logs Explorer previewer's ClickHouse list query in two:

1. **List query** (`genDefaultQueryOtel`) now selects `id, timestamp, event_message` — no `log_attributes` access at all.
2. **Hydration query** (`genAttributeHydrationQueryOtel`, new) fetches the attribute-derived columns for the page that was just returned, bounded to that page's own timestamp span.

The merge happens inside the existing infinite query in `useLogsPreview`, so `logData` keeps its current shape and no renderer or component changes.

## Why

`log_attributes` is a `Map(String, String)`, stored in ClickHouse as parallel key/value arrays. Reading **any** key decompresses the whole map — one key costs exactly what the entire map costs. It's the dominant term in row size, and it's what turns a large sort into one that can exhaust the server's memory.

`genDefaultQueryOtel` was selecting 2–8 attribute keys per source purely to fill list columns. Because the cost is all-or-nothing, trimming individual keys would save exactly zero — the projection either avoids the map entirely or may as well keep it inline. Hence the split rather than a trim.

The hydration query's time bracket is load-bearing, not decoration: `id` is not part of the sort key `(project, source, timestamp)`, so an `id IN (...)` lookup on its own would scan the whole selected range and hand back everything the lean projection saved. Same failure mode as #49021, which fixed it for the single-log lookup.

## The fallback rule

`otelListNeedsHydration` returns false — keeping today's single query — when:

- the table has no attribute columns to hydrate (`realtime_logs`, `storage_logs`, …), or
- the generated `WHERE` already reads `log_attributes`: any status/method/product-path filter, the `database` filter, or the pg_cron base condition.

Those queries pay for the map in `WHERE` no matter what, so splitting would add a round trip and save nothing. This means the change **degrades to exactly current behavior** rather than to something slower. Text search (`event_message ILIKE`) reads a real column, so it keeps the lean path.

The predicate works by inspecting the generated `WHERE` fragment for `log_attributes`, so it stays correct automatically as filter templates are added — including the `resolveUnknownOtelClause` fallback, which always emits a map lookup.

## Notes

- **Two sequential round trips per page** on the lean path. That's the tradeoff the split makes; the second query is small and tightly bounded.
- **Hydration failure degrades, it doesn't fail the page** — rows still render their timestamp and message via `defaultRenderCell`. Mirrors how the unified-logs inspection query treats its supplementary function-logs fetch.
- The hydration query uses POST (the `executeAnalyticsSql` default) rather than the list query's GET, since a 100-id `IN` list is ~4KB of query string.
- Bounds go through the endpoint's `iso_timestamp_*` params rather than an inline `WHERE timestamp`, following the convention #47978 established for these files.
- Independent of #49021 — different functions in the shared file, no shared code. Either can land first.

## Test plan

- [x] `Logs.utils.otel.test.ts` — lean projection snapshots, an explicit `not.toContain('log_attributes')`, the inline-fallback case, hydration query shape, id escaping, and the null/no-op cases; `otelListNeedsHydration` covered across all four branches
- [x] `useLogsPreview.test.ts` (new) — merge by id, unmatched rows passed through, and that the list row wins on shared keys so the normalized microsecond `timestamp` can't be clobbered
- [x] 267 tests passing across `components/interfaces/Settings/Logs`, `data/logs`, `hooks/analytics`, `tests/features/logs`
- [x] `typecheck`, `lint:ratchet`, Prettier
- [ ] **Manual, with `otelLegacyLogs` on** — this is the important one, since no automated test exercises the two-request path (the test suite runs with the flag off):
  - [ ] Edge logs list renders method/path/status; Postgres logs renders severity/detail/hint
  - [ ] "Load older" pages still render attributes
  - [ ] Applying a status/method filter still renders correctly (inline fallback path)
  - [ ] Text search still renders attributes (lean path with a filter)
  - [ ] Selecting a row still opens the correct detail panel

## Follow-up

Same split applies to unified logs (`ROW_PROJECTION` in `UnifiedLogs.queries.ts`), which is on a separate flag (`otelUnifiedLogs`) and entangled with `level`/`status` being derived from the map in `WHERE`. Not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
