### PR TITLE
fix(logs): route the unified logs export through the safe SQL boundary

### DIFF
--- a/apps/studio/data/logs/get-unified-logs.ts
+++ b/apps/studio/data/logs/get-unified-logs.ts
@@ -2,12 +2,13 @@ import { useMutation } from '@tanstack/react-query'
 import { useFlag } from 'common'
 import { toast } from 'sonner'
 
+import { executeAnalyticsSql } from './execute-analytics-sql'
 import { logsAllEndpointUrl, pickLogsQueryBuilder } from './logs-endpoint'
+import { analyticsLiteral, safeSql } from './safe-analytics-sql'
 import { getUnifiedLogsISOStartEnd } from './unified-logs-infinite-query'
 import { getUnifiedLogsQuery } from '@/components/interfaces/UnifiedLogs/UnifiedLogs.queries'
 import { getUnifiedLogsQuery as getUnifiedLogsQueryBq } from '@/components/interfaces/UnifiedLogs/UnifiedLogs.queries.bq'
 import { QuerySearchParamsType } from '@/components/interfaces/UnifiedLogs/UnifiedLogs.types'
-import { handleError, post } from '@/data/fetchers'
 import type { ResponseError, UseCustomMutationOptions } from '@/types'
 
 export type getUnifiedLogsVariables = {
@@ -31,17 +32,21 @@ export async function retrieveUnifiedLogs({
 
   const { isoTimestampStart, isoTimestampEnd } = getUnifiedLogsISOStartEnd(search, hoursAgo)
   const buildQuery = pickLogsQueryBuilder(useOtel, getUnifiedLogsQuery, getUnifiedLogsQueryBq)
-  const sql = `${buildQuery(search)} ORDER BY timestamp DESC, id DESC LIMIT ${limit}`
+  // `safeSql` (not a plain template literal) keeps the SafeLogSqlFragment brand
+  // intact, and `analyticsLiteral` rejects a non-finite limit instead of
+  // emitting `LIMIT NaN`. Mirrors the row-list query in
+  // `unified-logs-infinite-query.ts`.
+  const sql = safeSql`${buildQuery(search)} ORDER BY timestamp DESC, id DESC LIMIT ${analyticsLiteral(limit)}`
 
-  const endpoint = logsAllEndpointUrl(useOtel)
-  const { data, error } = await post(endpoint, {
-    params: { path: { ref: projectRef } },
-    body: { iso_timestamp_start: isoTimestampStart, iso_timestamp_end: isoTimestampEnd, sql },
+  const data = await executeAnalyticsSql({
+    projectRef,
+    endpoint: logsAllEndpointUrl(useOtel),
+    sql,
+    iso_timestamp_start: isoTimestampStart,
+    iso_timestamp_end: isoTimestampEnd,
   })
 
-  if (error) handleError(error)
-
-  const resultData = data?.result ?? []
+  const resultData = (data as { result?: any[] } | undefined)?.result ?? []
 
   const result = resultData.map((row: any) => {
     const ts = String(row.timestamp ?? '')


### PR DESCRIPTION
## What

`retrieveUnifiedLogs` (the CSV/JSON export behind the unified logs download button) now composes its SQL with `safeSql` and runs it through `executeAnalyticsSql`, instead of a plain template literal posted via a raw `post()` call.

## Why

Two related gaps, both narrow:

- **The brand was being dropped.** `getUnifiedLogsQuery` returns a `SafeLogSqlFragment`, but interpolating it into a plain template literal collapses it to `string`. This was the only place in `data/logs/` that then bypassed `executeAnalyticsSql` — the wire boundary whose whole job is to reject unbranded SQL at compile time. The inputs were already sanitized upstream, so this isn't a live injection bug; it's the one hole in an otherwise enforced invariant, and it's the kind that stops being theoretical the moment someone adds a parameter here.
- **`LIMIT` was interpolated raw.** `analyticsLiteral` now rejects a non-finite value instead of emitting `LIMIT NaN`. Not reachable from the dialog (it offers 100/500/1000), but the old code would have sent it verbatim.

No behaviour change for valid input.

## Notes

This started as a larger change — I'd proposed paging the export to break its `LIMIT 1000` sort into ten bounded ones. I dropped that after checking the numbers: in the investigation's fleet data, `LIMIT`-bearing runs had p99 memory of 986 MiB and **zero** runs above 10 GiB across 99,901 runs, with every OOM kill in the no-`LIMIT` cohort. The export is `LIMIT`-bearing at 1000, so it's not in the shape that caused problems. Paging would also likely *increase* total bytes read, since `ORDER BY timestamp` isn't sort-key aligned and none of the paged queries would terminate early.

I'd also claimed the export returned duplicate rows across page boundaries. It doesn't — it's a single request with no pagination. That issue belongs to the interactive list (`getUnifiedLogs`), which advances a timestamp-only cursor and dedupes client-side in `UnifiedLogs.tsx`. Untouched here.

So what's left is just the boundary fix.

## Test plan

- [x] `pnpm --filter studio run typecheck` — the brand is enforced by the type system, so this is the meaningful check: `executeAnalyticsSql` won't accept the argument if the fragment isn't branded
- [x] 160 tests passing across `data/logs` and `components/interfaces/UnifiedLogs`
- [x] `lint:ratchet`, Prettier
- [ ] Manual: unified logs → download as CSV and as JSON, confirm both still produce the same rows

No new unit test — there's no new runtime branch to cover beyond the non-finite-limit throw, and the guarantee this PR adds is a compile-time one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
