### PR TITLE
test(e2e): scan www content pages in warn mode

### DIFF
--- a/.github/workflows/www-e2e.yml
+++ b/.github/workflows/www-e2e.yml
@@ -198,7 +198,8 @@ jobs:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ steps.base-url.outputs.use_bypass == 'true' && secrets.VERCEL_AUTOMATION_BYPASS_WWW || '' }}
 
       - name: Upload Playwright report
-        if: failure() && steps.scope.outputs.skip == 'false'
+        # Findings only reach a reviewer through this artifact, so upload on green too.
+        if: always() && steps.base-url.outputs.should_test == 'true'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: www-playwright-report

--- a/.github/workflows/www-e2e.yml
+++ b/.github/workflows/www-e2e.yml
@@ -198,7 +198,9 @@ jobs:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ steps.base-url.outputs.use_bypass == 'true' && secrets.VERCEL_AUTOMATION_BYPASS_WWW || '' }}
 
       - name: Upload Playwright report
-        if: failure() && steps.scope.outputs.skip == 'false'
+        # Warn-mode a11y findings only reach a reviewer through this artifact, so
+        # it uploads on green runs too.
+        if: always() && steps.base-url.outputs.should_test == 'true'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: www-playwright-report

--- a/apps/www/components/Blog/BlogPostRenderer.tsx
+++ b/apps/www/components/Blog/BlogPostRenderer.tsx
@@ -200,7 +200,7 @@ const BlogPostRenderer = async ({
                     </div>
                   )}
 
-                  <article>
+                  <article id="sb-www-blog-main-article" data-testid="sb-www-blog-main-article">
                     <div className="prose prose-docs">
                       {blogMetaData.youtubeHero ? (
                         <iframe

--- a/apps/www/layouts/comparison.tsx
+++ b/apps/www/layouts/comparison.tsx
@@ -82,7 +82,11 @@ const LayoutComparison = ({ components, props }: Props) => {
         }}
       />
       <DefaultLayout>
-        <article className="mx-auto max-w-5xl px-8 py-16 sm:px-16 xl:px-20">
+        <article
+          id="sb-www-alternative-main-article"
+          data-testid="sb-www-alternative-main-article"
+          className="mx-auto max-w-5xl px-8 py-16 sm:px-16 xl:px-20"
+        >
           {/* Title and description */}
           <div className="mb-16 max-w-5xl space-y-8">
             <div className="space-y-4">

--- a/apps/www/pages/customers/[slug].tsx
+++ b/apps/www/pages/customers/[slug].tsx
@@ -145,7 +145,11 @@ function CaseStudyPage(props: any) {
 
             <div className="col-span-12 lg:col-span-8">
               <div>
-                <article className="flex flex-col gap-8">
+                <article
+                  id="sb-www-customer-main-article"
+                  data-testid="sb-www-customer-main-article"
+                  className="flex flex-col gap-8"
+                >
                   <div className="flex flex-col gap-4 sm:gap-8 max-w-xxl">
                     <Link
                       href="/customers"

--- a/apps/www/pages/events/[slug].tsx
+++ b/apps/www/pages/events/[slug].tsx
@@ -386,7 +386,11 @@ const EventPage = ({ event }: InferGetStaticPropsType<typeof getStaticProps>) =>
                 </Link>
               </div>
             )}
-            <main className="lg:col-span-2">
+            <main
+              id="sb-www-event-main-article"
+              data-testid="sb-www-event-main-article"
+              className="lg:col-span-2"
+            >
               <div className="prose prose-docs">
                 <h2 className="text-foreground-light text-sm font-mono uppercase">
                   About this event

--- a/e2e/www/README.md
+++ b/e2e/www/README.md
@@ -110,23 +110,23 @@ Slugs come from the filename, matching `getAllPostSlugs` in
 `apps/www/lib/posts.tsx`. Blog and event filenames drop their `YYYY-MM-DD-`
 prefix; customers and alternatives use the filename as-is.
 
-Each page gets one test: it must return a successful status, and an axe scan
-must report no `page-has-heading-one` violations. That is the only rule enforced
-today — add more to `ENFORCED_RULES` in `features/www-pages.spec.ts` once a class
-of issue reaches zero across the site.
+Each page gets one test: it must return a successful status, and an axe scan must
+report no `page-has-heading-one` violations. That rule passes on all four
+templates today, so enforcing it catches a new violation without failing on
+existing debt.
 
-`ENFORCED_RULES` is deliberately separate from the docs suite's list. Docs
-enforces `heading-order` as well; www cannot yet. A full-site scan found
-`heading-order` violations on the large majority of content pages, almost all
-from the same two shared components — the related-posts card (`h4` under an `h2`)
-and a trailing `h6`. Enforcing it here would fail nearly every pull request.
+It runs against the page landmark rather than the article, since every template
+renders its `<h1>` outside the article wrapper. `heading-order` runs against the
+article and is reported only: the alternatives template already violates it, so
+enforcing it would fail every alternatives pull request.
 
 ### Out of scope
 
 - Events with `disable_page_build: true`, which return a 404 by design
 - Static marketing routes under `apps/www/pages` and `apps/www/app`
 - Index and listing pages such as `/blog` and `/customers`
-- Link checking, and every accessibility rule other than the one above
+- Link checking
+- Shared chrome: header, footer, and anything else outside the article wrapper
 
 ### Limits
 
@@ -134,6 +134,27 @@ Resolved scope is capped at 20 pages so a large content drop cannot explode
 runtime. If a change resolves to more pages than that, only the first 20 in
 sorted order are tested. To test beyond the cap, use `pnpm e2e:www:all` or set
 `WWW_E2E_PAGE_PATHS` explicitly.
+
+## Accessibility scans
+
+The `@a11y`-tagged test scans each in-scope page for WCAG 2.1 A/AA violations, limited
+to the article wrapper for that template.
+
+```bash
+PLAYWRIGHT_BASE_URL=https://supabase.com pnpm e2e:www:a11y
+```
+
+**Warn mode.** Only `ENFORCED_RULES` in `utils/axe-helpers.ts` fails the build, and it
+holds rules that pass today, so it cannot fail on existing debt. Everything else lands
+as a warning annotation and in the run's `axe-results.json` attachment. Set
+`A11Y_ENFORCE_ALL=1` to make every finding blocking for a local triage run.
+
+**Scan your own preview.** The page list comes from your branch, but the content comes
+from whatever `PLAYWRIGHT_BASE_URL` points at. Production 404s on a page you just
+added.
+
+**Configuration:** article selectors per template live in `utils/www-selectors.ts`,
+rule lists in `utils/axe-helpers.ts`.
 
 ## Debug failures
 

--- a/e2e/www/README.md
+++ b/e2e/www/README.md
@@ -112,21 +112,22 @@ prefix; customers and alternatives use the filename as-is.
 
 Each page gets one test: it must return a successful status, and an axe scan
 must report no `page-has-heading-one` violations. That is the only rule enforced
-today — add more to `ENFORCED_RULES` in `features/www-pages.spec.ts` once a class
-of issue reaches zero across the site.
+today — add more to `ENFORCED_RULES` in `utils/axe-helpers.ts` once a class of
+issue reaches zero across the site.
 
-`ENFORCED_RULES` is deliberately separate from the docs suite's list. Docs
-enforces `heading-order` as well; www cannot yet. A full-site scan found
-`heading-order` violations on the large majority of content pages, almost all
-from the same two shared components — the related-posts card (`h4` under an `h2`)
-and a trailing `h6`. Enforcing it here would fail nearly every pull request.
+`heading-order` is scanned but never blocking. Article scoping already puts the
+two site-wide offenders out of reach — the footer `h6` sits outside `<main>`, and
+the blog related-posts `h4` sits below the article wrapper. The alternatives
+template still has one inside its article, so enforcing the rule would fail every
+alternatives pull request. It stays in `EXTRA_REPORTED_RULES` until that is fixed.
 
 ### Out of scope
 
 - Events with `disable_page_build: true`, which return a 404 by design
 - Static marketing routes under `apps/www/pages` and `apps/www/app`
 - Index and listing pages such as `/blog` and `/customers`
-- Link checking, and every accessibility rule other than the one above
+- Link checking
+- Shared chrome: header, footer, and anything else outside the article wrapper
 
 ### Limits
 
@@ -134,6 +135,47 @@ Resolved scope is capped at 20 pages so a large content drop cannot explode
 runtime. If a change resolves to more pages than that, only the first 20 in
 sorted order are tested. To test beyond the cap, use `pnpm e2e:www:all` or set
 `WWW_E2E_PAGE_PATHS` explicitly.
+
+## Accessibility scans
+
+The `@a11y`-tagged test scans each in-scope page for WCAG 2.1 A/AA violations using
+`@axe-core/playwright`, limited to the article wrapper for that template.
+
+```bash
+PLAYWRIGHT_BASE_URL=https://supabase.com pnpm e2e:www:a11y
+```
+
+Which pages get scanned comes from your branch, but the content comes from
+whatever you point `PLAYWRIGHT_BASE_URL` at. Production won't have your edits and
+will 404 on a page you just added, so use your pull request's preview to scan your
+own content.
+
+Findings are reported, not enforced. Only `ENFORCED_RULES` in `utils/axe-helpers.ts`
+fails the build; everything else lands as a warning annotation and in the
+`axe-results.json` attachment on the run. Set `A11Y_ENFORCE_ALL=1` to make every
+finding blocking locally.
+
+`wwwArticleSelectorForPagePath` in `utils/www-selectors.ts` maps each route prefix
+to its wrapper. The four content templates each wrap their body differently, so a
+route outside those four throws rather than guessing.
+
+`page-has-heading-one` runs against `<main id="main">` rather than the article.
+Blog and event templates render their `<h1>` outside the article wrapper, so an
+article-scoped scan would report a false violation on every one of those pages.
+
+`EXCLUDED_RULES` lists the rules the scan skips. `color-contrast` is most of the
+scan time and finds nothing inside an article, since www contrast comes from shared
+tokens and chrome. The rest target `<html>`, `<head>`, and `<body>`, which an
+article-scoped scan can't reach.
+
+Cross-origin frames are skipped, so a third-party embed isn't reported as ours.
+
+Event articles are short enough that a scan can fall under the 20-element floor and
+warn that a clean result proves nothing. That reflects the template, not a broken
+run.
+
+Not covered: shared chrome, listing pages, and most of WCAG. Keyboard navigation,
+focus management, and screen reader behavior need manual testing.
 
 ## Debug failures
 

--- a/e2e/www/README.md
+++ b/e2e/www/README.md
@@ -138,44 +138,23 @@ sorted order are tested. To test beyond the cap, use `pnpm e2e:www:all` or set
 
 ## Accessibility scans
 
-The `@a11y`-tagged test scans each in-scope page for WCAG 2.1 A/AA violations using
-`@axe-core/playwright`, limited to the article wrapper for that template.
+The `@a11y`-tagged test scans each in-scope page for WCAG 2.1 A/AA violations, limited
+to the article wrapper for that template.
 
 ```bash
 PLAYWRIGHT_BASE_URL=https://supabase.com pnpm e2e:www:a11y
 ```
 
-Which pages get scanned comes from your branch, but the content comes from
-whatever you point `PLAYWRIGHT_BASE_URL` at. Production won't have your edits and
-will 404 on a page you just added, so use your pull request's preview to scan your
-own content.
+**Warn mode.** Only `ENFORCED_RULES` in `utils/axe-helpers.ts` fails the build.
+Everything else lands as a warning annotation and in the run's `axe-results.json`
+attachment. Set `A11Y_ENFORCE_ALL=1` to make every finding blocking locally.
 
-Findings are reported, not enforced. Only `ENFORCED_RULES` in `utils/axe-helpers.ts`
-fails the build; everything else lands as a warning annotation and in the
-`axe-results.json` attachment on the run. Set `A11Y_ENFORCE_ALL=1` to make every
-finding blocking locally.
+**Scan your own preview.** The page list comes from your branch, but the content comes
+from whatever `PLAYWRIGHT_BASE_URL` points at. Production 404s on a page you just
+added.
 
-`wwwArticleSelectorForPagePath` in `utils/www-selectors.ts` maps each route prefix
-to its wrapper. The four content templates each wrap their body differently, so a
-route outside those four throws rather than guessing.
-
-`page-has-heading-one` runs against `<main id="main">` rather than the article.
-Blog and event templates render their `<h1>` outside the article wrapper, so an
-article-scoped scan would report a false violation on every one of those pages.
-
-`EXCLUDED_RULES` lists the rules the scan skips. `color-contrast` is most of the
-scan time and finds nothing inside an article, since www contrast comes from shared
-tokens and chrome. The rest target `<html>`, `<head>`, and `<body>`, which an
-article-scoped scan can't reach.
-
-Cross-origin frames are skipped, so a third-party embed isn't reported as ours.
-
-Event articles are short enough that a scan can fall under the 20-element floor and
-warn that a clean result proves nothing. That reflects the template, not a broken
-run.
-
-Not covered: shared chrome, listing pages, and most of WCAG. Keyboard navigation,
-focus management, and screen reader behavior need manual testing.
+**Configuration:** article selectors per template live in `utils/www-selectors.ts`,
+rule lists in `utils/axe-helpers.ts`.
 
 ## Debug failures
 

--- a/e2e/www/features/www-pages.spec.ts
+++ b/e2e/www/features/www-pages.spec.ts
@@ -1,9 +1,20 @@
 import { expect, test } from '@playwright/test'
 
-import { formatViolations, scan, violationIds } from '../../shared/axe.ts'
 import { parsePagePaths } from '../../shared/paths.ts'
-
-const ENFORCED_RULES = ['page-has-heading-one']
+import {
+  annotate,
+  attachScanReport,
+  blockingViolations,
+  ENFORCED_RULES,
+  formatViolations,
+  scanArticle,
+  scanLooksEmpty,
+  settleForAxe,
+  shouldEnforceAll,
+  unloadedResult,
+  violationIds,
+} from '../utils/axe-helpers.ts'
+import { wwwArticleSelectorForPagePath } from '../utils/www-selectors.ts'
 
 const pagePaths = parsePagePaths(process.env.WWW_E2E_PAGE_PATHS)
 
@@ -17,19 +28,70 @@ test.describe('WWW content pages', () => {
   })
 
   for (const pagePath of pagePaths) {
-    test(`${pagePath} loads and passes enforced a11y rules @a11y`, async ({ page }) => {
-      const response = await page.goto(pagePath)
-      expect(
-        response?.ok(),
-        `${pagePath} should return a successful status, got ${response?.status()}`
-      ).toBeTruthy()
+    test(`${pagePath} has no blocking accessibility violations @a11y`, async ({
+      page,
+    }, testInfo) => {
+      test.setTimeout(120_000)
 
-      const violations = await scan(page, { rules: ENFORCED_RULES })
+      const include = wwwArticleSelectorForPagePath(pagePath)
+
+      let response
+      try {
+        response = await page.goto(pagePath)
+      } catch (error) {
+        await attachScanReport(testInfo, unloadedResult(pagePath, pagePath, null, include))
+        throw error
+      }
+
+      const status = response?.status() ?? null
+
+      if (!response?.ok()) {
+        await attachScanReport(testInfo, unloadedResult(pagePath, page.url(), status, include))
+        expect(
+          response?.ok(),
+          `Expected a successful response for ${pagePath}, got ${status}`
+        ).toBeTruthy()
+        return
+      }
+
+      await settleForAxe(page)
+
+      await expect(
+        page.locator(include),
+        `No article matching "${include}" on ${pagePath}. This suite covers blog posts, ` +
+          'events, customer stories, and alternatives; other routes have no article element to scan.'
+      ).toBeVisible()
+
+      const result = await scanArticle(page, pagePath, include)
+      result.status = status
+
+      await attachScanReport(testInfo, result)
+
+      if (scanLooksEmpty(result)) {
+        annotate(
+          testInfo,
+          `${pagePath} scanned only ${result.elementCount} element(s) in ${include}, so a clean ` +
+            'result here proves nothing. Either the page had not finished rendering, or this ' +
+            'template renders a short article.'
+        )
+      }
+
+      const blocking = blockingViolations(result)
+
+      const reported = result.violations.filter((violation) => !blocking.includes(violation))
+      if (reported.length) {
+        annotate(
+          testInfo,
+          `${pagePath} has ${reported.length} non-blocking accessibility finding(s): ` +
+            reported.map((v) => `${v.id} (${v.nodes.length})`).join(', ')
+        )
+      }
+
+      const enforced = shouldEnforceAll() ? 'all WCAG 2.1 A/AA rules' : ENFORCED_RULES.join(', ')
 
       expect(
-        violationIds(violations),
-        `${pagePath} violates enforced a11y rules (${ENFORCED_RULES.join(', ')}):\n` +
-          formatViolations(violations)
+        violationIds(blocking),
+        `${pagePath} has blocking a11y violations (${enforced}):\n${formatViolations(blocking)}`
       ).toEqual([])
     })
   }

--- a/e2e/www/package.json
+++ b/e2e/www/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "scripts": {
     "e2e:www": "node --experimental-strip-types scripts/run-e2e-www.ts",
-    "e2e:www:all": "node --experimental-strip-types scripts/run-e2e-www.ts --all"
+    "e2e:www:all": "node --experimental-strip-types scripts/run-e2e-www.ts --all",
+    "e2e:www:a11y": "node --experimental-strip-types scripts/run-e2e-www.ts --grep @a11y",
+    "resolve-www-scope": "node --experimental-strip-types scripts/resolve-www-scope.ts"
   },
   "dependencies": {
     "@playwright/test": "^1.59.1",

--- a/e2e/www/playwright.config.ts
+++ b/e2e/www/playwright.config.ts
@@ -34,6 +34,13 @@ export default defineConfig({
         }
       : undefined,
   },
+  projects: [
+    {
+      name: 'pages',
+      testDir: './features',
+      testMatch: /.*\.spec\.ts/,
+    },
+  ],
   reporter: [['list'], ['html', { open: 'never', outputFolder: './playwright-report' }]],
   outputDir: './test-results',
 })

--- a/e2e/www/scripts/run-e2e-www.ts
+++ b/e2e/www/scripts/run-e2e-www.ts
@@ -12,6 +12,7 @@ runSuite({
   pagePathsEnv: 'WWW_E2E_PAGE_PATHS',
   baseRefEnv: 'WWW_E2E_BASE_REF',
   defaultBaseUrl: 'http://localhost:3000',
+  project: 'pages',
   resolveScope: resolveWwwScope,
   resolveAllPages: resolveAllWwwPages,
 }).catch((error) => {

--- a/e2e/www/utils/axe-helpers.ts
+++ b/e2e/www/utils/axe-helpers.ts
@@ -13,8 +13,6 @@ import { PAGE_SELECTOR } from './www-selectors.ts'
 // Outside the wcag2a/wcag2aa tag sweep, so it needs its own pass.
 export const EXTRA_REPORTED_RULES = ['heading-order']
 
-// Every template renders its `<h1>` outside the article wrapper, so this runs
-// against the page landmark. It passes on all four templates today.
 export const ENFORCED_RULES = ['page-has-heading-one']
 
 export const EXCLUDED_RULES = [

--- a/e2e/www/utils/axe-helpers.ts
+++ b/e2e/www/utils/axe-helpers.ts
@@ -1,0 +1,71 @@
+import type { Page } from '@playwright/test'
+import type { Result } from 'axe-core'
+
+import {
+  blockingViolations as blockingViolationsFor,
+  scanRegion,
+  unloadedResult as unloadedResultFor,
+  type A11yScanResult,
+} from '../../shared/a11y.ts'
+import { scan } from '../../shared/axe.ts'
+import { PAGE_SELECTOR } from './www-selectors.ts'
+
+// Outside the wcag2a/wcag2aa tag sweep, so it needs its own pass.
+export const EXTRA_REPORTED_RULES = ['heading-order']
+
+// Every template renders its `<h1>` outside the article wrapper, so this runs
+// against the page landmark. It passes on all four templates today.
+export const ENFORCED_RULES = ['page-has-heading-one']
+
+export const EXCLUDED_RULES = [
+  'color-contrast',
+  'html-has-lang',
+  'html-lang-valid',
+  'html-xml-lang-mismatch',
+  'document-title',
+  'aria-hidden-body',
+  'meta-viewport',
+  'meta-refresh',
+  'css-orientation-lock',
+]
+
+export async function scanArticle(
+  page: Page,
+  surface: string,
+  include: string
+): Promise<A11yScanResult> {
+  const result = await scanRegion(page, {
+    surface,
+    include,
+    enforcedRules: EXTRA_REPORTED_RULES,
+    excludeRules: EXCLUDED_RULES,
+  })
+
+  const pageViolations = await scan(page, { rules: ENFORCED_RULES, include: PAGE_SELECTOR })
+
+  return { ...result, violations: [...result.violations, ...pageViolations] }
+}
+
+export function unloadedResult(
+  surface: string,
+  url: string,
+  status: number | null,
+  include: string
+): A11yScanResult {
+  return unloadedResultFor(surface, url, status, include, EXCLUDED_RULES)
+}
+
+export function blockingViolations(result: A11yScanResult): Result[] {
+  return blockingViolationsFor(result, ENFORCED_RULES)
+}
+
+export type { A11yScanResult }
+export {
+  annotate,
+  attachScanReport,
+  MIN_MEANINGFUL_ELEMENTS,
+  scanLooksEmpty,
+  shouldEnforceAll,
+  WCAG_TAGS,
+} from '../../shared/a11y.ts'
+export { formatViolations, settleForAxe, violationIds } from '../../shared/axe.ts'

--- a/e2e/www/utils/axe-helpers.ts
+++ b/e2e/www/utils/axe-helpers.ts
@@ -1,0 +1,72 @@
+import type { Page } from '@playwright/test'
+import type { Result } from 'axe-core'
+
+import {
+  blockingViolations as blockingViolationsFor,
+  scanRegion,
+  unloadedResult as unloadedResultFor,
+  type A11yScanResult,
+} from '../../shared/a11y.ts'
+import { scan } from '../../shared/axe.ts'
+import { PAGE_SELECTOR } from './www-selectors.ts'
+
+// Worth reporting but outside the WCAG tag sweep, which covers wcag2a/wcag2aa
+// only. Reported, never blocking.
+export const EXTRA_REPORTED_RULES = ['heading-order']
+
+// Every template renders its `<h1>` outside the article wrapper, so this runs
+// against the page landmark rather than the article.
+export const ENFORCED_RULES = ['page-has-heading-one']
+
+export const EXCLUDED_RULES = [
+  'color-contrast',
+  'html-has-lang',
+  'html-lang-valid',
+  'html-xml-lang-mismatch',
+  'document-title',
+  'aria-hidden-body',
+  'meta-viewport',
+  'meta-refresh',
+  'css-orientation-lock',
+]
+
+export async function scanArticle(
+  page: Page,
+  surface: string,
+  include: string
+): Promise<A11yScanResult> {
+  const result = await scanRegion(page, {
+    surface,
+    include,
+    enforcedRules: EXTRA_REPORTED_RULES,
+    excludeRules: EXCLUDED_RULES,
+  })
+
+  const pageViolations = await scan(page, { rules: ENFORCED_RULES, include: PAGE_SELECTOR })
+
+  return { ...result, violations: [...result.violations, ...pageViolations] }
+}
+
+export function unloadedResult(
+  surface: string,
+  url: string,
+  status: number | null,
+  include: string
+): A11yScanResult {
+  return unloadedResultFor(surface, url, status, include, EXCLUDED_RULES)
+}
+
+export function blockingViolations(result: A11yScanResult): Result[] {
+  return blockingViolationsFor(result, ENFORCED_RULES)
+}
+
+export type { A11yScanResult }
+export {
+  annotate,
+  attachScanReport,
+  MIN_MEANINGFUL_ELEMENTS,
+  scanLooksEmpty,
+  shouldEnforceAll,
+  WCAG_TAGS,
+} from '../../shared/a11y.ts'
+export { formatViolations, settleForAxe, violationIds } from '../../shared/axe.ts'

--- a/e2e/www/utils/www-selectors.ts
+++ b/e2e/www/utils/www-selectors.ts
@@ -1,0 +1,30 @@
+export const BLOG_ARTICLE_SELECTOR = '[data-testid="sb-www-blog-main-article"]'
+export const EVENT_ARTICLE_SELECTOR = '[data-testid="sb-www-event-main-article"]'
+export const CUSTOMER_ARTICLE_SELECTOR = '[data-testid="sb-www-customer-main-article"]'
+export const ALTERNATIVE_ARTICLE_SELECTOR = '[data-testid="sb-www-alternative-main-article"]'
+
+// Default.tsx wraps every content template, and `#main` is the skip link target.
+export const PAGE_SELECTOR = '#main'
+
+const ARTICLE_SELECTORS_BY_PREFIX: ReadonlyArray<readonly [string, string]> = [
+  ['/blog/', BLOG_ARTICLE_SELECTOR],
+  ['/events/', EVENT_ARTICLE_SELECTOR],
+  ['/customers/', CUSTOMER_ARTICLE_SELECTOR],
+  ['/alternatives/', ALTERNATIVE_ARTICLE_SELECTOR],
+]
+
+// Only the four in-scope routes have a wrapper to scan, so anything else throws
+// rather than guessing at one.
+export function wwwArticleSelectorForPagePath(pagePath: string): string {
+  const pathname = pagePath.startsWith('http') ? new URL(pagePath).pathname : pagePath
+
+  for (const [prefix, selector] of ARTICLE_SELECTORS_BY_PREFIX) {
+    if (pathname.startsWith(prefix)) return selector
+  }
+
+  throw new Error(
+    `No article selector for "${pagePath}". This suite covers ${ARTICLE_SELECTORS_BY_PREFIX.map(
+      ([prefix]) => prefix
+    ).join(', ')} only.`
+  )
+}

--- a/e2e/www/utils/www-selectors.ts
+++ b/e2e/www/utils/www-selectors.ts
@@ -1,0 +1,32 @@
+export const BLOG_ARTICLE_SELECTOR = '[data-testid="sb-www-blog-main-article"]'
+export const EVENT_ARTICLE_SELECTOR = '[data-testid="sb-www-event-main-article"]'
+export const CUSTOMER_ARTICLE_SELECTOR = '[data-testid="sb-www-customer-main-article"]'
+export const ALTERNATIVE_ARTICLE_SELECTOR = '[data-testid="sb-www-alternative-main-article"]'
+
+// Every content template renders through Default.tsx, whose `<main id="main">`
+// is also the skip link target.
+export const PAGE_SELECTOR = '#main'
+
+const ARTICLE_SELECTORS_BY_PREFIX: ReadonlyArray<readonly [string, string]> = [
+  ['/blog/', BLOG_ARTICLE_SELECTOR],
+  ['/events/', EVENT_ARTICLE_SELECTOR],
+  ['/customers/', CUSTOMER_ARTICLE_SELECTOR],
+  ['/alternatives/', ALTERNATIVE_ARTICLE_SELECTOR],
+]
+
+// Each content template wraps its body differently, and the four in-scope
+// routes are the only ones with a wrapper to scan. Anything else is a caller
+// bug rather than a page worth guessing at.
+export function wwwArticleSelectorForPagePath(pagePath: string): string {
+  const pathname = pagePath.startsWith('http') ? new URL(pagePath).pathname : pagePath
+
+  for (const [prefix, selector] of ARTICLE_SELECTORS_BY_PREFIX) {
+    if (pathname.startsWith(prefix)) return selector
+  }
+
+  throw new Error(
+    `No article selector for "${pagePath}". This suite covers ${ARTICLE_SELECTORS_BY_PREFIX.map(
+      ([prefix]) => prefix
+    ).join(', ')} only.`
+  )
+}


### PR DESCRIPTION
Closes FE-4044

Stack: #49077 → #49081 → this → #49082 → #49079. Review in that order.

## Problem

The www suite enforced a single rule, `page-has-heading-one`, against the whole document. It had no warn mode, no WCAG sweep, no DOM settling, and no report artifact. Docs has all four.

## Solution

- Scan each changed page's article for WCAG 2.1 A/AA in warn mode. Only `ENFORCED_RULES` fails the build; everything else annotates and lands in `axe-results.json`.
- Add `id` and `data-testid` pairs to the four content templates. `apps/www` had no test hooks at all.
- Add `wwwArticleSelectorForPagePath`, a four-branch prefix dispatch. A route outside those four throws rather than guessing a wrapper.
- Run `page-has-heading-one` against `<main id="main">` rather than the article. Blog and event templates render their `h1` outside the article wrapper, so article scoping reported a false violation on every one of those pages.
- Report `heading-order` without blocking on it. The alternatives template has a violation inside its own article, so enforcing it would fail every alternatives content pull request.
- Upload the Playwright report on success as well as failure. Warn-mode findings were invisible on a green run, and the condition guarded the wrong step output, so the no-preview path tried to upload directories that do not exist.

## Manual testing

1. Install and add the browser.

   ```bash
   pnpm install --frozen-lockfile --filter=e2e-www...
   pnpm -C e2e/www exec playwright install chromium --only-shell
   ```

2. Run one page per template against this pull request's Vercel preview. Expect 5 passed, with non-blocking `heading-order` and `link-name` warnings on `/alternatives/` and a short-article warning on `/events/`.

   ```bash
   PLAYWRIGHT_BASE_URL=https://zone-www-dot-com-git-mirandalimonczenko-fe-4044-d3d015-supabase.vercel.app \
     WWW_E2E_PAGE_PATHS=/blog/postgres-changes-filters-and-column-selection,/events/prompt-to-prod-sentry,/customers/xendit,/alternatives/supabase-vs-firebase \
     pnpm -C e2e/www run e2e:www
   ```

3. Confirm an out-of-scope route fails with a clear message.

   ```bash
   PLAYWRIGHT_BASE_URL=https://zone-www-dot-com-git-mirandalimonczenko-fe-4044-d3d015-supabase.vercel.app \
     WWW_E2E_PAGE_PATHS=/pricing \
     pnpm -C e2e/www run e2e:www
   ```

