### PR TITLE
refactor(studio): extract notebook query-cell logic and give log cells display settings

### DIFF
--- a/apps/studio/components/interfaces/Explorer/NotebookEditor.tsx
+++ b/apps/studio/components/interfaces/Explorer/NotebookEditor.tsx
@@ -27,6 +27,7 @@ import { MarkdownCell } from './MarkdownCell'
 import { QueryCell } from './QueryCell'
 import { createMarkdownCellSkeleton, createQueryCellSkeleton } from './utils'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
+import { isQueryCell } from '@/data/content/notebooks/notebook-schema'
 import { useCurrentNotebook, useNotebooksStateSnapshot } from '@/state/notebooks/notebooks-state'
 import { createTabId, useTabsStateSnapshot } from '@/state/tabs'
 
@@ -112,15 +113,13 @@ export const NotebookEditor = () => {
                   strategy={verticalListSortingStrategy}
                 >
                   <div className="flex flex-col gap-y-4">
-                    {cells.map((cell) => {
-                      switch (cell._tag) {
-                        case 'markdown_cell':
-                          return <MarkdownCell key={cell.id} cell={cell} />
-                        case 'database_cell':
-                        case 'log_cell':
-                          return <QueryCell key={cell.id} cell={cell} />
-                      }
-                    })}
+                    {cells.map((cell) =>
+                      isQueryCell(cell) ? (
+                        <QueryCell key={cell.id} cell={cell} />
+                      ) : (
+                        <MarkdownCell key={cell.id} cell={cell} />
+                      )
+                    )}
                   </div>
                 </SortableContext>
               </DndContext>

--- a/apps/studio/components/interfaces/Explorer/QueryCell/DisplaySettingsButton.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryCell/DisplaySettingsButton.tsx
@@ -20,8 +20,9 @@ import {
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
 import { ExplorerToolbarAction } from '../ExplorerToolbar'
-import { type QueryChartConfig, type QueryDisplay, type QueryResult } from '../types'
+import { type QueryDisplay, type QueryResult } from '../types'
 import { checkHasNonPositiveValues } from '@/components/ui/QueryBlock/QueryBlock.utils'
+import { type ChartConfig } from '@/data/content/notebooks/notebook-schema'
 
 interface DisplaySettingsButtonProps {
   display: QueryDisplay
@@ -66,7 +67,7 @@ export const DisplaySettingsButton = ({
     onChange({ ...display, view })
   }
 
-  const onUpdateChartConfig = (payload: Partial<QueryChartConfig>) => {
+  const onUpdateChartConfig = (payload: Partial<ChartConfig>) => {
     onChange({
       ...display,
       chart: {

--- a/apps/studio/components/interfaces/Explorer/QueryCell/QueryCell.utils.test.ts
+++ b/apps/studio/components/interfaces/Explorer/QueryCell/QueryCell.utils.test.ts
@@ -1,0 +1,167 @@
+import { untrustedSql } from '@supabase/pg-meta'
+import { describe, expect, it } from 'vitest'
+
+import {
+  changeCellSource,
+  cloneQueryCell,
+  DEFAULT_CELL_ROW_LIMIT,
+  getCellDisplay,
+  setCellSql,
+  toQueryModel,
+} from './QueryCell.utils'
+import { type ChartConfig, type QueryCell } from '@/data/content/notebooks/notebook-schema'
+import { untrustedLogSql } from '@/data/logs/safe-analytics-sql'
+
+const CHART: ChartConfig = {
+  type: 'bar',
+  x_column: 'day',
+  y_columns: ['signups'],
+  cumulative: false,
+  scale: 'linear',
+  show_labels: true,
+}
+
+const DATABASE_CELL: QueryCell = {
+  _tag: 'database_cell',
+  id: 'cell-1',
+  title: 'Signups',
+  view: 'chart',
+  chart: CHART,
+  unchecked_sql: untrustedSql('select * from auth.users'),
+  row_limit: 50,
+  database_identifier: 'replica-1',
+}
+
+const LOG_CELL: QueryCell = {
+  _tag: 'log_cell',
+  id: 'cell-2',
+  title: 'Edge errors',
+  view: 'table',
+  chart: CHART,
+  unchecked_sql: untrustedLogSql('select timestamp from logs'),
+  time_range: { _tag: 'relative_time_range', unit: 'hour', amount: 1 },
+}
+
+describe('changeCellSource', () => {
+  it('keeps the query when only the database changes', () => {
+    const next = changeCellSource(DATABASE_CELL, {
+      _tag: 'database',
+      database_identifier: 'replica-2',
+    })
+
+    expect(next).toEqual({ ...DATABASE_CELL, database_identifier: 'replica-2' })
+  })
+
+  it('keeps the query when only the log time range changes', () => {
+    const time_range = { _tag: 'relative_time_range', unit: 'day', amount: 7 } as const
+    const next = changeCellSource(LOG_CELL, { _tag: 'logs', time_range })
+
+    expect(next).toEqual({ ...LOG_CELL, time_range })
+  })
+
+  it('carries the query text over when moving from the database to logs', () => {
+    const time_range = { _tag: 'relative_time_range', unit: 'hour', amount: 1 } as const
+    const next = changeCellSource(DATABASE_CELL, { _tag: 'logs', time_range })
+
+    expect(next).toEqual({
+      _tag: 'log_cell',
+      id: 'cell-1',
+      title: 'Signups',
+      view: 'chart',
+      chart: CHART,
+      unchecked_sql: 'select * from auth.users',
+      time_range,
+    })
+  })
+
+  it('carries the query text over and restores a default row limit when moving from logs to the database', () => {
+    const next = changeCellSource(LOG_CELL, { _tag: 'database', database_identifier: undefined })
+
+    expect(next).toEqual({
+      _tag: 'database_cell',
+      id: 'cell-2',
+      title: 'Edge errors',
+      view: 'table',
+      chart: CHART,
+      unchecked_sql: 'select timestamp from logs',
+      row_limit: DEFAULT_CELL_ROW_LIMIT,
+      database_identifier: undefined,
+    })
+  })
+
+  it('applies the selected database when moving from logs to the database', () => {
+    const next = changeCellSource(LOG_CELL, {
+      _tag: 'database',
+      database_identifier: 'replica-2',
+    })
+
+    expect(next).toMatchObject({ _tag: 'database_cell', database_identifier: 'replica-2' })
+  })
+
+  it('preserves the chart across a backend change so display settings survive', () => {
+    const next = changeCellSource(DATABASE_CELL, {
+      _tag: 'logs',
+      time_range: { _tag: 'relative_time_range', unit: 'hour', amount: 1 },
+    })
+
+    expect(next.chart).toEqual(CHART)
+    expect(next.chart).not.toBe(DATABASE_CELL.chart)
+  })
+})
+
+describe('setCellSql', () => {
+  it('writes the text back onto a database cell without touching its source', () => {
+    expect(setCellSql(DATABASE_CELL, 'select 1')).toEqual({
+      ...DATABASE_CELL,
+      unchecked_sql: 'select 1',
+    })
+  })
+
+  it('writes the text back onto a log cell without touching its time range', () => {
+    expect(setCellSql(LOG_CELL, 'select 2')).toEqual({ ...LOG_CELL, unchecked_sql: 'select 2' })
+  })
+})
+
+describe('cloneQueryCell', () => {
+  it('copies the chart series array rather than aliasing it', () => {
+    const clone = cloneQueryCell(DATABASE_CELL)
+
+    expect(clone).toEqual(DATABASE_CELL)
+    expect(clone.chart?.y_columns).not.toBe(DATABASE_CELL.chart?.y_columns)
+  })
+})
+
+describe('getCellDisplay', () => {
+  it('keeps a configured chart while the table view is selected', () => {
+    expect(getCellDisplay({ ...DATABASE_CELL, view: 'table' })).toEqual({
+      view: 'table',
+      chart: CHART,
+    })
+  })
+
+  it('reports no chart when a cell has never configured one', () => {
+    expect(getCellDisplay({ ...DATABASE_CELL, view: 'table', chart: undefined })).toEqual({
+      view: 'table',
+      chart: undefined,
+    })
+  })
+})
+
+describe('toQueryModel', () => {
+  it('tags a database cell with its row limit and database', () => {
+    expect(toQueryModel(DATABASE_CELL, 'select 3')).toEqual({
+      _tag: 'database',
+      uncheckedSql: 'select 3',
+      database_identifier: 'replica-1',
+      rowLimit: 50,
+    })
+  })
+
+  it('tags a log cell with its time range and no row limit', () => {
+    expect(toQueryModel(LOG_CELL, 'select 4')).toEqual({
+      _tag: 'logs',
+      uncheckedSql: 'select 4',
+      time_range: LOG_CELL.time_range,
+    })
+  })
+})

--- a/apps/studio/components/interfaces/Explorer/QueryCell/QueryCell.utils.ts
+++ b/apps/studio/components/interfaces/Explorer/QueryCell/QueryCell.utils.ts
@@ -1,0 +1,135 @@
+import { untrustedSql } from '@supabase/pg-meta'
+import { type Snapshot } from 'valtio'
+
+import { type ExplorerQueryModel } from '../QueryEditor'
+import { type QueryDisplay } from '../types'
+import { type ChartConfig, type QueryCell } from '@/data/content/notebooks/notebook-schema'
+import { untrustedLogSql } from '@/data/logs/safe-analytics-sql'
+import {
+  getQuerySourceBinding,
+  type QuerySourceBinding,
+} from '@/data/query-sources/query-source-registry'
+
+/** Row limit a database cell starts with when it has no saved one to carry over. */
+export const DEFAULT_CELL_ROW_LIMIT = 100
+
+/**
+ * Valtio snapshots are deep-readonly. Readonly properties assign to mutable ones, so only
+ * the array needs rebuilding to turn a snapshot's chart back into a writable config.
+ */
+type ReadonlyChartConfig = Omit<ChartConfig, 'y_columns'> & {
+  readonly y_columns: readonly string[]
+}
+
+export const cloneChartConfig = (
+  chart: ReadonlyChartConfig | undefined
+): ChartConfig | undefined => (chart ? { ...chart, y_columns: [...chart.y_columns] } : undefined)
+
+/** The display state a query cell hands the shared editor. */
+// `view` is already defaulted to 'table' by the domain transform, so there is nothing to
+// fall back to here — only the chart needs copying out of the snapshot.
+export const getCellDisplay = (cell: Snapshot<QueryCell>): QueryDisplay => ({
+  view: cell.view,
+  chart: cloneChartConfig(cell.chart),
+})
+
+/** Fields every query cell carries, copied out of a snapshot so the result is writable. */
+const copyQueryCellBase = (cell: Snapshot<QueryCell>) => ({
+  id: cell.id,
+  title: cell.title,
+  view: cell.view,
+  chart: cloneChartConfig(cell.chart),
+})
+
+/** A writable copy of a query cell, preserving its backend and every backend-specific field. */
+export const cloneQueryCell = (cell: Snapshot<QueryCell>): QueryCell =>
+  cell._tag === 'log_cell'
+    ? {
+        ...copyQueryCellBase(cell),
+        _tag: 'log_cell',
+        unchecked_sql: cell.unchecked_sql,
+        time_range: cell.time_range,
+      }
+    : {
+        ...copyQueryCellBase(cell),
+        _tag: 'database_cell',
+        unchecked_sql: cell.unchecked_sql,
+        row_limit: cell.row_limit,
+        database_identifier: cell.database_identifier,
+      }
+
+/**
+ * Applies a source binding to a query cell, carrying the query text across unchanged and
+ * rebranding it for the new backend's dialect.
+ *
+ * NOTE — carrying the text over is very likely not what a user wants when the backend
+ * actually changes. Postgres SQL and logs SQL are separate dialects over separate schemas,
+ * so a carried-over query will almost always fail to run, and the rebrand asserts a
+ * dialect the text was never written in. We keep it for now because it is the
+ * least-destructive option and needs no confirmation prompt; revisit once we know whether
+ * people switch source to port an existing query or to start a fresh one, at which point
+ * clearing the body (behind a confirmation) is the likely answer.
+ */
+export function changeCellSource(cell: Snapshot<QueryCell>, source: QuerySourceBinding): QueryCell {
+  const base = copyQueryCellBase(cell)
+
+  if (source._tag === 'logs') {
+    return {
+      ...base,
+      _tag: 'log_cell',
+      unchecked_sql: untrustedLogSql(cell.unchecked_sql),
+      time_range: source.time_range,
+    }
+  }
+
+  return {
+    ...base,
+    _tag: 'database_cell',
+    unchecked_sql: untrustedSql(cell.unchecked_sql),
+    row_limit: cell._tag === 'database_cell' ? cell.row_limit : DEFAULT_CELL_ROW_LIMIT,
+    database_identifier: source.database_identifier,
+  }
+}
+
+/**
+ * Writes the editor's text back onto a cell, branded for that cell's dialect. Separate
+ * from `cloneQueryCell` so the brand stays correlated with the cell tag in one narrowing
+ * rather than being re-derived at each call site.
+ */
+export function setCellSql(cell: Snapshot<QueryCell>, sql: string): QueryCell {
+  const base = copyQueryCellBase(cell)
+
+  if (cell._tag === 'log_cell') {
+    return {
+      ...base,
+      _tag: 'log_cell',
+      unchecked_sql: untrustedLogSql(sql),
+      time_range: cell.time_range,
+    }
+  }
+
+  return {
+    ...base,
+    _tag: 'database_cell',
+    unchecked_sql: untrustedSql(sql),
+    row_limit: cell.row_limit,
+    database_identifier: cell.database_identifier,
+  }
+}
+
+/**
+ * Builds the editor's query model from a cell and the editor's live text buffer. Branding
+ * the buffer is the editor boundary the safe-SQL model expects; which brand applies is
+ * decided by the cell's tag, so the dialect can't drift from the cell it belongs to.
+ */
+export function toQueryModel(cell: Snapshot<QueryCell>, sql: string): ExplorerQueryModel {
+  if (cell._tag === 'log_cell') {
+    return { ...getQuerySourceBinding(cell), uncheckedSql: untrustedLogSql(sql) }
+  }
+
+  return {
+    ...getQuerySourceBinding(cell),
+    uncheckedSql: untrustedSql(sql),
+    rowLimit: cell.row_limit,
+  }
+}

--- a/apps/studio/components/interfaces/Explorer/QueryCell/index.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryCell/index.tsx
@@ -1,132 +1,82 @@
-import { untrustedSql } from '@supabase/pg-meta'
 import { useState } from 'react'
 import { type Snapshot } from 'valtio'
 
 import { AddCellDropdown } from '../AddCellDropdown'
 import { MoveCellDropdownContent } from '../MoveCellDropdownContent'
-import { QueryEditor, type ExplorerQueryModel } from '../QueryEditor'
+import { QueryEditor } from '../QueryEditor'
 import { type QueryDisplay, type QueryResult } from '../types'
+import {
+  changeCellSource,
+  cloneChartConfig,
+  cloneQueryCell,
+  getCellDisplay,
+  setCellSql,
+  toQueryModel,
+} from './QueryCell.utils'
 import { SortableSection } from '@/components/ui/SortableSection'
 import {
-  type DatabaseCell as DatabaseCellSchema,
-  type LogCell as LogCellSchema,
+  isQueryCell,
+  type QueryCell as QueryCellSchema,
 } from '@/data/content/notebooks/notebook-schema'
-import { untrustedLogSql } from '@/data/logs/safe-analytics-sql'
-import {
-  getQuerySourceBinding,
-  type QuerySourceBinding,
-} from '@/data/query-sources/query-source-registry'
+import { type QuerySourceBinding } from '@/data/query-sources/query-source-registry'
 import { useCurrentNotebook, useNotebooksStateSnapshot } from '@/state/notebooks/notebooks-state'
 
 interface QueryCellProps {
-  cell: Snapshot<DatabaseCellSchema | LogCellSchema>
+  cell: Snapshot<QueryCellSchema>
 }
-
-/**
- * [Joshen] Aiming to keep PRs small so the following are deliberating missing for now:
- * - Auto limit logic
- * - Database selection logic
- *
- * QueryCell atm minimally supports running queries and rendering results
- */
-
-type QueryCellUpdate = { sql: string } | { title: string } | { display: QueryDisplay }
 
 /** Notebook adapter around the shared QueryEditor. */
 export const QueryCell = ({ cell }: QueryCellProps) => {
   const snap = useNotebooksStateSnapshot()
   const currentNotebook = useCurrentNotebook()
 
-  const { id, title: cellTitle, view, chart, unchecked_sql } = cell
-
-  const [sql, setSql] = useState<string>(unchecked_sql)
+  const [sql, setSql] = useState<string>(cell.unchecked_sql)
   const [result, setResult] = useState<QueryResult>()
 
-  const title = cellTitle ?? 'Untitled snippet'
-  const query: ExplorerQueryModel =
-    cell._tag === 'log_cell'
-      ? { ...getQuerySourceBinding(cell), uncheckedSql: untrustedLogSql(sql) }
-      : {
-          ...getQuerySourceBinding(cell),
-          uncheckedSql: untrustedSql(sql),
-          rowLimit: cell.row_limit,
-        }
-  const display: QueryDisplay = {
-    view: view ?? 'table',
-    chart: chart ? { ...chart, y_columns: [...chart.y_columns] } : undefined,
+  const title = cell.title ?? 'Untitled query'
+
+  /**
+   * Applies an update to this cell. The updater runs against the cell as the store holds
+   * it rather than the snapshot this component rendered with, so a concurrent edit isn't
+   * clobbered; `isQueryCell` keeps the per-backend helpers off a markdown cell that
+   * somehow shares the id.
+   */
+  const updateQueryCell = (updater: (candidate: Snapshot<QueryCellSchema>) => QueryCellSchema) => {
+    const notebookId = currentNotebook?.notebook.id
+    if (!notebookId) return
+
+    snap.updateCell({
+      id: notebookId,
+      cellId: cell.id,
+      updater: (candidate) => (isQueryCell(candidate) ? updater(candidate) : candidate),
+    })
   }
 
   const handleSourceChange = (source: QuerySourceBinding) => {
-    const notebookId = currentNotebook?.notebook.id
-    if (!notebookId) return
+    // The query text carries over (see `changeCellSource`), so the editor's buffer stays
+    // valid — but a result the old backend produced does not, since another engine
+    // returns unrelated columns.
+    const isBackendChange = (source._tag === 'logs') !== (cell._tag === 'log_cell')
+    if (isBackendChange) setResult(undefined)
 
-    snap.updateCell({
-      id: notebookId,
-      cellId: id,
-      updater: (candidate) => {
-        if (source._tag === 'database' && candidate._tag === 'log_cell') {
-          const { _tag, time_range, unchecked_sql, ...rest } = candidate
-          return {
-            ...rest,
-            _tag: 'database_cell' as const,
-            row_limit: 100,
-            database_identifier: source.database_identifier,
-            unchecked_sql: untrustedSql(unchecked_sql),
-          }
-        }
-
-        if (source._tag === 'logs' && candidate._tag === 'database_cell') {
-          const { _tag, row_limit, database_identifier, unchecked_sql, ...rest } = candidate
-          return {
-            ...rest,
-            _tag: 'log_cell' as const,
-            time_range: source.time_range,
-            unchecked_sql: untrustedLogSql(unchecked_sql),
-          }
-        }
-
-        if (source._tag === 'database' && candidate._tag === 'database_cell') {
-          return { ...candidate, database_identifier: source.database_identifier }
-        }
-
-        if (source._tag === 'logs' && candidate._tag === 'log_cell') {
-          return { ...candidate, time_range: source.time_range }
-        }
-
-        return candidate
-      },
-    })
+    updateQueryCell((candidate) => changeCellSource(candidate, source))
   }
 
-  const handleUpdateCell = (payload: QueryCellUpdate) => {
-    const notebookId = currentNotebook?.notebook.id
-    if (!notebookId) return
-
-    snap.updateCell({
-      id: notebookId,
-      cellId: id,
-      updater: (candidate) => {
-        if (candidate._tag !== 'database_cell' && candidate._tag !== 'log_cell') return candidate
-
-        if ('sql' in payload) {
-          return candidate._tag === 'database_cell'
-            ? { ...candidate, unchecked_sql: untrustedSql(payload.sql) }
-            : { ...candidate, unchecked_sql: untrustedLogSql(payload.sql) }
-        }
-
-        if ('title' in payload) {
-          const nextTitle = payload.title.trim()
-          return nextTitle ? { ...candidate, title: nextTitle } : candidate
-        }
-
-        return {
-          ...candidate,
-          view: payload.display.view,
-          chart: payload.display.chart,
-        }
-      },
-    })
+  const handleTitleChange = (value: string) => {
+    const nextTitle = value.trim()
+    if (!nextTitle) return
+    updateQueryCell((candidate) => ({ ...cloneQueryCell(candidate), title: nextTitle }))
   }
+
+  const handleSqlCommit = (value: string) =>
+    updateQueryCell((candidate) => setCellSql(candidate, value))
+
+  const handleDisplayChange = (display: QueryDisplay) =>
+    updateQueryCell((candidate) => ({
+      ...cloneQueryCell(candidate),
+      view: display.view,
+      chart: cloneChartConfig(display.chart),
+    }))
 
   return (
     <SortableSection
@@ -136,20 +86,18 @@ export const QueryCell = ({ cell }: QueryCellProps) => {
       gripClassName="mt-2 opacity-0 group-hover:opacity-100 has-[[data-state=open]]:opacity-100 transition"
     >
       <QueryEditor
-        id={id}
+        id={cell.id}
         variant="embedded"
         title={title}
-        query={query}
+        query={toQueryModel(cell, sql)}
         result={result}
-        display={cell._tag === 'database_cell' ? display : undefined}
-        onTitleChange={(title) => handleUpdateCell({ title })}
+        display={getCellDisplay(cell)}
+        onTitleChange={handleTitleChange}
         onSqlChange={setSql}
-        onSqlCommit={(sql) => handleUpdateCell({ sql })}
+        onSqlCommit={handleSqlCommit}
         onSourceChange={handleSourceChange}
         onResultChange={setResult}
-        onDisplayChange={
-          cell._tag === 'database_cell' ? (display) => handleUpdateCell({ display }) : undefined
-        }
+        onDisplayChange={handleDisplayChange}
       />
     </SortableSection>
   )

--- a/apps/studio/components/interfaces/Explorer/QueryResultChart.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryResultChart.tsx
@@ -1,12 +1,13 @@
 import { useMemo } from 'react'
 import { Chart, ChartBar, ChartCard, ChartContent, ChartLine } from 'ui-patterns/Chart'
 
-import { type QueryChartConfig, type QueryResult } from './types'
+import { type QueryResult } from './types'
 import NoDataPlaceholder from '@/components/ui/Charts/NoDataPlaceholder'
 import { formatLogTick, getCumulativeResults } from '@/components/ui/QueryBlock/QueryBlock.utils'
+import { type ChartConfig } from '@/data/content/notebooks/notebook-schema'
 
 interface QueryResultChartProps {
-  chart?: QueryChartConfig
+  chart?: ChartConfig
   result?: QueryResult
 }
 

--- a/apps/studio/components/interfaces/Explorer/QueryResultRenderer.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryResultRenderer.tsx
@@ -1,12 +1,13 @@
 import { QueryResultChart } from './QueryResultChart'
 import { QueryResultError } from './QueryResultError'
-import { type QueryChartConfig, type QueryResult } from './types'
+import { type QueryResult } from './types'
 import { DataGridResults } from '@/components/ui/DataGridResults'
+import { type ChartConfig } from '@/data/content/notebooks/notebook-schema'
 
 interface QueryResultRendererProps {
   result?: QueryResult
   view?: 'table' | 'chart'
-  chart?: QueryChartConfig
+  chart?: ChartConfig
 }
 
 export const QueryResultRenderer = ({ result, view, chart }: QueryResultRendererProps) => {

--- a/apps/studio/components/interfaces/Explorer/types.ts
+++ b/apps/studio/components/interfaces/Explorer/types.ts
@@ -1,19 +1,17 @@
+import { type ChartConfig } from '@/data/content/notebooks/notebook-schema'
+
 export type QueryResult = {
   rows?: readonly Record<string, unknown>[]
   error?: { message: string; formattedError?: string }
   autoLimit?: number
 }
 
-export type QueryChartConfig = {
-  type: 'bar' | 'line'
-  x_column: string
-  y_columns: string[]
-  cumulative: boolean
-  scale: 'linear' | 'log'
-  show_labels: boolean
-}
-
+/**
+ * How a query's results are rendered. `chart` is kept independently of `view` so a user
+ * who switches to the table and back gets their chart configuration returned rather than
+ * rebuilt — the same reason the notebook wire schema persists the two separately.
+ */
 export type QueryDisplay = {
   view: 'table' | 'chart'
-  chart?: QueryChartConfig
+  chart?: ChartConfig
 }

--- a/apps/studio/components/interfaces/Explorer/utils.ts
+++ b/apps/studio/components/interfaces/Explorer/utils.ts
@@ -1,5 +1,6 @@
 import { untrustedSql } from '@supabase/pg-meta'
 
+import { DEFAULT_CELL_ROW_LIMIT } from './QueryCell/QueryCell.utils'
 import { generateUuid } from '@/lib/api/snippets.browser'
 
 export const createQueryCellSkeleton = ({ sql }: { sql?: string } = {}) => {
@@ -9,7 +10,7 @@ export const createQueryCellSkeleton = ({ sql }: { sql?: string } = {}) => {
     view: 'table' as const,
     chart: undefined,
     unchecked_sql: untrustedSql(sql ?? ''),
-    row_limit: 100,
+    row_limit: DEFAULT_CELL_ROW_LIMIT,
   }
 }
 


### PR DESCRIPTION
Final PR of the stack. #49069, #49070, #49072 and #49074 have merged, so this now targets `master` directly.

**Rebased onto latest `master`**, which includes the centralized result-rendering work (#49096). See "Conflict resolution" below.

## What's left after master's own fixes

`QueryCell` was written for database cells and adapted to log cells afterwards. Master has since fixed most of it directly: `handleUpdateCell` no longer bails on a non-database cell, the cell's own binding is read via `getQuerySourceBinding`, and `database_identifier` / `time_range` propagate across a source change.

What remains:

- **`display` was only passed for database cells**, so the `view` field on `log_cell` stayed unreachable and a logs query could never be charted. That is the one behavioral fix left in this PR.
- The per-backend branching is inline and untested.

## What changed

Per-backend logic moves into `QueryCell.utils.ts`, where it is unit-tested: `changeCellSource`, `setCellSql`, `cloneQueryCell`, `getCellDisplay`, `toQueryModel`. Each narrows on the cell tag exactly once, so the SQL brand and the backend's parameters stay correlated rather than being re-derived at each call site. `cloneQueryCell` also rebuilds the chart's series array, which valtio hands over as `readonly string[]`.

`NotebookEditor` renders through `isQueryCell` (#49069) rather than a tag switch, so a new backend gets picked up by classifying it in `CELL_KINDS` instead of by remembering to add a `case`.

## Conflict resolution

Two rounds of master's work landed in this file set.

**`QueryCell/index.tsx` (master's own rework).** `changeCellSource` **subsumes the four source-change branches** master had inline, each covered by a test:

| Master's branch | Test |
|---|---|
| database → database (replica change) | `keeps the query when only the database changes` |
| logs → logs (time-range change) | `keeps the query when only the log time range changes` |
| database → logs | `carries the query text over when moving from the database to logs` |
| logs → database | `carries the query text over and restores a default row limit …` |

Two improvements fall out of consolidating them:

- A **logs → database** move now keeps the selected replica; pinned by `applies the selected database when moving from logs to the database`.
- The row-limit default is **named** rather than a hard-coded `100`. `Explorer/utils.ts` now shares `DEFAULT_CELL_ROW_LIMIT` with `createQueryCellSkeleton`, so cell creation and backend conversion can't drift.

Untouched from master: `snap.updateCell`, `AddCellDropdown`, `MoveCellDropdownContent`, the `SortableSection` grip props, and `NotebookEditor`'s add-cell buttons, skeletons, `reorderCells` and `insertCellAfter`.

**Centralized result rendering (#49096).** That PR moved `QueryCell/QueryResultChart.tsx` up to `Explorer/`, split `QueryResultTable` into `QueryResultError`, and added `QueryResultRenderer`. Since this PR removes `QueryChartConfig`, the type swap had to follow the move and also reach `QueryResultRenderer`, which is new and referenced the removed type. `QueryResultRenderer`, `QueryResultError` and `DataGridResults` are otherwise untouched — the empty/error-state centralization is fully preserved, and `QueryEditor` still renders through it.

## Behavior worth a second opinion

`changeCellSource` **carries the query text across a backend change** and rebrands it. This is probably not what a user wants — Postgres SQL and logs SQL are separate dialects over separate schemas, so a carried-over query will usually fail to run, and the rebrand asserts a dialect the text was never written in.

Keeping it for now because it destroys nothing and needs no confirmation prompt. The tradeoff is written up at the function. Worth revisiting once we know whether people switch source to port an existing query or to start a fresh one — if it's the latter, clearing the body behind a confirmation is the better answer.

Results *are* dropped on a backend change, since another engine returns unrelated columns.

## Incidental

`Explorer/types.ts` drops `QueryChartConfig`, which duplicated the wire schema's `ChartConfig` field for field. `chart` stays persisted alongside `view`, so switching to the table and back returns the user's chart settings rather than rebuilding them.

## Verification

Typecheck, Prettier, and the lint ratchet clean. 1013 tests pass across `state/`, the Explorer surfaces, notebooks, query sources, `data/sql`, the SQL editor, and `components/ui`; 13 of them are new coverage for the extracted helpers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved notebook cell rendering with more consistent handling of query and markdown cells.
  - Query cells now preserve SQL, source settings, display preferences, chart configuration, and query results when edited or switched between sources.
  - Added a default limit of 100 rows for applicable database queries.

- **Bug Fixes**
  - Prevented stale query results from carrying over when changing query sources.
  - Improved chart configuration consistency across query results and display settings.

- **Tests**
  - Added comprehensive coverage for query-cell updates, source transitions, SQL changes, display state, and chart data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->