### PR TITLE
test(docs): scan global elements outside the article

### DIFF
--- a/.github/workflows/docs-e2e.yml
+++ b/.github/workflows/docs-e2e.yml
@@ -72,8 +72,37 @@ jobs:
             docs_app:
               - 'apps/docs/**'
 
+      - name: Decide which suites run
+        id: gate
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DOCS: ${{ steps.changes.outputs.docs }}
+          DOCS_COMPONENTS: ${{ steps.changes.outputs.docs_components }}
+        run: |
+          set -euo pipefail
+
+          pages=false
+          global_elements=false
+          any=false
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            pages=true
+            global_elements=true
+          else
+            if [ "$DOCS" = "true" ]; then pages=true; fi
+            if [ "$DOCS_COMPONENTS" = "true" ]; then global_elements=true; fi
+          fi
+
+          if [ "$pages" = "true" ] || [ "$global_elements" = "true" ]; then any=true; fi
+
+          {
+            echo "pages=$pages"
+            echo "global_elements=$global_elements"
+            echo "any=$any"
+          } >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.docs == 'true' || steps.changes.outputs.docs_components == 'true'
+        if: steps.gate.outputs.any == 'true'
         with:
           persist-credentials: false
           # Need full history on PRs so we can diff against the base branch.
@@ -90,7 +119,7 @@ jobs:
             apps/docs/scripts/federated-content/sources
 
       - name: Use Node.js
-        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.docs == 'true' || steps.changes.outputs.docs_components == 'true'
+        if: steps.gate.outputs.any == 'true'
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
@@ -101,7 +130,7 @@ jobs:
       # fixed page list.
       - name: Resolve docs E2E scope
         id: scope
-        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.docs == 'true' || steps.changes.outputs.docs_components == 'true'
+        if: steps.gate.outputs.any == 'true'
         env:
           EVENT_NAME: ${{ github.event_name }}
           BASE_REF: ${{ github.base_ref }}
@@ -127,13 +156,13 @@ jobs:
         run: echo "No in-scope docs pages changed; skipping the page suite."
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        if: steps.scope.outputs.skip == 'false' || github.event_name == 'workflow_dispatch' || steps.changes.outputs.docs_components == 'true'
+        if: steps.scope.outputs.skip == 'false' || steps.gate.outputs.global_elements == 'true'
         name: Install pnpm
         with:
           run_install: false
 
       - name: Enable pnpm store cache
-        if: steps.scope.outputs.skip == 'false' || github.event_name == 'workflow_dispatch' || steps.changes.outputs.docs_components == 'true'
+        if: steps.scope.outputs.skip == 'false' || steps.gate.outputs.global_elements == 'true'
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
@@ -151,7 +180,7 @@ jobs:
       # A Vercel failure or timeout is not the author's problem, and the required
       # "Vercel – docs" check already reports it. Resolve no URL and skip below.
       - name: Wait for Vercel docs preview
-        if: (steps.scope.outputs.skip == 'false' || steps.changes.outputs.docs_components == 'true') && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && steps.changes.outputs.docs_app == 'true'
+        if: (steps.scope.outputs.skip == 'false' || steps.gate.outputs.global_elements == 'true') && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && steps.changes.outputs.docs_app == 'true'
         id: deployment
         continue-on-error: true
         run: node scripts/waitForVercelPreview.js
@@ -165,7 +194,7 @@ jobs:
       # The two suites disagree on one case: with no preview the page suite has
       # nothing to test, while the global element suite can fall back to production.
       - name: Resolve base URL
-        if: steps.scope.outputs.skip == 'false' || github.event_name == 'workflow_dispatch' || steps.changes.outputs.docs_components == 'true'
+        if: steps.scope.outputs.skip == 'false' || steps.gate.outputs.global_elements == 'true'
         id: base-url
         env:
           EVENT_NAME: ${{ github.event_name }}
@@ -174,7 +203,7 @@ jobs:
           PAGE_PATHS: ${{ steps.scope.outputs.paths }}
           PAGES_SKIP: ${{ steps.scope.outputs.skip }}
           DOCS_APP_CHANGED: ${{ steps.changes.outputs.docs_app }}
-          RUN_GLOBAL: ${{ github.event_name == 'workflow_dispatch' || steps.changes.outputs.docs_components == 'true' }}
+          RUN_GLOBAL: ${{ steps.gate.outputs.global_elements }}
         run: |
           set -euo pipefail
 
@@ -274,7 +303,7 @@ jobs:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ steps.base-url.outputs.use_bypass == 'true' && secrets.VERCEL_AUTOMATION_BYPASS_DOCS || '' }}
 
       - name: Upload Playwright report
-        if: failure() && (steps.scope.outputs.skip == 'false' || steps.changes.outputs.docs_components == 'true')
+        if: failure() && (steps.base-url.outputs.should_test == 'true' || steps.base-url.outputs.global_should_test == 'true')
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: docs-playwright-report

--- a/.github/workflows/docs-e2e.yml
+++ b/.github/workflows/docs-e2e.yml
@@ -44,6 +44,7 @@ jobs:
     steps:
       # Runs before checkout — reads the PR file list from the API. `docs`
       # mirrors the path scope this workflow used to have as a trigger filter;
+      # `docs_components` scopes the global element scan to the markup it reads;
       # `docs_app` decides whether a Vercel docs preview exists to test against.
       - name: Detect changed paths
         id: changes
@@ -59,11 +60,20 @@ jobs:
               - 'e2e/shared/**'
               - 'pnpm-lock.yaml'
               - '.github/workflows/docs-e2e.yml'
+            docs_components:
+              - 'apps/docs/app/**'
+              - 'apps/docs/components/**'
+              - 'apps/docs/features/ui/**'
+              - 'apps/docs/layouts/**'
+              - 'e2e/docs/**'
+              - 'e2e/shared/**'
+              - 'pnpm-lock.yaml'
+              - '.github/workflows/docs-e2e.yml'
             docs_app:
               - 'apps/docs/**'
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.docs == 'true'
+        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.docs == 'true' || steps.changes.outputs.docs_components == 'true'
         with:
           persist-credentials: false
           # Need full history on PRs so we can diff against the base branch.
@@ -80,16 +90,18 @@ jobs:
             apps/docs/scripts/federated-content/sources
 
       - name: Use Node.js
-        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.docs == 'true'
+        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.docs == 'true' || steps.changes.outputs.docs_components == 'true'
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
 
       # Map changed owned content (guides, troubleshooting, partials) to page
       # URLs. Harness-only PRs resolve to skip=true and exit before Playwright.
+      # This scope covers the page suite only; the global element suite scans a
+      # fixed page list.
       - name: Resolve docs E2E scope
         id: scope
-        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.docs == 'true'
+        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.docs == 'true' || steps.changes.outputs.docs_components == 'true'
         env:
           EVENT_NAME: ${{ github.event_name }}
           BASE_REF: ${{ github.base_ref }}
@@ -112,16 +124,16 @@ jobs:
 
       - name: Skip Playwright (no in-scope pages)
         if: steps.scope.outputs.skip == 'true'
-        run: echo "No in-scope docs pages changed; skipping Playwright suite."
+        run: echo "No in-scope docs pages changed; skipping the page suite."
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        if: steps.scope.outputs.skip == 'false'
+        if: steps.scope.outputs.skip == 'false' || github.event_name == 'workflow_dispatch' || steps.changes.outputs.docs_components == 'true'
         name: Install pnpm
         with:
           run_install: false
 
       - name: Enable pnpm store cache
-        if: steps.scope.outputs.skip == 'false'
+        if: steps.scope.outputs.skip == 'false' || github.event_name == 'workflow_dispatch' || steps.changes.outputs.docs_components == 'true'
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
@@ -139,7 +151,7 @@ jobs:
       # A Vercel failure or timeout is not the author's problem, and the required
       # "Vercel – docs" check already reports it. Resolve no URL and skip below.
       - name: Wait for Vercel docs preview
-        if: steps.scope.outputs.skip == 'false' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && steps.changes.outputs.docs_app == 'true'
+        if: (steps.scope.outputs.skip == 'false' || steps.changes.outputs.docs_components == 'true') && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && steps.changes.outputs.docs_app == 'true'
         id: deployment
         continue-on-error: true
         run: node scripts/waitForVercelPreview.js
@@ -150,16 +162,26 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
 
+      # The two suites disagree on one case: with no preview the page suite has
+      # nothing to test, while the global element suite can fall back to production.
       - name: Resolve base URL
-        if: steps.scope.outputs.skip == 'false'
+        if: steps.scope.outputs.skip == 'false' || github.event_name == 'workflow_dispatch' || steps.changes.outputs.docs_components == 'true'
         id: base-url
         env:
           EVENT_NAME: ${{ github.event_name }}
           BASE_URL_INPUT: ${{ inputs.base_url }}
           DEPLOYMENT_URL: ${{ steps.deployment.outputs.deployment-url }}
           PAGE_PATHS: ${{ steps.scope.outputs.paths }}
+          PAGES_SKIP: ${{ steps.scope.outputs.skip }}
+          DOCS_APP_CHANGED: ${{ steps.changes.outputs.docs_app }}
+          RUN_GLOBAL: ${{ github.event_name == 'workflow_dispatch' || steps.changes.outputs.docs_components == 'true' }}
         run: |
           set -euo pipefail
+
+          PAGES=false
+          if [ "$PAGES_SKIP" = "false" ]; then
+            PAGES=true
+          fi
 
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             printf 'url=%s\n' "$BASE_URL_INPUT" >> "$GITHUB_OUTPUT"
@@ -169,22 +191,46 @@ jobs:
             else
               echo "use_bypass=true" >> "$GITHUB_OUTPUT"
             fi
-            echo "should_test=true" >> "$GITHUB_OUTPUT"
+            echo "should_test=$PAGES" >> "$GITHUB_OUTPUT"
+            echo "global_should_test=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           if [ -n "$DEPLOYMENT_URL" ]; then
             printf 'url=%s\n' "$DEPLOYMENT_URL" >> "$GITHUB_OUTPUT"
             echo "use_bypass=true" >> "$GITHUB_OUTPUT"
-            echo "should_test=true" >> "$GITHUB_OUTPUT"
+            echo "should_test=$PAGES" >> "$GITHUB_OUTPUT"
+            echo "global_should_test=$RUN_GLOBAL" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # Production is not a substitute: it lacks pages this pull request
-          # adds, so testing it fails a required check for a valid change.
-          echo "url=" >> "$GITHUB_OUTPUT"
+          # A change that ships no markup leaves production serving the same
+          # global elements this would test.
+          GLOBAL=false
+          if [ "$RUN_GLOBAL" = "true" ] && [ "$DOCS_APP_CHANGED" != "true" ]; then
+            GLOBAL=true
+          fi
+
+          if [ "$GLOBAL" = "true" ]; then
+            echo "url=https://supabase.com" >> "$GITHUB_OUTPUT"
+          else
+            echo "url=" >> "$GITHUB_OUTPUT"
+          fi
           echo "use_bypass=false" >> "$GITHUB_OUTPUT"
+          # Production is not a substitute for the page suite: it lacks pages
+          # this pull request adds, so testing it fails a required check for a
+          # valid change.
           echo "should_test=false" >> "$GITHUB_OUTPUT"
+          echo "global_should_test=$GLOBAL" >> "$GITHUB_OUTPUT"
+
+          if [ "$RUN_GLOBAL" = "true" ] && [ "$GLOBAL" != "true" ]; then
+            echo "::warning::No Vercel docs preview URL for this pull request, so nothing is serving the global elements it changes. Skipping that scan rather than scanning production, which still has the old markup."
+          fi
+
+          if [ "$PAGES" != "true" ]; then
+            exit 0
+          fi
+
           echo "::warning::No Vercel docs preview URL for this pull request, so there is nothing serving its content to test. Skipping Playwright rather than testing production, which does not have pages this pull request adds."
           {
             echo "### Docs E2E skipped: no preview to test against"
@@ -203,11 +249,11 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Install dependencies
-        if: steps.base-url.outputs.should_test == 'true'
+        if: steps.base-url.outputs.should_test == 'true' || steps.base-url.outputs.global_should_test == 'true'
         run: pnpm install --frozen-lockfile --filter=e2e-docs...
 
       - name: Install Playwright Chromium
-        if: steps.base-url.outputs.should_test == 'true'
+        if: steps.base-url.outputs.should_test == 'true' || steps.base-url.outputs.global_should_test == 'true'
         run: pnpm -C e2e/docs exec playwright install chromium --with-deps --only-shell
 
       - name: Run docs E2E
@@ -219,12 +265,21 @@ jobs:
           DOCS_E2E_PAGE_PATHS: ${{ steps.scope.outputs.paths }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ steps.base-url.outputs.use_bypass == 'true' && secrets.VERCEL_AUTOMATION_BYPASS_DOCS || '' }}
 
+      - name: Run docs global elements E2E
+        if: steps.base-url.outputs.global_should_test == 'true'
+        working-directory: e2e/docs
+        run: pnpm run e2e:docs:global-elements
+        env:
+          PLAYWRIGHT_BASE_URL: ${{ steps.base-url.outputs.url }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ steps.base-url.outputs.use_bypass == 'true' && secrets.VERCEL_AUTOMATION_BYPASS_DOCS || '' }}
+
       - name: Upload Playwright report
-        if: failure() && steps.scope.outputs.skip == 'false'
+        if: failure() && (steps.scope.outputs.skip == 'false' || steps.changes.outputs.docs_components == 'true')
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: docs-playwright-report
           path: |
             e2e/docs/playwright-report/
+            e2e/docs/playwright-report-global-elements/
             e2e/docs/test-results/
           retention-days: 7

--- a/.github/workflows/docs-e2e.yml
+++ b/.github/workflows/docs-e2e.yml
@@ -44,6 +44,7 @@ jobs:
     steps:
       # Runs before checkout — reads the PR file list from the API. `docs`
       # mirrors the path scope this workflow used to have as a trigger filter;
+      # `docs_components` scopes the global element scan to the markup it reads;
       # `docs_app` decides whether a Vercel docs preview exists to test against.
       - name: Detect changed paths
         id: changes
@@ -59,11 +60,20 @@ jobs:
               - 'e2e/shared/**'
               - 'pnpm-lock.yaml'
               - '.github/workflows/docs-e2e.yml'
+            docs_components:
+              - 'apps/docs/app/**'
+              - 'apps/docs/components/**'
+              - 'apps/docs/features/ui/**'
+              - 'apps/docs/layouts/**'
+              - 'e2e/docs/**'
+              - 'e2e/shared/**'
+              - 'pnpm-lock.yaml'
+              - '.github/workflows/docs-e2e.yml'
             docs_app:
               - 'apps/docs/**'
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.docs == 'true'
+        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.docs == 'true' || steps.changes.outputs.docs_components == 'true'
         with:
           persist-credentials: false
           # Need full history on PRs so we can diff against the base branch.
@@ -80,16 +90,18 @@ jobs:
             apps/docs/scripts/federated-content/sources
 
       - name: Use Node.js
-        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.docs == 'true'
+        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.docs == 'true' || steps.changes.outputs.docs_components == 'true'
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
 
       # Map changed owned content (guides, troubleshooting, partials) to page
       # URLs. Harness-only PRs resolve to skip=true and exit before Playwright.
+      # This scope covers the page suite only; the global element suite scans a
+      # fixed page list.
       - name: Resolve docs E2E scope
         id: scope
-        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.docs == 'true'
+        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.docs == 'true' || steps.changes.outputs.docs_components == 'true'
         env:
           EVENT_NAME: ${{ github.event_name }}
           BASE_REF: ${{ github.base_ref }}
@@ -112,16 +124,16 @@ jobs:
 
       - name: Skip Playwright (no in-scope pages)
         if: steps.scope.outputs.skip == 'true'
-        run: echo "No in-scope docs pages changed; skipping Playwright suite."
+        run: echo "No in-scope docs pages changed; skipping the page suite."
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        if: steps.scope.outputs.skip == 'false'
+        if: steps.scope.outputs.skip == 'false' || github.event_name == 'workflow_dispatch' || steps.changes.outputs.docs_components == 'true'
         name: Install pnpm
         with:
           run_install: false
 
       - name: Enable pnpm store cache
-        if: steps.scope.outputs.skip == 'false'
+        if: steps.scope.outputs.skip == 'false' || github.event_name == 'workflow_dispatch' || steps.changes.outputs.docs_components == 'true'
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
@@ -139,7 +151,7 @@ jobs:
       # A Vercel failure or timeout is not the author's problem, and the required
       # "Vercel – docs" check already reports it. Resolve no URL and skip below.
       - name: Wait for Vercel docs preview
-        if: steps.scope.outputs.skip == 'false' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && steps.changes.outputs.docs_app == 'true'
+        if: (steps.scope.outputs.skip == 'false' || steps.changes.outputs.docs_components == 'true') && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && steps.changes.outputs.docs_app == 'true'
         id: deployment
         continue-on-error: true
         run: node scripts/waitForVercelPreview.js
@@ -150,16 +162,27 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
 
+      # Resolves a target for both suites. They disagree on one case only: with
+      # no preview, the page suite has nothing to test, while the global element
+      # suite can use production when apps/docs did not change.
       - name: Resolve base URL
-        if: steps.scope.outputs.skip == 'false'
+        if: steps.scope.outputs.skip == 'false' || github.event_name == 'workflow_dispatch' || steps.changes.outputs.docs_components == 'true'
         id: base-url
         env:
           EVENT_NAME: ${{ github.event_name }}
           BASE_URL_INPUT: ${{ inputs.base_url }}
           DEPLOYMENT_URL: ${{ steps.deployment.outputs.deployment-url }}
           PAGE_PATHS: ${{ steps.scope.outputs.paths }}
+          PAGES_SKIP: ${{ steps.scope.outputs.skip }}
+          DOCS_APP_CHANGED: ${{ steps.changes.outputs.docs_app }}
+          RUN_GLOBAL: ${{ github.event_name == 'workflow_dispatch' || steps.changes.outputs.docs_components == 'true' }}
         run: |
           set -euo pipefail
+
+          PAGES=false
+          if [ "$PAGES_SKIP" = "false" ]; then
+            PAGES=true
+          fi
 
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             printf 'url=%s\n' "$BASE_URL_INPUT" >> "$GITHUB_OUTPUT"
@@ -169,22 +192,47 @@ jobs:
             else
               echo "use_bypass=true" >> "$GITHUB_OUTPUT"
             fi
-            echo "should_test=true" >> "$GITHUB_OUTPUT"
+            echo "should_test=$PAGES" >> "$GITHUB_OUTPUT"
+            echo "global_should_test=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           if [ -n "$DEPLOYMENT_URL" ]; then
             printf 'url=%s\n' "$DEPLOYMENT_URL" >> "$GITHUB_OUTPUT"
             echo "use_bypass=true" >> "$GITHUB_OUTPUT"
-            echo "should_test=true" >> "$GITHUB_OUTPUT"
+            echo "should_test=$PAGES" >> "$GITHUB_OUTPUT"
+            echo "global_should_test=$RUN_GLOBAL" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # Production is not a substitute: it lacks pages this pull request
-          # adds, so testing it fails a required check for a valid change.
-          echo "url=" >> "$GITHUB_OUTPUT"
+          # No preview. A change that ships no markup of its own — the harness,
+          # the lockfile, this workflow — leaves production serving exactly the
+          # global elements it would test, so scan those there.
+          GLOBAL=false
+          if [ "$RUN_GLOBAL" = "true" ] && [ "$DOCS_APP_CHANGED" != "true" ]; then
+            GLOBAL=true
+          fi
+
+          if [ "$GLOBAL" = "true" ]; then
+            echo "url=https://supabase.com" >> "$GITHUB_OUTPUT"
+          else
+            echo "url=" >> "$GITHUB_OUTPUT"
+          fi
           echo "use_bypass=false" >> "$GITHUB_OUTPUT"
+          # Production is not a substitute for the page suite: it lacks pages
+          # this pull request adds, so testing it fails a required check for a
+          # valid change.
           echo "should_test=false" >> "$GITHUB_OUTPUT"
+          echo "global_should_test=$GLOBAL" >> "$GITHUB_OUTPUT"
+
+          if [ "$RUN_GLOBAL" = "true" ] && [ "$GLOBAL" != "true" ]; then
+            echo "::warning::No Vercel docs preview URL for this pull request, so nothing is serving the global elements it changes. Skipping that scan rather than scanning production, which still has the old markup."
+          fi
+
+          if [ "$PAGES" != "true" ]; then
+            exit 0
+          fi
+
           echo "::warning::No Vercel docs preview URL for this pull request, so there is nothing serving its content to test. Skipping Playwright rather than testing production, which does not have pages this pull request adds."
           {
             echo "### Docs E2E skipped: no preview to test against"
@@ -203,11 +251,11 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Install dependencies
-        if: steps.base-url.outputs.should_test == 'true'
+        if: steps.base-url.outputs.should_test == 'true' || steps.base-url.outputs.global_should_test == 'true'
         run: pnpm install --frozen-lockfile --filter=e2e-docs...
 
       - name: Install Playwright Chromium
-        if: steps.base-url.outputs.should_test == 'true'
+        if: steps.base-url.outputs.should_test == 'true' || steps.base-url.outputs.global_should_test == 'true'
         run: pnpm -C e2e/docs exec playwright install chromium --with-deps --only-shell
 
       - name: Run docs E2E
@@ -219,12 +267,21 @@ jobs:
           DOCS_E2E_PAGE_PATHS: ${{ steps.scope.outputs.paths }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ steps.base-url.outputs.use_bypass == 'true' && secrets.VERCEL_AUTOMATION_BYPASS_DOCS || '' }}
 
+      - name: Run docs global elements E2E
+        if: steps.base-url.outputs.global_should_test == 'true'
+        working-directory: e2e/docs
+        run: pnpm run e2e:docs:global-elements
+        env:
+          PLAYWRIGHT_BASE_URL: ${{ steps.base-url.outputs.url }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ steps.base-url.outputs.use_bypass == 'true' && secrets.VERCEL_AUTOMATION_BYPASS_DOCS || '' }}
+
       - name: Upload Playwright report
-        if: failure() && steps.scope.outputs.skip == 'false'
+        if: failure() && (steps.scope.outputs.skip == 'false' || steps.changes.outputs.docs_components == 'true')
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: docs-playwright-report
           path: |
             e2e/docs/playwright-report/
+            e2e/docs/playwright-report-global-elements/
             e2e/docs/test-results/
           retention-days: 7

--- a/apps/docs/components/Breadcrumbs.tsx
+++ b/apps/docs/components/Breadcrumbs.tsx
@@ -58,7 +58,7 @@ const BreadcrumbsInternal = ({
   )
 
   return (
-    <Breadcrumb className={cn(className)}>
+    <Breadcrumb data-testid="sb-docs-breadcrumbs" className={cn(className)}>
       <BreadcrumbList className="text-foreground-lighter p-0">
         {breadcrumbs.length >= ITEMS_TO_DISPLAY && (
           <>

--- a/apps/docs/components/GuidesSidebar.tsx
+++ b/apps/docs/components/GuidesSidebar.tsx
@@ -129,7 +129,10 @@ const GuidesSidebar = ({
   const tocVideoPreview = `https://img.youtube.com/vi/${video}/0.jpg`
 
   return (
-    <div className={cn('thin-scrollbar overflow-y-auto h-fit', 'px-px', className)}>
+    <div
+      data-testid="sb-docs-toc-sidebar"
+      className={cn('thin-scrollbar overflow-y-auto h-fit', 'px-px', className)}
+    >
       <div className="w-full relative border-l flex flex-col gap-6 lg:gap-8 px-2 h-fit">
         {video && (
           <div className="relative pl-5">

--- a/apps/docs/components/Navigation/Footer.tsx
+++ b/apps/docs/components/Navigation/Footer.tsx
@@ -5,7 +5,7 @@ import { LayoutMainContent } from '~/layouts/DefaultLayout'
 
 const Footer = ({ className }: { className?: string }) => (
   <LayoutMainContent className={cn('pt-0', className)}>
-    <footer role="contentinfo" aria-label="footer">
+    <footer role="contentinfo" aria-label="footer" data-testid="sb-docs-footer">
       <div className="mt-16">
         <ul className="flex flex-col gap-2">
           {primaryLinks.map(({ url, featherIcon: Icon, text, ctaLabel }) => (

--- a/apps/docs/components/Navigation/NavigationMenu/GlobalMobileMenu.tsx
+++ b/apps/docs/components/Navigation/NavigationMenu/GlobalMobileMenu.tsx
@@ -113,6 +113,7 @@ const GlobalMobileMenu = ({ open, setOpen }: Props) => {
       <AnimatePresence mode="wait">
         {open && (
           <m.div
+            data-testid="sb-docs-mobile-menu"
             variants={container}
             initial="hidden"
             animate="show"

--- a/apps/docs/components/Navigation/NavigationMenu/TopNavBar.tsx
+++ b/apps/docs/components/Navigation/NavigationMenu/TopNavBar.tsx
@@ -33,6 +33,7 @@ const TopNavBar: FC = () => {
     <>
       <nav
         aria-label="top bar"
+        data-testid="sb-docs-top-nav"
         className="w-full z-40 flex flex-col border-b backdrop-blur-sm backdrop-filter bg-default/75"
       >
         <div className="w-full px-5 lg:pl-10 flex justify-between h-(--header-height) gap-3">
@@ -59,6 +60,7 @@ const TopNavBar: FC = () => {
               <button
                 tabIndex={0}
                 title="Menu dropdown button"
+                data-testid="sb-docs-mobile-menu-trigger"
                 className={cn(
                   buttonVariants({ variant: 'default' }),
                   'flex lg:hidden border-default bg-surface-100/75 text-foreground-light rounded-md min-w-[30px] w-[30px] h-[30px] data-open:bg-overlay-hover/30'

--- a/apps/docs/layouts/MainSkeleton.tsx
+++ b/apps/docs/layouts/MainSkeleton.tsx
@@ -307,6 +307,7 @@ const NavContainer = memo(function NavContainer({ children }: PropsWithChildren)
   return (
     <nav
       aria-labelledby="main-nav-title"
+      data-testid="sb-docs-sidebar-nav"
       className={cn(
         'fixed lg:relative z-40 lg:z-auto',
         mobileMenuOpen ? 'w-[75%] sm:w-[50%] md:w-[33%] left-0' : 'w-0 -left-full',

--- a/e2e/docs/.gitignore
+++ b/e2e/docs/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 /test-results/
 /playwright-report/
+/playwright-report-global-elements/
 /playwright-report-local-smoke/
 /blob-report/
 /playwright/.cache/

--- a/e2e/docs/README.md
+++ b/e2e/docs/README.md
@@ -16,6 +16,7 @@ This page covers:
   scope is wrong
 - [What the suite covers](#what-the-suite-covers) — in-scope paths and limits
 - [Accessibility scans](#accessibility-scans) — WCAG coverage and skipped rules
+- [Global element scans](#global-element-scans) — navigation, sidebar, and footer
 - [Debug failures](#debug-failures) — reports and traces
 - [How CI uses this suite](#how-ci-uses-this-suite) — pull request behavior
 
@@ -185,13 +186,44 @@ own content.
 
 `EXCLUDED_RULES` in `utils/axe-helpers.ts` lists the rules the scan skips.
 `color-contrast` is most of the scan time and finds nothing inside an article, since
-docs contrast comes from shared tokens and chrome. The rest target `<html>`, `<head>`,
-and `<body>`, which an article-scoped scan can't reach.
+docs contrast comes from shared tokens and global elements. The rest target `<html>`,
+`<head>`, and `<body>`, which an article-scoped scan can't reach.
 
 Cross-origin frames are skipped, so a third-party embed isn't reported as ours.
 
-Not covered: `/docs/reference/*`, shared chrome, and most of WCAG. Keyboard
-navigation, focus management, and screen reader behavior need manual testing.
+Not covered: `/docs/reference/*` articles and most of WCAG. Keyboard navigation,
+focus management, and screen reader behavior need manual testing. For everything
+outside the article, see [Global element scans](#global-element-scans).
+
+## Global element scans
+
+Global elements are everything outside the article: the top navigation bar, sidebar
+navigation, content sidebar, breadcrumbs, and footer.
+
+```bash
+PLAYWRIGHT_BASE_URL=https://supabase.com pnpm e2e:docs:global-elements
+```
+
+**Why this is a separate suite:**
+
+- **Attribution.** Global markup renders on every page. Scanning it alongside changed
+  content would report a footer violation on a pull request that only edited an `.mdx`
+  file.
+- **Scope.** These elements don't vary by page, so the scope is a fixed list of one
+  page per layout rather than the changed-files scope the per-page suite uses. Each
+  element is scanned once instead of once per changed page.
+
+The two suites are separate Playwright projects, so a content pull request never runs
+this one. Its report lands in `playwright-report-global-elements/`.
+
+Rules that pass today are enforced, so they catch a newly introduced violation without
+failing on existing debt. Everything else annotates. `GLOBAL_ELEMENTS_ENFORCED_RULES` in
+`utils/axe-helpers.ts` is that set. Set `A11Y_ENFORCE_ALL=1` to make every finding
+blocking for a local triage run.
+
+**Configuration:** the element list, the page list, and which elements to expect at
+each viewport live in `utils/docs-global-elements.ts`. Rule lists are in
+`utils/axe-helpers.ts`.
 
 ## Debug failures
 
@@ -218,3 +250,16 @@ owned docs content, partials, or `e2e/docs`.
 Draft pull requests stay skipped until you mark them ready for review. Manual
 `workflow_dispatch` runs require a `page_paths` input and accept an optional
 `base_url`, which defaults to production.
+
+The same workflow runs the global element suite as a second step, on pull
+requests that touch `apps/docs/app/**`, `apps/docs/components/**`,
+`apps/docs/features/ui/**`, `apps/docs/layouts/**`, `e2e/docs/**`,
+`e2e/shared/**`, `pnpm-lock.yaml`, or the workflow itself. A content-only pull
+request skips it.
+
+Both steps prefer the Vercel preview. They differ when no preview resolves: the
+page suite skips, while the global element suite falls back to production if
+`apps/docs` didn't change, since a harness-only change ships no markup of its
+own. A fork pull request runs without repository secrets and resolves no
+preview, so an `apps/docs` change from a fork skips both steps. Cover it by
+running the workflow manually against its preview.

--- a/e2e/docs/README.md
+++ b/e2e/docs/README.md
@@ -116,7 +116,11 @@ To test every guide and troubleshooting entry instead of a changed-files scope
 PLAYWRIGHT_BASE_URL=https://supabase.com pnpm e2e:docs:all
 ```
 
-This ignores `DOCS_E2E_PAGE_PATHS` and the 20-page cap described in
+This is the whole-site audit: it selects both the `pages` and `global-elements`
+projects, so one run covers every article plus everything outside it, in a single
+`playwright-report/`. The per-project commands scope a run to one of them.
+
+It ignores `DOCS_E2E_PAGE_PATHS` and the 20-page cap described in
 [Limits](#limits), and tests every page listed by
 `pnpm -C e2e/docs resolve-docs-scope` across the whole `guides` and
 `troubleshooting` trees — several hundred pages as of this writing. `--all`
@@ -214,7 +218,8 @@ PLAYWRIGHT_BASE_URL=https://supabase.com pnpm e2e:docs:global-elements
   element is scanned once instead of once per changed page.
 
 The two suites are separate Playwright projects, so a content pull request never runs
-this one. Its report lands in `playwright-report-global-elements/`.
+this one. On its own its report lands in `playwright-report-global-elements/`. Under
+`pnpm e2e:docs:all` both projects run together and share `playwright-report/`.
 
 Rules that pass today are enforced, so they catch a newly introduced violation without
 failing on existing debt. Everything else annotates. `GLOBAL_ELEMENTS_ENFORCED_RULES` in

--- a/e2e/docs/README.md
+++ b/e2e/docs/README.md
@@ -16,6 +16,7 @@ This page covers:
   scope is wrong
 - [What the suite covers](#what-the-suite-covers) — in-scope paths and limits
 - [Accessibility scans](#accessibility-scans) — WCAG coverage and skipped rules
+- [Global element scans](#global-element-scans) — navigation, sidebar, and footer
 - [Debug failures](#debug-failures) — reports and traces
 - [How CI uses this suite](#how-ci-uses-this-suite) — pull request behavior
 
@@ -185,13 +186,90 @@ own content.
 
 `EXCLUDED_RULES` in `utils/axe-helpers.ts` lists the rules the scan skips.
 `color-contrast` is most of the scan time and finds nothing inside an article, since
-docs contrast comes from shared tokens and chrome. The rest target `<html>`, `<head>`,
-and `<body>`, which an article-scoped scan can't reach.
+docs contrast comes from shared tokens and global elements. The rest target `<html>`,
+`<head>`, and `<body>`, which an article-scoped scan can't reach.
 
 Cross-origin frames are skipped, so a third-party embed isn't reported as ours.
 
-Not covered: `/docs/reference/*`, shared chrome, and most of WCAG. Keyboard
-navigation, focus management, and screen reader behavior need manual testing.
+Not covered: `/docs/reference/*` articles and most of WCAG. Keyboard navigation,
+focus management, and screen reader behavior need manual testing. For everything
+outside the article, see [Global element scans](#global-element-scans).
+
+## Global element scans
+
+This suite scans what the per-page suite excludes: the top navigation bar,
+sidebar navigation, content sidebar, breadcrumbs, and footer.
+
+```bash
+PLAYWRIGHT_BASE_URL=https://supabase.com pnpm e2e:docs:global-elements
+```
+
+These elements are global, so scope is a fixed list — one page per layout, in
+`utils/docs-global-elements.ts` — instead of the changed-files scope the
+per-page suite uses. A second page on a layout already covered would scan the
+same markup for the same result. Add a page only for a layout the list doesn't
+reach yet.
+
+Every page runs at two viewports, 1280x800 and 390x844. A layout hides
+different elements at each width, so the two runs scan different markup. One
+extra test opens the mobile menu overlay and scans it, because that markup only
+exists once opened. The overlay is the same list on every page, so one page
+covers it.
+
+Each page asserts that its elements are visible, then scans the page with the
+article excluded. Elements are matched on `data-testid` attributes in
+`apps/docs`, so a styling or markup change can't quietly drop one from the scan.
+Visibility rather than presence matters here, since axe skips hidden subtrees and
+an attached element that renders nothing would pass while scanning nothing. Which
+elements to expect at which width lives in `GLOBAL_ELEMENTS`. A missing element
+is a soft failure: the test still reports its scan.
+
+This suite keeps the page-level rules the article scan skips, such as
+`color-contrast`, `html-has-lang`, and `document-title`, because global elements
+are where those live. It drops only `page-has-heading-one`, whose target is the
+excluded article. `color-contrast` is most of the scan time, and this is the
+only suite that runs it.
+
+Like the article scan, most findings are reported as warnings. Blocking rules
+are `GLOBAL_ELEMENTS_ENFORCED_RULES` in `utils/axe-helpers.ts`. A violation in a
+global element appears on every docs page, so keep that list green rather than
+growing it.
+
+Everything on that list passes today and is applicable on every scanned surface,
+so each rule guards something. Before adding one, check that axe reports passing
+nodes for it rather than reporting it as inapplicable, and that it has no
+`incomplete` nodes. Inapplicable rules guard nothing, and undecided ones can flip
+to failing on an unrelated change.
+
+`button-name` is reported rather than blocking. The filter comboboxes on
+`/docs/guides/troubleshooting` have no accessible name, and they also trip
+`aria-required-attr`. The sidebar toggle in `layouts/MainSkeleton.tsx` is
+icon-only and unnamed, which shows up at mobile width. Promote the rule once
+those are named.
+
+The same markup repeats across 13 surfaces, so a finding is reported once and
+suppressed afterward. The set of what's been seen lives in one worker process,
+so a run split across N workers can report a finding up to N times. Playwright
+also replaces a worker after a failing test, which starts the set over.
+
+The two suites are Playwright projects in `playwright.config.ts` and keep
+separate reports, so `pnpm e2e:docs` on a content pull request never picks up
+global elements:
+
+| Suite           | Project           | Command                         | Report folder                        |
+| --------------- | ----------------- | ------------------------------- | ------------------------------------ |
+| Per-page        | `pages`           | `pnpm e2e:docs`                 | `playwright-report/`                 |
+| Global elements | `global-elements` | `pnpm e2e:docs:global-elements` | `playwright-report-global-elements/` |
+
+Not covered:
+
+- Keyboard behavior in the mobile menu, including focus order and focus
+  trapping. Axe reports the markup, not the interaction.
+- Global elements that arrive through `packages/ui` rather than `apps/docs`. CI
+  doesn't watch that path, so run this manually when a shared component changes.
+- Client library reference pages such as `/docs/reference/javascript/*`, which
+  serve a bare link list to a headless browser and render nothing to scan.
+  `/docs/reference/cli/introduction` covers the reference layout instead.
 
 ## Debug failures
 
@@ -218,3 +296,16 @@ owned docs content, partials, or `e2e/docs`.
 Draft pull requests stay skipped until you mark them ready for review. Manual
 `workflow_dispatch` runs require a `page_paths` input and accept an optional
 `base_url`, which defaults to production.
+
+The same workflow runs the global element suite as a second step, on pull
+requests that touch `apps/docs/app/**`, `apps/docs/components/**`,
+`apps/docs/features/ui/**`, `apps/docs/layouts/**`, `e2e/docs/**`,
+`e2e/shared/**`, `pnpm-lock.yaml`, or the workflow itself. A content-only pull
+request skips it.
+
+Both steps prefer the Vercel preview. They differ when no preview resolves: the
+page suite skips, while the global element suite falls back to production if
+`apps/docs` didn't change, since a harness-only change ships no markup of its
+own. A fork pull request runs without repository secrets and resolves no
+preview, so an `apps/docs` change from a fork skips both steps. Cover it by
+running the workflow manually against its preview.

--- a/e2e/docs/README.md
+++ b/e2e/docs/README.md
@@ -197,79 +197,28 @@ outside the article, see [Global element scans](#global-element-scans).
 
 ## Global element scans
 
-This suite scans what the per-page suite excludes: the top navigation bar,
-sidebar navigation, content sidebar, breadcrumbs, and footer.
+Global elements are everything outside the article: the top navigation bar, sidebar
+navigation, content sidebar, breadcrumbs, and footer.
 
 ```bash
 PLAYWRIGHT_BASE_URL=https://supabase.com pnpm e2e:docs:global-elements
 ```
 
-These elements are global, so scope is a fixed list — one page per layout, in
-`utils/docs-global-elements.ts` — instead of the changed-files scope the
-per-page suite uses. A second page on a layout already covered would scan the
-same markup for the same result. Add a page only for a layout the list doesn't
-reach yet.
+**Why this is a separate suite:**
 
-Every page runs at two viewports, 1280x800 and 390x844. A layout hides
-different elements at each width, so the two runs scan different markup. One
-extra test opens the mobile menu overlay and scans it, because that markup only
-exists once opened. The overlay is the same list on every page, so one page
-covers it.
+- **Attribution.** Global markup renders on every page. Scanning it alongside changed
+  content would report a footer violation on a pull request that only edited an `.mdx`
+  file.
+- **Scope.** These elements don't vary by page, so the scope is a fixed list of one
+  page per layout rather than the changed-files scope the per-page suite uses. Each
+  element is scanned once instead of once per changed page.
 
-Each page asserts that its elements are visible, then scans the page with the
-article excluded. Elements are matched on `data-testid` attributes in
-`apps/docs`, so a styling or markup change can't quietly drop one from the scan.
-Visibility rather than presence matters here, since axe skips hidden subtrees and
-an attached element that renders nothing would pass while scanning nothing. Which
-elements to expect at which width lives in `GLOBAL_ELEMENTS`. A missing element
-is a soft failure: the test still reports its scan.
+The two suites are separate Playwright projects, so a content pull request never runs
+this one. Its report lands in `playwright-report-global-elements/`.
 
-This suite keeps the page-level rules the article scan skips, such as
-`color-contrast`, `html-has-lang`, and `document-title`, because global elements
-are where those live. It drops only `page-has-heading-one`, whose target is the
-excluded article. `color-contrast` is most of the scan time, and this is the
-only suite that runs it.
-
-Like the article scan, most findings are reported as warnings. Blocking rules
-are `GLOBAL_ELEMENTS_ENFORCED_RULES` in `utils/axe-helpers.ts`. A violation in a
-global element appears on every docs page, so keep that list green rather than
-growing it.
-
-Everything on that list passes today and is applicable on every scanned surface,
-so each rule guards something. Before adding one, check that axe reports passing
-nodes for it rather than reporting it as inapplicable, and that it has no
-`incomplete` nodes. Inapplicable rules guard nothing, and undecided ones can flip
-to failing on an unrelated change.
-
-`button-name` is reported rather than blocking. The filter comboboxes on
-`/docs/guides/troubleshooting` have no accessible name, and they also trip
-`aria-required-attr`. The sidebar toggle in `layouts/MainSkeleton.tsx` is
-icon-only and unnamed, which shows up at mobile width. Promote the rule once
-those are named.
-
-The same markup repeats across 13 surfaces, so a finding is reported once and
-suppressed afterward. The set of what's been seen lives in one worker process,
-so a run split across N workers can report a finding up to N times. Playwright
-also replaces a worker after a failing test, which starts the set over.
-
-The two suites are Playwright projects in `playwright.config.ts` and keep
-separate reports, so `pnpm e2e:docs` on a content pull request never picks up
-global elements:
-
-| Suite           | Project           | Command                         | Report folder                        |
-| --------------- | ----------------- | ------------------------------- | ------------------------------------ |
-| Per-page        | `pages`           | `pnpm e2e:docs`                 | `playwright-report/`                 |
-| Global elements | `global-elements` | `pnpm e2e:docs:global-elements` | `playwright-report-global-elements/` |
-
-Not covered:
-
-- Keyboard behavior in the mobile menu, including focus order and focus
-  trapping. Axe reports the markup, not the interaction.
-- Global elements that arrive through `packages/ui` rather than `apps/docs`. CI
-  doesn't watch that path, so run this manually when a shared component changes.
-- Client library reference pages such as `/docs/reference/javascript/*`, which
-  serve a bare link list to a headless browser and render nothing to scan.
-  `/docs/reference/cli/introduction` covers the reference layout instead.
+**Configuration:** the element list, the page list, and which elements to expect at
+each viewport live in `utils/docs-global-elements.ts`. Blocking rules are
+`GLOBAL_ELEMENTS_ENFORCED_RULES` in `utils/axe-helpers.ts`.
 
 ## Debug failures
 

--- a/e2e/docs/global-elements/docs-global-elements.spec.ts
+++ b/e2e/docs/global-elements/docs-global-elements.spec.ts
@@ -1,0 +1,152 @@
+import { expect, test } from '@playwright/test'
+import type { Page, TestInfo } from '@playwright/test'
+
+import {
+  annotate,
+  attachScanReport,
+  blockingViolations,
+  dedupeViolations,
+  scanExcluding,
+  shouldEnforceAll,
+  unloadedResult,
+} from '../../shared/a11y.ts'
+import { formatViolations, settleForAxe, violationIds } from '../../shared/axe.ts'
+import { elementsForViewport, renderedLocator, VIEWPORTS } from '../../shared/viewports.ts'
+import type { ViewportName } from '../../shared/viewports.ts'
+import {
+  GLOBAL_ELEMENTS_ENFORCED_RULES,
+  GLOBAL_ELEMENTS_EXCLUDED_RULES,
+} from '../utils/axe-helpers.js'
+import {
+  articleSelectorsOnPage,
+  GLOBAL_ELEMENT_PAGES,
+  GLOBAL_ELEMENTS,
+  MOBILE_MENU_SELECTOR,
+  type GlobalElement,
+} from '../utils/docs-global-elements.js'
+
+// One broken global element would otherwise report on every test that scans it.
+const seenFindings = new Set<string>()
+
+async function load(page: Page, testInfo: TestInfo, path: string, surface: string) {
+  let response
+  try {
+    response = await page.goto(path)
+  } catch (error) {
+    await attachScanReport(
+      testInfo,
+      unloadedResult(surface, path, null, 'document', GLOBAL_ELEMENTS_EXCLUDED_RULES)
+    )
+    throw error
+  }
+
+  const status = response?.status() ?? null
+
+  if (!response?.ok()) {
+    await attachScanReport(
+      testInfo,
+      unloadedResult(surface, page.url(), status, 'document', GLOBAL_ELEMENTS_EXCLUDED_RULES)
+    )
+    expect(response?.ok(), `Expected a successful response for ${path}, got ${status}`).toBeTruthy()
+  }
+
+  return status
+}
+
+async function scanAndAssert(
+  page: Page,
+  testInfo: TestInfo,
+  surface: string,
+  status: number | null
+) {
+  const exclude = await articleSelectorsOnPage(page)
+  const result = await scanExcluding(page, {
+    surface,
+    exclude,
+    excludeRules: GLOBAL_ELEMENTS_EXCLUDED_RULES,
+  })
+  result.status = status
+  result.violations = dedupeViolations(result.violations, seenFindings)
+
+  await attachScanReport(testInfo, result)
+
+  const blocking = blockingViolations(result, GLOBAL_ELEMENTS_ENFORCED_RULES)
+
+  const reported = result.violations.filter((violation) => !blocking.includes(violation))
+  if (reported.length) {
+    annotate(
+      testInfo,
+      `${surface} global elements have ${reported.length} non-blocking accessibility finding(s): ` +
+        reported.map((violation) => `${violation.id} (${violation.nodes.length})`).join(', ')
+    )
+  }
+
+  const enforced = shouldEnforceAll()
+    ? 'all WCAG 2.1 A/AA rules'
+    : GLOBAL_ELEMENTS_ENFORCED_RULES.join(', ')
+
+  expect(
+    violationIds(blocking).sort(),
+    `${surface} global elements have blocking a11y violations (${enforced}):\n${formatViolations(blocking)}`
+  ).toEqual([])
+}
+
+function configsFor(elements: GlobalElement[], viewport: ViewportName) {
+  return elementsForViewport(
+    elements.map((name) => GLOBAL_ELEMENTS[name]),
+    viewport
+  )
+}
+
+test.describe('Docs global elements', () => {
+  for (const { path, layout, elements } of GLOBAL_ELEMENT_PAGES) {
+    for (const viewport of Object.keys(VIEWPORTS) as ViewportName[]) {
+      const surface = `${path} at ${viewport}`
+
+      test(`${surface} (${layout}) global elements have no blocking accessibility violations @global-elements`, async ({
+        page,
+      }, testInfo) => {
+        await page.setViewportSize(VIEWPORTS[viewport])
+
+        const status = await load(page, testInfo, path, surface)
+
+        await settleForAxe(page)
+
+        // Visible, not attached: axe skips hidden subtrees.
+        // Soft, so a missing element still reports its scan.
+        for (const { selector, label } of configsFor(elements, viewport)) {
+          await expect
+            .soft(
+              renderedLocator(page, selector),
+              `${surface} should render the ${label} (${selector})`
+            )
+            .toBeVisible()
+        }
+
+        await scanAndAssert(page, testInfo, surface, status)
+      })
+    }
+  }
+
+  // Same overlay on every page, and its markup only exists once opened.
+  test('the mobile menu overlay has no blocking accessibility violations @global-elements', async ({
+    page,
+  }, testInfo) => {
+    const path = '/docs'
+    const surface = '/docs with the mobile menu open'
+
+    await page.setViewportSize(VIEWPORTS.mobile)
+
+    const status = await load(page, testInfo, path, surface)
+
+    await renderedLocator(page, GLOBAL_ELEMENTS.menuTrigger.selector).click()
+    await expect(
+      page.locator(MOBILE_MENU_SELECTOR),
+      `${surface} should open the mobile menu overlay`
+    ).toBeVisible()
+
+    await settleForAxe(page)
+
+    await scanAndAssert(page, testInfo, surface, status)
+  })
+})

--- a/e2e/docs/global-elements/docs-global-elements.spec.ts
+++ b/e2e/docs/global-elements/docs-global-elements.spec.ts
@@ -1,0 +1,153 @@
+import { expect, test } from '@playwright/test'
+import type { Page, TestInfo } from '@playwright/test'
+
+import {
+  annotate,
+  attachScanReport,
+  blockingViolations,
+  dedupeViolations,
+  scanExcluding,
+  shouldEnforceAll,
+  unloadedResult,
+} from '../../shared/a11y.ts'
+import { formatViolations, settleForAxe, violationIds } from '../../shared/axe.ts'
+import { elementsForViewport, renderedLocator, VIEWPORTS } from '../../shared/viewports.ts'
+import type { ViewportName } from '../../shared/viewports.ts'
+import {
+  GLOBAL_ELEMENTS_ENFORCED_RULES,
+  GLOBAL_ELEMENTS_EXCLUDED_RULES,
+} from '../utils/axe-helpers.js'
+import {
+  articleSelectorsOnPage,
+  GLOBAL_ELEMENT_PAGES,
+  GLOBAL_ELEMENTS,
+  MOBILE_MENU_SELECTOR,
+  type GlobalElement,
+} from '../utils/docs-global-elements.js'
+
+// Global markup repeats across pages and viewports, so a single broken element
+// would otherwise be reported by every test that scans it.
+const seenFindings = new Set<string>()
+
+async function load(page: Page, testInfo: TestInfo, path: string, surface: string) {
+  let response
+  try {
+    response = await page.goto(path)
+  } catch (error) {
+    await attachScanReport(
+      testInfo,
+      unloadedResult(surface, path, null, 'document', GLOBAL_ELEMENTS_EXCLUDED_RULES)
+    )
+    throw error
+  }
+
+  const status = response?.status() ?? null
+
+  if (!response?.ok()) {
+    await attachScanReport(
+      testInfo,
+      unloadedResult(surface, page.url(), status, 'document', GLOBAL_ELEMENTS_EXCLUDED_RULES)
+    )
+    expect(response?.ok(), `Expected a successful response for ${path}, got ${status}`).toBeTruthy()
+  }
+
+  return status
+}
+
+async function scanAndAssert(
+  page: Page,
+  testInfo: TestInfo,
+  surface: string,
+  status: number | null
+) {
+  const exclude = await articleSelectorsOnPage(page)
+  const result = await scanExcluding(page, {
+    surface,
+    exclude,
+    excludeRules: GLOBAL_ELEMENTS_EXCLUDED_RULES,
+  })
+  result.status = status
+  result.violations = dedupeViolations(result.violations, seenFindings)
+
+  await attachScanReport(testInfo, result)
+
+  const blocking = blockingViolations(result, GLOBAL_ELEMENTS_ENFORCED_RULES)
+
+  const reported = result.violations.filter((violation) => !blocking.includes(violation))
+  if (reported.length) {
+    annotate(
+      testInfo,
+      `${surface} global elements have ${reported.length} non-blocking accessibility finding(s): ` +
+        reported.map((violation) => `${violation.id} (${violation.nodes.length})`).join(', ')
+    )
+  }
+
+  const enforced = shouldEnforceAll()
+    ? 'all WCAG 2.1 A/AA rules'
+    : GLOBAL_ELEMENTS_ENFORCED_RULES.join(', ')
+
+  expect(
+    violationIds(blocking).sort(),
+    `${surface} global elements have blocking a11y violations (${enforced}):\n${formatViolations(blocking)}`
+  ).toEqual([])
+}
+
+function configsFor(elements: GlobalElement[], viewport: ViewportName) {
+  return elementsForViewport(
+    elements.map((name) => GLOBAL_ELEMENTS[name]),
+    viewport
+  )
+}
+
+test.describe('Docs global elements', () => {
+  for (const { path, layout, elements } of GLOBAL_ELEMENT_PAGES) {
+    for (const viewport of Object.keys(VIEWPORTS) as ViewportName[]) {
+      const surface = `${path} at ${viewport}`
+
+      test(`${surface} (${layout}) global elements have no blocking accessibility violations @global-elements`, async ({
+        page,
+      }, testInfo) => {
+        await page.setViewportSize(VIEWPORTS[viewport])
+
+        const status = await load(page, testInfo, path, surface)
+
+        await settleForAxe(page)
+
+        // Visible, not attached: axe skips hidden subtrees.
+        // Soft, so a missing element still reports its scan.
+        for (const { selector, label } of configsFor(elements, viewport)) {
+          await expect
+            .soft(
+              renderedLocator(page, selector),
+              `${surface} should render the ${label} (${selector})`
+            )
+            .toBeVisible()
+        }
+
+        await scanAndAssert(page, testInfo, surface, status)
+      })
+    }
+  }
+
+  // Same overlay on every page, and its markup only exists once opened.
+  test('the mobile menu overlay has no blocking accessibility violations @global-elements', async ({
+    page,
+  }, testInfo) => {
+    const path = '/docs'
+    const surface = '/docs with the mobile menu open'
+
+    await page.setViewportSize(VIEWPORTS.mobile)
+
+    const status = await load(page, testInfo, path, surface)
+
+    await renderedLocator(page, GLOBAL_ELEMENTS.menuTrigger.selector).click()
+    await expect(
+      page.locator(MOBILE_MENU_SELECTOR),
+      `${surface} should open the mobile menu overlay`
+    ).toBeVisible()
+
+    await settleForAxe(page)
+
+    await scanAndAssert(page, testInfo, surface, status)
+  })
+})

--- a/e2e/docs/package.json
+++ b/e2e/docs/package.json
@@ -7,6 +7,7 @@
     "e2e:docs": "node --experimental-strip-types scripts/run-e2e-docs.ts",
     "e2e:docs:all": "node --experimental-strip-types scripts/run-e2e-docs.ts --all",
     "e2e:docs:a11y": "node --experimental-strip-types scripts/run-e2e-docs.ts --grep @a11y",
+    "e2e:docs:global-elements": "node --experimental-strip-types scripts/run-e2e-docs-global-elements.ts",
     "e2e:ui": "node --experimental-strip-types scripts/run-e2e-docs.ts --ui",
     "e2e:docs:local-smoke": "playwright test --config=playwright.local-smoke.config.ts",
     "resolve-docs-scope": "node --experimental-strip-types scripts/resolve-docs-scope.ts"

--- a/e2e/docs/playwright.config.ts
+++ b/e2e/docs/playwright.config.ts
@@ -10,17 +10,24 @@ const BYPASS_SECRET = isSupabaseHost(BASE_URL)
   ? process.env.VERCEL_AUTOMATION_BYPASS_SECRET
   : undefined
 
-// maxFailures, the worker pool, and reporters are config-level only in Playwright,
-// so the selected project has to be read from argv.
-const IS_GLOBAL_ELEMENTS = process.argv.some(
-  (arg) => arg === '--project=global-elements' || arg === 'global-elements'
-)
+// maxFailures and reporters are config-level only in Playwright, so the selected
+// projects have to be read from argv.
+const SELECTED_PROJECTS = process.argv.flatMap((arg, index) => {
+  if (arg.startsWith('--project=')) return [arg.slice('--project='.length)]
+  if (arg === '--project' || arg === '-p') return [process.argv[index + 1] ?? '']
+  return []
+})
 
-const REPORT_FOLDER = IS_GLOBAL_ELEMENTS
+const RUNS_GLOBAL_ELEMENTS = SELECTED_PROJECTS.includes('global-elements')
+
+// An `--all` run selects both projects, and one combined report is the point of it.
+const GLOBAL_ELEMENTS_ONLY = RUNS_GLOBAL_ELEMENTS && !SELECTED_PROJECTS.includes('pages')
+
+const REPORT_FOLDER = GLOBAL_ELEMENTS_ONLY
   ? './playwright-report-global-elements'
   : './playwright-report'
 
-const JSON_REPORT = IS_GLOBAL_ELEMENTS
+const JSON_REPORT = GLOBAL_ELEMENTS_ONLY
   ? './test-results/global-elements-results.json'
   : './test-results/test-results.json'
 
@@ -31,12 +38,12 @@ export default defineConfig({
   forbidOnly: IS_CI,
   retries: IS_CI ? 2 : 0,
   // An early stop hides findings from the remaining surfaces.
-  maxFailures: IS_GLOBAL_ELEMENTS ? 0 : 3,
+  maxFailures: RUNS_GLOBAL_ELEMENTS ? 0 : 3,
   expect: {
     timeout: 15_000,
   },
   fullyParallel: false,
-  workers: IS_GLOBAL_ELEMENTS ? (IS_CI ? 2 : undefined) : 1,
+  workers: RUNS_GLOBAL_ELEMENTS ? (IS_CI ? 2 : undefined) : 1,
   use: {
     baseURL: BASE_URL,
     browserName: 'chromium',
@@ -57,6 +64,8 @@ export default defineConfig({
       name: 'pages',
       testDir: './features',
       testMatch: /.*\.spec\.ts/,
+      // Pinned, since the top-level cap rises when global elements are selected too.
+      workers: 1,
       use: {
         browserName: 'chromium',
       },

--- a/e2e/docs/playwright.config.ts
+++ b/e2e/docs/playwright.config.ts
@@ -10,18 +10,33 @@ const BYPASS_SECRET = isSupabaseHost(BASE_URL)
   ? process.env.VERCEL_AUTOMATION_BYPASS_SECRET
   : undefined
 
+// maxFailures, the worker pool, and reporters are config-level only in Playwright,
+// so the selected project has to be read from argv.
+const IS_GLOBAL_ELEMENTS = process.argv.some(
+  (arg) => arg === '--project=global-elements' || arg === 'global-elements'
+)
+
+const REPORT_FOLDER = IS_GLOBAL_ELEMENTS
+  ? './playwright-report-global-elements'
+  : './playwright-report'
+
+const JSON_REPORT = IS_GLOBAL_ELEMENTS
+  ? './test-results/global-elements-results.json'
+  : './test-results/test-results.json'
+
 export default defineConfig({
   testDir: './features',
   testMatch: /.*\.spec\.ts/,
   timeout: 60_000,
   forbidOnly: IS_CI,
   retries: IS_CI ? 2 : 0,
-  maxFailures: 3,
+  // An early stop hides findings from the remaining surfaces.
+  maxFailures: IS_GLOBAL_ELEMENTS ? 0 : 3,
   expect: {
     timeout: 15_000,
   },
   fullyParallel: false,
-  workers: 1,
+  workers: IS_GLOBAL_ELEMENTS ? (IS_CI ? 2 : undefined) : 1,
   use: {
     baseURL: BASE_URL,
     browserName: 'chromium',
@@ -39,20 +54,31 @@ export default defineConfig({
   },
   projects: [
     {
-      name: 'Features',
+      name: 'pages',
       testDir: './features',
       testMatch: /.*\.spec\.ts/,
       use: {
         browserName: 'chromium',
       },
     },
+    {
+      name: 'global-elements',
+      testDir: './global-elements',
+      testMatch: /.*\.spec\.ts/,
+      timeout: 120_000,
+      fullyParallel: true,
+      workers: IS_CI ? 2 : undefined,
+      use: {
+        browserName: 'chromium',
+      },
+    },
   ],
   reporter: IS_CI
-    ? [['list'], ['html', { open: 'never', outputFolder: './playwright-report' }]]
+    ? [['list'], ['html', { open: 'never', outputFolder: REPORT_FOLDER }]]
     : [
         ['list'],
-        ['html', { open: 'never', outputFolder: './playwright-report' }],
-        ['json', { outputFile: './test-results/test-results.json' }],
+        ['html', { open: 'never', outputFolder: REPORT_FOLDER }],
+        ['json', { outputFile: JSON_REPORT }],
       ],
   outputDir: './test-results',
 })

--- a/e2e/docs/playwright.config.ts
+++ b/e2e/docs/playwright.config.ts
@@ -10,18 +10,33 @@ const BYPASS_SECRET = isSupabaseHost(BASE_URL)
   ? process.env.VERCEL_AUTOMATION_BYPASS_SECRET
   : undefined
 
+// Playwright accepts maxFailures, the top-level worker pool, and reporters at
+// config level only, so the two suites are told apart by the selected project.
+const IS_GLOBAL_ELEMENTS = process.argv.some(
+  (arg) => arg === '--project=global-elements' || arg === 'global-elements'
+)
+
+const REPORT_FOLDER = IS_GLOBAL_ELEMENTS
+  ? './playwright-report-global-elements'
+  : './playwright-report'
+
+const JSON_REPORT = IS_GLOBAL_ELEMENTS
+  ? './test-results/global-elements-results.json'
+  : './test-results/test-results.json'
+
 export default defineConfig({
   testDir: './features',
   testMatch: /.*\.spec\.ts/,
   timeout: 60_000,
   forbidOnly: IS_CI,
   retries: IS_CI ? 2 : 0,
-  maxFailures: 3,
+  // Report every global element surface: an early stop hides findings from the rest.
+  maxFailures: IS_GLOBAL_ELEMENTS ? 0 : 3,
   expect: {
     timeout: 15_000,
   },
   fullyParallel: false,
-  workers: 1,
+  workers: IS_GLOBAL_ELEMENTS ? (IS_CI ? 2 : undefined) : 1,
   use: {
     baseURL: BASE_URL,
     browserName: 'chromium',
@@ -39,20 +54,31 @@ export default defineConfig({
   },
   projects: [
     {
-      name: 'Features',
+      name: 'pages',
       testDir: './features',
       testMatch: /.*\.spec\.ts/,
       use: {
         browserName: 'chromium',
       },
     },
+    {
+      name: 'global-elements',
+      testDir: './global-elements',
+      testMatch: /.*\.spec\.ts/,
+      timeout: 120_000,
+      fullyParallel: true,
+      workers: IS_CI ? 2 : undefined,
+      use: {
+        browserName: 'chromium',
+      },
+    },
   ],
   reporter: IS_CI
-    ? [['list'], ['html', { open: 'never', outputFolder: './playwright-report' }]]
+    ? [['list'], ['html', { open: 'never', outputFolder: REPORT_FOLDER }]]
     : [
         ['list'],
-        ['html', { open: 'never', outputFolder: './playwright-report' }],
-        ['json', { outputFile: './test-results/test-results.json' }],
+        ['html', { open: 'never', outputFolder: REPORT_FOLDER }],
+        ['json', { outputFile: JSON_REPORT }],
       ],
   outputDir: './test-results',
 })

--- a/e2e/docs/scripts/run-e2e-docs-global-elements.ts
+++ b/e2e/docs/scripts/run-e2e-docs-global-elements.ts
@@ -3,18 +3,14 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { runSuite } from '../../shared/run-suite.ts'
-import { resolveAllDocsPages, resolveDocsScope } from '../utils/resolve-docs-scope.ts'
 
+// Fixed page list, so unlike `pnpm e2e:docs` this resolves nothing from git.
 runSuite({
   root: join(dirname(fileURLToPath(import.meta.url)), '..'),
   label: 'docs',
   devCommand: 'pnpm dev:docs',
-  pagePathsEnv: 'DOCS_E2E_PAGE_PATHS',
-  baseRefEnv: 'DOCS_E2E_BASE_REF',
   defaultBaseUrl: 'http://localhost:3001',
-  project: 'pages',
-  resolveScope: resolveDocsScope,
-  resolveAllPages: resolveAllDocsPages,
+  project: 'global-elements',
 }).catch((error) => {
   console.error(error instanceof Error ? error.message : error)
   process.exit(1)

--- a/e2e/docs/scripts/run-e2e-docs-global-elements.ts
+++ b/e2e/docs/scripts/run-e2e-docs-global-elements.ts
@@ -3,18 +3,15 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { runSuite } from '../../shared/run-suite.ts'
-import { resolveAllDocsPages, resolveDocsScope } from '../utils/resolve-docs-scope.ts'
 
+// Scope is the fixed page list in utils/docs-global-elements.ts, so unlike
+// `pnpm e2e:docs` this resolves nothing from git.
 runSuite({
   root: join(dirname(fileURLToPath(import.meta.url)), '..'),
   label: 'docs',
   devCommand: 'pnpm dev:docs',
-  pagePathsEnv: 'DOCS_E2E_PAGE_PATHS',
-  baseRefEnv: 'DOCS_E2E_BASE_REF',
   defaultBaseUrl: 'http://localhost:3001',
-  project: 'pages',
-  resolveScope: resolveDocsScope,
-  resolveAllPages: resolveAllDocsPages,
+  project: 'global-elements',
 }).catch((error) => {
   console.error(error instanceof Error ? error.message : error)
   process.exit(1)

--- a/e2e/docs/scripts/run-e2e-docs.ts
+++ b/e2e/docs/scripts/run-e2e-docs.ts
@@ -13,6 +13,7 @@ runSuite({
   baseRefEnv: 'DOCS_E2E_BASE_REF',
   defaultBaseUrl: 'http://localhost:3001',
   project: 'pages',
+  allProjects: ['pages', 'global-elements'],
   resolveScope: resolveDocsScope,
   resolveAllPages: resolveAllDocsPages,
 }).catch((error) => {

--- a/e2e/docs/utils/axe-helpers.ts
+++ b/e2e/docs/utils/axe-helpers.ts
@@ -22,6 +22,27 @@ export const EXCLUDED_RULES = [
   'css-orientation-lock',
 ]
 
+// These pass today, so enforcing them only catches a newly introduced violation.
+// They must sit within WCAG_TAGS, since scanExcluding makes one tagged pass.
+export const GLOBAL_ELEMENTS_ENFORCED_RULES = [
+  'aria-allowed-attr',
+  'aria-deprecated-role',
+  'aria-hidden-focus',
+  'aria-roles',
+  'aria-valid-attr',
+  'bypass',
+  'document-title',
+  'html-has-lang',
+  'html-lang-valid',
+  'image-alt',
+  'link-name',
+  'meta-viewport',
+  'nested-interactive',
+]
+
+// `page-has-heading-one` targets the excluded article.
+export const GLOBAL_ELEMENTS_EXCLUDED_RULES = ['page-has-heading-one']
+
 export async function scanArticle(
   page: Page,
   surface: string,

--- a/e2e/docs/utils/axe-helpers.ts
+++ b/e2e/docs/utils/axe-helpers.ts
@@ -22,6 +22,27 @@ export const EXCLUDED_RULES = [
   'css-orientation-lock',
 ]
 
+// Keep this list green: a violation here lands on every docs page. Rules must
+// be within WCAG_TAGS, since scanExcluding makes one tagged pass.
+export const GLOBAL_ELEMENTS_ENFORCED_RULES = [
+  'aria-allowed-attr',
+  'aria-deprecated-role',
+  'aria-hidden-focus',
+  'aria-roles',
+  'aria-valid-attr',
+  'bypass',
+  'document-title',
+  'html-has-lang',
+  'html-lang-valid',
+  'image-alt',
+  'link-name',
+  'meta-viewport',
+  'nested-interactive',
+]
+
+// `page-has-heading-one` targets the excluded article.
+export const GLOBAL_ELEMENTS_EXCLUDED_RULES = ['page-has-heading-one']
+
 export async function scanArticle(
   page: Page,
   surface: string,

--- a/e2e/docs/utils/docs-global-elements.ts
+++ b/e2e/docs/utils/docs-global-elements.ts
@@ -1,0 +1,91 @@
+import type { Page } from '@playwright/test'
+
+import type { ViewportName } from '../../shared/viewports.ts'
+import { GUIDE_ARTICLE_SELECTOR, TROUBLESHOOTING_ARTICLE_SELECTOR } from './docs-links.js'
+
+interface GlobalElementConfig {
+  selector: string
+  label: string
+  // Defaults to both viewports.
+  viewports?: readonly ViewportName[]
+}
+
+const ELEMENT_TABLE = {
+  topNav: { selector: '[data-testid="sb-docs-top-nav"]', label: 'top navigation bar' },
+  sidebarNav: {
+    selector: '[data-testid="sb-docs-sidebar-nav"]',
+    label: 'sidebar navigation',
+    // In the DOM at mobile, but collapsed to `w-0 -left-full`.
+    viewports: ['desktop'],
+  },
+  tocSidebar: {
+    selector: '[data-testid="sb-docs-toc-sidebar"]',
+    label: 'content sidebar',
+    // `hidden md:flex`, so axe skips it below 768px.
+    viewports: ['desktop'],
+  },
+  breadcrumbs: { selector: '[data-testid="sb-docs-breadcrumbs"]', label: 'breadcrumbs' },
+  footer: { selector: '[data-testid="sb-docs-footer"]', label: 'site footer' },
+  menuTrigger: {
+    selector: '[data-testid="sb-docs-mobile-menu-trigger"]',
+    label: 'mobile menu trigger',
+    viewports: ['mobile'],
+  },
+} as const
+
+export type GlobalElement = keyof typeof ELEMENT_TABLE
+
+export const GLOBAL_ELEMENTS: Record<GlobalElement, GlobalElementConfig> = ELEMENT_TABLE
+
+export const MOBILE_MENU_SELECTOR = '[data-testid="sb-docs-mobile-menu"]'
+
+export interface GlobalElementPage {
+  path: string
+  layout: string
+  elements: GlobalElement[]
+}
+
+// A second page on a covered layout would scan the same markup.
+export const GLOBAL_ELEMENT_PAGES: GlobalElementPage[] = [
+  {
+    path: '/docs',
+    layout: 'home',
+    elements: ['topNav', 'menuTrigger', 'footer'],
+  },
+  {
+    path: '/docs/guides/getting-started',
+    layout: 'guides section landing',
+    elements: ['topNav', 'menuTrigger', 'sidebarNav', 'tocSidebar', 'footer'],
+  },
+  {
+    path: '/docs/guides/database/postgres/row-level-security',
+    layout: 'guide with table of contents',
+    elements: ['topNav', 'menuTrigger', 'sidebarNav', 'tocSidebar', 'breadcrumbs', 'footer'],
+  },
+  {
+    path: '/docs/guides/troubleshooting',
+    layout: 'troubleshooting index',
+    elements: ['topNav', 'menuTrigger', 'footer'],
+  },
+  {
+    path: '/docs/guides/troubleshooting/all-about-supabase-egress-a_Sg_e',
+    layout: 'troubleshooting entry',
+    elements: ['topNav', 'menuTrigger', 'breadcrumbs', 'footer'],
+  },
+  {
+    path: '/docs/reference/cli/introduction',
+    layout: 'reference',
+    elements: ['topNav', 'menuTrigger', 'sidebarNav', 'footer'],
+  },
+]
+
+const ARTICLE_SELECTORS = [GUIDE_ARTICLE_SELECTOR, TROUBLESHOOTING_ARTICLE_SELECTOR]
+
+// Excluding a selector that matches nothing would silently widen the scan.
+export async function articleSelectorsOnPage(page: Page): Promise<string[]> {
+  const present: string[] = []
+  for (const selector of ARTICLE_SELECTORS) {
+    if ((await page.locator(selector).count()) > 0) present.push(selector)
+  }
+  return present
+}

--- a/e2e/docs/utils/docs-global-elements.ts
+++ b/e2e/docs/utils/docs-global-elements.ts
@@ -1,0 +1,91 @@
+import type { Page } from '@playwright/test'
+
+import type { ViewportName } from '../../shared/viewports.ts'
+import { GUIDE_ARTICLE_SELECTOR, TROUBLESHOOTING_ARTICLE_SELECTOR } from './docs-links.js'
+
+interface GlobalElementConfig {
+  selector: string
+  label: string
+  // Where the element renders. Defaults to both viewports.
+  viewports?: readonly ViewportName[]
+}
+
+const ELEMENT_TABLE = {
+  topNav: { selector: '[data-testid="sb-docs-top-nav"]', label: 'top navigation bar' },
+  sidebarNav: {
+    selector: '[data-testid="sb-docs-sidebar-nav"]',
+    label: 'sidebar navigation',
+    // In the DOM at mobile, but collapsed to `w-0 -left-full`.
+    viewports: ['desktop'],
+  },
+  tocSidebar: {
+    selector: '[data-testid="sb-docs-toc-sidebar"]',
+    label: 'content sidebar',
+    // `hidden md:flex`, so axe skips it below 768px.
+    viewports: ['desktop'],
+  },
+  breadcrumbs: { selector: '[data-testid="sb-docs-breadcrumbs"]', label: 'breadcrumbs' },
+  footer: { selector: '[data-testid="sb-docs-footer"]', label: 'site footer' },
+  menuTrigger: {
+    selector: '[data-testid="sb-docs-mobile-menu-trigger"]',
+    label: 'mobile menu trigger',
+    viewports: ['mobile'],
+  },
+} as const
+
+export type GlobalElement = keyof typeof ELEMENT_TABLE
+
+export const GLOBAL_ELEMENTS: Record<GlobalElement, GlobalElementConfig> = ELEMENT_TABLE
+
+export const MOBILE_MENU_SELECTOR = '[data-testid="sb-docs-mobile-menu"]'
+
+export interface GlobalElementPage {
+  path: string
+  layout: string
+  elements: GlobalElement[]
+}
+
+// One page per layout. A second page on a covered layout scans the same markup.
+export const GLOBAL_ELEMENT_PAGES: GlobalElementPage[] = [
+  {
+    path: '/docs',
+    layout: 'home',
+    elements: ['topNav', 'menuTrigger', 'footer'],
+  },
+  {
+    path: '/docs/guides/getting-started',
+    layout: 'guides section landing',
+    elements: ['topNav', 'menuTrigger', 'sidebarNav', 'tocSidebar', 'footer'],
+  },
+  {
+    path: '/docs/guides/database/postgres/row-level-security',
+    layout: 'guide with table of contents',
+    elements: ['topNav', 'menuTrigger', 'sidebarNav', 'tocSidebar', 'breadcrumbs', 'footer'],
+  },
+  {
+    path: '/docs/guides/troubleshooting',
+    layout: 'troubleshooting index',
+    elements: ['topNav', 'menuTrigger', 'footer'],
+  },
+  {
+    path: '/docs/guides/troubleshooting/all-about-supabase-egress-a_Sg_e',
+    layout: 'troubleshooting entry',
+    elements: ['topNav', 'menuTrigger', 'breadcrumbs', 'footer'],
+  },
+  {
+    path: '/docs/reference/cli/introduction',
+    layout: 'reference',
+    elements: ['topNav', 'menuTrigger', 'sidebarNav', 'footer'],
+  },
+]
+
+const ARTICLE_SELECTORS = [GUIDE_ARTICLE_SELECTOR, TROUBLESHOOTING_ARTICLE_SELECTOR]
+
+// Excluding a selector that matches nothing would silently widen the scan.
+export async function articleSelectorsOnPage(page: Page): Promise<string[]> {
+  const present: string[] = []
+  for (const selector of ARTICLE_SELECTORS) {
+    if ((await page.locator(selector).count()) > 0) present.push(selector)
+  }
+  return present
+}

--- a/e2e/shared/run-suite.ts
+++ b/e2e/shared/run-suite.ts
@@ -10,6 +10,8 @@ type SuiteBase = {
   devCommand: string
   defaultBaseUrl: string
   project?: string
+  // Projects an `--all` run selects instead of `project`, for a whole-suite report.
+  allProjects?: string[]
 }
 
 type ScopedSuite = {
@@ -108,7 +110,8 @@ export async function runSuite(config: SuiteConfig): Promise<void> {
   }
 
   // First, so an explicit --project on the command line overrides it.
-  const projectArgs = config.project ? [`--project=${config.project}`] : []
+  const selected = (runAll && config.allProjects) || (config.project ? [config.project] : [])
+  const projectArgs = selected.map((project) => `--project=${project}`)
   const env = { ...process.env }
   if (config.pagePathsEnv && pages) env[config.pagePathsEnv] = pages.join(',')
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "e2e:docs": "pnpm --prefix e2e/docs run e2e:docs",
     "e2e:docs:all": "pnpm --prefix e2e/docs run e2e:docs:all",
     "e2e:docs:a11y": "pnpm --prefix e2e/docs run e2e:docs:a11y",
+    "e2e:docs:global-elements": "pnpm --prefix e2e/docs run e2e:docs:global-elements",
     "e2e:docs:ui": "pnpm --prefix e2e/docs run e2e:ui",
     "e2e:docs:local-smoke": "pnpm --prefix e2e/docs run e2e:docs:local-smoke",
     "e2e:www": "pnpm --prefix e2e/www run e2e:www",


### PR DESCRIPTION
Closes DOCS-1284

Stack: #49077 → this → #49078 → #49082 → #49079. Review in that order.

## Problem

The docs a11y scan stops at the article wrapper, so nothing checks the top navigation bar, sidebar navigation, content sidebar, breadcrumbs, or footer. A violation in any of those is on every docs page.

This work existed in #48909, but that branch predates `e2e/shared` and three of its changes had gone stale against `master`.

## Solution

- Add a `global-elements` Playwright project that scans the document with the article excluded, across 6 pages, one per layout, at two viewports, plus one pass with the mobile menu open.
- Rename the existing project to `pages`.
- Trigger it from a `docs_components` paths filter in `docs-e2e.yml`. No new workflow file, and a content-only pull request never runs it.
- Add `data-testid` hooks to the six components it targets. #48909 used `data-test`; `data-testid` is the majority convention in this repo and works with `getByTestId`.
- Dedupe findings across tests, so one broken footer link reports once instead of 13 times.
- Keep the page-level rules the article scan skips, since global elements are where they live. Drop only `page-has-heading-one`, whose target is the excluded article.

Supersedes and closes #48909.

## Manual testing

1. Run the global element scan against the preview. Expect 13 passed.

   ```bash
   PLAYWRIGHT_BASE_URL=https://docs-git-a11y-docs-global-elements-supabase.vercel.app \
     pnpm -C e2e/docs run e2e:docs:global-elements
   ```

2. Run the page suite against the same preview. It reports the `pages` project only and does not pick up global elements.

   ```bash
   DOCS_E2E_PAGE_PATHS=/docs/guides/database/postgres/row-level-security \
     PLAYWRIGHT_BASE_URL=https://docs-git-a11y-docs-global-elements-supabase.vercel.app \
     pnpm -C e2e/docs run e2e:docs
   ```
