### PR TITLE
feat(studio): add read replicas section on Infrastructure

### DIFF
--- a/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.sections.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.sections.tsx
@@ -68,7 +68,7 @@ export function ComputeSection({
           <DocsButton href={`${DOCS_URL}/guides/platform/compute-and-disk`} />
         </PageSectionAside>
       </PageSectionMeta>
-      <PageSectionContent ref={settingsRef} className="scroll-mt-24">
+      <PageSectionContent ref={settingsRef} id="compute" className="scroll-mt-24">
         <ComputeSizeField form={form} disabled={disabled} />
       </PageSectionContent>
     </PageSection>

--- a/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.sections.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.sections.tsx
@@ -68,7 +68,7 @@ export function ComputeSection({
           <DocsButton href={`${DOCS_URL}/guides/platform/compute-and-disk`} />
         </PageSectionAside>
       </PageSectionMeta>
-      <PageSectionContent ref={settingsRef} id="compute" className="scroll-mt-24">
+      <PageSectionContent ref={settingsRef} className="scroll-mt-24">
         <ComputeSizeField form={form} disabled={disabled} />
       </PageSectionContent>
     </PageSection>

--- a/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.tsx
@@ -2,7 +2,7 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useParams } from 'common'
 import { AnimatePresence, motion } from 'framer-motion'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, type ReactNode } from 'react'
 import { useForm, useWatch } from 'react-hook-form'
 import { CloudProvider } from 'shared-data'
 import { toast } from 'sonner'
@@ -62,7 +62,17 @@ import {
 } from '@/hooks/misc/useSelectedProject'
 import { GB, PROJECT_STATUS } from '@/lib/constants'
 
-export function DiskManagementForm({ chartsClassName }: { chartsClassName?: string } = {}) {
+export function DiskManagementForm({
+  chartsClassName,
+  overviewExtra,
+  beforeScaling,
+}: {
+  chartsClassName?: string
+  /** Rendered above usage charts in the overview block (for example topology). */
+  overviewExtra?: ReactNode
+  /** Rendered between overview and the Scaling section (for example read replicas). */
+  beforeScaling?: ReactNode
+} = {}) {
   const { ref: projectRef } = useParams()
   const { data: project, isPending: isProjectPending } = useSelectedProjectQuery()
   const { data: org } = useSelectedOrganizationQuery()
@@ -391,7 +401,8 @@ export function DiskManagementForm({ chartsClassName }: { chartsClassName?: stri
       <form id="disk-compute-form" onSubmit={form.handleSubmit(onSubmit)}>
         <PageContainer size="default" className="pb-16">
           <PageSection>
-            <PageSectionContent>
+            <PageSectionContent className="flex flex-col gap-y-6">
+              {overviewExtra}
               <ComputeAndDiskUsageCharts className={chartsClassName} />
             </PageSectionContent>
           </PageSection>
@@ -419,6 +430,8 @@ export function DiskManagementForm({ chartsClassName }: { chartsClassName?: stri
               />
             </div>
           )}
+
+          {beforeScaling}
 
           <PageSection>
             <PageSectionMeta>

--- a/apps/studio/components/interfaces/ProjectHome/TopSection.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/TopSection.tsx
@@ -1,4 +1,3 @@
-import { ReactFlowProvider } from '@xyflow/react'
 import Link from 'next/link'
 import { Badge, cn, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
@@ -96,9 +95,7 @@ export const TopSection = () => {
                 'w-full h-[400px] md:h-[500px] border border-muted rounded-md overflow-hidden flex flex-col relative'
               )}
             >
-              <ReactFlowProvider>
-                <InstanceConfiguration />
-              </ReactFlowProvider>
+              <InstanceConfiguration />
             </div>
           </div>
         )}

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureTopology.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureTopology.tsx
@@ -1,0 +1,15 @@
+import { InstanceConfiguration } from '@/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration'
+import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
+
+/** Project topology: load balancer, primary, and read replicas. */
+export const InfrastructureTopology = () => {
+  const { infrastructureReadReplicas } = useIsFeatureEnabled(['infrastructure:read_replicas'])
+
+  if (!infrastructureReadReplicas) return null
+
+  return (
+    <div className="w-full h-[400px] border border-muted rounded-md overflow-hidden flex flex-col relative">
+      <InstanceConfiguration />
+    </div>
+  )
+}

--- a/apps/studio/components/interfaces/Settings/Infrastructure/ReadReplicas/AddReadReplicaSheet.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/ReadReplicas/AddReadReplicaSheet.tsx
@@ -1,0 +1,67 @@
+import { parseAsBoolean, useQueryState } from 'nuqs'
+import { useRef } from 'react'
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from 'ui'
+
+import { ReadReplicaForm } from './ReadReplicaForm'
+import { DiscardChangesConfirmationDialog } from '@/components/ui-patterns/Dialogs/DiscardChangesConfirmationDialog'
+import { DocsButton } from '@/components/ui/DocsButton'
+import { useConfirmOnClose } from '@/hooks/ui/useConfirmOnClose'
+import { DOCS_URL } from '@/lib/constants'
+
+interface AddReadReplicaSheetProps {
+  onSuccess?: () => void
+}
+
+export const AddReadReplicaSheet = ({ onSuccess }: AddReadReplicaSheetProps) => {
+  const [addReplica, setAddReplica] = useQueryState(
+    'addReplica',
+    parseAsBoolean.withDefault(false).withOptions({
+      history: 'push',
+      clearOnDefault: true,
+    })
+  )
+
+  const visible = addReplica === true
+  const checkIsDirtyRef = useRef<() => boolean>(() => false)
+
+  const onClose = () => {
+    checkIsDirtyRef.current = () => false
+    setAddReplica(false)
+  }
+
+  const { confirmOnClose, handleOpenChange, modalProps } = useConfirmOnClose({
+    checkIsDirty: () => checkIsDirtyRef.current(),
+    onClose,
+  })
+
+  return (
+    <>
+      <Sheet open={visible} onOpenChange={handleOpenChange}>
+        <SheetContent size="lg" showClose={false} className="max-w-3xl">
+          <div className="flex flex-col h-full min-h-0" tabIndex={-1}>
+            <SheetHeader className="flex items-center justify-between">
+              <div>
+                <SheetTitle>Add read replica</SheetTitle>
+                <SheetDescription>
+                  Deploy a read-only copy of the complete Postgres database.
+                </SheetDescription>
+              </div>
+              <DocsButton
+                href={`${DOCS_URL}/guides/platform/read-replicas`}
+                topic="read replica settings"
+              />
+            </SheetHeader>
+
+            <ReadReplicaForm
+              checkIsDirtyRef={checkIsDirtyRef}
+              onClose={onClose}
+              onCancel={confirmOnClose}
+              onSuccess={() => onSuccess?.()}
+            />
+          </div>
+        </SheetContent>
+      </Sheet>
+      <DiscardChangesConfirmationDialog {...modalProps} />
+    </>
+  )
+}

--- a/apps/studio/components/interfaces/Settings/Infrastructure/ReadReplicas/ReadReplicasSection.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/ReadReplicas/ReadReplicasSection.tsx
@@ -2,7 +2,7 @@ import { useParams } from 'common'
 import { Database } from 'icons'
 import { Plus } from 'lucide-react'
 import { parseAsBoolean, useQueryState } from 'nuqs'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Button, Card, CardContent, Table, TableBody, TableHead, TableHeader, TableRow } from 'ui'
 import { EmptyStatePresentational } from 'ui-patterns/EmptyStatePresentational'
 import {
@@ -44,12 +44,15 @@ export const ReadReplicasSection = () => {
     isPending: isDatabasesLoading,
     isError: isDatabasesError,
     isSuccess: isDatabasesSuccess,
-  } = useReadReplicasQuery({ projectRef }, { refetchInterval: statusRefetchInterval })
-
-  const readReplicas = useMemo(
-    () => databases.filter((x) => x.identifier !== projectRef),
-    [databases, projectRef]
+  } = useReadReplicasQuery(
+    { projectRef },
+    {
+      enabled: infrastructureReadReplicas,
+      refetchInterval: infrastructureReadReplicas ? statusRefetchInterval : false,
+    }
   )
+
+  const readReplicas = databases.filter((database) => database.identifier !== projectRef)
   const hasReplicas = isDatabasesSuccess && readReplicas.length > 0
 
   useEffect(() => {
@@ -60,9 +63,11 @@ export const ReadReplicasSection = () => {
       REPLICA_STATUS.ACTIVE_UNHEALTHY,
       REPLICA_STATUS.INIT_READ_REPLICA_FAILED,
     ]
-    const replicasInTransition = readReplicas.filter((db) => !fixedStatuses.includes(db.status))
+    const replicasInTransition = databases.filter(
+      (database) => database.identifier !== projectRef && !fixedStatuses.includes(database.status)
+    )
     if (replicasInTransition.length === 0) setStatusRefetchInterval(false)
-  }, [isDatabasesSuccess, readReplicas])
+  }, [isDatabasesSuccess, databases, projectRef])
 
   if (!infrastructureReadReplicas) return null
 

--- a/apps/studio/components/interfaces/Settings/Infrastructure/ReadReplicas/ReadReplicasSection.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/ReadReplicas/ReadReplicasSection.tsx
@@ -83,7 +83,12 @@ export const ReadReplicasSection = () => {
           </PageSectionSummary>
           <PageSectionAside>
             <DocsButton href={`${DOCS_URL}/guides/platform/read-replicas`} />
-            <Button variant="primary" icon={<Plus />} onClick={() => setAddReplica(true)}>
+            <Button
+              type="button"
+              variant="primary"
+              icon={<Plus />}
+              onClick={() => setAddReplica(true)}
+            >
               Add read replica
             </Button>
           </PageSectionAside>
@@ -129,7 +134,12 @@ export const ReadReplicasSection = () => {
               title="No read replicas"
               description="All reads and writes currently go to the primary."
             >
-              <Button variant="default" icon={<Plus />} onClick={() => setAddReplica(true)}>
+              <Button
+                type="button"
+                variant="default"
+                icon={<Plus />}
+                onClick={() => setAddReplica(true)}
+              >
                 Add read replica
               </Button>
             </EmptyStatePresentational>

--- a/apps/studio/components/interfaces/Settings/Infrastructure/ReadReplicas/ReadReplicasSection.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/ReadReplicas/ReadReplicasSection.tsx
@@ -1,0 +1,138 @@
+import { useParams } from 'common'
+import { Database } from 'icons'
+import { Plus } from 'lucide-react'
+import { parseAsBoolean, useQueryState } from 'nuqs'
+import { useEffect, useMemo, useState } from 'react'
+import { Button, Card, CardContent, Table, TableBody, TableHead, TableHeader, TableRow } from 'ui'
+import { EmptyStatePresentational } from 'ui-patterns/EmptyStatePresentational'
+import {
+  PageSection,
+  PageSectionAside,
+  PageSectionContent,
+  PageSectionDescription,
+  PageSectionMeta,
+  PageSectionSummary,
+  PageSectionTitle,
+} from 'ui-patterns/PageSection'
+import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
+
+import { AddReadReplicaSheet } from './AddReadReplicaSheet'
+import { ReadReplicaRow } from './ReadReplicaRow'
+import { REPLICA_STATUS } from './ReadReplicas.constants'
+import { AlertError } from '@/components/ui/AlertError'
+import { DocsButton } from '@/components/ui/DocsButton'
+import { useReadReplicasQuery } from '@/data/read-replicas/replicas-query'
+import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
+import { DOCS_URL } from '@/lib/constants'
+
+export const ReadReplicasSection = () => {
+  const { ref: projectRef } = useParams()
+  const { infrastructureReadReplicas } = useIsFeatureEnabled(['infrastructure:read_replicas'])
+  const [, setAddReplica] = useQueryState(
+    'addReplica',
+    parseAsBoolean.withDefault(false).withOptions({
+      history: 'push',
+      clearOnDefault: true,
+    })
+  )
+
+  const [statusRefetchInterval, setStatusRefetchInterval] = useState<number | false>(5000)
+
+  const {
+    data: databases = [],
+    error: databasesError,
+    isPending: isDatabasesLoading,
+    isError: isDatabasesError,
+    isSuccess: isDatabasesSuccess,
+  } = useReadReplicasQuery({ projectRef }, { refetchInterval: statusRefetchInterval })
+
+  const readReplicas = useMemo(
+    () => databases.filter((x) => x.identifier !== projectRef),
+    [databases, projectRef]
+  )
+  const hasReplicas = isDatabasesSuccess && readReplicas.length > 0
+
+  useEffect(() => {
+    if (!isDatabasesSuccess) return
+
+    const fixedStatuses = [
+      REPLICA_STATUS.ACTIVE_HEALTHY,
+      REPLICA_STATUS.ACTIVE_UNHEALTHY,
+      REPLICA_STATUS.INIT_READ_REPLICA_FAILED,
+    ]
+    const replicasInTransition = readReplicas.filter((db) => !fixedStatuses.includes(db.status))
+    if (replicasInTransition.length === 0) setStatusRefetchInterval(false)
+  }, [isDatabasesSuccess, readReplicas])
+
+  if (!infrastructureReadReplicas) return null
+
+  return (
+    <>
+      <PageSection>
+        <PageSectionMeta>
+          <PageSectionSummary>
+            <PageSectionTitle>Read replicas</PageSectionTitle>
+            <PageSectionDescription>
+              Scale reads or serve queries closer to users.
+            </PageSectionDescription>
+          </PageSectionSummary>
+          <PageSectionAside>
+            <DocsButton href={`${DOCS_URL}/guides/platform/read-replicas`} />
+            <Button variant="primary" icon={<Plus />} onClick={() => setAddReplica(true)}>
+              Add read replica
+            </Button>
+          </PageSectionAside>
+        </PageSectionMeta>
+
+        <PageSectionContent className="flex flex-col gap-y-4">
+          {isDatabasesError && (
+            <AlertError error={databasesError} subject="Failed to retrieve read replicas" />
+          )}
+
+          {isDatabasesLoading && <GenericSkeletonLoader />}
+
+          {isDatabasesSuccess && hasReplicas && (
+            <Card>
+              <CardContent className="p-0">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className="w-[20px]" />
+                      <TableHead className="w-[250px]">Name</TableHead>
+                      <TableHead className="w-[150px]">Status</TableHead>
+                      <TableHead className="w-[150px]">Lag</TableHead>
+                      <TableHead />
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {readReplicas.map((replica) => (
+                      <ReadReplicaRow
+                        key={replica.identifier}
+                        replica={replica}
+                        onUpdateReplica={() => setStatusRefetchInterval(5000)}
+                      />
+                    ))}
+                  </TableBody>
+                </Table>
+              </CardContent>
+            </Card>
+          )}
+
+          {isDatabasesSuccess && !hasReplicas && (
+            <EmptyStatePresentational
+              icon={Database}
+              title="No read replicas"
+              description="All reads and writes currently go to the primary."
+            >
+              <Button variant="default" icon={<Plus />} onClick={() => setAddReplica(true)}>
+                Add read replica
+              </Button>
+            </EmptyStatePresentational>
+          )}
+        </PageSectionContent>
+      </PageSection>
+
+      <AddReadReplicaSheet onSuccess={() => setStatusRefetchInterval(5000)} />
+    </>
+  )
+}

--- a/apps/studio/pages/project/[ref]/settings/infrastructure.tsx
+++ b/apps/studio/pages/project/[ref]/settings/infrastructure.tsx
@@ -7,6 +7,8 @@ import {
 } from 'ui-patterns/PageHeader'
 
 import { DiskManagementForm } from '@/components/interfaces/DiskManagement/DiskManagementForm'
+import { InfrastructureTopology } from '@/components/interfaces/Settings/Infrastructure/InfrastructureTopology'
+import { ReadReplicasSection } from '@/components/interfaces/Settings/Infrastructure/ReadReplicas/ReadReplicasSection'
 import { DefaultLayout } from '@/components/layouts/DefaultLayout'
 import SettingsLayout from '@/components/layouts/ProjectSettingsLayout/SettingsLayout'
 import type { NextPageWithLayout } from '@/types'
@@ -19,12 +21,15 @@ const InfrastructureSettings: NextPageWithLayout = () => {
           <PageHeaderSummary>
             <PageHeaderTitle>Infrastructure</PageHeaderTitle>
             <PageHeaderDescription>
-              View and configure compute and disk for your project.
+              Configure compute, disk, and read replicas for your project.
             </PageHeaderDescription>
           </PageHeaderSummary>
         </PageHeaderMeta>
       </PageHeader>
-      <DiskManagementForm />
+      <DiskManagementForm
+        overviewExtra={<InfrastructureTopology />}
+        beforeScaling={<ReadReplicasSection />}
+      />
     </>
   )
 }

--- a/apps/studio/tests/components/Settings/Infrastructure/ReadReplicasSection.test.tsx
+++ b/apps/studio/tests/components/Settings/Infrastructure/ReadReplicasSection.test.tsx
@@ -1,0 +1,58 @@
+import { screen } from '@testing-library/react'
+import { HttpResponse } from 'msw'
+import { describe, expect, test, vi } from 'vitest'
+
+import { ReadReplicasSection } from '@/components/interfaces/Settings/Infrastructure/ReadReplicas/ReadReplicasSection'
+import type { components } from '@/data/api'
+import { customRender } from '@/tests/lib/custom-render'
+import { addAPIMock } from '@/tests/lib/msw'
+
+type DatabaseDetailResponse = components['schemas']['DatabaseDetailResponse']
+type DatabaseStatusResponse = components['schemas']['DatabaseStatusResponse']
+type LoadBalancerDetailResponse = components['schemas']['LoadBalancerDetailResponse']
+
+vi.mock('@/hooks/misc/useIsFeatureEnabled', () => ({
+  useIsFeatureEnabled: () => ({ infrastructureReadReplicas: true }),
+}))
+
+describe('ReadReplicasSection', () => {
+  test('renders the read replicas section with add CTA and empty state', async () => {
+    addAPIMock({
+      method: 'get',
+      path: '/platform/projects/:ref/databases',
+      response: () =>
+        HttpResponse.json<DatabaseDetailResponse[]>([
+          {
+            cloud_provider: 'AWS',
+            connectionString: 'postgresql://postgres:password@db.default.supabase.co:5432/postgres',
+            db_host: 'db.default.supabase.co',
+            db_name: 'postgres',
+            db_port: 5432,
+            db_user: 'postgres',
+            identifier: 'default',
+            inserted_at: '2026-01-01T00:00:00.000Z',
+            region: 'us-east-1',
+            restUrl: 'https://default.supabase.co',
+            size: 't4g.small',
+            status: 'ACTIVE_HEALTHY',
+          },
+        ]),
+    })
+    addAPIMock({
+      method: 'get',
+      path: '/platform/projects/:ref/databases-statuses',
+      response: () => HttpResponse.json<DatabaseStatusResponse[]>([]),
+    })
+    addAPIMock({
+      method: 'get',
+      path: '/platform/projects/:ref/load-balancers',
+      response: () => HttpResponse.json<LoadBalancerDetailResponse[]>([]),
+    })
+
+    customRender(<ReadReplicasSection />)
+
+    expect(await screen.findByText('Read replicas')).toBeInTheDocument()
+    expect(await screen.findByText('No read replicas')).toBeInTheDocument()
+    expect(screen.getAllByRole('button', { name: /Add read replica/i }).length).toBeGreaterThan(0)
+  })
+})

--- a/apps/studio/tests/components/Settings/Infrastructure/ReadReplicasSection.test.tsx
+++ b/apps/studio/tests/components/Settings/Infrastructure/ReadReplicasSection.test.tsx
@@ -1,6 +1,6 @@
 import { screen } from '@testing-library/react'
 import { HttpResponse } from 'msw'
-import { describe, expect, test, vi } from 'vitest'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 import { ReadReplicasSection } from '@/components/interfaces/Settings/Infrastructure/ReadReplicas/ReadReplicasSection'
 import type { components } from '@/data/api'
@@ -11,48 +11,81 @@ type DatabaseDetailResponse = components['schemas']['DatabaseDetailResponse']
 type DatabaseStatusResponse = components['schemas']['DatabaseStatusResponse']
 type LoadBalancerDetailResponse = components['schemas']['LoadBalancerDetailResponse']
 
-vi.mock('@/hooks/misc/useIsFeatureEnabled', () => ({
-  useIsFeatureEnabled: () => ({ infrastructureReadReplicas: true }),
+const { mockUseIsFeatureEnabled } = vi.hoisted(() => ({
+  mockUseIsFeatureEnabled: vi.fn(() => ({ infrastructureReadReplicas: true })),
 }))
 
+vi.mock('@/hooks/misc/useIsFeatureEnabled', () => ({
+  useIsFeatureEnabled: mockUseIsFeatureEnabled,
+}))
+
+const addReplicaListMocks = () => {
+  addAPIMock({
+    method: 'get',
+    path: '/platform/projects/:ref/databases',
+    response: () =>
+      HttpResponse.json<DatabaseDetailResponse[]>([
+        {
+          cloud_provider: 'AWS',
+          connectionString: 'postgresql://postgres:password@db.default.supabase.co:5432/postgres',
+          db_host: 'db.default.supabase.co',
+          db_name: 'postgres',
+          db_port: 5432,
+          db_user: 'postgres',
+          identifier: 'default',
+          inserted_at: '2026-01-01T00:00:00.000Z',
+          region: 'us-east-1',
+          restUrl: 'https://default.supabase.co',
+          size: 't4g.small',
+          status: 'ACTIVE_HEALTHY',
+        },
+      ]),
+  })
+  addAPIMock({
+    method: 'get',
+    path: '/platform/projects/:ref/databases-statuses',
+    response: () => HttpResponse.json<DatabaseStatusResponse[]>([]),
+  })
+  addAPIMock({
+    method: 'get',
+    path: '/platform/projects/:ref/load-balancers',
+    response: () => HttpResponse.json<LoadBalancerDetailResponse[]>([]),
+  })
+}
+
 describe('ReadReplicasSection', () => {
+  beforeEach(() => {
+    mockUseIsFeatureEnabled.mockReturnValue({ infrastructureReadReplicas: true })
+  })
+
   test('renders the read replicas section with add CTA and empty state', async () => {
-    addAPIMock({
-      method: 'get',
-      path: '/platform/projects/:ref/databases',
-      response: () =>
-        HttpResponse.json<DatabaseDetailResponse[]>([
-          {
-            cloud_provider: 'AWS',
-            connectionString: 'postgresql://postgres:password@db.default.supabase.co:5432/postgres',
-            db_host: 'db.default.supabase.co',
-            db_name: 'postgres',
-            db_port: 5432,
-            db_user: 'postgres',
-            identifier: 'default',
-            inserted_at: '2026-01-01T00:00:00.000Z',
-            region: 'us-east-1',
-            restUrl: 'https://default.supabase.co',
-            size: 't4g.small',
-            status: 'ACTIVE_HEALTHY',
-          },
-        ]),
-    })
-    addAPIMock({
-      method: 'get',
-      path: '/platform/projects/:ref/databases-statuses',
-      response: () => HttpResponse.json<DatabaseStatusResponse[]>([]),
-    })
-    addAPIMock({
-      method: 'get',
-      path: '/platform/projects/:ref/load-balancers',
-      response: () => HttpResponse.json<LoadBalancerDetailResponse[]>([]),
-    })
+    mockUseIsFeatureEnabled.mockReturnValue({ infrastructureReadReplicas: true })
+    addReplicaListMocks()
 
     customRender(<ReadReplicasSection />)
 
     expect(await screen.findByText('Read replicas')).toBeInTheDocument()
     expect(await screen.findByText('No read replicas')).toBeInTheDocument()
     expect(screen.getAllByRole('button', { name: /Add read replica/i }).length).toBeGreaterThan(0)
+  })
+
+  test('does not fetch replicas when the feature is disabled', async () => {
+    mockUseIsFeatureEnabled.mockReturnValue({ infrastructureReadReplicas: false })
+
+    let fetchedReplicas = false
+    addAPIMock({
+      method: 'get',
+      path: '/platform/projects/:ref/databases',
+      response: () => {
+        fetchedReplicas = true
+        return HttpResponse.json<DatabaseDetailResponse[]>([])
+      },
+    })
+
+    customRender(<ReadReplicasSection />)
+
+    expect(screen.queryByText('Read replicas')).not.toBeInTheDocument()
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(fetchedReplicas).toBe(false)
   })
 })


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature. Stack 2 of 5 for [PIPE-1007](https://linear.app/supabase/issue/PIPE-1007/move-read-replicas-out-of-replication-into-infrastructure).

## What is the current behavior?

Settings / Infrastructure only covers compute and disk.

## What is the new behavior?

Adds topology, a Read replicas list, and the add-replica sheet on Infrastructure. Still gated on `infrastructure:read_replicas`.

| Before | After |
| --- | --- |
| <img width="1279" height="1323" alt="Infrastructure  Settings  Chisel  Toolshed  Supabase" src="https://github.com/user-attachments/assets/34e7b414-a326-415b-984c-00ae0000f46e" /> | <img width="1279" height="1323" alt="Infrastructure  Settings  Chisel  Toolshed  Supabase" src="https://github.com/user-attachments/assets/547cd7ac-435e-45d1-80ad-2f35476f579f" /> |

## Additional context

[#49043](https://github.com/supabase/supabase/pull/49043) is merged. This PR targets `master`.

Please review, but do not merge. `infrastructure:read_replicas` is already on, so merging this alone would show replicas on both Infrastructure and Replication. Merge 2→5 ([#49045](https://github.com/supabase/supabase/pull/49045), [#49046](https://github.com/supabase/supabase/pull/49046), [#48921](https://github.com/supabase/supabase/pull/48921)) in succession once they are all reviewed.

Replica detail still uses the old Replication URL until #49045.

## To test

`infrastructure:read_replicas` is an enabled-feature, on by default in `enabled-features.json`. There is no Feature Preview or ConfigCat switch. On this preview you should already see it: Settings → Infrastructure shows topology and a Read replicas section. If those are missing, your profile lists `infrastructure:read_replicas` in `disabled_features` (from `/platform/profile`), and you cannot flip it in the UI.

Open [Settings / Infrastructure](https://studio-staging-git-danny-pipe-1007-02-infra-section-supabase.vercel.app/dashboard/project/_/settings/infrastructure). Confirm the topology, Read replicas section, and Add read replica sheet. Replication should still list replicas too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added infrastructure topology visibility to project infrastructure settings.
  * Added read replica management, including status monitoring, empty states, creation flow, documentation access, and discard-change confirmation.
  * Infrastructure settings now include read replicas alongside compute and disk configuration.
  * Added flexible placement for supplemental disk overview and scaling content.

* **Bug Fixes**
  * Simplified project configuration rendering for more reliable display.

* **Tests**
  * Added coverage for enabled and disabled read replica states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->