### PR TITLE
test(studio): add get_notebook eval cases (FE-4088)

### DIFF
--- a/apps/studio/evals/dataset.ts
+++ b/apps/studio/evals/dataset.ts
@@ -463,4 +463,47 @@ export const dataset: AssistantEvalCase[] = [
         'Guards against inventing a notebook instead of calling the tool and reporting the real, negative result',
     },
   },
+  {
+    input: { prompt: 'What queries does my Auth health check notebook run?' },
+    expected: {
+      requiredTools: ['list_notebooks', 'get_notebook'],
+      correctAnswer:
+        "Reports exactly two queries: a database query for signups per day from auth.users, and a logs query for auth errors against the auth_logs source scoped to the last hour. May (but does not have to) note that the remaining cell is markdown and runs no query. Accurate statements about a cell's configuration — the signups cell's 30-row limit or its line chart, the auth errors cell's relative time range — are acceptable. Does not attribute any query, table, or log source the notebook does not contain, and does not misstate the auth errors cell's time range.",
+    },
+    metadata: {
+      category: ['general_help'],
+      description:
+        'Resolves a notebook name to an id via list_notebooks, then reads it — guards against paraphrasing cells into queries the notebook does not contain',
+    },
+  },
+  {
+    input: { prompt: "Summarize what's in my Edge function error triage notebook" },
+    expected: {
+      requiredTools: ['list_notebooks', 'get_notebook'],
+      correctAnswer:
+        'Summarizes the notebook as intro text plus a single logs query for edge function failures over the last day. Does not claim the notebook contains a database query.',
+    },
+    metadata: {
+      category: ['general_help'],
+      description: 'Baseline read of a smaller, single-query notebook',
+    },
+  },
+  {
+    input: { prompt: 'Get the notebook with id 00000000-0000-0000-0000-000000000000' },
+    expected: {
+      requiredTools: [
+        {
+          name: 'get_notebook',
+          input: { id: { equals: '00000000-0000-0000-0000-000000000000' } },
+        },
+      ],
+      correctAnswer:
+        'States that no notebook with that id was found, and does not describe any notebook contents.',
+    },
+    metadata: {
+      category: ['general_help'],
+      description:
+        'Exercises the not-found error path of get_notebook and guards against hallucinating contents for a notebook that does not exist',
+    },
+  },
 ]

--- a/apps/studio/evals/dataset.ts
+++ b/apps/studio/evals/dataset.ts
@@ -481,7 +481,7 @@ export const dataset: AssistantEvalCase[] = [
     expected: {
       requiredTools: ['list_notebooks', 'get_notebook'],
       correctAnswer:
-        'Summarizes the notebook as intro text plus a single logs query for edge function failures over the last day. Does not claim the notebook contains a database query.',
+        'Summarizes the notebook as a markdown intro plus one log cell ("hello-world failures") that queries function_edge_logs for TypeError failures over the last day. Log cells hold SQL against a logs source, so describing that cell\'s SQL, columns, or time range is correct and acceptable. Does not attribute a third cell, or any Postgres database cell, to the notebook.',
     },
     metadata: {
       category: ['general_help'],

--- a/apps/studio/lib/ai/prompts.ts
+++ b/apps/studio/lib/ai/prompts.ts
@@ -767,6 +767,7 @@ export const NOTEBOOKS_PROMPT = `
 - Use \`execute_sql\` for a single ad-hoc question with no need to persist it.
 - When the request clearly calls for a notebook, call \`create_notebook\` or \`update_notebook\` directly; both tools handle user approval.
 - \`update_notebook\` re-fetches the notebook right before applying edits, so the latest save always wins — it cannot detect edits made by someone else in between.
+- When describing an existing notebook, report each query cell's configuration that changes what it returns — a log cell's time range, a database cell's row limit — and don't count markdown cells as queries.
 `
 
 export const OUTPUT_ONLY_PROMPT = `


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Feature (test coverage) — second PR of the notebooks-evals plan, covering FE-4088 (Evals: Assistant can read notebook). Follows #49010 (FE-4086, list_notebooks).

## What is the current behavior?

`dataset.ts` has no coverage for `get_notebook`. Separately, `NOTEBOOKS_PROMPT` only covers *choosing* between `create_notebook`, `update_notebook`, and `execute_sql` — it says nothing about reading or describing an existing notebook.

## What is the new behavior?

**Eval cases** (`evals/dataset.ts`), three of them:

- Resolve a notebook by name via `list_notebooks`, then `get_notebook`, and report the queries it actually contains.
- Summarize a smaller, single-log-cell notebook as a baseline.
- Report a nonexistent notebook id as not found instead of hallucinating contents. The mock's `execute` throws, which the AI SDK surfaces to the model as a `tool-error` part rather than failing the eval task.

No new scorers or tool changes — `toolUsageScorer` and `correctnessScorer` already cover these, and `get_notebook` has unit coverage in `notebook-tools.test.ts`.

**Prompt change** (`lib/ai/prompts.ts`) — please review this one separately, it's the only production behavior change here:

Running the first case surfaced a real gap. The assistant transcribed each cell's SQL correctly but was inconsistent about the configuration that changes what a cell returns — dropping the log cell's time range in some runs, miscounting markdown cells as queries in others. Adds one bullet to `NOTEBOOKS_PROMPT` telling it to report a query cell's configuration and not count markdown cells as queries. Gated behind the Explorer flag, same as the rest of that prompt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added notebook evaluation scenarios for database and log queries, including concise summaries and nonexistent notebook handling.
  * Improved notebook descriptions by reporting query configurations that affect returned results.
  * Markdown cells are now excluded from query counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->