### PR TITLE
Add log scale support to query result chart

### DIFF
--- a/apps/studio/components/interfaces/Explorer/QueryCell/DisplaySettingsButton.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryCell/DisplaySettingsButton.tsx
@@ -1,4 +1,5 @@
 import { BarChart2, Settings2, Table } from 'lucide-react'
+import { useEffect, useEffectEvent, useMemo } from 'react'
 import {
   Checkbox,
   Popover,
@@ -12,23 +13,34 @@ import {
   SelectValue,
   ToggleGroup,
   ToggleGroupItem,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
 } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { type Snapshot } from 'valtio'
 
 import { ExplorerToolbarAction } from '../ExplorerToolbar'
+import { type QueryResult } from '../types'
+import { checkHasNonPositiveValues } from '@/components/ui/QueryBlock/QueryBlock.utils'
 import { type DatabaseCell as DatabaseCellSchema } from '@/data/content/notebooks/notebook-schema'
 import { useCurrentNotebook, useNotebooksStateSnapshot } from '@/state/notebooks/notebooks-state'
 
 interface DisplaySettingsButtonProps {
   cell: Snapshot<DatabaseCellSchema>
+  result?: QueryResult
   columns: string[]
   disabled: boolean
 }
 
 // [Joshen] TODO support multiple y axis charts
 
-export const DisplaySettingsButton = ({ cell, columns, disabled }: DisplaySettingsButtonProps) => {
+export const DisplaySettingsButton = ({
+  cell,
+  result,
+  columns,
+  disabled,
+}: DisplaySettingsButtonProps) => {
   const snap = useNotebooksStateSnapshot()
   const currentNotebook = useCurrentNotebook()
   const cells = currentNotebook?.notebook.content?.cells ?? []
@@ -37,11 +49,21 @@ export const DisplaySettingsButton = ({ cell, columns, disabled }: DisplaySettin
   const {
     type = 'bar',
     x_column,
-    y_columns,
+    y_columns = [],
     cumulative = false,
     show_labels = false,
     scale = 'linear',
   } = chart ?? {}
+
+  const hasNonPositiveValues = useMemo(
+    () => checkHasNonPositiveValues(result?.rows ?? [], y_columns[0]),
+    [result, y_columns]
+  )
+
+  const canToggleLogScale = useMemo(() => {
+    if (y_columns.length === 0 || !result || (result.rows ?? []).length === 0) return false
+    return !hasNonPositiveValues
+  }, [hasNonPositiveValues, result, y_columns.length])
 
   const onChangeView = (view: 'table' | 'chart') => {
     const notebookId = currentNotebook?.notebook.id
@@ -84,12 +106,22 @@ export const DisplaySettingsButton = ({ cell, columns, disabled }: DisplaySettin
     snap.updateCells({ id: notebookId, cells: nextCells })
   }
 
+  const resetToLinearScale = useEffectEvent(() => {
+    onUpdateChartConfig({ scale: 'linear' })
+  })
+
+  useEffect(() => {
+    if (hasNonPositiveValues && scale === 'log') {
+      resetToLinearScale()
+    }
+  }, [hasNonPositiveValues, scale])
+
   return (
     <Popover>
       <PopoverTrigger asChild>
         <ExplorerToolbarAction disabled={disabled} icon={<Settings2 />} tooltip="Result settings" />
       </PopoverTrigger>
-      <PopoverContent side="bottom" className="flex flex-col gap-y-3 p-0 py-3">
+      <PopoverContent side="bottom" className="flex flex-col gap-y-3 p-0 py-3 mr-8">
         <div className="flex flex-col gap-y-3 px-3">
           <p className="text-xs tracking-tighter uppercase font-mono text-foreground-lighter">
             Result display settings
@@ -187,7 +219,24 @@ export const DisplaySettingsButton = ({ cell, columns, disabled }: DisplaySettin
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="linear">Linear</SelectItem>
-                    <SelectItem value="log">Logarithmic</SelectItem>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <SelectItem
+                          disabled={!canToggleLogScale}
+                          value="log"
+                          className={!canToggleLogScale ? '!pointer-events-auto' : undefined}
+                        >
+                          Logarithmic
+                        </SelectItem>
+                      </TooltipTrigger>
+                      {!canToggleLogScale && (
+                        <TooltipContent side="right">
+                          {y_columns.length === 0
+                            ? 'Select a column for the Y axis first'
+                            : 'Data contains zero or negative values'}
+                        </TooltipContent>
+                      )}
+                    </Tooltip>
                   </SelectContent>
                 </Select>
               </FormItemLayout>

--- a/apps/studio/components/interfaces/Explorer/QueryCell/QueryResultChart.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryCell/QueryResultChart.tsx
@@ -4,7 +4,7 @@ import { type Snapshot } from 'valtio'
 
 import { type QueryResult } from '../types'
 import NoDataPlaceholder from '@/components/ui/Charts/NoDataPlaceholder'
-import { getCumulativeResults } from '@/components/ui/QueryBlock/QueryBlock.utils'
+import { formatLogTick, getCumulativeResults } from '@/components/ui/QueryBlock/QueryBlock.utils'
 import { type DatabaseCell as DatabaseCellSchema } from '@/data/content/notebooks/notebook-schema'
 
 interface QueryResultChartProps {
@@ -23,7 +23,7 @@ const toChartValue = (value: unknown): string | number => {
 
 export const QueryResultChart = ({ cell, result }: QueryResultChartProps) => {
   const { chart } = cell
-  const { type, x_column, y_columns = [], cumulative, show_labels } = chart ?? {}
+  const { type, x_column, y_columns = [], cumulative, show_labels, scale } = chart ?? {}
 
   const hasConfig = !!x_column && y_columns.length > 0
   const chartRows = useMemo(() => {
@@ -76,6 +76,11 @@ export const QueryResultChart = ({ cell, result }: QueryResultChartProps) => {
                 showXAxis={show_labels}
                 showYAxis={show_labels}
                 data={resultToRender}
+                YAxisProps={{
+                  scale: scale === 'log' ? 'log' : 'auto',
+                  domain: scale === 'log' ? [1, 'auto'] : undefined,
+                  tickFormatter: scale === 'log' ? formatLogTick : undefined,
+                }}
               />
             )}
             {type === 'line' && (
@@ -86,6 +91,11 @@ export const QueryResultChart = ({ cell, result }: QueryResultChartProps) => {
                 showXAxis={show_labels}
                 showYAxis={show_labels}
                 data={resultToRender}
+                YAxisProps={{
+                  scale: scale === 'log' ? 'log' : 'auto',
+                  domain: scale === 'log' ? [1, 'auto'] : undefined,
+                  tickFormatter: scale === 'log' ? formatLogTick : undefined,
+                }}
               />
             )}
           </div>

--- a/apps/studio/components/interfaces/Explorer/QueryCell/index.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryCell/index.tsx
@@ -120,6 +120,7 @@ export const QueryCell = ({ cell }: QueryCellProps) => {
           <ExplorerToolbarActions>
             <DisplaySettingsButton
               cell={cell}
+              result={result}
               columns={columns}
               disabled={(result?.rows ?? []).length === 0}
             />

--- a/packages/ui-patterns/src/Chart/charts/chart-bar.tsx
+++ b/packages/ui-patterns/src/Chart/charts/chart-bar.tsx
@@ -73,6 +73,9 @@ export interface ChartBarProps {
   }
 }
 
+// [Joshen] JFYI - shouldn't rely on xKey's value to determine if its a time-based format
+// Preferably provide an additional param like xFormat to be more deterministic
+
 export const ChartBar = ({
   data,
   xKey = 'timestamp',

--- a/packages/ui-patterns/src/Chart/charts/chart-line.tsx
+++ b/packages/ui-patterns/src/Chart/charts/chart-line.tsx
@@ -84,6 +84,9 @@ export interface ChartLineProps {
   referenceLines?: ChartReferenceLine[]
 }
 
+// [Joshen] JFYI - shouldn't rely on xKey's value to determine if its a time-based format
+// Preferably provide an additional param like xFormat to be more deterministic
+
 export const ChartLine = ({
   data,
   xKey = 'timestamp',
@@ -305,7 +308,7 @@ export const ChartLine = ({
                 fillOpacity={fillOpacity}
                 stroke={lineColor}
                 strokeWidth={strokeWidth}
-                stackId={`stack-${key}`}
+                stackId={keysToRender.length > 1 ? `stack-${key}` : undefined}
               />
             )
           })}


### PR DESCRIPTION
## Context

Related to Explorer/Notebooks - Adds support for log scale in the charts
<img width="980" height="477" alt="image" src="https://github.com/user-attachments/assets/b3764023-bd9a-4edd-92d4-1b61df93b97e" />


Prevents setting to log scale if y axis has yet to be selected, or if the data set contains non positive values
<img width="393" height="188" alt="image" src="https://github.com/user-attachments/assets/57695d9e-9724-47ed-aa2a-c104c16837b2" />
<img width="408" height="159" alt="image" src="https://github.com/user-attachments/assets/2290bb69-0ddb-4449-afad-aabae6ace669" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added logarithmic Y-axis scaling for line and bar charts.
  - Added logarithmic tick formatting and appropriate chart bounds.
  - Added contextual guidance when logarithmic scaling is unavailable.

- **Bug Fixes**
  - Automatically switches charts back to linear scaling when data contains values that cannot support logarithmic scaling.
  - Prevented unnecessary stacking for single-series area charts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->