### PR TITLE
fix(studio): derive mcp tool scopes for access tokens from their real source

### DIFF
--- a/apps/studio/app/api/scoped-access-token-permissions/MCPToolScopeMappings.ts
+++ b/apps/studio/app/api/scoped-access-token-permissions/MCPToolScopeMappings.ts
@@ -1,104 +1,109 @@
-import {
-  EndpointMap,
-  McpMap,
-  ScopeGroupAlternatives,
-} from '@/data/scoped-access-tokens/permission-scope-map-query'
+import { permissions } from '@supabase/shared-types'
 
-/*
- * Manually extracted from platform mcp controller code: the exact tool registry of
- * @supabase/mcp-server-supabase@0.8.1, the version the platform pins. Each tool maps to alternative
- * groups of Management API endpoints — a token can use the tool when it holds every scope required
- * by at least one alternative's endpoints (OR between alternatives, AND across the endpoints within
- * one), mirroring the ScopeGroupAlternatives semantics.
- *
- * Deriving a tool's requirement from the endpoint(s) it actually calls — rather than hand-picking
- * scopes — means the requirement can never drift from what those endpoints enforce; only this
- * endpoint list needs maintaining when the mcp-server version changes.
- */
-export const MCPToolEndpointMapping: Record<string, string[][]> = {
-  apply_migration: [['POST /v1/projects/{ref}/database/migrations']],
-  // Computes a local confirmation hash without calling the platform — no endpoint, so no gate.
-  confirm_cost: [[]],
-  create_branch: [['POST /v1/projects/{ref}/branches']],
-  create_project: [['POST /v1/projects']],
-  delete_branch: [['DELETE /v1/branches/{branch_id_or_ref}']],
-  deploy_edge_function: [['POST /v1/projects/{ref}/functions/deploy']],
-  execute_sql: [['POST /v1/projects/{ref}/database/query']],
-  generate_typescript_types: [['GET /v1/projects/{ref}/types/typescript']],
-  get_advisors: [['GET /v1/projects/{ref}/advisors/security']],
-  // Calls getOrganization + the org-scoped listProjects to price a project, so it needs both.
-  get_cost: [['GET /v1/organizations/{slug}', 'GET /v1/organizations/{slug}/projects']],
-  get_edge_function: [['GET /v1/projects/{ref}/functions/{function_slug}']],
-  get_logs: [['GET /v1/projects/{ref}/analytics/endpoints/logs.all']],
-  get_organization: [['GET /v1/organizations/{slug}']],
-  get_project: [['GET /v1/projects/{ref}']],
-  get_project_url: [['GET /v1/projects/{ref}']],
-  get_publishable_keys: [['GET /v1/projects/{ref}/api-keys']],
-  get_storage_config: [['GET /v1/projects/{ref}/config/storage']],
-  list_branches: [['GET /v1/projects/{ref}/branches']],
-  list_edge_functions: [['GET /v1/projects/{ref}/functions']],
-  // Runs through the read-only query endpoint (read_only forced true), not the general one.
-  list_extensions: [['POST /v1/projects/{ref}/database/query/read-only']],
-  list_migrations: [['GET /v1/projects/{ref}/database/migrations']],
-  list_organizations: [['GET /v1/organizations']],
-  list_projects: [['GET /v1/projects']],
-  list_storage_buckets: [['GET /v1/projects/{ref}/storage/buckets']],
-  // Runs through the read-only query endpoint (read_only forced true), not the general one.
-  list_tables: [['POST /v1/projects/{ref}/database/query/read-only']],
-  merge_branch: [['POST /v1/branches/{branch_id_or_ref}/merge']],
-  pause_project: [['POST /v1/projects/{ref}/pause']],
-  rebase_branch: [['POST /v1/branches/{branch_id_or_ref}/push']],
-  reset_branch: [['POST /v1/branches/{branch_id_or_ref}/reset']],
-  restore_project: [['POST /v1/projects/{ref}/restore']],
-  // Queries the public content API — no endpoint, so no gate.
-  search_docs: [[]],
-  update_storage_config: [['PATCH /v1/projects/{ref}/config/storage']],
-}
+import { McpMap } from '@/data/scoped-access-tokens/permission-scope-map-query'
 
-/*
- * Combines two ScopeGroupAlternatives with logical AND: every alternative of `a` paired with every
- * alternative of `b`, preserving DNF (OR between alternatives, AND within a pair). An empty input —
- * no alternatives, the "satisfied by nobody" marker — makes the combination unsatisfiable too, which
- * is how a tool loses a whole alternative when one of its endpoints isn't found in the fetched spec,
- * rather than silently dropping just that endpoint's contribution.
- */
-const andCombine = (
-  a: ScopeGroupAlternatives,
-  b: ScopeGroupAlternatives
-): ScopeGroupAlternatives => {
-  if (a.length === 0 || b.length === 0) return []
-  const combined: ScopeGroupAlternatives = []
-  for (const groupA of a) {
-    for (const groupB of b) {
-      combined.push(Array.from(new Set([...groupA, ...groupB])))
-    }
+type ExtractIds<T> = {
+  [K in keyof T]: {
+    [P in keyof T[K]]: T[K][P] extends { id: infer I } ? I : never
   }
-  return combined
 }
+const FGA_PERMISSIONS = Object.fromEntries(
+  Object.entries(permissions.FgaPermissions).map(([group, groupPermissions]) => [
+    group,
+    Object.fromEntries(Object.entries(groupPermissions).map(([key, { id }]) => [key, id])),
+  ])
+) as ExtractIds<typeof permissions.FgaPermissions>
 
 /*
- * Resolves one alternative's endpoint keys against the live endpoints map, ANDing together the
- * scope groups each endpoint is annotated with. Folding starts from `[[]]` — one empty group, the
- * AND-identity — so an alternative with no endpoints (confirm_cost, search_docs) resolves to `[[]]`
- * (ungated) rather than `[]` (unsatisfiable).
+ * Transcribed directly from platform's MCP controller (mcp.controller.ts, the
+ * @supabase/mcp-server-supabase@0.8.1 version the platform pins): each tool's
+ * `assertFgaPermissions([...])` call(s). This is the actual runtime gate for MCP tool calls, and it
+ * is NOT always the same as the equivalent REST endpoint's `x-fga-permissions` annotation — see
+ * create_branch and get_cost below, where the two diverge — so it must be hand-maintained against
+ * the controller source rather than derived from the OpenAPI spec.
+ *
+ * Update this whenever the platform bumps @supabase/mcp-server-supabase or changes
+ * mcp.controller.ts.
  */
-const resolveAlternative = (
-  endpointKeys: string[],
-  endpoints: EndpointMap
-): ScopeGroupAlternatives =>
-  endpointKeys.reduce((acc, key) => andCombine(acc, endpoints[key] ?? []), [
-    [],
-  ] as ScopeGroupAlternatives)
+export const MCPToolScopeMappings: McpMap = {
+  // --- account ---
+  list_organizations: [[FGA_PERMISSIONS.USER.ORGANIZATIONS_READ]],
+  get_organization: [[FGA_PERMISSIONS.ORGANIZATION.ADMIN_READ]],
+  list_projects: [[FGA_PERMISSIONS.USER.PROJECTS_READ]],
+  get_project: [[FGA_PERMISSIONS.PROJECT.ADMIN_READ]],
+  create_project: [[FGA_PERMISSIONS.ORGANIZATION.PROJECTS_CREATE]],
+  pause_project: [[FGA_PERMISSIONS.PROJECT.ADMIN_WRITE]],
+  restore_project: [[FGA_PERMISSIONS.PROJECT.ADMIN_WRITE]],
 
-/**
- * Builds the MCP tool -> scope-group map by resolving MCPToolEndpointMapping against the endpoints
- * actually indexed from the fetched OpenAPI specs, so a tool's requirement is always exactly what
- * its backing endpoint(s) enforce.
- */
-export const buildMcpToolScopeMap = (endpoints: EndpointMap): McpMap =>
-  Object.fromEntries(
-    Object.entries(MCPToolEndpointMapping).map(([tool, alternatives]) => [
-      tool,
-      alternatives.flatMap((endpointKeys) => resolveAlternative(endpointKeys, endpoints)),
-    ])
-  )
+  // --- branching ---
+  // listBranches has no direct assertFgaPermissions call (uses getBranchReadAccess instead), but
+  // requires at least development or production read, matching the v1 list-branches gate.
+  list_branches: [
+    [FGA_PERMISSIONS.PROJECT.BRANCHING_DEVELOPMENT_READ],
+    [FGA_PERMISSIONS.PROJECT.BRANCHING_PRODUCTION_READ],
+  ],
+  // createBranch always creates a development branch, so — unlike the REST endpoint's annotation,
+  // which also offers a production-create alternative — only development create gates it.
+  create_branch: [[FGA_PERMISSIONS.PROJECT.BRANCHING_DEVELOPMENT_CREATE]],
+  // delete/merge/reset/rebase all check whichever of development/production the target branch
+  // actually is (assertBranchFgaPermission), so both alternatives are offered.
+  delete_branch: [
+    [FGA_PERMISSIONS.PROJECT.BRANCHING_DEVELOPMENT_DELETE],
+    [FGA_PERMISSIONS.PROJECT.BRANCHING_PRODUCTION_DELETE],
+  ],
+  merge_branch: [
+    [FGA_PERMISSIONS.PROJECT.BRANCHING_DEVELOPMENT_WRITE],
+    [FGA_PERMISSIONS.PROJECT.BRANCHING_PRODUCTION_WRITE],
+  ],
+  reset_branch: [
+    [FGA_PERMISSIONS.PROJECT.BRANCHING_DEVELOPMENT_WRITE],
+    [FGA_PERMISSIONS.PROJECT.BRANCHING_PRODUCTION_WRITE],
+  ],
+  // Implemented via pushBranch, same dev/prod write check as merge/reset.
+  rebase_branch: [
+    [FGA_PERMISSIONS.PROJECT.BRANCHING_DEVELOPMENT_WRITE],
+    [FGA_PERMISSIONS.PROJECT.BRANCHING_PRODUCTION_WRITE],
+  ],
+
+  // --- database ---
+  // The controller's outer gate is DATABASE_READ for every call, read or write; writes are
+  // additionally gated by DATABASE_WRITE deeper inside executeProjectDatabaseQuery. Since this UI
+  // never grants database_write without database_read, one database_read group covers both.
+  execute_sql: [[FGA_PERMISSIONS.PROJECT.DATABASE_READ]],
+  // Both run through executeSql with read_only forced true, so they gate the same as execute_sql.
+  list_extensions: [[FGA_PERMISSIONS.PROJECT.DATABASE_READ]],
+  list_tables: [[FGA_PERMISSIONS.PROJECT.DATABASE_READ]],
+  list_migrations: [[FGA_PERMISSIONS.PROJECT.DATABASE_MIGRATIONS_READ]],
+  apply_migration: [[FGA_PERMISSIONS.PROJECT.DATABASE_MIGRATIONS_WRITE]],
+
+  // --- debugging ---
+  get_logs: [[FGA_PERMISSIONS.PROJECT.ANALYTICS_LOGS_READ]],
+  // Security and performance advisors are gated identically.
+  get_advisors: [[FGA_PERMISSIONS.PROJECT.ADVISORS_READ]],
+
+  // --- development ---
+  generate_typescript_types: [[FGA_PERMISSIONS.PROJECT.DATABASE_READ]],
+  get_project_url: [[FGA_PERMISSIONS.PROJECT.ADMIN_READ]],
+  get_publishable_keys: [[FGA_PERMISSIONS.PROJECT.API_GATEWAY_KEYS_READ]],
+
+  // --- functions ---
+  list_edge_functions: [[FGA_PERMISSIONS.PROJECT.EDGE_FUNCTIONS_READ]],
+  get_edge_function: [[FGA_PERMISSIONS.PROJECT.EDGE_FUNCTIONS_READ]],
+  deploy_edge_function: [[FGA_PERMISSIONS.PROJECT.EDGE_FUNCTIONS_WRITE]],
+
+  // --- storage ---
+  get_storage_config: [[FGA_PERMISSIONS.PROJECT.STORAGE_CONFIG_READ]],
+  update_storage_config: [[FGA_PERMISSIONS.PROJECT.STORAGE_CONFIG_WRITE]],
+  list_storage_buckets: [[FGA_PERMISSIONS.PROJECT.STORAGE_READ]],
+
+  // --- built by the mcp-server-supabase package on top of the platform primitives above, not its
+  //     own controller assertion ---
+  // Calls getOrganization (ORGANIZATION.ADMIN_READ) + listProjects (USER.PROJECTS_READ) to price a
+  // project, and needs both together.
+  get_cost: [[FGA_PERMISSIONS.ORGANIZATION.ADMIN_READ, FGA_PERMISSIONS.USER.PROJECTS_READ]],
+
+  // Computes a local confirmation hash without calling the platform — no gate.
+  confirm_cost: [[]],
+  // Queries the public content API — no gate.
+  search_docs: [[]],
+}

--- a/apps/studio/app/api/scoped-access-token-permissions/MCPToolScopeMappings.ts
+++ b/apps/studio/app/api/scoped-access-token-permissions/MCPToolScopeMappings.ts
@@ -1,204 +1,104 @@
-import { constants, permissions } from '@supabase/shared-types'
+import {
+  EndpointMap,
+  McpMap,
+  ScopeGroupAlternatives,
+} from '@/data/scoped-access-tokens/permission-scope-map-query'
 
-import { McpMap } from '@/data/scoped-access-tokens/permission-scope-map-query'
-
-const { OAuthScope } = constants
-
-type OAuthScopeValue = (typeof OAuthScope)[keyof typeof OAuthScope]
-
-// Manually extracted from platform mcp controller code. Each tool maps to alternative OAuth-scope
-// groups with the same semantics as ScopeGroupAlternatives: a token can call the tool when it
-// holds ALL scopes of at least ONE group (OR between groups, AND within a group). Most tools
-// assert a single scope; execute_sql asserts database:read OR database:write depending on the
-// session's read_only mode (mcp.controller.ts), so it carries two alternatives.
-const MCPToolOAuthScopeMapping: Record<string, OAuthScopeValue[][]> = {
-  apply_migration: [[OAuthScope.DATABASE_WRITE]],
-  // Computes a local confirmation hash without calling the platform — no scope gates it.
+/*
+ * Manually extracted from platform mcp controller code: the exact tool registry of
+ * @supabase/mcp-server-supabase@0.8.1, the version the platform pins. Each tool maps to alternative
+ * groups of Management API endpoints — a token can use the tool when it holds every scope required
+ * by at least one alternative's endpoints (OR between alternatives, AND across the endpoints within
+ * one), mirroring the ScopeGroupAlternatives semantics.
+ *
+ * Deriving a tool's requirement from the endpoint(s) it actually calls — rather than hand-picking
+ * scopes — means the requirement can never drift from what those endpoints enforce; only this
+ * endpoint list needs maintaining when the mcp-server version changes.
+ */
+export const MCPToolEndpointMapping: Record<string, string[][]> = {
+  apply_migration: [['POST /v1/projects/{ref}/database/migrations']],
+  // Computes a local confirmation hash without calling the platform — no endpoint, so no gate.
   confirm_cost: [[]],
-  create_branch: [[OAuthScope.ENVIRONMENT_WRITE]],
-  create_project: [[OAuthScope.PROJECTS_WRITE]],
-  delete_branch: [[OAuthScope.ENVIRONMENT_WRITE]],
-  deploy_edge_function: [[OAuthScope.EDGE_FUNCTIONS_WRITE]],
-  execute_sql: [[OAuthScope.DATABASE_READ], [OAuthScope.DATABASE_WRITE]],
-  generate_typescript_types: [[OAuthScope.DATABASE_READ]],
-  get_advisors: [[OAuthScope.DATABASE_READ]],
-  // Calls getOrganization + listProjects to price a project, so it needs both read scopes.
-  // (The type=branch path returns a constant with no platform call; gating on the project
-  // path's scopes fails closed for branch-only pricing, which is fine for advisory display.)
-  get_cost: [[OAuthScope.ORGANIZATIONS_READ, OAuthScope.PROJECTS_READ]],
-  get_edge_function: [[OAuthScope.EDGE_FUNCTIONS_READ]],
-  get_logs: [[OAuthScope.ANALYTICS_READ]],
-  get_organization: [[OAuthScope.ORGANIZATIONS_READ]],
-  get_project: [[OAuthScope.PROJECTS_READ]],
-  get_project_url: [[OAuthScope.PROJECTS_READ]],
-  get_publishable_keys: [[OAuthScope.SECRETS_READ]],
-  get_storage_config: [[OAuthScope.STORAGE_READ]],
-  list_branches: [[OAuthScope.ENVIRONMENT_READ]],
-  list_edge_functions: [[OAuthScope.EDGE_FUNCTIONS_READ]],
-  // Runs through executeSql with read_only forced true.
-  list_extensions: [[OAuthScope.DATABASE_READ]],
-  list_migrations: [[OAuthScope.DATABASE_READ]],
-  list_organizations: [[OAuthScope.ORGANIZATIONS_READ]],
-  list_projects: [[OAuthScope.PROJECTS_READ]],
-  list_storage_buckets: [[OAuthScope.STORAGE_READ]],
-  // Runs through executeSql with read_only forced true.
-  list_tables: [[OAuthScope.DATABASE_READ]],
-  merge_branch: [[OAuthScope.ENVIRONMENT_WRITE]],
-  pause_project: [[OAuthScope.PROJECTS_WRITE]],
-  rebase_branch: [[OAuthScope.ENVIRONMENT_WRITE]],
-  reset_branch: [[OAuthScope.ENVIRONMENT_WRITE]],
-  restore_project: [[OAuthScope.PROJECTS_WRITE]],
-  // Queries the public content API — no scope gates it.
+  create_branch: [['POST /v1/projects/{ref}/branches']],
+  create_project: [['POST /v1/projects']],
+  delete_branch: [['DELETE /v1/branches/{branch_id_or_ref}']],
+  deploy_edge_function: [['POST /v1/projects/{ref}/functions/deploy']],
+  execute_sql: [['POST /v1/projects/{ref}/database/query']],
+  generate_typescript_types: [['GET /v1/projects/{ref}/types/typescript']],
+  get_advisors: [['GET /v1/projects/{ref}/advisors/security']],
+  // Calls getOrganization + the org-scoped listProjects to price a project, so it needs both.
+  get_cost: [['GET /v1/organizations/{slug}', 'GET /v1/organizations/{slug}/projects']],
+  get_edge_function: [['GET /v1/projects/{ref}/functions/{function_slug}']],
+  get_logs: [['GET /v1/projects/{ref}/analytics/endpoints/logs.all']],
+  get_organization: [['GET /v1/organizations/{slug}']],
+  get_project: [['GET /v1/projects/{ref}']],
+  get_project_url: [['GET /v1/projects/{ref}']],
+  get_publishable_keys: [['GET /v1/projects/{ref}/api-keys']],
+  get_storage_config: [['GET /v1/projects/{ref}/config/storage']],
+  list_branches: [['GET /v1/projects/{ref}/branches']],
+  list_edge_functions: [['GET /v1/projects/{ref}/functions']],
+  // Runs through the read-only query endpoint (read_only forced true), not the general one.
+  list_extensions: [['POST /v1/projects/{ref}/database/query/read-only']],
+  list_migrations: [['GET /v1/projects/{ref}/database/migrations']],
+  list_organizations: [['GET /v1/organizations']],
+  list_projects: [['GET /v1/projects']],
+  list_storage_buckets: [['GET /v1/projects/{ref}/storage/buckets']],
+  // Runs through the read-only query endpoint (read_only forced true), not the general one.
+  list_tables: [['POST /v1/projects/{ref}/database/query/read-only']],
+  merge_branch: [['POST /v1/branches/{branch_id_or_ref}/merge']],
+  pause_project: [['POST /v1/projects/{ref}/pause']],
+  rebase_branch: [['POST /v1/branches/{branch_id_or_ref}/push']],
+  reset_branch: [['POST /v1/branches/{branch_id_or_ref}/reset']],
+  restore_project: [['POST /v1/projects/{ref}/restore']],
+  // Queries the public content API — no endpoint, so no gate.
   search_docs: [[]],
-  update_storage_config: [[OAuthScope.STORAGE_WRITE]],
-}
-
-type ExtractIds<T> = {
-  [K in keyof T]: {
-    [P in keyof T[K]]: T[K][P] extends { id: infer I } ? I : never
-  }
-}
-const FGA_PERMISSIONS = Object.fromEntries(
-  Object.entries(permissions.FgaPermissions).map(([group, permissions]) => [
-    group,
-    Object.fromEntries(Object.entries(permissions).map(([key, { id }]) => [key, id])),
-  ])
-) as ExtractIds<typeof permissions.FgaPermissions>
-
-// Duplicated from platform (packages/api-core/src/lib/permissions/fga-permissions.ts)
-// Ideally, this could be exported from @supabase/shared-types
-export const legacyOauthScopeToFgaPermissionMap: Record<string, string[]> = {
-  'analytics:read': [
-    FGA_PERMISSIONS.PROJECT.ANALYTICS_LOGS_READ,
-    FGA_PERMISSIONS.PROJECT.ANALYTICS_USAGE_READ,
-  ],
-  'analytics:write': [],
-  'analytics_config:read': [FGA_PERMISSIONS.PROJECT.ANALYTICS_CONFIG_READ],
-  'analytics_config:write': [FGA_PERMISSIONS.PROJECT.ANALYTICS_CONFIG_WRITE],
-  'auth:read': [FGA_PERMISSIONS.PROJECT.AUTH_CONFIG_READ],
-  // Note(Hieu) Auth:write scope grants access to all auth config endpoints.
-  // However, one endpoint requires minimum administrator role, so this oauth scope must also include the FGA PROJECT.ADMIN_WRITE permission
-  'auth:write': [FGA_PERMISSIONS.PROJECT.ADMIN_WRITE, FGA_PERMISSIONS.PROJECT.AUTH_CONFIG_WRITE],
-  'database:read': [
-    FGA_PERMISSIONS.USER.SNIPPETS_READ,
-    FGA_PERMISSIONS.PROJECT.ADVISORS_READ,
-    FGA_PERMISSIONS.PROJECT.BACKUPS_READ,
-    FGA_PERMISSIONS.PROJECT.DATABASE_READ,
-    FGA_PERMISSIONS.PROJECT.DATABASE_CONFIG_READ,
-    FGA_PERMISSIONS.PROJECT.DATABASE_JIT_READ,
-    FGA_PERMISSIONS.PROJECT.DATABASE_MIGRATIONS_READ,
-    FGA_PERMISSIONS.PROJECT.DATABASE_POOLING_CONFIG_READ,
-    FGA_PERMISSIONS.PROJECT.DATABASE_READONLY_CONFIG_READ,
-    FGA_PERMISSIONS.PROJECT.DATABASE_SSL_CONFIG_READ,
-    FGA_PERMISSIONS.PROJECT.SNIPPETS_READ,
-  ],
-  'database:write': [
-    FGA_PERMISSIONS.PROJECT.ADMIN_WRITE,
-    FGA_PERMISSIONS.PROJECT.BACKUPS_WRITE,
-    // Note(Hieu): Include database read permission here to align with the project query endpoint.
-    // RLS and FGA guard this endpoint with database read first, then perform an additional check for write queries.
-    // The OAuth guard requires database write directly, which causes a discrepancy error if we don't include read here.
-    FGA_PERMISSIONS.PROJECT.DATABASE_READ,
-    FGA_PERMISSIONS.PROJECT.DATABASE_WRITE,
-    FGA_PERMISSIONS.PROJECT.DATABASE_CONFIG_WRITE,
-    FGA_PERMISSIONS.PROJECT.DATABASE_MIGRATIONS_WRITE,
-    FGA_PERMISSIONS.PROJECT.DATABASE_POOLING_CONFIG_WRITE,
-    FGA_PERMISSIONS.PROJECT.DATABASE_READONLY_CONFIG_WRITE,
-    FGA_PERMISSIONS.PROJECT.DATABASE_SSL_CONFIG_WRITE,
-    FGA_PERMISSIONS.PROJECT.DATABASE_WEBHOOKS_CONFIG_WRITE,
-  ],
-  'domains:read': [
-    FGA_PERMISSIONS.PROJECT.CUSTOM_DOMAIN_READ,
-    FGA_PERMISSIONS.PROJECT.VANITY_SUBDOMAIN_READ,
-  ],
-  'domains:write': [
-    FGA_PERMISSIONS.PROJECT.CUSTOM_DOMAIN_WRITE,
-    FGA_PERMISSIONS.PROJECT.VANITY_SUBDOMAIN_WRITE,
-  ],
-  'edge_functions:read': [FGA_PERMISSIONS.PROJECT.EDGE_FUNCTIONS_READ],
-  'edge_functions:write': [FGA_PERMISSIONS.PROJECT.EDGE_FUNCTIONS_WRITE],
-  'environment:read': [
-    FGA_PERMISSIONS.PROJECT.ACTION_RUNS_READ,
-    FGA_PERMISSIONS.PROJECT.BRANCHING_DEVELOPMENT_READ,
-    FGA_PERMISSIONS.PROJECT.BRANCHING_PRODUCTION_READ,
-  ],
-  'environment:write': [
-    FGA_PERMISSIONS.PROJECT.ACTION_RUNS_WRITE,
-    FGA_PERMISSIONS.PROJECT.BRANCHING_DEVELOPMENT_CREATE,
-    FGA_PERMISSIONS.PROJECT.BRANCHING_DEVELOPMENT_DELETE,
-    FGA_PERMISSIONS.PROJECT.BRANCHING_DEVELOPMENT_WRITE,
-    FGA_PERMISSIONS.PROJECT.BRANCHING_PRODUCTION_CREATE,
-    FGA_PERMISSIONS.PROJECT.BRANCHING_PRODUCTION_DELETE,
-    FGA_PERMISSIONS.PROJECT.BRANCHING_PRODUCTION_WRITE,
-  ],
-  'organizations:read': [
-    FGA_PERMISSIONS.USER.ORGANIZATIONS_READ,
-    FGA_PERMISSIONS.ORGANIZATION.ADMIN_READ,
-    FGA_PERMISSIONS.ORGANIZATION.MEMBERS_READ,
-  ],
-  'organizations:write': [],
-  'projects:read': [
-    FGA_PERMISSIONS.USER.PROJECTS_READ,
-    FGA_PERMISSIONS.ORGANIZATION.PROJECTS_READ,
-    FGA_PERMISSIONS.PROJECT.ADMIN_READ,
-    FGA_PERMISSIONS.PROJECT.DATABASE_NETWORK_BANS_READ,
-    FGA_PERMISSIONS.PROJECT.DATABASE_NETWORK_RESTRICTIONS_READ,
-  ],
-  'projects:write': [
-    FGA_PERMISSIONS.ORGANIZATION.ADMIN_WRITE,
-    FGA_PERMISSIONS.ORGANIZATION.PROJECTS_CREATE,
-    FGA_PERMISSIONS.PROJECT.ADMIN_WRITE,
-    FGA_PERMISSIONS.PROJECT.DATABASE_NETWORK_BANS_WRITE,
-    FGA_PERMISSIONS.PROJECT.DATABASE_NETWORK_RESTRICTIONS_WRITE,
-  ],
-  'rest:read': [FGA_PERMISSIONS.PROJECT.DATA_API_CONFIG_READ],
-  'rest:write': [FGA_PERMISSIONS.PROJECT.DATA_API_CONFIG_WRITE],
-  'secrets:read': [
-    FGA_PERMISSIONS.PROJECT.API_GATEWAY_KEYS_READ,
-    FGA_PERMISSIONS.PROJECT.AUTH_SIGNING_KEYS_READ,
-    FGA_PERMISSIONS.PROJECT.EDGE_FUNCTIONS_SECRETS_READ,
-  ],
-  'secrets:write': [
-    FGA_PERMISSIONS.PROJECT.API_GATEWAY_KEYS_WRITE,
-    FGA_PERMISSIONS.PROJECT.AUTH_SIGNING_KEYS_WRITE,
-    FGA_PERMISSIONS.PROJECT.EDGE_FUNCTIONS_SECRETS_WRITE,
-  ],
-  'storage:read': [
-    FGA_PERMISSIONS.PROJECT.STORAGE_READ,
-    FGA_PERMISSIONS.PROJECT.STORAGE_CONFIG_READ,
-  ],
-  'storage:write': [
-    FGA_PERMISSIONS.PROJECT.STORAGE_WRITE,
-    FGA_PERMISSIONS.PROJECT.STORAGE_CONFIG_WRITE,
-  ],
+  update_storage_config: [['PATCH /v1/projects/{ref}/config/storage']],
 }
 
 /*
- * Build a map of MCP tools/FGA permissions by expanding each OAuth-scope group to the FGA
- * permissions it implies:
- * {
- *    execute_sql: [["snippets_read", "database_read", ...], ["project_admin_write", ...]]
- * }
- * Groups are expanded independently, preserving the OR-of-AND structure. A group is an AND, so it
- * is kept only when every one of its scopes maps to at least one FGA permission — a partial
- * expansion would weaken the requirement (e.g. [ORGANIZATIONS_READ, PROJECTS_READ] shrinking to
- * projects_read alone). A group with any unmapped scope is dropped whole, so the tool stays gated
- * rather than becoming ungated; an explicitly empty group ([]) is the deliberate ungated marker
- * and is vacuously kept.
- * The code is duplicated from platform until we find a better way to share those mappings
+ * Combines two ScopeGroupAlternatives with logical AND: every alternative of `a` paired with every
+ * alternative of `b`, preserving DNF (OR between alternatives, AND within a pair). An empty input —
+ * no alternatives, the "satisfied by nobody" marker — makes the combination unsatisfiable too, which
+ * is how a tool loses a whole alternative when one of its endpoints isn't found in the fetched spec,
+ * rather than silently dropping just that endpoint's contribution.
  */
-export const expandOAuthScopeGroups = (
-  oAuthScopeGroups: string[][],
-  fgaPermissionMap: Record<string, string[]>
-): string[][] =>
-  oAuthScopeGroups
-    .filter((group) => group.every((oAuthScope) => (fgaPermissionMap[oAuthScope] ?? []).length > 0))
-    .map((group) => group.flatMap((oAuthScope) => fgaPermissionMap[oAuthScope] ?? []))
+const andCombine = (
+  a: ScopeGroupAlternatives,
+  b: ScopeGroupAlternatives
+): ScopeGroupAlternatives => {
+  if (a.length === 0 || b.length === 0) return []
+  const combined: ScopeGroupAlternatives = []
+  for (const groupA of a) {
+    for (const groupB of b) {
+      combined.push(Array.from(new Set([...groupA, ...groupB])))
+    }
+  }
+  return combined
+}
 
-export const MCPToolScopeMappings = Object.entries(MCPToolOAuthScopeMapping).reduce(
-  (acc, [mcpTool, oAuthScopeGroups]) => {
-    acc[mcpTool] = expandOAuthScopeGroups(oAuthScopeGroups, legacyOauthScopeToFgaPermissionMap)
-    return acc
-  },
-  {} as McpMap
-)
+/*
+ * Resolves one alternative's endpoint keys against the live endpoints map, ANDing together the
+ * scope groups each endpoint is annotated with. Folding starts from `[[]]` — one empty group, the
+ * AND-identity — so an alternative with no endpoints (confirm_cost, search_docs) resolves to `[[]]`
+ * (ungated) rather than `[]` (unsatisfiable).
+ */
+const resolveAlternative = (
+  endpointKeys: string[],
+  endpoints: EndpointMap
+): ScopeGroupAlternatives =>
+  endpointKeys.reduce((acc, key) => andCombine(acc, endpoints[key] ?? []), [
+    [],
+  ] as ScopeGroupAlternatives)
+
+/**
+ * Builds the MCP tool -> scope-group map by resolving MCPToolEndpointMapping against the endpoints
+ * actually indexed from the fetched OpenAPI specs, so a tool's requirement is always exactly what
+ * its backing endpoint(s) enforce.
+ */
+export const buildMcpToolScopeMap = (endpoints: EndpointMap): McpMap =>
+  Object.fromEntries(
+    Object.entries(MCPToolEndpointMapping).map(([tool, alternatives]) => [
+      tool,
+      alternatives.flatMap((endpointKeys) => resolveAlternative(endpointKeys, endpoints)),
+    ])
+  )

--- a/apps/studio/app/api/scoped-access-token-permissions/buildAPIPermissionScopeMap.test.ts
+++ b/apps/studio/app/api/scoped-access-token-permissions/buildAPIPermissionScopeMap.test.ts
@@ -6,8 +6,11 @@ import {
   buildAPIPermissionScopeMap,
   getScopesAndEndpointsForAPI,
 } from './buildAPIPermissionScopeMap'
-import { expandOAuthScopeGroups, MCPToolScopeMappings } from './MCPToolScopeMappings'
-import { type ScopeMap } from '@/data/scoped-access-tokens/permission-scope-map-query'
+import { buildMcpToolScopeMap, MCPToolEndpointMapping } from './MCPToolScopeMappings'
+import {
+  type EndpointMap,
+  type ScopeMap,
+} from '@/data/scoped-access-tokens/permission-scope-map-query'
 import { mswServer } from '@/tests/lib/msw'
 
 describe('getScopesAndEndpointsForAPI', () => {
@@ -135,48 +138,73 @@ describe('addMCPToolsToScopes', () => {
   })
 })
 
-describe('MCPToolScopeMappings', () => {
+describe('buildMcpToolScopeMap', () => {
   // Platform gates execute_sql on database:read OR database:write depending on the MCP session's
-  // read_only mode (mcp.controller.ts), so the derived requirement must be two alternatives — a
-  // single conjunctive group would hide the tool from read-only tokens the platform accepts.
-  test('execute_sql derives the database:read bundle OR the database:write bundle', () => {
-    expect(MCPToolScopeMappings.execute_sql).toHaveLength(2)
-    const [readGroup, writeGroup] = MCPToolScopeMappings.execute_sql
-    expect(readGroup).toContain('database_read')
-    expect(readGroup).not.toContain('database_write')
-    expect(writeGroup).toContain('database_write')
-  })
+  // read_only mode (mcp.controller.ts), and both alternatives are the same one endpoint's own
+  // alternative groups — a single conjunctive group would hide the tool from read-only tokens the
+  // platform accepts.
+  test('execute_sql derives the database:read alternative OR the database:write alternative', () => {
+    const endpoints: EndpointMap = {
+      'POST /v1/projects/{ref}/database/query': [['database_read'], ['database_write']],
+    }
 
-  test('single-scope tools derive a single conjunctive group', () => {
-    expect(MCPToolScopeMappings.apply_migration).toHaveLength(1)
-    expect(MCPToolScopeMappings.apply_migration[0]).toContain('database_write')
-  })
-
-  test('tools without a platform scope gate stay ungated ([[]]), not disabled ([])', () => {
-    expect(MCPToolScopeMappings.confirm_cost).toEqual([[]])
-    expect(MCPToolScopeMappings.search_docs).toEqual([[]])
-  })
-
-  // A group is an AND: expanding only its mapped scopes would weaken the requirement (e.g.
-  // [organizations:read, projects:read] shrinking to projects_read alone) and report the tool
-  // enabled for an incomplete grant.
-  test('a group with any unmapped scope is dropped whole, not partially expanded', () => {
-    const map = { 'projects:read': ['projects_read'] }
-
-    expect(expandOAuthScopeGroups([['organizations:read', 'projects:read']], map)).toEqual([])
-    // Other alternatives and the ungated marker survive the drop untouched.
-    expect(expandOAuthScopeGroups([['organizations:read'], ['projects:read'], []], map)).toEqual([
-      ['projects_read'],
-      [],
+    expect(buildMcpToolScopeMap(endpoints).execute_sql).toEqual([
+      ['database_read'],
+      ['database_write'],
     ])
   })
 
-  // Guards the OAuth-scope -> legacy-map join: a scope key drifting out of the legacy map must
-  // not inject undefined into the payload (flatMap doesn't flatten it) or silently disable a
-  // gated tool by dropping all its groups.
+  test('single-endpoint tools derive a single conjunctive group from that endpoint', () => {
+    const endpoints: EndpointMap = {
+      'POST /v1/projects/{ref}/database/migrations': [['database_migrations_write']],
+    }
+
+    expect(buildMcpToolScopeMap(endpoints).apply_migration).toEqual([['database_migrations_write']])
+  })
+
+  test('tools without a backing endpoint stay ungated ([[]]), not disabled ([])', () => {
+    const map = buildMcpToolScopeMap({})
+
+    expect(map.confirm_cost).toEqual([[]])
+    expect(map.search_docs).toEqual([[]])
+  })
+
+  // get_cost calls two endpoints (getOrganization + the org-scoped listProjects) and needs both,
+  // so their scopes must combine into one AND group rather than either one alone satisfying it.
+  test('get_cost requires the scopes of both its endpoints together', () => {
+    const endpoints: EndpointMap = {
+      'GET /v1/organizations/{slug}': [['organization_admin_read']],
+      'GET /v1/organizations/{slug}/projects': [['organization_projects_read']],
+    }
+
+    expect(buildMcpToolScopeMap(endpoints).get_cost).toEqual([
+      ['organization_admin_read', 'organization_projects_read'],
+    ])
+  })
+
+  // A group is an AND: satisfying it from only one of its two endpoints would weaken the
+  // requirement and report the tool enabled for an incomplete grant. Losing the endpoint from the
+  // fetched spec must drop the whole alternative instead.
+  test('a tool loses a whole alternative when one of its AND-ed endpoints is missing', () => {
+    const endpoints: EndpointMap = {
+      'GET /v1/organizations/{slug}': [['organization_admin_read']],
+    }
+
+    expect(buildMcpToolScopeMap(endpoints).get_cost).toEqual([])
+  })
+
+  // Guards the endpoint-key join: an endpoint missing from the fetched spec must not inject
+  // undefined into the payload or silently disable a gated tool by dropping all its groups, and
+  // every referenced endpoint must resolve to something under a spec that covers all of them.
   test('every derived group is non-empty strings, and only the ungated tools lack scopes', () => {
     const ungated = ['confirm_cost', 'search_docs']
-    for (const [tool, groups] of Object.entries(MCPToolScopeMappings)) {
+    const allEndpointKeys = new Set(Object.values(MCPToolEndpointMapping).flat(2))
+    const endpoints: EndpointMap = Object.fromEntries(
+      Array.from(allEndpointKeys).map((key) => [key, [[`scope_for:${key}`]]])
+    )
+
+    const map = buildMcpToolScopeMap(endpoints)
+    for (const [tool, groups] of Object.entries(map)) {
       expect(groups.length, `${tool} lost all its alternatives`).toBeGreaterThan(0)
       for (const group of groups) {
         if (!ungated.includes(tool))
@@ -187,18 +215,11 @@ describe('MCPToolScopeMappings', () => {
     }
   })
 
-  test('get_cost requires both organization and project read bundles together', () => {
-    expect(MCPToolScopeMappings.get_cost).toHaveLength(1)
-    expect(MCPToolScopeMappings.get_cost[0]).toEqual(
-      expect.arrayContaining(['organizations_read', 'projects_read'])
-    )
-  })
-
   // Drift guard: the exact tool registry of @supabase/mcp-server-supabase@0.8.1, the version the
   // platform pins. When the platform bumps the MCP server, this list (and the mapping) must be
   // re-derived from the controller's assertMcpOAuthScope calls.
   test('covers exactly the tool registry of the deployed MCP server', () => {
-    expect(Object.keys(MCPToolScopeMappings).sort()).toEqual([
+    expect(Object.keys(MCPToolEndpointMapping).sort()).toEqual([
       'apply_migration',
       'confirm_cost',
       'create_branch',
@@ -296,15 +317,19 @@ describe('buildAPIPermissionScopeMap', () => {
     expect(Object.keys(map.endpoints)).toHaveLength(1)
   })
 
-  test('returns a copy of the tool mapping so callers cannot corrupt the module singleton', async () => {
+  test('derives mcp_tools fresh from the fetched specs, independent across calls', async () => {
     stubSpecs({ paths: {} }, { paths: {} })
 
     const map = await buildAPIPermissionScopeMap()
-    expect(map.mcp_tools).toEqual(MCPToolScopeMappings)
-    expect(map.mcp_tools).not.toBe(MCPToolScopeMappings)
 
-    const before = structuredClone(MCPToolScopeMappings.execute_sql)
-    map.mcp_tools.execute_sql.push(['tampered'])
-    expect(MCPToolScopeMappings.execute_sql).toEqual(before)
+    // No endpoint in the spec backs execute_sql, so it's unsatisfiable...
+    expect(map.mcp_tools.execute_sql).toEqual([])
+    // ...while the ungated tools stay callable regardless.
+    expect(map.mcp_tools.confirm_cost).toEqual([[]])
+
+    // Mutating one call's result can't affect another — each call builds its own object.
+    map.mcp_tools.confirm_cost.push(['tampered'])
+    const secondMap = await buildAPIPermissionScopeMap()
+    expect(secondMap.mcp_tools.confirm_cost).toEqual([[]])
   })
 })

--- a/apps/studio/app/api/scoped-access-token-permissions/buildAPIPermissionScopeMap.test.ts
+++ b/apps/studio/app/api/scoped-access-token-permissions/buildAPIPermissionScopeMap.test.ts
@@ -6,11 +6,8 @@ import {
   buildAPIPermissionScopeMap,
   getScopesAndEndpointsForAPI,
 } from './buildAPIPermissionScopeMap'
-import { buildMcpToolScopeMap, MCPToolEndpointMapping } from './MCPToolScopeMappings'
-import {
-  type EndpointMap,
-  type ScopeMap,
-} from '@/data/scoped-access-tokens/permission-scope-map-query'
+import { MCPToolScopeMappings } from './MCPToolScopeMappings'
+import { type ScopeMap } from '@/data/scoped-access-tokens/permission-scope-map-query'
 import { mswServer } from '@/tests/lib/msw'
 
 describe('getScopesAndEndpointsForAPI', () => {
@@ -138,73 +135,54 @@ describe('addMCPToolsToScopes', () => {
   })
 })
 
-describe('buildMcpToolScopeMap', () => {
-  // Platform gates execute_sql on database:read OR database:write depending on the MCP session's
-  // read_only mode (mcp.controller.ts), and both alternatives are the same one endpoint's own
-  // alternative groups — a single conjunctive group would hide the tool from read-only tokens the
-  // platform accepts.
-  test('execute_sql derives the database:read alternative OR the database:write alternative', () => {
-    const endpoints: EndpointMap = {
-      'POST /v1/projects/{ref}/database/query': [['database_read'], ['database_write']],
-    }
+describe('MCPToolScopeMappings', () => {
+  // Transcribed straight from mcp.controller.ts: executeSql's outer guard is DATABASE_READ for
+  // every call (read or write) — DATABASE_WRITE is checked deeper inside
+  // executeProjectDatabaseQuery for writes only, not at this layer — so a single group is correct,
+  // not an OR with database_write.
+  test('execute_sql requires only database_read', () => {
+    expect(MCPToolScopeMappings.execute_sql).toEqual([['database_read']])
+  })
 
-    expect(buildMcpToolScopeMap(endpoints).execute_sql).toEqual([
-      ['database_read'],
-      ['database_write'],
+  test('single-scope tools derive a single conjunctive group', () => {
+    expect(MCPToolScopeMappings.apply_migration).toEqual([['database_migrations_write']])
+  })
+
+  test('tools without a platform call stay ungated ([[]]), not disabled ([])', () => {
+    expect(MCPToolScopeMappings.confirm_cost).toEqual([[]])
+    expect(MCPToolScopeMappings.search_docs).toEqual([[]])
+  })
+
+  // create_branch always creates a development branch (mcp.controller.ts only ever checks
+  // BRANCHING_DEVELOPMENT_CREATE), unlike the REST endpoint's annotation which also offers a
+  // production-create alternative — the two guards genuinely differ here.
+  test('create_branch requires only development create, unlike its REST endpoint', () => {
+    expect(MCPToolScopeMappings.create_branch).toEqual([['branching_development_create']])
+  })
+
+  // delete/merge/reset/rebase check whichever of development/production the target branch is
+  // (assertBranchFgaPermission), so both alternatives are offered.
+  test('branch mutation tools offer the development OR production alternative', () => {
+    expect(MCPToolScopeMappings.delete_branch).toEqual([
+      ['branching_development_delete'],
+      ['branching_production_delete'],
+    ])
+    expect(MCPToolScopeMappings.rebase_branch).toEqual([
+      ['branching_development_write'],
+      ['branching_production_write'],
     ])
   })
 
-  test('single-endpoint tools derive a single conjunctive group from that endpoint', () => {
-    const endpoints: EndpointMap = {
-      'POST /v1/projects/{ref}/database/migrations': [['database_migrations_write']],
-    }
-
-    expect(buildMcpToolScopeMap(endpoints).apply_migration).toEqual([['database_migrations_write']])
+  // get_cost calls getOrganization (organization_admin_read) + the generic account-wide
+  // listProjects (projects_read, not the org-scoped organization_projects_read) and needs both
+  // together — a single AND group, not two independent alternatives.
+  test('get_cost requires both organization and account-wide project read together', () => {
+    expect(MCPToolScopeMappings.get_cost).toEqual([['organization_admin_read', 'projects_read']])
   })
 
-  test('tools without a backing endpoint stay ungated ([[]]), not disabled ([])', () => {
-    const map = buildMcpToolScopeMap({})
-
-    expect(map.confirm_cost).toEqual([[]])
-    expect(map.search_docs).toEqual([[]])
-  })
-
-  // get_cost calls two endpoints (getOrganization + the org-scoped listProjects) and needs both,
-  // so their scopes must combine into one AND group rather than either one alone satisfying it.
-  test('get_cost requires the scopes of both its endpoints together', () => {
-    const endpoints: EndpointMap = {
-      'GET /v1/organizations/{slug}': [['organization_admin_read']],
-      'GET /v1/organizations/{slug}/projects': [['organization_projects_read']],
-    }
-
-    expect(buildMcpToolScopeMap(endpoints).get_cost).toEqual([
-      ['organization_admin_read', 'organization_projects_read'],
-    ])
-  })
-
-  // A group is an AND: satisfying it from only one of its two endpoints would weaken the
-  // requirement and report the tool enabled for an incomplete grant. Losing the endpoint from the
-  // fetched spec must drop the whole alternative instead.
-  test('a tool loses a whole alternative when one of its AND-ed endpoints is missing', () => {
-    const endpoints: EndpointMap = {
-      'GET /v1/organizations/{slug}': [['organization_admin_read']],
-    }
-
-    expect(buildMcpToolScopeMap(endpoints).get_cost).toEqual([])
-  })
-
-  // Guards the endpoint-key join: an endpoint missing from the fetched spec must not inject
-  // undefined into the payload or silently disable a gated tool by dropping all its groups, and
-  // every referenced endpoint must resolve to something under a spec that covers all of them.
   test('every derived group is non-empty strings, and only the ungated tools lack scopes', () => {
     const ungated = ['confirm_cost', 'search_docs']
-    const allEndpointKeys = new Set(Object.values(MCPToolEndpointMapping).flat(2))
-    const endpoints: EndpointMap = Object.fromEntries(
-      Array.from(allEndpointKeys).map((key) => [key, [[`scope_for:${key}`]]])
-    )
-
-    const map = buildMcpToolScopeMap(endpoints)
-    for (const [tool, groups] of Object.entries(map)) {
+    for (const [tool, groups] of Object.entries(MCPToolScopeMappings)) {
       expect(groups.length, `${tool} lost all its alternatives`).toBeGreaterThan(0)
       for (const group of groups) {
         if (!ungated.includes(tool))
@@ -217,9 +195,9 @@ describe('buildMcpToolScopeMap', () => {
 
   // Drift guard: the exact tool registry of @supabase/mcp-server-supabase@0.8.1, the version the
   // platform pins. When the platform bumps the MCP server, this list (and the mapping) must be
-  // re-derived from the controller's assertMcpOAuthScope calls.
+  // re-derived from the controller's assertFgaPermissions calls.
   test('covers exactly the tool registry of the deployed MCP server', () => {
-    expect(Object.keys(MCPToolEndpointMapping).sort()).toEqual([
+    expect(Object.keys(MCPToolScopeMappings).sort()).toEqual([
       'apply_migration',
       'confirm_cost',
       'create_branch',
@@ -317,19 +295,15 @@ describe('buildAPIPermissionScopeMap', () => {
     expect(Object.keys(map.endpoints)).toHaveLength(1)
   })
 
-  test('derives mcp_tools fresh from the fetched specs, independent across calls', async () => {
+  test('returns a copy of the tool mapping so callers cannot corrupt the module singleton', async () => {
     stubSpecs({ paths: {} }, { paths: {} })
 
     const map = await buildAPIPermissionScopeMap()
+    expect(map.mcp_tools).toEqual(MCPToolScopeMappings)
+    expect(map.mcp_tools).not.toBe(MCPToolScopeMappings)
 
-    // No endpoint in the spec backs execute_sql, so it's unsatisfiable...
-    expect(map.mcp_tools.execute_sql).toEqual([])
-    // ...while the ungated tools stay callable regardless.
-    expect(map.mcp_tools.confirm_cost).toEqual([[]])
-
-    // Mutating one call's result can't affect another — each call builds its own object.
-    map.mcp_tools.confirm_cost.push(['tampered'])
-    const secondMap = await buildAPIPermissionScopeMap()
-    expect(secondMap.mcp_tools.confirm_cost).toEqual([[]])
+    const before = structuredClone(MCPToolScopeMappings.execute_sql)
+    map.mcp_tools.execute_sql.push(['tampered'])
+    expect(MCPToolScopeMappings.execute_sql).toEqual(before)
   })
 })

--- a/apps/studio/app/api/scoped-access-token-permissions/buildAPIPermissionScopeMap.ts
+++ b/apps/studio/app/api/scoped-access-token-permissions/buildAPIPermissionScopeMap.ts
@@ -1,8 +1,9 @@
+import { cloneDeep } from 'lodash'
 import z from 'zod'
 
 // We don't have an OpenAPI that describes mcp tools security requirements so
 // we have this hard coded file that must be updated when they change
-import { buildMcpToolScopeMap } from './MCPToolScopeMappings'
+import { MCPToolScopeMappings } from './MCPToolScopeMappings'
 import {
   EndpointMap,
   McpMap,
@@ -29,13 +30,14 @@ export const buildAPIPermissionScopeMap = async (): Promise<PermissionScopeMap> 
   const { scopes, endpoints } = getScopesAndEndpointsForAPI({
     paths: { ...apiV1Specs.paths, ...apiV2Specs.paths },
   })
-  const mcpTools = buildMcpToolScopeMap(endpoints)
-  addMCPToolsToScopes(scopes, mcpTools)
+  addMCPToolsToScopes(scopes, MCPToolScopeMappings)
 
   return {
     scopes,
     endpoints,
-    mcp_tools: mcpTools,
+    // Deep copy so a caller mutating the response can't corrupt the module-level mapping, which
+    // outlives every request in a long-running server.
+    mcp_tools: cloneDeep(MCPToolScopeMappings),
   }
 }
 

--- a/apps/studio/app/api/scoped-access-token-permissions/buildAPIPermissionScopeMap.ts
+++ b/apps/studio/app/api/scoped-access-token-permissions/buildAPIPermissionScopeMap.ts
@@ -1,9 +1,8 @@
-import { cloneDeep } from 'lodash'
 import z from 'zod'
 
 // We don't have an OpenAPI that describes mcp tools security requirements so
 // we have this hard coded file that must be updated when they change
-import { MCPToolScopeMappings } from './MCPToolScopeMappings'
+import { buildMcpToolScopeMap } from './MCPToolScopeMappings'
 import {
   EndpointMap,
   McpMap,
@@ -30,14 +29,13 @@ export const buildAPIPermissionScopeMap = async (): Promise<PermissionScopeMap> 
   const { scopes, endpoints } = getScopesAndEndpointsForAPI({
     paths: { ...apiV1Specs.paths, ...apiV2Specs.paths },
   })
-  addMCPToolsToScopes(scopes, MCPToolScopeMappings)
+  const mcpTools = buildMcpToolScopeMap(endpoints)
+  addMCPToolsToScopes(scopes, mcpTools)
 
   return {
     scopes,
     endpoints,
-    // Deep copy so a caller mutating the response can't corrupt the module-level mapping, which
-    // outlives every request in a long-running server.
-    mcp_tools: cloneDeep(MCPToolScopeMappings),
+    mcp_tools: mcpTools,
   }
 }
 

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/RiskMarker.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/RiskMarker.tsx
@@ -75,7 +75,7 @@ export const RiskMarker = ({
           </div>
         )}
         {mcpTools.length > 0 && (
-          <div className="space-y-1">
+          <div className="space-y-1 mt-5">
             {/* getMcpToolsForScopes is associative, not conjunctive: these scopes contribute to
                 the listed tools, but a tool may need scopes from other capabilities too — the
                 review step's enabled-tools list is the authoritative view. Keep this heading


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

The review step wasn't showing MCP tools a configured permission should have enabled, because tool requirements were derived from an oversizedlegacy OAuth-scope bundle instead of the endpoint each tool actually calls. Derive from the endpoint instead so it can't drift.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated MCP tool access controls to reflect each tool’s required permissions, including alternative access paths and unrestricted tools.
  * Corrected permission handling for SQL execution, branch creation, and cost retrieval.

* **UI Improvements**
  * Improved spacing in the access-token risk details tooltip.

* **Bug Fixes**
  * Improved validation to detect mismatches between MCP tools and their configured permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->