### PR TITLE
fix(studio): harden Explorer query persistence

### DIFF
--- a/apps/studio/components/interfaces/Explorer/ExplorerQuerySourceMenu.test.tsx
+++ b/apps/studio/components/interfaces/Explorer/ExplorerQuerySourceMenu.test.tsx
@@ -1,0 +1,126 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { FeatureFlagContext } from 'common'
+import { mockAnimationsApi } from 'jsdom-testing-mocks'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ExplorerQuerySourceMenu } from './ExplorerQuerySourceMenu'
+import { customRender } from '@/tests/lib/custom-render'
+import { addAPIMock } from '@/tests/lib/msw'
+
+mockAnimationsApi()
+
+beforeEach(() => {
+  addAPIMock({
+    method: 'get',
+    path: '/platform/projects/:ref',
+    response: {
+      id: 1,
+      ref: 'default',
+      organization_id: 1,
+      name: 'Test Project',
+      status: 'ACTIVE_HEALTHY',
+      cloud_provider: 'AWS',
+      region: 'us-east-1',
+      db_host: 'db.default.supabase.co',
+      restUrl: 'https://default.supabase.co/rest/v1/',
+      inserted_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-01T00:00:00Z',
+      subscription_id: 'sub_123',
+      is_branch_enabled: false,
+      is_physical_backups_enabled: false,
+      high_availability: false,
+      integration_source: null,
+      connectionString: 'postgresql://postgres@localhost:5432/postgres',
+      is_hibernating: false,
+    },
+  })
+})
+
+describe('ExplorerQuerySourceMenu', () => {
+  const renderWithFlags = (
+    source: Parameters<typeof ExplorerQuerySourceMenu>[0]['source'],
+    flags: Record<string, boolean>
+  ) =>
+    customRender(
+      <FeatureFlagContext.Provider value={{ configcat: flags, posthog: {}, hasLoaded: true }}>
+        <ExplorerQuerySourceMenu source={source} onSourceChange={vi.fn()} />
+      </FeatureFlagContext.Provider>
+    )
+
+  it('emits a complete default binding when the query changes source', async () => {
+    const onSourceChange = vi.fn()
+
+    customRender(
+      <ExplorerQuerySourceMenu
+        source={{
+          id: 'logs',
+          type: 'logs',
+          parameters: { time_range: { type: 'relative', amount: 1, unit: 'hour' } },
+        }}
+        onSourceChange={onSourceChange}
+      />
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: 'Query source: Logs' }))
+    await userEvent.click(screen.getByText('Database'))
+
+    expect(onSourceChange).toHaveBeenCalledWith({
+      id: 'database',
+      type: 'database',
+      parameters: {},
+    })
+  })
+
+  it('emits the selected log time range as source parameters', async () => {
+    const onSourceChange = vi.fn()
+
+    customRender(
+      <ExplorerQuerySourceMenu
+        source={{
+          id: 'logs',
+          type: 'logs',
+          parameters: { time_range: { type: 'relative', amount: 1, unit: 'hour' } },
+        }}
+        onSourceChange={onSourceChange}
+      />
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: 'Query source: Logs' }))
+    await userEvent.hover(screen.getByText('Time range'))
+    await userEvent.click(await screen.findByText('Last 3 hours'))
+
+    expect(onSourceChange).toHaveBeenCalledWith({
+      id: 'logs',
+      type: 'logs',
+      parameters: { time_range: { type: 'relative', amount: 3, unit: 'hour' } },
+    })
+  })
+
+  it('does not offer logs when source flags are disabled for a database query', async () => {
+    renderWithFlags(
+      { id: 'database', type: 'database', parameters: {} },
+      { sqlEditorLogsSource: false, otelLegacyLogs: false }
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: 'Query source: Database' }))
+
+    expect(screen.queryByText('Logs')).not.toBeInTheDocument()
+  })
+
+  it('keeps logs available when an existing query already uses it', async () => {
+    renderWithFlags(
+      {
+        id: 'logs',
+        type: 'logs',
+        parameters: { time_range: { type: 'relative', amount: 1, unit: 'hour' } },
+      },
+      { sqlEditorLogsSource: false, otelLegacyLogs: false }
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: 'Query source: Logs' }))
+
+    expect(screen.getAllByText('Logs')).toHaveLength(2)
+    expect(screen.getByText('Database')).toBeInTheDocument()
+  })
+})

--- a/apps/studio/components/interfaces/Explorer/ExplorerQuerySourceMenu.tsx
+++ b/apps/studio/components/interfaces/Explorer/ExplorerQuerySourceMenu.tsx
@@ -1,7 +1,5 @@
 import { useFlag, useParams } from 'common'
-import dayjs from 'dayjs'
 import { Check, ChevronDown } from 'lucide-react'
-import { useState } from 'react'
 import {
   Button,
   DropdownMenu,
@@ -15,7 +13,7 @@ import { DatabaseParametersSubMenu } from '@/components/interfaces/QuerySources/
 import { LogsCustomRangeDialog } from '@/components/interfaces/QuerySources/LogsCustomRangeDialog'
 import { LogsTimeRangeSubMenu } from '@/components/interfaces/QuerySources/LogsTimeRangeSubMenu'
 import { QuerySourceIcon } from '@/components/interfaces/QuerySources/QuerySourceIcon'
-import { maybeShowUpgradePromptIfNotEntitled } from '@/components/interfaces/Settings/Logs/Logs.utils'
+import { useLogsCustomRange } from '@/components/interfaces/QuerySources/useLogsCustomRange'
 import UpgradePrompt from '@/components/interfaces/Settings/Logs/UpgradePrompt'
 import {
   createDefaultCellSource,
@@ -23,7 +21,6 @@ import {
   QUERY_SOURCES,
   type CellSource,
 } from '@/data/query-sources/query-source-registry'
-import { useCheckEntitlements } from '@/hooks/misc/useCheckEntitlements'
 
 export type ExplorerQuerySourceMenuProps = {
   source: CellSource
@@ -42,10 +39,16 @@ export const ExplorerQuerySourceMenu = ({
   const { ref } = useParams()
   const isLogsSourceEnabled = useFlag('sqlEditorLogsSource')
   const isOtelLogsEnabled = useFlag('otelLegacyLogs')
-  const [isCustomRangeOpen, setIsCustomRangeOpen] = useState(false)
-  const [showUpgradePrompt, setShowUpgradePrompt] = useState(false)
-  const { getEntitlementNumericValue } = useCheckEntitlements('log.retention_days')
-  const entitledToLogDays = getEntitlementNumericValue()
+  const {
+    isCustomRangeOpen,
+    setIsCustomRangeOpen,
+    showUpgradePrompt,
+    setShowUpgradePrompt,
+    handleApplyCustomRange,
+  } = useLogsCustomRange({
+    onRangeChange: (timeRange) =>
+      onSourceChange({ id: 'logs', type: 'logs', parameters: { time_range: timeRange } }),
+  })
 
   const availableSources = QUERY_SOURCES.filter(
     (candidate) =>
@@ -53,26 +56,6 @@ export const ExplorerQuerySourceMenu = ({
       (isLogsSourceEnabled && isOtelLogsEnabled) ||
       source.type === 'logs'
   )
-
-  const applyCustomRange = ({ from, to }: { from: Date; to: Date }) => {
-    const fromIso = dayjs(from).startOf('day').toISOString()
-    if (maybeShowUpgradePromptIfNotEntitled(fromIso, entitledToLogDays)) {
-      setShowUpgradePrompt(true)
-      return
-    }
-
-    onSourceChange({
-      id: 'logs',
-      type: 'logs',
-      parameters: {
-        time_range: {
-          type: 'absolute',
-          from: fromIso,
-          to: dayjs(to).endOf('day').toISOString(),
-        },
-      },
-    })
-  }
 
   return (
     <>
@@ -143,7 +126,7 @@ export const ExplorerQuerySourceMenu = ({
           <LogsCustomRangeDialog
             open={isCustomRangeOpen}
             onOpenChange={setIsCustomRangeOpen}
-            onApply={applyCustomRange}
+            onApply={handleApplyCustomRange}
           />
           <UpgradePrompt show={showUpgradePrompt} setShowUpgradePrompt={setShowUpgradePrompt} />
         </>

--- a/apps/studio/components/interfaces/Explorer/ExplorerQueryTabCoordinator.test.tsx
+++ b/apps/studio/components/interfaces/Explorer/ExplorerQueryTabCoordinator.test.tsx
@@ -1,0 +1,30 @@
+import { LOCAL_STORAGE_KEYS } from 'common'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { ExplorerQueryTabCoordinator } from './ExplorerQueryTabCoordinator'
+import { explorerQueryState } from '@/state/explorer-query'
+import { createTabsState, TabsStateContext } from '@/state/tabs'
+import { customRender } from '@/tests/lib/custom-render'
+
+const QUERY_ID = 'pagehide-query'
+
+afterEach(() => {
+  explorerQueryState.removeDraft({ id: QUERY_ID, projectRef: 'default' })
+})
+
+describe('ExplorerQueryTabCoordinator', () => {
+  it('flushes pending query edits when the page is hidden', () => {
+    const key = LOCAL_STORAGE_KEYS.EXPLORER_QUERY_DRAFTS('default')
+    explorerQueryState.createDraft({ id: QUERY_ID, projectRef: 'default' })
+    explorerQueryState.updateDraft({ id: QUERY_ID, sql: 'select 1' })
+
+    customRender(
+      <TabsStateContext.Provider value={createTabsState('default')}>
+        <ExplorerQueryTabCoordinator />
+      </TabsStateContext.Provider>
+    )
+    window.dispatchEvent(new Event('pagehide'))
+
+    expect(JSON.parse(localStorage.getItem(key) ?? '{}')[QUERY_ID].sql).toBe('select 1')
+  })
+})

--- a/apps/studio/components/interfaces/Explorer/ExplorerQueryTabCoordinator.tsx
+++ b/apps/studio/components/interfaces/Explorer/ExplorerQueryTabCoordinator.tsx
@@ -15,12 +15,14 @@ export const ExplorerQueryTabCoordinator = () => {
   useEffect(() => {
     return tabs.registerTabTypeHandler('query', {
       confirmClose: (queryTabs) => {
+        for (const tab of queryTabs) {
+          const queryId = tab.metadata?.queryId
+          if (ref && queryId) explorerQueryState.restoreDraft({ id: queryId, projectRef: ref })
+        }
+
         const populatedDraftCount = queryTabs.filter((tab) => {
           const queryId = tab.metadata?.queryId
-          if (!ref || !queryId) return false
-
-          explorerQueryState.restoreDraft({ id: queryId, projectRef: ref })
-
+          if (!queryId) return false
           return explorerQueryState.drafts[queryId]?.uncheckedSql.trim().length > 0
         }).length
 
@@ -40,6 +42,23 @@ export const ExplorerQueryTabCoordinator = () => {
       },
     })
   }, [ref, tabs])
+
+  useEffect(() => {
+    if (!ref) return
+
+    const flushProjectDrafts = () => explorerQueryState.flushPendingPersistence({ projectRef: ref })
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') flushProjectDrafts()
+    }
+
+    window.addEventListener('pagehide', flushProjectDrafts)
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+
+    return () => {
+      window.removeEventListener('pagehide', flushProjectDrafts)
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+    }
+  }, [ref])
 
   return null
 }

--- a/apps/studio/components/interfaces/Explorer/QueryTab.test.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryTab.test.tsx
@@ -1,0 +1,180 @@
+import { act, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { HttpResponse } from 'msw'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { QueryTab } from './QueryTab'
+import type { ReadReplicasData } from '@/data/read-replicas/replicas-query'
+import { explorerQueryState } from '@/state/explorer-query'
+import { createTabsState, TabsStateContext } from '@/state/tabs'
+import { customRender } from '@/tests/lib/custom-render'
+import { addAPIMock } from '@/tests/lib/msw'
+import { setupSqlEditorMocks } from '@/tests/lib/sql-editor-test-utils'
+
+const testContext = vi.hoisted(() => ({
+  flags: { otelLegacyLogs: true } as Record<string, boolean>,
+  params: { ref: 'default', id: 'query-test' } as { ref?: string; id?: string },
+}))
+
+vi.mock('common', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('common')>()
+  return {
+    ...actual,
+    IS_PLATFORM: true,
+    useParams: () => testContext.params,
+    useFlag: (flag: string) => testContext.flags[flag] ?? false,
+  }
+})
+
+vi.mock('@/components/ui/CodeEditor/CodeEditor', () => ({
+  CodeEditor: ({ value }: { value: string }) => (
+    <textarea aria-label="SQL editor" value={value} readOnly />
+  ),
+}))
+
+vi.mock('./ExplorerQuerySourceMenu', () => ({ ExplorerQuerySourceMenu: () => null }))
+
+const renderQueryTab = () =>
+  customRender(
+    <TabsStateContext.Provider value={createTabsState('default')}>
+      <QueryTab />
+    </TabsStateContext.Provider>
+  )
+
+const createDraft = (
+  source:
+    | { id: 'database'; type: 'database'; parameters: { identifier?: string } }
+    | {
+        id: 'logs'
+        type: 'logs'
+        parameters: {
+          time_range: { type: 'relative'; amount: number; unit: 'hour' }
+        }
+      }
+) => {
+  explorerQueryState.removeDraft({ id: 'query-test', projectRef: 'default' })
+  explorerQueryState.createDraft({
+    id: 'query-test',
+    projectRef: 'default',
+    sql: 'select 1',
+    source,
+  })
+}
+
+beforeEach(() => {
+  setupSqlEditorMocks()
+  testContext.flags.otelLegacyLogs = true
+  testContext.params = { ref: 'default', id: 'query-test' }
+  explorerQueryState.removeDraft({ id: 'query-test', projectRef: 'default' })
+})
+
+afterEach(() => explorerQueryState.flushPendingPersistence())
+
+describe('QueryTab execution', () => {
+  it('keeps loading while dynamic route parameters are unavailable', () => {
+    testContext.params = {}
+
+    renderQueryTab()
+
+    expect(screen.getByRole('status', { name: 'Loading query' })).toBeInTheDocument()
+    expect(screen.queryByText('Query draft not found')).not.toBeInTheDocument()
+  })
+
+  it('records an unavailable error and skips the logs endpoint when the flag is off', async () => {
+    testContext.flags.otelLegacyLogs = false
+    createDraft({
+      id: 'logs',
+      type: 'logs',
+      parameters: { time_range: { type: 'relative', amount: 1, unit: 'hour' } },
+    })
+    const requests: Request[] = []
+    addAPIMock({
+      method: 'post',
+      path: '/platform/projects/:ref/analytics/endpoints/logs.all.otel',
+      response: ({ request }) => {
+        requests.push(request)
+        return HttpResponse.json({ result: [] })
+      },
+    })
+
+    renderQueryTab()
+    const runButton = await screen.findByRole('button', { name: 'Run' })
+    await waitFor(() => expect(runButton).toBeEnabled())
+    await userEvent.click(runButton)
+
+    expect(
+      await screen.findByText("Error: Querying logs isn't available for this project yet.")
+    ).toBeInTheDocument()
+    expect(requests).toHaveLength(0)
+  })
+
+  it('waits for replicas, then fails closed when the selected database is absent', async () => {
+    createDraft({
+      id: 'database',
+      type: 'database',
+      parameters: { identifier: 'missing-replica' },
+    })
+    let releaseReplicas: () => void = () => undefined
+    const replicasPending = new Promise<void>((resolve) => {
+      releaseReplicas = resolve
+    })
+    addAPIMock({
+      method: 'get',
+      path: '/platform/projects/:ref/databases',
+      response: async () => {
+        await replicasPending
+        return HttpResponse.json<ReadReplicasData>([])
+      },
+    })
+    const requests: Request[] = []
+    addAPIMock({
+      method: 'post',
+      path: '/platform/pg-meta/:ref/query',
+      response: ({ request }) => {
+        requests.push(request)
+        return HttpResponse.json([])
+      },
+    })
+
+    renderQueryTab()
+    const runButton = await screen.findByRole('button', { name: 'Run' })
+    expect(runButton).toBeDisabled()
+
+    act(() => releaseReplicas())
+    await waitFor(() => expect(runButton).toBeEnabled())
+    await userEvent.click(runButton)
+
+    expect(
+      await screen.findByText('Error: Unable to run query: Connection string is missing')
+    ).toBeInTheDocument()
+    expect(requests).toHaveLength(0)
+  })
+
+  it('resolves a relative logs range before sending the request', async () => {
+    createDraft({
+      id: 'logs',
+      type: 'logs',
+      parameters: { time_range: { type: 'relative', amount: 2, unit: 'hour' } },
+    })
+    const bodies: Array<{ iso_timestamp_start: string; iso_timestamp_end: string }> = []
+    addAPIMock({
+      method: 'post',
+      path: '/platform/projects/:ref/analytics/endpoints/logs.all.otel',
+      response: async ({ request }) => {
+        bodies.push((await request.json()) as (typeof bodies)[number])
+        return HttpResponse.json({ result: [] })
+      },
+    })
+
+    renderQueryTab()
+    const runButton = await screen.findByRole('button', { name: 'Run' })
+    await waitFor(() => expect(runButton).toBeEnabled())
+    await userEvent.click(runButton)
+    await waitFor(() => expect(bodies).toHaveLength(1))
+
+    expect(
+      new Date(bodies[0].iso_timestamp_end).getTime() -
+        new Date(bodies[0].iso_timestamp_start).getTime()
+    ).toBe(2 * 60 * 60 * 1000)
+  })
+})

--- a/apps/studio/components/interfaces/Explorer/QueryTab.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryTab.tsx
@@ -17,10 +17,11 @@ export const QueryTab = () => {
   const router = useRouter()
   const tabs = useContext(TabsStateContext)
   const querySnap = useExplorerQueryStateSnapshot()
-  const [hasRestored, setHasRestored] = useState(false)
+  const [restoredQueryKey, setRestoredQueryKey] = useState<string>()
   const stateDraft = id ? querySnap.drafts[id] : undefined
   const draft = stateDraft?.projectRef === ref ? stateDraft : undefined
   const result = draft && id ? querySnap.results[id] : undefined
+  const queryKey = id && ref ? `${ref}:${id}` : undefined
 
   useEffect(() => {
     if (!id || !ref) return
@@ -36,12 +37,16 @@ export const QueryTab = () => {
         isPreview: false,
       })
     }
-    setHasRestored(true)
+    setRestoredQueryKey(`${ref}:${id}`)
   }, [id, ref, tabs])
 
-  if (!hasRestored) {
+  if (!queryKey || restoredQueryKey !== queryKey) {
     return (
-      <div className="flex h-full items-center justify-center bg-surface-100">
+      <div
+        role="status"
+        aria-label="Loading query"
+        className="flex h-full items-center justify-center bg-surface-100"
+      >
         <Loader2 className="animate-spin text-foreground-muted" size={18} />
       </div>
     )

--- a/apps/studio/components/interfaces/QuerySources/LogsTimeRangeSubMenu.test.tsx
+++ b/apps/studio/components/interfaces/QuerySources/LogsTimeRangeSubMenu.test.tsx
@@ -1,10 +1,11 @@
-import { screen } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { mockAnimationsApi } from 'jsdom-testing-mocks'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from 'ui'
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi, type Mock } from 'vitest'
 
 import { LogsTimeRangeSubMenu } from './LogsTimeRangeSubMenu'
+import type { LogTimeRange } from '@/data/query-sources/query-source-registry'
 import { customRender } from '@/tests/lib/custom-render'
 
 mockAnimationsApi()
@@ -14,16 +15,22 @@ vi.mock('@/hooks/misc/useCheckEntitlements', () => ({
 }))
 
 const renderSubMenu = ({
-  onRangeChange = vi.fn(),
-  onOpenCustomRange = vi.fn(),
-  onShowUpgrade = vi.fn(),
+  onRangeChange = vi.fn<(range: LogTimeRange) => void>(),
+  onOpenCustomRange = vi.fn<() => void>(),
+  onShowUpgrade = vi.fn<() => void>(),
+  range = { type: 'relative', amount: 1, unit: 'hour' } as LogTimeRange,
+}: {
+  onRangeChange?: Mock<(range: LogTimeRange) => void>
+  onOpenCustomRange?: Mock<() => void>
+  onShowUpgrade?: Mock<() => void>
+  range?: LogTimeRange
 } = {}) => {
   customRender(
     <DropdownMenu defaultOpen>
       <DropdownMenuTrigger>Open</DropdownMenuTrigger>
       <DropdownMenuContent>
         <LogsTimeRangeSubMenu
-          range={{ type: 'relative', amount: 1, unit: 'hour' }}
+          range={range}
           onRangeChange={onRangeChange}
           onOpenCustomRange={onOpenCustomRange}
           onShowUpgrade={onShowUpgrade}
@@ -53,5 +60,14 @@ describe('LogsTimeRangeSubMenu', () => {
     await userEvent.click(await screen.findByText('Custom range…'))
 
     expect(onOpenCustomRange).toHaveBeenCalledOnce()
+  })
+
+  it('marks the structurally matching preset as selected', async () => {
+    renderSubMenu({ range: { type: 'relative', amount: 3, unit: 'hour' } })
+
+    await userEvent.hover(await screen.findByText('Time range'))
+
+    await waitFor(() => expect(screen.getAllByText('Last 3 hours')).toHaveLength(2))
+    expect(document.querySelector('.lucide-check')).toBeInTheDocument()
   })
 })

--- a/apps/studio/components/layouts/Tabs/RecentItems.tsx
+++ b/apps/studio/components/layouts/Tabs/RecentItems.tsx
@@ -17,6 +17,8 @@ export function getRecentItemHref(item: RecentItem, projectRef: string) {
       return `/project/${projectRef}/explorer/notebook/${item.metadata?.notebookId}`
     case 'chat':
       return `/project/${projectRef}/explorer/chat/${item.metadata?.chatId}`
+    case 'query':
+      return `/project/${projectRef}/explorer/query/${item.metadata?.queryId}`
     case 'r':
     case 'v':
     case 'm':

--- a/apps/studio/state/explorer-query.test.ts
+++ b/apps/studio/state/explorer-query.test.ts
@@ -1,19 +1,26 @@
 import { LOCAL_STORAGE_KEYS } from 'common'
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { createExplorerQueryState } from './explorer-query'
+import {
+  createExplorerQueryState,
+  EXPLORER_QUERY_PERSIST_DELAY,
+  MAX_PERSISTED_EXPLORER_QUERY_DRAFTS,
+} from './explorer-query'
 
 const createMemoryStorage = () => {
   const values = new Map<string, string>()
 
   return {
     getItem: (key: string) => values.get(key) ?? null,
-    setItem: (key: string, value: string) => values.set(key, value),
+    setItem: vi.fn((key: string, value: string) => values.set(key, value)),
     removeItem: (key: string) => values.delete(key),
   }
 }
 
 describe('explorer query drafts', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
   it('persists and restores drafts within their project', () => {
     const storage = createMemoryStorage()
     const firstState = createExplorerQueryState(storage)
@@ -77,13 +84,112 @@ describe('explorer query drafts', () => {
     })
   })
 
+  it('ignores a malformed root value', () => {
+    const storage = createMemoryStorage()
+    storage.setItem(LOCAL_STORAGE_KEYS.EXPLORER_QUERY_DRAFTS('project-a'), JSON.stringify([]))
+
+    const state = createExplorerQueryState(storage)
+    expect(state.restoreDraft({ id: 'query-1', projectRef: 'project-a' })).toBe(false)
+  })
+
+  it('drops entries with malformed draft fields', () => {
+    const storage = createMemoryStorage()
+    storage.setItem(
+      LOCAL_STORAGE_KEYS.EXPLORER_QUERY_DRAFTS('project-a'),
+      JSON.stringify({
+        'query-1': { name: 'Invalid query', sql: 123, updatedAt: 1 },
+      })
+    )
+
+    const state = createExplorerQueryState(storage)
+    expect(state.restoreDraft({ id: 'query-1', projectRef: 'project-a' })).toBe(false)
+  })
+
+  it('falls back to the database source when persisted source data is invalid', () => {
+    const storage = createMemoryStorage()
+    storage.setItem(
+      LOCAL_STORAGE_KEYS.EXPLORER_QUERY_DRAFTS('project-a'),
+      JSON.stringify({
+        'query-1': {
+          name: 'Recoverable query',
+          sql: 'select 1',
+          updatedAt: 1,
+          source: { id: 'logs', type: 'logs', parameters: {} },
+        },
+      })
+    )
+
+    const state = createExplorerQueryState(storage)
+    expect(state.restoreDraft({ id: 'query-1', projectRef: 'project-a' })).toBe(true)
+    expect(state.drafts['query-1'].source).toEqual({
+      id: 'database',
+      type: 'database',
+      parameters: {},
+    })
+  })
+
+  it('debounces SQL persistence while updating in-memory state immediately', () => {
+    const storage = createMemoryStorage()
+    const state = createExplorerQueryState(storage)
+    const key = LOCAL_STORAGE_KEYS.EXPLORER_QUERY_DRAFTS('project-a')
+    state.createDraft({ id: 'query-1', projectRef: 'project-a' })
+    storage.setItem.mockClear()
+
+    state.updateDraft({ id: 'query-1', sql: 's' })
+    state.updateDraft({ id: 'query-1', sql: 'se' })
+    state.updateDraft({ id: 'query-1', sql: 'select 1' })
+
+    expect(state.drafts['query-1'].uncheckedSql).toBe('select 1')
+    expect(storage.setItem).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(EXPLORER_QUERY_PERSIST_DELAY)
+
+    expect(storage.setItem).toHaveBeenCalledOnce()
+    expect(JSON.parse(storage.getItem(key)!)['query-1'].sql).toBe('select 1')
+  })
+
+  it('flushes pending SQL persistence before the debounce elapses', () => {
+    const storage = createMemoryStorage()
+    const state = createExplorerQueryState(storage)
+    const key = LOCAL_STORAGE_KEYS.EXPLORER_QUERY_DRAFTS('project-a')
+    state.createDraft({ id: 'query-1', projectRef: 'project-a' })
+    storage.setItem.mockClear()
+
+    state.updateDraft({ id: 'query-1', sql: 'select 1' })
+    state.flushPendingPersistence({ projectRef: 'project-a' })
+
+    expect(storage.setItem).toHaveBeenCalledOnce()
+    expect(JSON.parse(storage.getItem(key)!)['query-1'].sql).toBe('select 1')
+
+    vi.advanceTimersByTime(EXPLORER_QUERY_PERSIST_DELAY)
+    expect(storage.setItem).toHaveBeenCalledOnce()
+  })
+
+  it('retains only the most recently updated persisted drafts', () => {
+    const storage = createMemoryStorage()
+    const state = createExplorerQueryState(storage)
+    const key = LOCAL_STORAGE_KEYS.EXPLORER_QUERY_DRAFTS('project-a')
+
+    for (let index = 0; index <= MAX_PERSISTED_EXPLORER_QUERY_DRAFTS; index++) {
+      vi.setSystemTime(index)
+      state.createDraft({ id: `query-${index}`, projectRef: 'project-a' })
+    }
+
+    const persisted = JSON.parse(storage.getItem(key)!)
+    expect(Object.keys(persisted)).toHaveLength(MAX_PERSISTED_EXPLORER_QUERY_DRAFTS)
+    expect(persisted['query-0']).toBeUndefined()
+    expect(persisted[`query-${MAX_PERSISTED_EXPLORER_QUERY_DRAFTS}`]).toBeDefined()
+  })
+
   it('removes the persisted draft and its session result when its tab closes', () => {
     const storage = createMemoryStorage()
     const state = createExplorerQueryState(storage)
 
     state.createDraft({ id: 'query-1', projectRef: 'project-a', sql: 'select 1' })
+    state.updateDraft({ id: 'query-1', sql: 'select 2' })
     state.setResult({ id: 'query-1', result: { rows: [{ value: 1 }], executedAt: 1 } })
     state.removeDraft({ id: 'query-1', projectRef: 'project-a' })
+    vi.advanceTimersByTime(EXPLORER_QUERY_PERSIST_DELAY)
 
     expect(state.drafts['query-1']).toBeUndefined()
     expect(state.results['query-1']).toBeUndefined()

--- a/apps/studio/state/explorer-query.ts
+++ b/apps/studio/state/explorer-query.ts
@@ -1,6 +1,7 @@
 import { untrustedSql, type UntrustedSqlFragment } from '@supabase/pg-meta'
 import { LOCAL_STORAGE_KEYS, safeLocalStorage } from 'common'
 import { proxy, ref, snapshot, useSnapshot } from 'valtio'
+import { z } from 'zod'
 
 import { type QueryResult } from '@/components/interfaces/Explorer/types'
 import {
@@ -33,36 +34,46 @@ type PersistedExplorerQueryDrafts = Record<string, PersistedExplorerQueryDraft>
 
 type StorageLike = Pick<typeof safeLocalStorage, 'getItem' | 'setItem' | 'removeItem'>
 
+export const EXPLORER_QUERY_PERSIST_DELAY = 300
+export const MAX_PERSISTED_EXPLORER_QUERY_DRAFTS = 50
+
+const persistedDraftsSchema = z.record(z.string(), z.unknown())
+const persistedDraftSchema = z.object({
+  name: z.string(),
+  sql: z.string(),
+  updatedAt: z.number(),
+  source: z.unknown().optional(),
+})
+
 const readPersistedDrafts = (storage: StorageLike, projectRef: string) => {
   const raw = storage.getItem(LOCAL_STORAGE_KEYS.EXPLORER_QUERY_DRAFTS(projectRef))
   if (!raw) return {} as PersistedExplorerQueryDrafts
 
   try {
-    const parsed = JSON.parse(raw)
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {}
+    const parsed = persistedDraftsSchema.safeParse(JSON.parse(raw))
+    if (!parsed.success) return {}
 
     return Object.fromEntries(
-      Object.entries(parsed).flatMap(([id, value]) => {
-        if (
-          value === null ||
-          typeof value !== 'object' ||
-          !('name' in value) ||
-          typeof value.name !== 'string' ||
-          !('sql' in value) ||
-          typeof value.sql !== 'string' ||
-          !('updatedAt' in value) ||
-          typeof value.updatedAt !== 'number'
-        ) {
-          return []
-        }
+      Object.entries(parsed.data).flatMap(([id, value]) => {
+        const draft = persistedDraftSchema.safeParse(value)
+        if (!draft.success) return []
 
-        const parsedSource =
-          'source' in value ? cellSourceSchema.safeParse(value.source) : { success: false as const }
+        const parsedSource = cellSourceSchema.safeParse(draft.data.source)
         const source = parsedSource.success
           ? parsedSource.data
           : createDefaultCellSource('database')
 
-        return [[id, { name: value.name, source, sql: value.sql, updatedAt: value.updatedAt }]]
+        return [
+          [
+            id,
+            {
+              name: draft.data.name,
+              source,
+              sql: draft.data.sql,
+              updatedAt: draft.data.updatedAt,
+            },
+          ],
+        ]
       })
     )
   } catch {
@@ -76,11 +87,22 @@ const writePersistedDrafts = (
   drafts: PersistedExplorerQueryDrafts
 ) => {
   const key = LOCAL_STORAGE_KEYS.EXPLORER_QUERY_DRAFTS(projectRef)
-  if (Object.keys(drafts).length === 0) storage.removeItem(key)
-  else storage.setItem(key, JSON.stringify(drafts))
+  const retainedDrafts = Object.fromEntries(
+    Object.entries(drafts)
+      .sort(([, a], [, b]) => b.updatedAt - a.updatedAt)
+      .slice(0, MAX_PERSISTED_EXPLORER_QUERY_DRAFTS)
+  )
+
+  if (Object.keys(retainedDrafts).length === 0) storage.removeItem(key)
+  else storage.setItem(key, JSON.stringify(retainedDrafts))
 }
 
 export const createExplorerQueryState = (storage: StorageLike = safeLocalStorage) => {
+  const pendingPersistence = new Map<
+    string,
+    { timeout: ReturnType<typeof setTimeout>; persist: () => void }
+  >()
+
   const state = proxy({
     drafts: {} as Record<string, ExplorerQueryDraft>,
     results: {} as Record<string, ExplorerQueryResult>,
@@ -154,17 +176,45 @@ export const createExplorerQueryState = (storage: StorageLike = safeLocalStorage
       if (sql !== undefined) draft.uncheckedSql = untrustedSql(sql)
       draft.updatedAt = Date.now()
 
-      const persisted = readPersistedDrafts(storage, draft.projectRef)
-      persisted[id] = {
-        name: draft.name,
-        source: draft.source,
-        sql: draft.uncheckedSql,
-        updatedAt: draft.updatedAt,
+      const persist = () => {
+        const pending = pendingPersistence.get(id)
+        if (pending) clearTimeout(pending.timeout)
+        pendingPersistence.delete(id)
+        const currentDraft = state.drafts[id]
+        if (!currentDraft) return
+
+        const persisted = readPersistedDrafts(storage, currentDraft.projectRef)
+        persisted[id] = {
+          name: currentDraft.name,
+          source: currentDraft.source,
+          sql: currentDraft.uncheckedSql,
+          updatedAt: currentDraft.updatedAt,
+        }
+        writePersistedDrafts(storage, currentDraft.projectRef, persisted)
       }
-      writePersistedDrafts(storage, draft.projectRef, persisted)
+
+      const pending = pendingPersistence.get(id)
+      if (pending) clearTimeout(pending.timeout)
+
+      if (name !== undefined || source !== undefined) persist()
+      else {
+        const timeout = setTimeout(persist, EXPLORER_QUERY_PERSIST_DELAY)
+        pendingPersistence.set(id, { timeout, persist })
+      }
+    },
+
+    flushPendingPersistence: ({ projectRef }: { projectRef?: string } = {}) => {
+      for (const [id, pending] of [...pendingPersistence]) {
+        if (projectRef !== undefined && state.drafts[id]?.projectRef !== projectRef) continue
+        pending.persist()
+      }
     },
 
     removeDraft: ({ id, projectRef }: { id: string; projectRef: string }) => {
+      const pending = pendingPersistence.get(id)
+      if (pending) clearTimeout(pending.timeout)
+      pendingPersistence.delete(id)
+
       if (state.drafts[id]?.projectRef === projectRef) {
         delete state.drafts[id]
         delete state.results[id]

--- a/apps/studio/state/tabs.test.ts
+++ b/apps/studio/state/tabs.test.ts
@@ -374,4 +374,57 @@ describe('explorer query tabs', () => {
 
     expect(router.push).toHaveBeenCalledWith('/project/default/explorer/query/query-1')
   })
+
+  it('keeps Explorer tabs open when closing all table editor tabs', () => {
+    const store = createTabsState('default')
+    const router = fakeRouter()
+    store.addTab({
+      id: 'r-1',
+      type: ENTITY_TYPE.TABLE,
+      label: 'users',
+      metadata: { tableId: 1, schema: 'public' },
+      isPreview: false,
+    })
+    store.addTab({
+      id: 'query-query-1',
+      type: 'query',
+      label: 'Untitled query',
+      metadata: { queryId: 'query-1' },
+      isPreview: false,
+    })
+
+    store.handleTabCloseAll({
+      editor: 'table',
+      router,
+      onClearDashboardHistory: vi.fn(),
+    })
+
+    expect(store.openTabs).toEqual(['query-query-1'])
+    expect(store.tabsMap['query-query-1']).toBeDefined()
+  })
+
+  it('runs query cleanup for every query closed in bulk', () => {
+    const store = createTabsState('default')
+    store.addTab({
+      id: 'query-query-1',
+      type: 'query',
+      label: 'Query 1',
+      metadata: { queryId: 'query-1' },
+      isPreview: false,
+    })
+    store.addTab({
+      id: 'query-query-2',
+      type: 'query',
+      label: 'Query 2',
+      metadata: { queryId: 'query-2' },
+      isPreview: false,
+    })
+    const onClose = vi.fn()
+    store.registerTabTypeHandler('query', { onClose })
+
+    store.closeTabs(['query-query-1', 'query-query-2'])
+
+    expect(onClose).toHaveBeenCalledTimes(2)
+    expect(onClose.mock.calls.map(([tab]) => tab.metadata?.queryId)).toEqual(['query-1', 'query-2'])
+  })
 })


### PR DESCRIPTION

<img width="1690" height="1034" alt="image" src="https://github.com/user-attachments/assets/2dc5b10b-8e64-413b-861e-8b0b62e2d880" />

## Summary

- debounce draft persistence and flush pending edits when the page exits
- validate untrusted local storage with Zod, recover from malformed entries, and retain the 50 most recently updated drafts
- harden route restoration, recent-item routing, close confirmation, and local cleanup
- disable execution while project or replica data is resolving and fail closed for missing replicas
- use an HTTP-safe UUID generator for self-hosted Studio
- adopt the upstream Explorer toolbar title API
- expand component and state coverage for persistence and execution behavior

## To test

1. Open Explorer, select **Run SQL**, then enter SQL and rename the query.
2. Reload the page and confirm the draft is restored; close its tab and confirm it is discarded after the prompt.

## Why

This layer makes local-only Explorer drafts resilient to rapid edits, reloads, stale browser data, and tab lifecycle edge cases.

## Impact

Queries remain local-only, and closing their tabs discards them after confirmation. Save-as-notebook functionality remains intentionally out of scope.

## Validation

- fresh non-incremental Studio TypeScript check
- 68 Vitest tests pass across Explorer, query sources, tabs layout, and query/tab state
- Studio ESLint ratchet and Prettier check both clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Explorer query drafts now save automatically and restore reliably across navigation, tab closures, page exits, and visibility changes.
  - Recent query items now open directly to their associated Explorer query.
  - Logs time-range selections are handled consistently, including custom ranges and preset matching.

- **Bug Fixes**
  - Prevented stale query loading states when switching between queries.
  - Improved handling of invalid or outdated saved drafts.
  - Limited saved drafts to the 50 most recently updated queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->