### PR TITLE
perf(logs): narrow the log-key discovery window, widening only when idle

### DIFF
--- a/apps/studio/data/logs/otel-log-keys-query.test.ts
+++ b/apps/studio/data/logs/otel-log-keys-query.test.ts
@@ -1,0 +1,74 @@
+import dayjs from 'dayjs'
+import { HttpResponse } from 'msw'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { fetchOtelLogKeys } from './otel-log-keys-query'
+import { addAPIMock } from '@/tests/lib/msw'
+
+const OTEL_ENDPOINT = '/platform/projects/:ref/analytics/endpoints/logs.all.otel'
+
+interface RecordedRequest {
+  lookbackHours: number
+}
+
+/**
+ * Answers key-discovery requests with `keysPerCall[n]` for the nth call, and
+ * records the width of each requested window so the escalation is observable.
+ */
+function mockKeyDiscovery(keysPerCall: string[][]) {
+  const requests: RecordedRequest[] = []
+  addAPIMock({
+    method: 'post',
+    path: OTEL_ENDPOINT,
+    response: async ({ request }) => {
+      const body = (await request.clone().json()) as {
+        iso_timestamp_start: string
+        iso_timestamp_end: string
+      }
+      requests.push({
+        lookbackHours: dayjs(body.iso_timestamp_end).diff(dayjs(body.iso_timestamp_start), 'hour'),
+      })
+      const keys = keysPerCall[requests.length - 1] ?? []
+      return HttpResponse.json({ result: keys.map((key) => ({ key })) })
+    },
+  })
+  return requests
+}
+
+describe('fetchOtelLogKeys', () => {
+  beforeEach(() => {
+    addAPIMock({ method: 'get', path: OTEL_ENDPOINT, response: { result: [] } })
+  })
+
+  // `mapKeys` decompresses the whole log_attributes map for every row in the
+  // window, so the narrow first step is the point of the change — a busy source
+  // must never pay for the wide one.
+  it('asks for one hour first and stops there when keys come back', async () => {
+    const requests = mockKeyDiscovery([['request.method', 'request.path']])
+
+    const keys = await fetchOtelLogKeys({ projectRef: 'default', source: 'edge_logs' })
+
+    expect(keys).toEqual(['request.method', 'request.path'])
+    expect(requests).toEqual([{ lookbackHours: 1 }])
+  })
+
+  // An empty window means the source was idle, not that it has no keys — so a
+  // quiet project still resolves, just over more (and cheaper) scans.
+  it('widens the window while a source returns nothing', async () => {
+    const requests = mockKeyDiscovery([[], [], ['level', 'msg']])
+
+    const keys = await fetchOtelLogKeys({ projectRef: 'default', source: 'auth_logs' })
+
+    expect(keys).toEqual(['level', 'msg'])
+    expect(requests.map((r) => r.lookbackHours)).toEqual([1, 24, 24 * 7])
+  })
+
+  it('gives up after the widest window rather than looping', async () => {
+    const requests = mockKeyDiscovery([[], [], []])
+
+    const keys = await fetchOtelLogKeys({ projectRef: 'default', source: 'edge_logs' })
+
+    expect(keys).toEqual([])
+    expect(requests).toHaveLength(3)
+  })
+})

--- a/apps/studio/data/logs/otel-log-keys-query.ts
+++ b/apps/studio/data/logs/otel-log-keys-query.ts
@@ -5,21 +5,34 @@ import { logsKeys } from './keys'
 import { logsAllEndpointUrl } from './logs-endpoint'
 import { analyticsLiteral, safeSql } from './safe-analytics-sql'
 
-const LOOKBACK_HOURS = 24 * 7
+// `mapKeys` is the one operation that cannot avoid `log_attributes`: it reads
+// the map itself, so the scan decompresses it for every row of the source in the
+// window. Cost is therefore proportional to the window, and this query is only
+// after the *names* a source uses — which are stable, not something a wider
+// window discovers more of on a busy project.
+//
+// So start narrow and widen only when a window turns up nothing, which means the
+// source was idle rather than that the keys are missing. A busy project answers
+// from the first step; an idle one escalates, but its scans are small by
+// definition. The last step preserves the original 7-day reach, so no project
+// that resolved keys before stops resolving them now.
+const LOOKBACK_HOURS_STEPS = [1, 24, 24 * 7] as const
 
 const KEYS_STALE_TIME = 5 * 60 * 1000
 
-export async function fetchOtelLogKeys({
+async function fetchKeysForWindow({
   projectRef,
   source,
+  lookbackHours,
   signal,
 }: {
   projectRef: string
   source: string
+  lookbackHours: number
   signal?: AbortSignal
 }): Promise<string[]> {
   const end = new Date()
-  const start = new Date(end.getTime() - LOOKBACK_HOURS * 60 * 60 * 1000)
+  const start = new Date(end.getTime() - lookbackHours * 60 * 60 * 1000)
   const sql = safeSql`SELECT arrayJoin(mapKeys(log_attributes)) AS key, count() AS n FROM logs WHERE source = ${analyticsLiteral(source)} GROUP BY key ORDER BY n DESC LIMIT 500`
   const data = await executeAnalyticsSql({
     projectRef,
@@ -32,6 +45,22 @@ export async function fetchOtelLogKeys({
   })
   const rows = (data?.result ?? []) as { key: string }[]
   return rows.map((r) => r.key).filter(Boolean)
+}
+
+export async function fetchOtelLogKeys({
+  projectRef,
+  source,
+  signal,
+}: {
+  projectRef: string
+  source: string
+  signal?: AbortSignal
+}): Promise<string[]> {
+  for (const lookbackHours of LOOKBACK_HOURS_STEPS) {
+    const keys = await fetchKeysForWindow({ projectRef, source, lookbackHours, signal })
+    if (keys.length > 0) return keys
+  }
+  return []
 }
 
 /**


### PR DESCRIPTION
## What

`fetchOtelLogKeys` used a fixed 7-day lookback. It now starts at 1 hour and widens (1h → 24h → 7d) only when a window comes back empty.

## Why

```sql
SELECT arrayJoin(mapKeys(log_attributes)) AS key, count() AS n
FROM logs WHERE source = '<source>' GROUP BY key ORDER BY n DESC LIMIT 500
```

`mapKeys` is the one operation that can't avoid `log_attributes` — it reads the map itself. So this scan decompresses the widest column in the table for every row of the source across the whole window, and the `LIMIT 500` bounds the output, not the read. For scale, a ClickHouse read-path investigation measured 22 GiB for **one hour** of a high-volume `edge_logs` source with the map materialized; this window was ~168 hours.

What the query actually wants is the set of attribute *names* a source uses. Those are stable — a wider window doesn't surface more of them on a busy project, it just re-reads the same map for longer.

## Why escalate rather than just shorten

A short window alone would regress low-traffic projects: an idle source produces no rows in the last hour, so the drawer would show no fields. Widening on an empty result distinguishes the two cases — empty means *idle*, not *keyless*.

- Busy project: answers at 1h. That's the ~168× saving, on the projects where it matters most.
- Idle project: escalates to 24h, then 7d. Slightly more requests than before, but its scans are small by definition — read cost is proportional to rows, and it has few.
- The final step preserves the original 7-day reach, so **no project that resolved keys before stops resolving them now**.

Escalation stops after the widest window; there's no unbounded loop.

## Callers

The Field Reference drawer (`LogsExplorerHeader`, `LogsQueryPanel` — both gated on `showReference`, so on demand) and `useLogsAttributeKeys`, which fetches imperatively at submit time for the AI rewrite. `staleTime` is 5 minutes. The returned key list is unchanged.

## Notes

The read-volume claim is reasoned from the map's storage layout plus the window size, not measured against these projects specifically. The escalation design means it's safe either way — but if you want the number before merging, `system.query_log` filtered to this query's comment on one of the high-volume projects would settle it.

## Test plan

- [x] `otel-log-keys-query.test.ts` (new, MSW) — stops at 1h when keys return; walks 1h → 24h → 7d while empty; gives up after the widest window instead of looping. Asserts the requested window width per call, so the escalation itself is covered rather than just the return value.
- [x] 200 tests passing across `data/logs`, `hooks/analytics`, `components/interfaces/Settings/Logs`
- [x] `typecheck`, `lint:ratchet`, Prettier
- [ ] Manual: open the Logs Explorer Field Reference drawer on a busy project and confirm the field list is unchanged; repeat on a quiet project to confirm the escalation still populates it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
