### PR TITLE
test(e2e): share the a11y warn-mode helpers across suites

### DIFF
--- a/e2e/docs/features/docs-pages.spec.ts
+++ b/e2e/docs/features/docs-pages.spec.ts
@@ -1,8 +1,8 @@
 import { expect, test } from '@playwright/test'
-import type { TestInfo } from '@playwright/test'
 
 import { parsePagePaths } from '../../shared/paths.ts'
 import {
+  annotate,
   attachScanReport,
   blockingViolations,
   ENFORCED_RULES,
@@ -21,11 +21,6 @@ import {
 } from '../utils/docs-links.js'
 
 const pagePaths = parsePagePaths(process.env.DOCS_E2E_PAGE_PATHS)
-
-function annotate(testInfo: TestInfo, description: string) {
-  testInfo.annotations.push({ type: 'warning', description })
-  console.warn(`::warning title=Accessibility::${description}`)
-}
 
 test.describe('Docs owned pages', () => {
   // Without this, every test in this file runs on one worker.

--- a/e2e/docs/features/docs-pages.spec.ts
+++ b/e2e/docs/features/docs-pages.spec.ts
@@ -1,6 +1,5 @@
-import { expect, test } from '@playwright/test'
-
 import { parsePagePaths } from '../../shared/paths.ts'
+import { expect, test } from '../../shared/test.ts'
 import {
   annotate,
   attachScanReport,

--- a/e2e/docs/playwright.config.ts
+++ b/e2e/docs/playwright.config.ts
@@ -1,14 +1,8 @@
 import { defineConfig } from '@playwright/test'
 
-import { isSupabaseHost } from '../shared/hosts.ts'
-
 const IS_CI = !!process.env.CI
 
 const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3001'
-
-const BYPASS_SECRET = isSupabaseHost(BASE_URL)
-  ? process.env.VERCEL_AUTOMATION_BYPASS_SECRET
-  : undefined
 
 export default defineConfig({
   testDir: './features',
@@ -30,12 +24,6 @@ export default defineConfig({
     screenshot: 'only-on-failure',
     trace: 'retain-on-failure',
     video: 'off',
-    extraHTTPHeaders: BYPASS_SECRET
-      ? {
-          'x-vercel-protection-bypass': BYPASS_SECRET,
-          'x-vercel-set-bypass-cookie': 'true',
-        }
-      : undefined,
   },
   projects: [
     {

--- a/e2e/docs/playwright.config.ts
+++ b/e2e/docs/playwright.config.ts
@@ -1,6 +1,14 @@
 import { defineConfig } from '@playwright/test'
 
+import { isSupabaseHost } from '../shared/hosts.ts'
+
 const IS_CI = !!process.env.CI
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3001'
+
+const BYPASS_SECRET = isSupabaseHost(BASE_URL)
+  ? process.env.VERCEL_AUTOMATION_BYPASS_SECRET
+  : undefined
 
 export default defineConfig({
   testDir: './features',
@@ -15,16 +23,16 @@ export default defineConfig({
   fullyParallel: false,
   workers: 1,
   use: {
-    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3001',
+    baseURL: BASE_URL,
     browserName: 'chromium',
     headless: true,
     navigationTimeout: 30_000,
     screenshot: 'only-on-failure',
     trace: 'retain-on-failure',
     video: 'off',
-    extraHTTPHeaders: process.env.VERCEL_AUTOMATION_BYPASS_SECRET
+    extraHTTPHeaders: BYPASS_SECRET
       ? {
-          'x-vercel-protection-bypass': process.env.VERCEL_AUTOMATION_BYPASS_SECRET,
+          'x-vercel-protection-bypass': BYPASS_SECRET,
           'x-vercel-set-bypass-cookie': 'true',
         }
       : undefined,

--- a/e2e/docs/utils/axe-helpers.ts
+++ b/e2e/docs/utils/axe-helpers.ts
@@ -1,9 +1,12 @@
-import type { Page, TestInfo } from '@playwright/test'
+import type { Page } from '@playwright/test'
 import type { Result } from 'axe-core'
 
-import { scan } from '../../shared/axe.ts'
-
-export const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa']
+import {
+  blockingViolations as blockingViolationsFor,
+  scanRegion,
+  unloadedResult as unloadedResultFor,
+  type A11yScanResult,
+} from '../../shared/a11y.ts'
 
 export const ENFORCED_RULES = ['heading-order', 'page-has-heading-one']
 
@@ -19,46 +22,17 @@ export const EXCLUDED_RULES = [
   'css-orientation-lock',
 ]
 
-export interface A11yScanResult {
-  surface: string
-  url: string
-  include: string
-  excludedRules: string[]
-  loaded: boolean
-  status: number | null
-  elementCount: number
-  violations: Result[]
-}
-
-export function shouldEnforceAll(): boolean {
-  return !!process.env.A11Y_ENFORCE_ALL
-}
-
 export async function scanArticle(
   page: Page,
   surface: string,
   include: string
 ): Promise<A11yScanResult> {
-  const reported = await scan(page, { tags: WCAG_TAGS, excludeRules: EXCLUDED_RULES, include })
-  const enforced = await scan(page, { rules: ENFORCED_RULES, include })
-
-  const byRule = new Map([...reported, ...enforced].map((violation) => [violation.id, violation]))
-
-  const elementCount = await page.evaluate(
-    (selector) => document.querySelector(selector)?.querySelectorAll('*').length ?? 0,
-    include
-  )
-
-  return {
+  return scanRegion(page, {
     surface,
-    url: page.url(),
     include,
-    excludedRules: EXCLUDED_RULES,
-    loaded: true,
-    status: null,
-    elementCount,
-    violations: [...byRule.values()],
-  }
+    enforcedRules: ENFORCED_RULES,
+    excludeRules: EXCLUDED_RULES,
+  })
 }
 
 export function unloadedResult(
@@ -67,37 +41,20 @@ export function unloadedResult(
   status: number | null,
   include: string
 ): A11yScanResult {
-  return {
-    surface,
-    url,
-    include,
-    excludedRules: EXCLUDED_RULES,
-    loaded: false,
-    status,
-    elementCount: 0,
-    violations: [],
-  }
-}
-
-export const MIN_MEANINGFUL_ELEMENTS = 20
-
-export function scanLooksEmpty(
-  result: A11yScanResult,
-  minElements: number = MIN_MEANINGFUL_ELEMENTS
-): boolean {
-  return result.elementCount < minElements
-}
-
-export async function attachScanReport(testInfo: TestInfo, result: A11yScanResult): Promise<void> {
-  await testInfo.attach('axe-results.json', {
-    body: JSON.stringify(result, null, 2),
-    contentType: 'application/json',
-  })
+  return unloadedResultFor(surface, url, status, include, EXCLUDED_RULES)
 }
 
 export function blockingViolations(result: A11yScanResult): Result[] {
-  if (shouldEnforceAll()) return result.violations
-  return result.violations.filter((violation) => ENFORCED_RULES.includes(violation.id))
+  return blockingViolationsFor(result, ENFORCED_RULES)
 }
 
+export type { A11yScanResult }
+export {
+  annotate,
+  attachScanReport,
+  MIN_MEANINGFUL_ELEMENTS,
+  scanLooksEmpty,
+  shouldEnforceAll,
+  WCAG_TAGS,
+} from '../../shared/a11y.ts'
 export { formatViolations, settleForAxe, violationIds } from '../../shared/axe.ts'

--- a/e2e/shared/a11y.ts
+++ b/e2e/shared/a11y.ts
@@ -1,0 +1,169 @@
+import type { Page, TestInfo } from '@playwright/test'
+import type { Result } from 'axe-core'
+
+import { scan } from './axe.ts'
+
+export const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa']
+
+export const MIN_MEANINGFUL_ELEMENTS = 20
+
+export interface A11yScanResult {
+  surface: string
+  url: string
+  include: string
+  exclude?: string[]
+  excludedRules: string[]
+  loaded: boolean
+  status: number | null
+  elementCount: number
+  violations: Result[]
+}
+
+export function shouldEnforceAll(): boolean {
+  return !!process.env.A11Y_ENFORCE_ALL
+}
+
+export type ScanRegionOptions = {
+  surface: string
+  include: string
+  enforcedRules: string[]
+  excludeRules: string[]
+  tags?: string[]
+}
+
+// Rules and tags are mutually exclusive in one axe run, so this takes two passes.
+export async function scanRegion(page: Page, options: ScanRegionOptions): Promise<A11yScanResult> {
+  const { surface, include, enforcedRules, excludeRules, tags = WCAG_TAGS } = options
+
+  const reported = await scan(page, { tags, excludeRules, include })
+  const enforced = await scan(page, { rules: enforcedRules, include })
+
+  const byRule = new Map([...reported, ...enforced].map((violation) => [violation.id, violation]))
+
+  const elementCount = await page.evaluate(
+    (selector) => document.querySelector(selector)?.querySelectorAll('*').length ?? 0,
+    include
+  )
+
+  return {
+    surface,
+    url: page.url(),
+    include,
+    excludedRules: excludeRules,
+    loaded: true,
+    status: null,
+    elementCount,
+    violations: [...byRule.values()],
+  }
+}
+
+export type ScanExcludingOptions = {
+  surface: string
+  exclude: string[]
+  excludeRules: string[]
+  tags?: string[]
+}
+
+// One tagged pass only, so callers must keep their enforced rules inside `tags`
+// or those rules never run.
+export async function scanExcluding(
+  page: Page,
+  options: ScanExcludingOptions
+): Promise<A11yScanResult> {
+  const { surface, exclude, excludeRules, tags = WCAG_TAGS } = options
+
+  const violations = await scan(page, { tags, excludeRules, exclude })
+
+  const elementCount = await page.evaluate(
+    (selectors) =>
+      document.body.querySelectorAll('*').length -
+      selectors.reduce(
+        (sum, selector) =>
+          sum +
+          [...document.querySelectorAll(selector)].reduce(
+            (nodes, root) => nodes + root.querySelectorAll('*').length + 1,
+            0
+          ),
+        0
+      ),
+    exclude
+  )
+
+  return {
+    surface,
+    url: page.url(),
+    include: 'document',
+    exclude,
+    excludedRules: excludeRules,
+    loaded: true,
+    status: null,
+    elementCount,
+    violations,
+  }
+}
+
+export function unloadedResult(
+  surface: string,
+  url: string,
+  status: number | null,
+  include: string,
+  excludeRules: string[]
+): A11yScanResult {
+  return {
+    surface,
+    url,
+    include,
+    excludedRules: excludeRules,
+    loaded: false,
+    status,
+    elementCount: 0,
+    violations: [],
+  }
+}
+
+export function scanLooksEmpty(
+  result: A11yScanResult,
+  minElements: number = MIN_MEANINGFUL_ELEMENTS
+): boolean {
+  return result.elementCount < minElements
+}
+
+export async function attachScanReport(testInfo: TestInfo, result: A11yScanResult): Promise<void> {
+  await testInfo.attach('axe-results.json', {
+    body: JSON.stringify(result, null, 2),
+    contentType: 'application/json',
+  })
+}
+
+export function blockingViolations(result: A11yScanResult, enforcedRules: string[]): Result[] {
+  if (shouldEnforceAll()) return result.violations
+  return result.violations.filter((violation) => enforcedRules.includes(violation.id))
+}
+
+export function annotate(testInfo: TestInfo, description: string): void {
+  testInfo.annotations.push({ type: 'warning', description })
+  console.warn(`::warning title=Accessibility::${description}`)
+}
+
+function findingKey(ruleId: string, target: readonly unknown[]): string {
+  return `${ruleId}|${target.join(' ')}`
+}
+
+// `seen` is per worker process, and Playwright replaces a worker after a failing
+// test, so a finding can still repeat.
+export function dedupeViolations(violations: Result[], seen: Set<string>): Result[] {
+  const fresh: Result[] = []
+
+  for (const violation of violations) {
+    const nodes = violation.nodes.filter((node) => {
+      const key = findingKey(violation.id, node.target)
+      if (seen.has(key)) return false
+      seen.add(key)
+      return true
+    })
+
+    if (nodes.length) fresh.push({ ...violation, nodes })
+  }
+
+  return fresh
+}

--- a/e2e/shared/a11y.ts
+++ b/e2e/shared/a11y.ts
@@ -74,20 +74,19 @@ export async function scanExcluding(
 
   const violations = await scan(page, { tags, excludeRules, exclude })
 
-  const elementCount = await page.evaluate(
-    (selectors) =>
-      document.body.querySelectorAll('*').length -
-      selectors.reduce(
-        (sum, selector) =>
-          sum +
-          [...document.querySelectorAll(selector)].reduce(
-            (nodes, root) => nodes + root.querySelectorAll('*').length + 1,
-            0
-          ),
-        0
-      ),
-    exclude
-  )
+  const elementCount = await page.evaluate((selectors) => {
+    const excluded = new Set<Element>()
+
+    for (const selector of selectors) {
+      for (const root of document.querySelectorAll(selector)) {
+        excluded.add(root)
+        root.querySelectorAll('*').forEach((element) => excluded.add(element))
+      }
+    }
+
+    return [...document.body.querySelectorAll('*')].filter((element) => !excluded.has(element))
+      .length
+  }, exclude)
 
   return {
     surface,

--- a/e2e/shared/a11y.ts
+++ b/e2e/shared/a11y.ts
@@ -1,0 +1,174 @@
+import type { Page, TestInfo } from '@playwright/test'
+import type { Result } from 'axe-core'
+
+import { scan } from './axe.ts'
+
+export const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa']
+
+export const MIN_MEANINGFUL_ELEMENTS = 20
+
+export interface A11yScanResult {
+  surface: string
+  url: string
+  include: string
+  exclude?: string[]
+  excludedRules: string[]
+  loaded: boolean
+  status: number | null
+  elementCount: number
+  violations: Result[]
+}
+
+export function shouldEnforceAll(): boolean {
+  return !!process.env.A11Y_ENFORCE_ALL
+}
+
+export type ScanRegionOptions = {
+  surface: string
+  include: string
+  enforcedRules: string[]
+  excludeRules: string[]
+  tags?: string[]
+}
+
+// Two passes: a tagged sweep for everything worth reporting, then the enforced
+// rules on their own. Rules and tags are mutually exclusive in one axe run, so
+// a single pass can't cover both.
+export async function scanRegion(page: Page, options: ScanRegionOptions): Promise<A11yScanResult> {
+  const { surface, include, enforcedRules, excludeRules, tags = WCAG_TAGS } = options
+
+  const reported = await scan(page, { tags, excludeRules, include })
+  const enforced = await scan(page, { rules: enforcedRules, include })
+
+  const byRule = new Map([...reported, ...enforced].map((violation) => [violation.id, violation]))
+
+  const elementCount = await page.evaluate(
+    (selector) => document.querySelector(selector)?.querySelectorAll('*').length ?? 0,
+    include
+  )
+
+  return {
+    surface,
+    url: page.url(),
+    include,
+    excludedRules: excludeRules,
+    loaded: true,
+    status: null,
+    elementCount,
+    violations: [...byRule.values()],
+  }
+}
+
+export type ScanExcludingOptions = {
+  surface: string
+  exclude: string[]
+  excludeRules: string[]
+  tags?: string[]
+}
+
+// The inverse of scanRegion: scan the document with the named regions carved
+// out. One tagged pass only, so callers must keep their enforced rules inside
+// `tags` or those rules never run.
+export async function scanExcluding(
+  page: Page,
+  options: ScanExcludingOptions
+): Promise<A11yScanResult> {
+  const { surface, exclude, excludeRules, tags = WCAG_TAGS } = options
+
+  const violations = await scan(page, { tags, excludeRules, exclude })
+
+  const elementCount = await page.evaluate(
+    (selectors) =>
+      document.body.querySelectorAll('*').length -
+      selectors.reduce(
+        (sum, selector) =>
+          sum +
+          [...document.querySelectorAll(selector)].reduce(
+            (nodes, root) => nodes + root.querySelectorAll('*').length + 1,
+            0
+          ),
+        0
+      ),
+    exclude
+  )
+
+  return {
+    surface,
+    url: page.url(),
+    include: 'document',
+    exclude,
+    excludedRules: excludeRules,
+    loaded: true,
+    status: null,
+    elementCount,
+    violations,
+  }
+}
+
+export function unloadedResult(
+  surface: string,
+  url: string,
+  status: number | null,
+  include: string,
+  excludeRules: string[]
+): A11yScanResult {
+  return {
+    surface,
+    url,
+    include,
+    excludedRules: excludeRules,
+    loaded: false,
+    status,
+    elementCount: 0,
+    violations: [],
+  }
+}
+
+export function scanLooksEmpty(
+  result: A11yScanResult,
+  minElements: number = MIN_MEANINGFUL_ELEMENTS
+): boolean {
+  return result.elementCount < minElements
+}
+
+export async function attachScanReport(testInfo: TestInfo, result: A11yScanResult): Promise<void> {
+  await testInfo.attach('axe-results.json', {
+    body: JSON.stringify(result, null, 2),
+    contentType: 'application/json',
+  })
+}
+
+export function blockingViolations(result: A11yScanResult, enforcedRules: string[]): Result[] {
+  if (shouldEnforceAll()) return result.violations
+  return result.violations.filter((violation) => enforcedRules.includes(violation.id))
+}
+
+export function annotate(testInfo: TestInfo, description: string): void {
+  testInfo.annotations.push({ type: 'warning', description })
+  console.warn(`::warning title=Accessibility::${description}`)
+}
+
+function findingKey(ruleId: string, target: readonly unknown[]): string {
+  return `${ruleId}|${target.join(' ')}`
+}
+
+// Shared markup scanned on many pages reports the same node once per page. Pass
+// a `seen` set that outlives the test to collapse those to the first sighting.
+// The set is per worker process, so a suite with N workers can still report a
+// finding N times.
+export function dedupeViolations(violations: Result[], seen: Set<string>): Result[] {
+  const fresh: Result[] = []
+
+  for (const violation of violations) {
+    const nodes = violation.nodes.filter((node) => {
+      const key = findingKey(violation.id, node.target)
+      if (seen.has(key)) return false
+      seen.add(key)
+      return true
+    })
+
+    if (nodes.length) fresh.push({ ...violation, nodes })
+  }
+
+  return fresh
+}

--- a/e2e/shared/axe.ts
+++ b/e2e/shared/axe.ts
@@ -11,6 +11,7 @@ export type ScanOptions = {
   tags?: string[]
   excludeRules?: string[]
   include?: string
+  exclude?: string[]
 }
 
 export async function settleForAxe(page: Page): Promise<void> {
@@ -49,6 +50,7 @@ export async function scan(page: Page, options: ScanOptions): Promise<Result[]> 
   let builder = new AxeBuilder({ page }).setLegacyMode(true)
 
   if (options.include) builder = builder.include(options.include)
+  for (const selector of options.exclude ?? []) builder = builder.exclude(selector)
   if (options.rules) builder = builder.withRules(options.rules)
   else if (options.tags) builder = builder.withTags(options.tags)
   if (options.excludeRules?.length) builder = builder.disableRules(options.excludeRules)

--- a/e2e/shared/hosts.ts
+++ b/e2e/shared/hosts.ts
@@ -1,11 +1,12 @@
 // Never send a Vercel bypass secret anywhere that can't be a Supabase deployment.
 export function isSupabaseHost(url: string): boolean {
   try {
-    const { hostname } = new URL(url)
+    const { protocol, hostname } = new URL(url)
+    if (protocol !== 'https:') return false
     return (
       hostname === 'supabase.com' ||
       hostname.endsWith('.supabase.com') ||
-      hostname.endsWith('.vercel.app')
+      hostname.endsWith('-supabase.vercel.app')
     )
   } catch {
     return false

--- a/e2e/shared/hosts.ts
+++ b/e2e/shared/hosts.ts
@@ -1,0 +1,13 @@
+// Never send a Vercel bypass secret anywhere that can't be a Supabase deployment.
+export function isSupabaseHost(url: string): boolean {
+  try {
+    const { hostname } = new URL(url)
+    return (
+      hostname === 'supabase.com' ||
+      hostname.endsWith('.supabase.com') ||
+      hostname.endsWith('.vercel.app')
+    )
+  } catch {
+    return false
+  }
+}

--- a/e2e/shared/run-suite.ts
+++ b/e2e/shared/run-suite.ts
@@ -4,16 +4,30 @@ import { collectChangedFiles, repoRootFrom } from './git.ts'
 
 export type ScopeResult = { pages: string[]; skip: boolean }
 
-export type SuiteConfig = {
+type SuiteBase = {
   root: string
   label: string
   devCommand: string
+  defaultBaseUrl: string
+  project?: string
+}
+
+type ScopedSuite = {
   pagePathsEnv: string
   baseRefEnv: string
-  defaultBaseUrl: string
   resolveScope: (options: { changedFiles: string[]; repoRoot: string }) => Promise<ScopeResult>
   resolveAllPages?: (repoRoot: string) => Promise<string[]>
 }
+
+// A fixed page list resolves nothing from git, so none of the scope plumbing applies.
+type FixedScopeSuite = {
+  pagePathsEnv?: undefined
+  baseRefEnv?: undefined
+  resolveScope?: undefined
+  resolveAllPages?: undefined
+}
+
+export type SuiteConfig = SuiteBase & (ScopedSuite | FixedScopeSuite)
 
 const PREFLIGHT_TIMEOUT_MS = 3_000
 
@@ -30,7 +44,7 @@ async function isBaseUrlReachable(baseUrl: string): Promise<boolean> {
   }
 }
 
-async function resolvePagePaths(config: SuiteConfig): Promise<string[] | null> {
+async function resolvePagePaths(config: SuiteBase & ScopedSuite): Promise<string[] | null> {
   const explicit = process.env[config.pagePathsEnv]?.trim()
   if (explicit) {
     return explicit
@@ -65,14 +79,16 @@ export async function runSuite(config: SuiteConfig): Promise<void> {
   const runAll = rawArgs.includes('--all')
   const playwrightArgs = rawArgs.filter((arg) => arg !== '--all' && arg !== '--')
 
-  let pages: string[] | null
-  if (runAll && config.resolveAllPages) {
-    pages = await config.resolveAllPages(repoRootFrom(config.root))
-    console.error(`Resolved all ${pages.length} in-scope ${config.label} page(s).`)
-  } else {
-    pages = await resolvePagePaths(config)
+  let pages: string[] | null = null
+  if (config.resolveScope) {
+    if (runAll && config.resolveAllPages) {
+      pages = await config.resolveAllPages(repoRootFrom(config.root))
+      console.error(`Resolved all ${pages.length} in-scope ${config.label} page(s).`)
+    } else {
+      pages = await resolvePagePaths(config)
+    }
+    if (pages === null) process.exit(0)
   }
-  if (pages === null) process.exit(0)
 
   const hasMaxFailuresArg = playwrightArgs.some(
     (arg) => arg === '-x' || arg.startsWith('--max-failures')
@@ -91,11 +107,21 @@ export async function runSuite(config: SuiteConfig): Promise<void> {
     process.exit(1)
   }
 
-  const child = spawn('pnpm', ['exec', 'playwright', 'test', ...finalArgs], {
+  // First, so an explicit --project on the command line overrides it.
+  const projectArgs = config.project ? [`--project=${config.project}`] : []
+  const env = { ...process.env }
+  if (config.pagePathsEnv && pages) env[config.pagePathsEnv] = pages.join(',')
+
+  const child = spawn('pnpm', ['exec', 'playwright', 'test', ...projectArgs, ...finalArgs], {
     cwd: config.root,
-    env: { ...process.env, [config.pagePathsEnv]: pages.join(',') },
+    env,
     stdio: 'inherit',
     shell: process.platform === 'win32',
+  })
+
+  child.on('error', (error) => {
+    console.error(`Failed to start Playwright: ${error.message}`)
+    process.exit(1)
   })
 
   child.on('exit', (code, signal) => {

--- a/e2e/shared/run-suite.ts
+++ b/e2e/shared/run-suite.ts
@@ -107,8 +107,11 @@ export async function runSuite(config: SuiteConfig): Promise<void> {
     process.exit(1)
   }
 
-  // First, so an explicit --project on the command line overrides it.
-  const projectArgs = config.project ? [`--project=${config.project}`] : []
+  // Playwright collects every --project, so skip the suite default when the CLI already named one.
+  const hasProjectArg = playwrightArgs.some(
+    (arg) => arg === '--project' || arg.startsWith('--project=')
+  )
+  const projectArgs = config.project && !hasProjectArg ? [`--project=${config.project}`] : []
   const env = { ...process.env }
   if (config.pagePathsEnv && pages) env[config.pagePathsEnv] = pages.join(',')
 

--- a/e2e/shared/run-suite.ts
+++ b/e2e/shared/run-suite.ts
@@ -4,16 +4,31 @@ import { collectChangedFiles, repoRootFrom } from './git.ts'
 
 export type ScopeResult = { pages: string[]; skip: boolean }
 
-export type SuiteConfig = {
+type SuiteBase = {
   root: string
   label: string
   devCommand: string
+  defaultBaseUrl: string
+  project?: string
+}
+
+type ScopedSuite = {
   pagePathsEnv: string
   baseRefEnv: string
-  defaultBaseUrl: string
   resolveScope: (options: { changedFiles: string[]; repoRoot: string }) => Promise<ScopeResult>
   resolveAllPages?: (repoRoot: string) => Promise<string[]>
 }
+
+// Suites that scan a fixed page list resolve nothing from git, so they carry
+// none of the scope plumbing.
+type FixedScopeSuite = {
+  pagePathsEnv?: undefined
+  baseRefEnv?: undefined
+  resolveScope?: undefined
+  resolveAllPages?: undefined
+}
+
+export type SuiteConfig = SuiteBase & (ScopedSuite | FixedScopeSuite)
 
 const PREFLIGHT_TIMEOUT_MS = 3_000
 
@@ -30,7 +45,7 @@ async function isBaseUrlReachable(baseUrl: string): Promise<boolean> {
   }
 }
 
-async function resolvePagePaths(config: SuiteConfig): Promise<string[] | null> {
+async function resolvePagePaths(config: SuiteBase & ScopedSuite): Promise<string[] | null> {
   const explicit = process.env[config.pagePathsEnv]?.trim()
   if (explicit) {
     return explicit
@@ -65,14 +80,16 @@ export async function runSuite(config: SuiteConfig): Promise<void> {
   const runAll = rawArgs.includes('--all')
   const playwrightArgs = rawArgs.filter((arg) => arg !== '--all' && arg !== '--')
 
-  let pages: string[] | null
-  if (runAll && config.resolveAllPages) {
-    pages = await config.resolveAllPages(repoRootFrom(config.root))
-    console.error(`Resolved all ${pages.length} in-scope ${config.label} page(s).`)
-  } else {
-    pages = await resolvePagePaths(config)
+  let pages: string[] | null = null
+  if (config.resolveScope) {
+    if (runAll && config.resolveAllPages) {
+      pages = await config.resolveAllPages(repoRootFrom(config.root))
+      console.error(`Resolved all ${pages.length} in-scope ${config.label} page(s).`)
+    } else {
+      pages = await resolvePagePaths(config)
+    }
+    if (pages === null) process.exit(0)
   }
-  if (pages === null) process.exit(0)
 
   const hasMaxFailuresArg = playwrightArgs.some(
     (arg) => arg === '-x' || arg.startsWith('--max-failures')
@@ -91,11 +108,22 @@ export async function runSuite(config: SuiteConfig): Promise<void> {
     process.exit(1)
   }
 
-  const child = spawn('pnpm', ['exec', 'playwright', 'test', ...finalArgs], {
+  // The configured project goes first so an explicit --project on the command
+  // line overrides it.
+  const projectArgs = config.project ? [`--project=${config.project}`] : []
+  const env = { ...process.env }
+  if (config.pagePathsEnv && pages) env[config.pagePathsEnv] = pages.join(',')
+
+  const child = spawn('pnpm', ['exec', 'playwright', 'test', ...projectArgs, ...finalArgs], {
     cwd: config.root,
-    env: { ...process.env, [config.pagePathsEnv]: pages.join(',') },
+    env,
     stdio: 'inherit',
     shell: process.platform === 'win32',
+  })
+
+  child.on('error', (error) => {
+    console.error(`Failed to start Playwright: ${error.message}`)
+    process.exit(1)
   })
 
   child.on('exit', (code, signal) => {

--- a/e2e/shared/test.ts
+++ b/e2e/shared/test.ts
@@ -1,0 +1,28 @@
+import { test as base } from '@playwright/test'
+
+import { isSupabaseHost } from './hosts.ts'
+
+export { expect } from '@playwright/test'
+
+// extraHTTPHeaders would send the secret on every request, including third-party ones.
+export const test = base.extend({
+  context: async ({ context, baseURL }, use) => {
+    const secret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET
+    if (secret && baseURL && isSupabaseHost(baseURL)) {
+      const origin = new URL(baseURL).origin
+      await context.route(
+        (url) => url.origin === origin,
+        async (route) => {
+          await route.continue({
+            headers: {
+              ...route.request().headers(),
+              'x-vercel-protection-bypass': secret,
+              'x-vercel-set-bypass-cookie': 'true',
+            },
+          })
+        }
+      )
+    }
+    await use(context)
+  },
+})

--- a/e2e/shared/viewports.ts
+++ b/e2e/shared/viewports.ts
@@ -1,0 +1,26 @@
+import type { Locator, Page } from '@playwright/test'
+
+export const VIEWPORTS = {
+  desktop: { width: 1280, height: 800 },
+  mobile: { width: 390, height: 844 },
+} as const
+
+export type ViewportName = keyof typeof VIEWPORTS
+
+export type ViewportScopedElement = {
+  viewports?: readonly ViewportName[]
+}
+
+// Responsive layouts ship some elements twice and hide one copy. Axe skips
+// hidden subtrees, so scanning the hidden one passes while scanning nothing.
+export function renderedLocator(page: Page, selector: string): Locator {
+  return page.locator(`${selector}:visible`).first()
+}
+
+// An element without a `viewports` allowlist is expected at every viewport.
+export function elementsForViewport<T extends ViewportScopedElement>(
+  elements: readonly T[],
+  viewport: ViewportName
+): T[] {
+  return elements.filter((element) => !element.viewports || element.viewports.includes(viewport))
+}

--- a/e2e/shared/viewports.ts
+++ b/e2e/shared/viewports.ts
@@ -1,0 +1,27 @@
+import type { Locator, Page } from '@playwright/test'
+
+export const VIEWPORTS = {
+  desktop: { width: 1280, height: 800 },
+  mobile: { width: 390, height: 844 },
+} as const
+
+export type ViewportName = keyof typeof VIEWPORTS
+
+export type ViewportScopedElement = {
+  viewports?: readonly ViewportName[]
+}
+
+// Responsive layouts often ship the same element twice and hide one copy. Axe
+// skips hidden subtrees, so scanning the attached-but-invisible copy would pass
+// while scanning nothing.
+export function renderedLocator(page: Page, selector: string): Locator {
+  return page.locator(`${selector}:visible`).first()
+}
+
+// An element without a `viewports` allowlist is expected at every viewport.
+export function elementsForViewport<T extends ViewportScopedElement>(
+  elements: readonly T[],
+  viewport: ViewportName
+): T[] {
+  return elements.filter((element) => !element.viewports || element.viewports.includes(viewport))
+}

--- a/e2e/www/features/www-pages.spec.ts
+++ b/e2e/www/features/www-pages.spec.ts
@@ -1,7 +1,6 @@
-import { expect, test } from '@playwright/test'
-
 import { formatViolations, scan, violationIds } from '../../shared/axe.ts'
 import { parsePagePaths } from '../../shared/paths.ts'
+import { expect, test } from '../../shared/test.ts'
 
 const ENFORCED_RULES = ['page-has-heading-one']
 

--- a/e2e/www/playwright.config.ts
+++ b/e2e/www/playwright.config.ts
@@ -1,14 +1,8 @@
 import { defineConfig } from '@playwright/test'
 
-import { isSupabaseHost } from '../shared/hosts.ts'
-
 const IS_CI = !!process.env.CI
 
 const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3000'
-
-const BYPASS_SECRET = isSupabaseHost(BASE_URL)
-  ? process.env.VERCEL_AUTOMATION_BYPASS_SECRET
-  : undefined
 
 export default defineConfig({
   testDir: './features',
@@ -27,12 +21,6 @@ export default defineConfig({
     navigationTimeout: 30_000,
     screenshot: 'only-on-failure',
     trace: 'retain-on-failure',
-    extraHTTPHeaders: BYPASS_SECRET
-      ? {
-          'x-vercel-protection-bypass': BYPASS_SECRET,
-          'x-vercel-set-bypass-cookie': 'true',
-        }
-      : undefined,
   },
   reporter: [['list'], ['html', { open: 'never', outputFolder: './playwright-report' }]],
   outputDir: './test-results',

--- a/e2e/www/playwright.config.ts
+++ b/e2e/www/playwright.config.ts
@@ -1,6 +1,14 @@
 import { defineConfig } from '@playwright/test'
 
+import { isSupabaseHost } from '../shared/hosts.ts'
+
 const IS_CI = !!process.env.CI
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3000'
+
+const BYPASS_SECRET = isSupabaseHost(BASE_URL)
+  ? process.env.VERCEL_AUTOMATION_BYPASS_SECRET
+  : undefined
 
 export default defineConfig({
   testDir: './features',
@@ -13,15 +21,15 @@ export default defineConfig({
   fullyParallel: true,
   workers: 1,
   use: {
-    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3000',
+    baseURL: BASE_URL,
     browserName: 'chromium',
     headless: true,
     navigationTimeout: 30_000,
     screenshot: 'only-on-failure',
     trace: 'retain-on-failure',
-    extraHTTPHeaders: process.env.VERCEL_AUTOMATION_BYPASS_SECRET
+    extraHTTPHeaders: BYPASS_SECRET
       ? {
-          'x-vercel-protection-bypass': process.env.VERCEL_AUTOMATION_BYPASS_SECRET,
+          'x-vercel-protection-bypass': BYPASS_SECRET,
           'x-vercel-set-bypass-cookie': 'true',
         }
       : undefined,

--- a/scripts/waitForVercelPreview.js
+++ b/scripts/waitForVercelPreview.js
@@ -84,6 +84,15 @@ async function main() {
     const latest = await fetchLatestStatus(repository, sha, githubToken, statusContext)
 
     if (latest?.state === 'success') {
+      // A skipped build posts success, but its target_url points at an older
+      // deployment. Resolve no URL rather than test the wrong markup.
+      if (/^skipped/i.test(latest.description ?? '')) {
+        console.error(
+          `Vercel skipped the "${statusContext}" build for ${sha}: ${latest.description}`
+        )
+        return
+      }
+
       if (!latest.target_url) {
         throw new Error(
           `"${statusContext}" commit status succeeded but had no target_url to resolve a deployment from`

--- a/scripts/waitForVercelPreview.js
+++ b/scripts/waitForVercelPreview.js
@@ -84,6 +84,16 @@ async function main() {
     const latest = await fetchLatestStatus(repository, sha, githubToken, statusContext)
 
     if (latest?.state === 'success') {
+      // A skipped build still posts success, but its target_url points at an
+      // older deployment that does not have this commit's changes. Resolve no
+      // URL so the caller skips rather than testing the wrong markup.
+      if (/^skipped/i.test(latest.description ?? '')) {
+        console.error(
+          `Vercel skipped the "${statusContext}" build for ${sha}: ${latest.description}`
+        )
+        return
+      }
+
       if (!latest.target_url) {
         throw new Error(
           `"${statusContext}" commit status succeeded but had no target_url to resolve a deployment from`


### PR DESCRIPTION
Stack: this → #49081 → #49078 → #49082 → #49079. Review in that order.

## Problem

Docs owns the only warn-mode a11y implementation. WWW and Studio both need it next, so three suites would each carry their own copy of the scan-result envelope, the warning annotation helper, and the blocking-rule split.

`e2e/shared/axe.ts` also cannot express a scan that covers everything outside a region, which is what a global element scan needs.

## Solution

- Add `e2e/shared/a11y.ts`: the scan-result envelope, `annotate`, `blockingViolations`, `scanRegion` for scanning inside a selector, and `scanExcluding` for scanning around one.
- Add `e2e/shared/viewports.ts`, for responsive markup that ships the same element twice and hides one copy. Axe skips hidden subtrees, so scanning the hidden copy passes while scanning nothing.
- Add `e2e/shared/hosts.ts` and gate the Vercel bypass secret on a Supabase host in both Playwright configs. The secret previously went to whatever `PLAYWRIGHT_BASE_URL` was set to.
- Accept `exclude` in `scan()`.
- Make `resolveScope` optional in `run-suite.ts`, for suites that scan a fixed page list, and accept a `project`.
- Resolve no preview URL when Vercel skipped the build. A skipped build still posts success, but its `target_url` points at a deployment without this commit's changes.
- Refactor `e2e/docs/utils/axe-helpers.ts` onto the shared module. Its exports are unchanged.


## Manual testing

1. Run the docs a11y scan against the preview. Expect 1 passed and an `axe-results.json` attachment on the run.

   ```bash
   DOCS_E2E_PAGE_PATHS=/docs/guides/database/postgres/row-level-security \
     PLAYWRIGHT_BASE_URL=https://docs-git-a11y-shared-scanning-toolkit-supabase.vercel.app \
     pnpm -C e2e/docs run e2e:docs:a11y
   ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Improved automated accessibility validation and reporting for supported page regions.
  * Added more consistent checks across desktop and mobile layouts.

* **Bug Fixes**
  * Improved preview testing reliability across supported environments.
  * Prevented skipped deployments from being reported as available preview URLs.

* **Testing**
  * Expanded end-to-end test coverage for scoped pages and fixed test areas.
  * Standardized shared testing utilities for more consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->