### PR TITLE
docs(skills): record the log_attributes cost model in the ClickHouse logs skill

### DIFF
--- a/.claude/skills/clickhouse-logs-queries/SKILL.md
+++ b/.claude/skills/clickhouse-logs-queries/SKILL.md
@@ -84,13 +84,20 @@ guessing (see below).
 access. There are no unnesting joins:
 
 ```sql
+-- edge requests with method and path
 select
   log_attributes['request.method'] as method,
   log_attributes['request.path'] as path,
   log_attributes['response.status_code'] as status
 from logs
 where source = 'edge_logs'
+order by timestamp desc
+limit 100
 ```
+
+**Before you write that, read [Reading the map is all-or-nothing](#reading-the-map-is-all-or-nothing).**
+It is by far the most expensive thing you can do to a logs query, and the cost is
+invisible from the syntax.
 
 The key keeps the dotted path that BigQuery expressed through nested structs, with
 the `metadata` root dropped: BigQuery `metadata.request.method` becomes
@@ -104,6 +111,94 @@ Common keys by source:
 - `auth_logs`: `level`, `status`, `path`, `msg`, `error`
 - `function_edge_logs`: `response.status_code`, `request.method`, `request.pathname`, `function_id`, `execution_id`, `execution_time_ms`
 - `function_logs`: `event_type`, `function_id`, `execution_id`, `level`
+
+### Reading the map is all-or-nothing
+
+`Map(String, String)` is stored as two parallel arrays — one of keys, one of
+values. ClickHouse cannot read one entry out of that: **any subscript
+decompresses both arrays in full.** Reading a single key costs exactly what
+reading the whole map costs.
+
+The map also dominates row size. On a high-volume `edge_logs` source it measured
+149 GiB against 11 GiB for `event_message` — around 93% of row bytes, averaging
+54 keys per row. The practical effect, measured on one hour of one project:
+
+| the query selects                             | bytes read    |
+| --------------------------------------------- | ------------- |
+| the whole `log_attributes` map                | 22.00 GiB     |
+| just `log_attributes['response.status_code']` | **22.00 GiB** |
+| no `log_attributes` at all                    | **1.50 GiB**  |
+
+Three rules follow, and they are the difference between a cheap query and one
+that can exhaust the server's memory while sorting:
+
+- **Trimming keys saves nothing.** Going from five keys to one is a no-op. A
+  query either avoids the map entirely or may as well select all of it.
+- **A row list should not touch the map.** Select `id, timestamp, event_message`
+  and fetch attributes for the rendered page in a second query (see below).
+- **This applies to `where` too, not just `select`.** A predicate on
+  `log_attributes['...']` reads the map for every row that passes the `source`
+  and time filters. If a filter already reads the map, the projection is free —
+  splitting the query buys nothing at that point.
+
+#### Fetch attributes for a page, not for a scan
+
+When you do need attributes alongside a list, get the rows first, then fetch
+attributes for just that page — bounded by the page's own timestamp span:
+
+```sql
+-- 1. the list: no map access
+select id, timestamp, event_message
+from logs
+where source = 'edge_logs'
+order by timestamp desc
+limit 100;
+```
+
+```sql
+-- 2. attributes for the page just returned
+select id, log_attributes['request.method'] as method
+from logs
+where source = 'edge_logs'
+  and timestamp >= :page_min_ts   -- from the rows above
+  and timestamp <= :page_max_ts
+  and id in (:ids)
+limit 100
+```
+
+The timestamp bracket is what prunes, and it is not optional: **`id` is not part
+of the sort key**, so `where id in (...)` on its own scans the entire window and
+gives back everything step 1 saved. Measured, this pattern costs ~50 MB for a
+page against 22 GiB inline.
+
+### Point lookups need a source and a time bracket
+
+The same trap, for a single row. `id` alone is never enough:
+
+```sql
+-- wrong: scans the whole selected range
+select id, timestamp, log_attributes from logs where id = 'abc' limit 1;
+```
+
+The table's sort key is `(project, source, timestamp)`. Add `source` — it narrows
+the sorted range before the time bound even applies — and bracket the timestamp
+tightly around the row you already have client-side:
+
+```sql
+-- right: source narrows the range, the caller bounds ±1 minute around the row
+select id, timestamp, log_attributes
+from logs
+where id = 'abc' and source = 'edge_logs'
+limit 1;
+```
+
+### Window size multiplies map cost
+
+Whenever a query reads the map, its cost scales with the time range. This matters
+most for queries that _must_ read it — `mapKeys` reads the map by definition, so a
+key-discovery query over 7 days costs ~168× the same query over one hour, for a
+result that barely changes. Prefer the narrowest window that answers the
+question, and widen only when a narrow one comes back empty.
 
 ### Numeric fields are strings
 
@@ -135,6 +230,10 @@ limit 100;
 rank them by frequency. (The Studio codebase does exactly this for the Field
 Reference drawer and to feed real keys to the AI rewrite.)
 
+`mapKeys` reads the map by definition, so this is one of the most expensive
+queries you can run — keep the window narrow. Key _names_ are stable, so an hour
+of a busy source returns the same set a week would.
+
 ## ClickHouse vs BigQuery functions
 
 These are the substitutions that trip people up most:
@@ -160,9 +259,11 @@ reads far more data than you need.
 - **Start every query with an identifying comment** (e.g. `-- errors since last deploy`). It labels the query in logs and review, and makes each of several queries in a file easy to tell apart.
 - **Always include a `LIMIT`.** Even for aggregates while you iterate.
 - **Always query `from logs where source = '...'`.** There is no per-service table (no `edge_logs`, `postgres_logs`, etc. table) — there is one `logs` table, and `source` scopes it to a service. Filtering by `source` is required, not just an optimization.
-- **Keep the time range tight.** A smaller window returns results faster.
+- **Keep the time range tight.** A smaller window returns results faster — and when the query reads `log_attributes`, cost scales with the window.
+- **Never reference `log_attributes` in a row list.** Reading one key costs what the whole map costs, so a list query either avoids it entirely or pays for all of it. See [Reading the map is all-or-nothing](#reading-the-map-is-all-or-nothing).
 - **Filter on the real columns** (`source`, `timestamp`) before reaching into
   `log_attributes`.
+- **Never look up by `id` alone.** `id` is not in the sort key — add `source` and a tight timestamp bracket, or the lookup scans the whole window.
 - **Order by `timestamp desc`** to see the most recent logs first.
 - **Use `count()`**, not `count(*)` or `select *`.
 

--- a/.claude/skills/clickhouse-logs-queries/references/codebase-integration.md
+++ b/.claude/skills/clickhouse-logs-queries/references/codebase-integration.md
@@ -82,11 +82,44 @@ The map-key discovery hook (`apps/studio/data/logs/otel-log-keys-query.ts`,
 `fetchOtelLogKeys` / `useOtelLogKeysQuery`) is the canonical example of a small,
 correctly-branded OTEL query — read it before writing a new one.
 
+## Keep `log_attributes` out of row lists
+
+The cost model is in [the main skill file](../SKILL.md#reading-the-map-is-all-or-nothing):
+reading one key costs what the whole map costs, so a list projection is
+all-or-nothing. In this codebase that shape is already built — reuse it rather
+than reinventing it:
+
+- `genDefaultQueryOtel` emits the lean projection (`id, timestamp,
+event_message`) and `genAttributeHydrationQueryOtel` fetches the aliased
+  columns for one rendered page. `useLogsPreview` runs the second query inside
+  the list query's `queryFn` and merges by `id`, so the row shape the renderers
+  consume is unchanged.
+- `otelListNeedsHydration` is the gate. It inspects the generated `WHERE` for
+  `log_attributes` and keeps the single-query form when a filter already reads
+  the map — those queries pay for it regardless, so splitting would add a round
+  trip and save nothing. Write new filters normally; the gate picks them up
+  without being updated.
+
+For a point lookup, follow `getUnifiedLogInspection`
+(`apps/studio/data/logs/unified-log-inspection-query.ts`): filter by `source`,
+and bound `iso_timestamp_start`/`iso_timestamp_end` to a tight window around the
+row's own timestamp, which the caller already has from the page it rendered.
+Bound time through those request params, not an inline `WHERE timestamp` — that
+is the convention every query in these files follows.
+
 ## Checklist
 
 - [ ] Every dynamic value goes through `analyticsLiteral` (or another sanitizer),
-      never string concatenation.
+      never string concatenation. Compose with `safeSql`, never a plain template
+      literal — interpolating a fragment into one silently drops the brand.
 - [ ] The query filters by `source` and includes a `LIMIT`.
+- [ ] No `log_attributes` in a row-list projection. If the rendered row needs
+      attributes, hydrate the page separately rather than trimming keys —
+      trimming saves nothing.
+- [ ] A lookup by `id` also filters by `source` and is bounded to a tight
+      timestamp window; `id` is not in the sort key.
+- [ ] The time window is the narrowest that answers the question, especially for
+      any query that reads the map.
 - [ ] Numeric `log_attributes` values are wrapped in `toInt32OrZero`.
 - [ ] The endpoint and builder are chosen with `logsAllEndpointUrl` /
       `pickLogsQueryBuilder` off `useFlag('otelLegacyLogs')`.


### PR DESCRIPTION
## What

Adds the `log_attributes` cost model to `clickhouse-logs-queries`, plus the two query patterns that avoid it.

## Why

The skill taught bracket access into `log_attributes` with no cost model at all. Its strongest existing hint was *"filter on the real columns before reaching into `log_attributes`"* — which reads as a mild ordering preference, not as "this column is ~93% of your bytes and reading one key costs the whole map."

That gap is why the expensive queries in Studio look reasonable. `log_attributes['request.method'] as method` appears to be a single-field read. Nothing in the syntax suggests it decompresses two full arrays. Anyone writing a new logs query from this skill would reproduce it.

## What changed

**`SKILL.md`**

- New **Reading the map is all-or-nothing** section: `Map(String, String)` is parallel key/value arrays, so any subscript decompresses both in full. Includes the measured table (whole map 22.00 GiB / one key 22.00 GiB / no map 1.50 GiB, one hour, one project) because the equality between the first two rows is the whole point and is more convincing shown than asserted.
- The three rules that follow: trimming keys saves nothing; a row list must not touch the map; the same applies to `WHERE`, so a query already filtering on the map may as well project it.
- **Fetch attributes for a page, not for a scan** — the two-query pattern, with the warning that the timestamp bracket is load-bearing because `id` is not in the sort key.
- **Point lookups need a source and a time bracket** — wrong/right pair for the `where id = '...'` trap.
- **Window size multiplies map cost** — why a wide `mapKeys` discovery query is so expensive, and that key names are stable so a narrow window suffices.
- Two entries added to Best practices, and a forward-reference from the section that first introduces bracket access.
- Fixed an example that selected three map keys with **no `LIMIT`**, three lines below the rule "always include a `LIMIT`."

**`references/codebase-integration.md`**

- Points at the implementations rather than describing the patterns abstractly: `genDefaultQueryOtel` / `genAttributeHydrationQueryOtel` / `otelListNeedsHydration` for lists, `getUnifiedLogInspection` for point lookups. Notes that the gate inspects the generated `WHERE`, so new filters are picked up without updating it.
- Checklist gains: no map in a row-list projection, `id` lookups need `source` + a time bracket, narrowest window, and compose with `safeSql` rather than a plain template literal (which silently drops the brand — the bug in #49023).

## Notes

The measured figures come from a ClickHouse read-path investigation on a high-volume project; they're representative rather than universal, and the text says "measured on one hour of one project" rather than implying they generalize.

**This documents patterns that are still in draft.** `genAttributeHydrationQueryOtel` and `otelListNeedsHydration` land in #49022; the point-lookup fix is #49021. If those change shape in review, this needs updating with them — worth merging after them rather than before.

## Test plan

- [x] Prettier
- [x] Anchor links resolve (`#reading-the-map-is-all-or-nothing`, referenced from two places in `SKILL.md` and once cross-file)
- [x] Every code identifier referenced exists at the stated path — on their respective branches for the two in-flight ones
- [ ] Skill loads cleanly and reads well end to end

## Not included

A mechanical guard: `expect(sql).not.toContain('log_attributes')` across the list builders would fail CI on a regression instead of relying on someone loading the skill. That test can only pass on top of #49022 (on `master` the list builders still emit map access), so it belongs there rather than here. Happy to add it to that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
