### PR TITLE
fix(blog): point Service Versions links at the General settings page

### DIFF
--- a/apps/www/_blog/2023-09-06-increase-performance-pgvector-hnsw.mdx
+++ b/apps/www/_blog/2023-09-06-increase-performance-pgvector-hnsw.mdx
@@ -31,7 +31,7 @@ USING hnsw (embedding vector_ip_ops);
 
 <aside className="bg-gray-300 rounded-lg px-6 py-2 bold">
 
-💡 If you have an existing database that was created before the release, you can initiate a software update in the [Dashboard's Infrastructure Settings](https://supabase.com/dashboard/project/_/settings/infrastructure).
+💡 If you have an existing database that was created before the release, you can initiate a software update in the [Dashboard's General Settings](https://supabase.com/dashboard/project/_/settings/general).
 
 </aside>
 

--- a/apps/www/_blog/2024-05-01-pgvector-0-7-0.mdx
+++ b/apps/www/_blog/2024-05-01-pgvector-0-7-0.mdx
@@ -194,4 +194,4 @@ with
 ```
 
 If you are unsure which version of pgvector your project is using, search for `vector` on the [Extensions page](https://supabase.com/dashboard/project/_/database/extensions). If you are using a previous version, you can upgrade
-by navigating to the **Service Versions** section on the [Infrastructure page](https://supabase.com/dashboard/project/_/settings/infrastructure) and upgrading your Postgres version to `15.1.1.47` or later.
+by navigating to the **Service Versions** section on the [General settings page](https://supabase.com/dashboard/project/_/settings/general) and upgrading your Postgres version to `15.1.1.47` or later.


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix (two blog links point at a settings page that no longer holds the section they name).

## What is the current behavior?

#49053 moved the docs links for the project upgrade UI from `settings/infrastructure` to `settings/general`, but it only covered `apps/docs`. Two posts in `apps/www/_blog` describe the same flow and still send readers to Infrastructure:

- `2024-05-01-pgvector-0-7-0.mdx` says to upgrade "by navigating to the **Service Versions** section on the [Infrastructure page]"
- `2023-09-06-increase-performance-pgvector-hnsw.mdx` says you can "initiate a software update in the [Dashboard's Infrastructure Settings]"

Neither is on that page anymore. In current master:

- `ServiceVersionsSection` is imported by exactly one page, `pages/project/[ref]/settings/general.tsx`
- `pages/project/[ref]/settings/infrastructure.tsx` renders only `DiskManagementForm`, and its own page description is "View and configure compute and disk for your project"

So the first post names a section by title and links to a page that does not contain it, and the second sends you somewhere with no software update control at all. `ServiceVersionsSection` is the right destination for both: it pulls in `ProjectUpgradeAlert` and `useProjectUpgradeEligibilityQuery`, which is the Postgres version upgrade flow those posts are describing.

## What is the new behavior?

Both point at `settings/general`, and the link text names the page it now goes to. That matches how #49053 rewrote the equivalent docs sentence, which became "[General Settings](/dashboard/project/_/settings/general)".

Two lines, two files.

## Additional context

I deliberately left a third one alone. `2023-12-15-introducing-read-replicas.mdx` says you can "manage and visualize read replicas from the [infrastructure settings page]", which is also stale, but I could not pin the replacement with any confidence. The read replica UI now lives under `database/replication/replica/[replicaId]`, and `database/replication/index.tsx` renders `Destinations` and `ReplicationDiagram` behind a `useHighAvailability` check, so it is not obviously the page that post means. That is a call for someone who knows where read replica management is meant to live, and guessing would be worse than leaving it.

Everything else still pointing at `settings/infrastructure` I checked and left, because it is correct: compute sizing, disk size and IO config all still live there.

These are `/dashboard` URLs so I could not verify them with a status code, they are behind auth. The evidence above is from the code instead: which page imports the section, and what the Infrastructure page actually renders on current master.

Gates on this branch: `test:prettier` passes repo wide, `typecheck --filter=www --force` passes 8/8, and the www vitest suite passes (6 files, 75 tests). I did not run `pnpm build`, which cannot finish in my environment because the docs `build:federated-content` step needs `DOCS_GITHUB_APP_PRIVATE_KEY`.

Freshman contributor. Spotted this with Claude Code's help while checking what #49053 covered, and I traced the section to its current page myself before changing anything.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated pgvector upgrade instructions to direct users to the General Settings page.
  * Corrected the existing-database software update link in performance guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->