### PR TITLE
test(www): scan global elements outside the article

### DIFF
--- a/.github/workflows/www-e2e.yml
+++ b/.github/workflows/www-e2e.yml
@@ -56,9 +56,49 @@ jobs:
               - '.github/workflows/www-e2e.yml'
             www_app:
               - 'apps/www/**'
+            www_components:
+              - 'apps/www/components/**'
+              - 'apps/www/layouts/**'
+              - 'apps/www/app/layout.tsx'
+              - 'apps/www/pages/_app.tsx'
+              - 'apps/www/pages/_document.tsx'
+              - 'e2e/www/**'
+              - 'e2e/shared/**'
+              - 'pnpm-lock.yaml'
+              - '.github/workflows/www-e2e.yml'
+
+      # Separate gates, so a content-only pull request never scans chrome.
+      - name: Decide which suites run
+        id: gate
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          WWW: ${{ steps.changes.outputs.www }}
+          WWW_COMPONENTS: ${{ steps.changes.outputs.www_components }}
+        run: |
+          set -euo pipefail
+
+          pages=false
+          global_elements=false
+          any=false
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            pages=true
+            global_elements=true
+          else
+            if [ "$WWW" = "true" ]; then pages=true; fi
+            if [ "$WWW_COMPONENTS" = "true" ]; then global_elements=true; fi
+          fi
+
+          if [ "$pages" = "true" ] || [ "$global_elements" = "true" ]; then any=true; fi
+
+          {
+            echo "pages=$pages"
+            echo "global_elements=$global_elements"
+            echo "any=$any"
+          } >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.www == 'true'
+        if: steps.gate.outputs.any == 'true'
         with:
           persist-credentials: false
           # String '0' — numeric 0 is falsy in Actions expressions.
@@ -74,14 +114,14 @@ jobs:
             apps/www/_alternatives
 
       - name: Use Node.js
-        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.www == 'true'
+        if: steps.gate.outputs.any == 'true'
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
 
       - name: Resolve www E2E scope
         id: scope
-        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.www == 'true'
+        if: steps.gate.outputs.pages == 'true'
         env:
           EVENT_NAME: ${{ github.event_name }}
           BASE_REF: ${{ github.base_ref }}
@@ -107,13 +147,13 @@ jobs:
         run: echo "No in-scope www pages changed; skipping Playwright suite."
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        if: steps.scope.outputs.skip == 'false'
+        if: steps.gate.outputs.any == 'true'
         name: Install pnpm
         with:
           run_install: false
 
       - name: Enable pnpm store cache
-        if: steps.scope.outputs.skip == 'false'
+        if: steps.gate.outputs.any == 'true'
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
@@ -122,7 +162,7 @@ jobs:
       # Vercel skips the preview when only the harness changed, so wait for one
       # only when apps/www changed. See scripts/waitForVercelPreview.js.
       - name: Wait for Vercel www preview
-        if: steps.scope.outputs.skip == 'false' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && steps.changes.outputs.www_app == 'true'
+        if: steps.gate.outputs.any == 'true' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && steps.changes.outputs.www_app == 'true'
         id: deployment
         continue-on-error: true
         run: node scripts/waitForVercelPreview.js
@@ -134,7 +174,7 @@ jobs:
           VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
 
       - name: Resolve base URL
-        if: steps.scope.outputs.skip == 'false'
+        if: steps.gate.outputs.pages == 'true' && steps.scope.outputs.skip == 'false'
         id: base-url
         env:
           EVENT_NAME: ${{ github.event_name }}
@@ -180,12 +220,56 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
+      # Production already serves the fixed page list, so a run without a preview
+      # still tests the right markup when the pull request ships no markup itself.
+      - name: Resolve global element base URL
+        if: steps.gate.outputs.global_elements == 'true'
+        id: ge-url
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_URL_INPUT: ${{ inputs.base_url }}
+          DEPLOYMENT_URL: ${{ steps.deployment.outputs.deployment-url }}
+          WWW_APP: ${{ steps.changes.outputs.www_app }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            printf 'url=%s\n' "$BASE_URL_INPUT" >> "$GITHUB_OUTPUT"
+            if [ "$BASE_URL_INPUT" = "https://supabase.com" ]; then
+              echo "use_bypass=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "use_bypass=true" >> "$GITHUB_OUTPUT"
+            fi
+            echo "should_test=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ -n "$DEPLOYMENT_URL" ]; then
+            printf 'url=%s\n' "$DEPLOYMENT_URL" >> "$GITHUB_OUTPUT"
+            echo "use_bypass=true" >> "$GITHUB_OUTPUT"
+            echo "should_test=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$WWW_APP" != "true" ]; then
+            echo "url=https://supabase.com" >> "$GITHUB_OUTPUT"
+            echo "use_bypass=false" >> "$GITHUB_OUTPUT"
+            echo "should_test=true" >> "$GITHUB_OUTPUT"
+            echo "No preview, but this pull request changes no www markup, so production is the same surface."
+            exit 0
+          fi
+
+          echo "url=" >> "$GITHUB_OUTPUT"
+          echo "use_bypass=false" >> "$GITHUB_OUTPUT"
+          echo "should_test=false" >> "$GITHUB_OUTPUT"
+          echo "::warning::No Vercel www preview URL for this pull request. Skipping the global element suite rather than scanning production, which does not have the chrome changes this pull request makes."
+
       - name: Install dependencies
-        if: steps.base-url.outputs.should_test == 'true'
+        if: steps.base-url.outputs.should_test == 'true' || steps.ge-url.outputs.should_test == 'true'
         run: pnpm install --frozen-lockfile --filter=e2e-www...
 
       - name: Install Playwright Chromium
-        if: steps.base-url.outputs.should_test == 'true'
+        if: steps.base-url.outputs.should_test == 'true' || steps.ge-url.outputs.should_test == 'true'
         run: pnpm -C e2e/www exec playwright install chromium --with-deps --only-shell
 
       - name: Run www E2E
@@ -197,13 +281,23 @@ jobs:
           WWW_E2E_PAGE_PATHS: ${{ steps.scope.outputs.paths }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ steps.base-url.outputs.use_bypass == 'true' && secrets.VERCEL_AUTOMATION_BYPASS_WWW || '' }}
 
+      - name: Run www global element E2E
+        if: steps.ge-url.outputs.should_test == 'true'
+        working-directory: e2e/www
+        run: pnpm run e2e:www:global-elements
+        env:
+          PLAYWRIGHT_BASE_URL: ${{ steps.ge-url.outputs.url }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ steps.ge-url.outputs.use_bypass == 'true' && secrets.VERCEL_AUTOMATION_BYPASS_WWW || '' }}
+
       - name: Upload Playwright report
         # Findings only reach a reviewer through this artifact, so upload on green too.
-        if: always() && steps.base-url.outputs.should_test == 'true'
+        if: always() && (steps.base-url.outputs.should_test == 'true' || steps.ge-url.outputs.should_test == 'true')
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: www-playwright-report
           path: |
             e2e/www/playwright-report/
             e2e/www/test-results/
+            e2e/www/playwright-report-global-elements/
+            e2e/www/test-results-global-elements/
           retention-days: 7

--- a/.github/workflows/www-e2e.yml
+++ b/.github/workflows/www-e2e.yml
@@ -56,9 +56,50 @@ jobs:
               - '.github/workflows/www-e2e.yml'
             www_app:
               - 'apps/www/**'
+            www_components:
+              - 'apps/www/components/**'
+              - 'apps/www/layouts/**'
+              - 'apps/www/app/layout.tsx'
+              - 'apps/www/pages/_app.tsx'
+              - 'apps/www/pages/_document.tsx'
+              - 'e2e/www/**'
+              - 'e2e/shared/**'
+              - 'pnpm-lock.yaml'
+              - '.github/workflows/www-e2e.yml'
+
+      # Content pages and shared chrome move independently, so each suite gets
+      # its own gate and a content-only pull request never scans chrome.
+      - name: Decide which suites run
+        id: gate
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          WWW: ${{ steps.changes.outputs.www }}
+          WWW_COMPONENTS: ${{ steps.changes.outputs.www_components }}
+        run: |
+          set -euo pipefail
+
+          pages=false
+          global_elements=false
+          any=false
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            pages=true
+            global_elements=true
+          else
+            if [ "$WWW" = "true" ]; then pages=true; fi
+            if [ "$WWW_COMPONENTS" = "true" ]; then global_elements=true; fi
+          fi
+
+          if [ "$pages" = "true" ] || [ "$global_elements" = "true" ]; then any=true; fi
+
+          {
+            echo "pages=$pages"
+            echo "global_elements=$global_elements"
+            echo "any=$any"
+          } >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.www == 'true'
+        if: steps.gate.outputs.any == 'true'
         with:
           persist-credentials: false
           # String '0' — numeric 0 is falsy in Actions expressions.
@@ -74,14 +115,14 @@ jobs:
             apps/www/_alternatives
 
       - name: Use Node.js
-        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.www == 'true'
+        if: steps.gate.outputs.any == 'true'
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
 
       - name: Resolve www E2E scope
         id: scope
-        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.www == 'true'
+        if: steps.gate.outputs.pages == 'true'
         env:
           EVENT_NAME: ${{ github.event_name }}
           BASE_REF: ${{ github.base_ref }}
@@ -107,13 +148,13 @@ jobs:
         run: echo "No in-scope www pages changed; skipping Playwright suite."
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        if: steps.scope.outputs.skip == 'false'
+        if: steps.gate.outputs.any == 'true'
         name: Install pnpm
         with:
           run_install: false
 
       - name: Enable pnpm store cache
-        if: steps.scope.outputs.skip == 'false'
+        if: steps.gate.outputs.any == 'true'
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
@@ -122,7 +163,7 @@ jobs:
       # Vercel skips the preview when only the harness changed, so wait for one
       # only when apps/www changed. See scripts/waitForVercelPreview.js.
       - name: Wait for Vercel www preview
-        if: steps.scope.outputs.skip == 'false' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && steps.changes.outputs.www_app == 'true'
+        if: steps.gate.outputs.any == 'true' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && steps.changes.outputs.www_app == 'true'
         id: deployment
         continue-on-error: true
         run: node scripts/waitForVercelPreview.js
@@ -134,7 +175,7 @@ jobs:
           VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
 
       - name: Resolve base URL
-        if: steps.scope.outputs.skip == 'false'
+        if: steps.gate.outputs.pages == 'true' && steps.scope.outputs.skip == 'false'
         id: base-url
         env:
           EVENT_NAME: ${{ github.event_name }}
@@ -180,12 +221,57 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
+      # The global-element suite scans a fixed page list that production already
+      # serves, so a run without a preview still tests the right markup as long
+      # as the pull request ships none of its own.
+      - name: Resolve global element base URL
+        if: steps.gate.outputs.global_elements == 'true'
+        id: ge-url
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_URL_INPUT: ${{ inputs.base_url }}
+          DEPLOYMENT_URL: ${{ steps.deployment.outputs.deployment-url }}
+          WWW_APP: ${{ steps.changes.outputs.www_app }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            printf 'url=%s\n' "$BASE_URL_INPUT" >> "$GITHUB_OUTPUT"
+            if [ "$BASE_URL_INPUT" = "https://supabase.com" ]; then
+              echo "use_bypass=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "use_bypass=true" >> "$GITHUB_OUTPUT"
+            fi
+            echo "should_test=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ -n "$DEPLOYMENT_URL" ]; then
+            printf 'url=%s\n' "$DEPLOYMENT_URL" >> "$GITHUB_OUTPUT"
+            echo "use_bypass=true" >> "$GITHUB_OUTPUT"
+            echo "should_test=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$WWW_APP" != "true" ]; then
+            echo "url=https://supabase.com" >> "$GITHUB_OUTPUT"
+            echo "use_bypass=false" >> "$GITHUB_OUTPUT"
+            echo "should_test=true" >> "$GITHUB_OUTPUT"
+            echo "No preview, but this pull request changes no www markup, so production is the same surface."
+            exit 0
+          fi
+
+          echo "url=" >> "$GITHUB_OUTPUT"
+          echo "use_bypass=false" >> "$GITHUB_OUTPUT"
+          echo "should_test=false" >> "$GITHUB_OUTPUT"
+          echo "::warning::No Vercel www preview URL for this pull request. Skipping the global element suite rather than scanning production, which does not have the chrome changes this pull request makes."
+
       - name: Install dependencies
-        if: steps.base-url.outputs.should_test == 'true'
+        if: steps.base-url.outputs.should_test == 'true' || steps.ge-url.outputs.should_test == 'true'
         run: pnpm install --frozen-lockfile --filter=e2e-www...
 
       - name: Install Playwright Chromium
-        if: steps.base-url.outputs.should_test == 'true'
+        if: steps.base-url.outputs.should_test == 'true' || steps.ge-url.outputs.should_test == 'true'
         run: pnpm -C e2e/www exec playwright install chromium --with-deps --only-shell
 
       - name: Run www E2E
@@ -197,14 +283,24 @@ jobs:
           WWW_E2E_PAGE_PATHS: ${{ steps.scope.outputs.paths }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ steps.base-url.outputs.use_bypass == 'true' && secrets.VERCEL_AUTOMATION_BYPASS_WWW || '' }}
 
+      - name: Run www global element E2E
+        if: steps.ge-url.outputs.should_test == 'true'
+        working-directory: e2e/www
+        run: pnpm run e2e:www:global-elements
+        env:
+          PLAYWRIGHT_BASE_URL: ${{ steps.ge-url.outputs.url }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ steps.ge-url.outputs.use_bypass == 'true' && secrets.VERCEL_AUTOMATION_BYPASS_WWW || '' }}
+
       - name: Upload Playwright report
         # Warn-mode a11y findings only reach a reviewer through this artifact, so
         # it uploads on green runs too.
-        if: always() && steps.base-url.outputs.should_test == 'true'
+        if: always() && (steps.base-url.outputs.should_test == 'true' || steps.ge-url.outputs.should_test == 'true')
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: www-playwright-report
           path: |
             e2e/www/playwright-report/
             e2e/www/test-results/
+            e2e/www/playwright-report-global-elements/
+            e2e/www/test-results-global-elements/
           retention-days: 7

--- a/apps/www/components/Blog/BlogPostRenderer.tsx
+++ b/apps/www/components/Blog/BlogPostRenderer.tsx
@@ -39,9 +39,9 @@ const NextCard = (props: NextCardProps) => {
             </div>
             <div className="flex flex-col gap-2">
               {'title' in post && (
-                <h4 className="text-foreground text-lg text-balance">
+                <h2 className="text-foreground text-lg text-balance">
                   {(post as { title?: string }).title}
-                </h4>
+                </h2>
               )}
               {'formattedDate' in post && (
                 <p className="small">{(post as { formattedDate?: string }).formattedDate}</p>

--- a/apps/www/components/Footer/index.tsx
+++ b/apps/www/components/Footer/index.tsx
@@ -208,7 +208,7 @@ const Footer = (props: Props) => {
               {footerData.map((segment) => {
                 return (
                   <div key={`footer_${segment.title}`}>
-                    <h6 className="text-foreground overwrite text-base">{segment.title}</h6>
+                    <h3 className="text-foreground overwrite text-base">{segment.title}</h3>
                     <ul className="mt-4 space-y-2">
                       {segment.links.map(({ component: Component, ...link }, idx) => {
                         const children = (

--- a/apps/www/components/Nav/HamburgerMenu.tsx
+++ b/apps/www/components/Nav/HamburgerMenu.tsx
@@ -10,6 +10,7 @@ const HamburgerButton = (props: HamburgerButtonProps) => (
   <div className="inset-y-0 flex items-center lg:hidden" onClick={() => props.toggleFlyOut()}>
     <button
       tabIndex={0}
+      data-testid="sb-www-mobile-menu-trigger"
       className={cn(
         'text-foreground-lighter bg-transparent hover:text-foreground-light hover:bg-overlay inline-flex items-center justify-center rounded-md p-2 focus-ring'
       )}

--- a/apps/www/components/Nav/MobileMenu.tsx
+++ b/apps/www/components/Nav/MobileMenu.tsx
@@ -214,6 +214,7 @@ export const MobileMenu = ({ open, setOpen, menu }: Props) => {
             initial="hidden"
             animate="show"
             exit="exit"
+            data-testid="sb-www-mobile-menu"
             className="bg-overlay fixed overflow-hidden inset-0 z-50 h-screen max-h-screen w-screen supports-[height:100cqh]:h-[100cqh] supports-[height:100svh]:h-svh transform"
           >
             <div className="absolute h-16 px-6 flex items-center justify-between w-screen left-0 top-0 z-50 bg-overlay before:content[''] before:absolute before:w-full before:h-3 before:inset-0 before:top-full before:bg-linear-to-b before:from-background-overlay before:to-transparent">

--- a/apps/www/components/Nav/index.tsx
+++ b/apps/www/components/Nav/index.tsx
@@ -106,6 +106,7 @@ const Nav = ({ hideNavbar, stickyNavbar = true }: Props) => {
           )}
         />
         <nav
+          data-testid="sb-www-nav"
           className={cn(
             `relative z-40 border-default border-b backdrop-blur-xs transition-all duration-300`,
             showLaunchWeekNavMode && 'border-muted border-b bg-transparent',

--- a/apps/www/layouts/comparison.tsx
+++ b/apps/www/layouts/comparison.tsx
@@ -42,7 +42,7 @@ const LayoutComparison = ({ components, props }: Props) => {
                 <p className="text-muted text-sm">{label}</p>
               </div>
               <div>
-                <h4 className="text-foreground text-lg">{post.title}</h4>
+                <h2 className="text-foreground text-lg">{post.title}</h2>
                 <p className="small">{post.date}</p>
               </div>
             </div>

--- a/apps/www/pages/events/[slug].tsx
+++ b/apps/www/pages/events/[slug].tsx
@@ -386,7 +386,7 @@ const EventPage = ({ event }: InferGetStaticPropsType<typeof getStaticProps>) =>
                 </Link>
               </div>
             )}
-            <main
+            <div
               id="sb-www-event-main-article"
               data-testid="sb-www-event-main-article"
               className="lg:col-span-2"
@@ -397,7 +397,7 @@ const EventPage = ({ event }: InferGetStaticPropsType<typeof getStaticProps>) =>
                 </h2>
                 <MDXClient {...content} components={mdxComponents()} />
               </div>
-              <aside className="mt-8">
+              <aside aria-label="Registration" className="mt-8">
                 <Button
                   variant="primary"
                   size="medium"
@@ -420,8 +420,8 @@ const EventPage = ({ event }: InferGetStaticPropsType<typeof getStaticProps>) =>
                   </Link>
                 </Button>
               </aside>
-            </main>
-            <aside className="order-first lg:order-last">
+            </div>
+            <aside aria-label="Event details" className="order-first lg:order-last">
               {partnersArray && partnersArray.length > 0 && (
                 <div className="flex flex-col gap-4 mb-8">
                   <h2 className="text-foreground-light text-sm font-mono uppercase">Partners</h2>

--- a/e2e/www/.gitignore
+++ b/e2e/www/.gitignore
@@ -1,5 +1,7 @@
 node_modules/
 /test-results/
+/test-results-global-elements/
 /playwright-report/
+/playwright-report-global-elements/
 /blob-report/
 /playwright/.cache/

--- a/e2e/www/README.md
+++ b/e2e/www/README.md
@@ -5,7 +5,7 @@ site content pages.
 
 Use this suite when you change blog posts, events, customer stories, or
 alternatives pages under `apps/www`. It loads each in-scope page, checks that it
-returns a successful status, and scans it for a single accessibility rule.
+returns a successful status, and scans it for accessibility violations.
 
 This page covers:
 
@@ -15,6 +15,8 @@ This page covers:
 - [Override which pages run](#override-which-pages-run) — when the default git
   scope is wrong
 - [What the suite covers](#what-the-suite-covers) — in-scope paths and limits
+- [Accessibility scans](#accessibility-scans) — WCAG coverage and warn mode
+- [Global element scans](#global-element-scans) — nav, footer, and page scaffolding
 - [Debug failures](#debug-failures) — reports and traces
 - [How CI uses this suite](#how-ci-uses-this-suite) — pull request behavior
 
@@ -124,9 +126,13 @@ enforcing it would fail every alternatives pull request.
 
 - Events with `disable_page_build: true`, which return a 404 by design
 - Static marketing routes under `apps/www/pages` and `apps/www/app`
-- Index and listing pages such as `/blog` and `/customers`
+- Index and listing pages such as `/blog` and `/customers`, for the page suite.
+  The global-element suite covers them.
 - Link checking
-- Shared chrome: header, footer, and anything else outside the article wrapper
+
+Shared chrome — the nav, the footer, and everything else outside the article
+wrapper — belongs to the global-element suite described in
+[Global element scans](#global-element-scans).
 
 ### Limits
 
@@ -156,6 +162,34 @@ added.
 **Configuration:** article selectors per template live in `utils/www-selectors.ts`,
 rule lists in `utils/axe-helpers.ts`.
 
+## Global element scans
+
+Global elements are everything outside the article: the nav, the footer, and the rest
+of the page scaffolding.
+
+```bash
+PLAYWRIGHT_BASE_URL=https://supabase.com pnpm e2e:www:global-elements
+```
+
+**Why this is a separate suite:**
+
+- **Attribution.** Global markup renders on every page. Scanning it alongside changed
+  content would report the footer's heading skip on a pull request that only edited an
+  `.mdx` file. That skip is on nearly every www page.
+- **Scope.** These elements don't vary by page, so the scope is a fixed list of one page
+  per layout rather than the changed-files scope the page scan uses. Each element is
+  scanned once instead of once per changed page.
+
+The two suites are separate Playwright projects, so a content pull request never runs
+this one. Its report lands in `playwright-report-global-elements/`.
+
+**Point it at your preview, not production,** when you change global elements. The
+`data-testid` hooks it looks for only exist on branches that carry them.
+
+**Configuration:** the page list, the element list, and which elements to expect at
+each viewport live in `utils/www-global-elements.ts`. Rule lists are in
+`utils/axe-helpers.ts`.
+
 ## Debug failures
 
 1. Open the HTML report after a run:
@@ -164,12 +198,18 @@ rule lists in `utils/axe-helpers.ts`.
    pnpm -C e2e/www exec playwright show-report
    ```
 
-2. Inspect traces and screenshots under `test-results/` for failed runs.
+2. Inspect traces and screenshots under `test-results/` for failed runs. The
+   global-element suite writes to `test-results-global-elements/` and
+   `playwright-report-global-elements/` instead, so the two runs never overwrite
+   each other's output.
 
 ## How CI uses this suite
 
-The workflow at `.github/workflows/www-e2e.yml` runs on pull requests that touch
-owned www content, `e2e/www`, or `e2e/shared`.
+The workflow at `.github/workflows/www-e2e.yml` runs both suites in one job, each
+behind its own paths filter.
+
+The page suite runs on pull requests that touch owned www content, `e2e/www`, or
+`e2e/shared`.
 
 1. Diff the pull request against its base branch and resolve in-scope page paths.
 2. Skip Playwright when nothing in scope changed.
@@ -178,9 +218,20 @@ owned www content, `e2e/www`, or `e2e/shared`.
    than test against production, which does not have pages the pull request adds.
 4. Run the suite with `WWW_E2E_PAGE_PATHS` set to the resolved list.
 
+The global-element suite runs on pull requests that touch `apps/www/components`,
+`apps/www/layouts`, the app shell, or the harness. A content-only pull request
+never reaches it.
+
+1. Reuse the same preview when one resolved.
+2. Fall back to production when no preview resolved and the pull request changes
+   no `apps/www` files. A harness-only change ships no markup, so production is
+   the same surface.
+3. Skip when no preview resolved and the pull request does change `apps/www`,
+   because production would not have those chrome changes.
+
 Draft pull requests stay skipped until you mark them ready for review. Manual
-`workflow_dispatch` runs require a `page_paths` input and accept an optional
-`base_url`, which defaults to production.
+`workflow_dispatch` runs accept an optional `base_url`, which defaults to
+production, and require a `page_paths` input for the page suite only.
 
 ## Shared helpers
 

--- a/e2e/www/README.md
+++ b/e2e/www/README.md
@@ -125,9 +125,13 @@ alternatives pull request. It stays in `EXTRA_REPORTED_RULES` until that is fixe
 
 - Events with `disable_page_build: true`, which return a 404 by design
 - Static marketing routes under `apps/www/pages` and `apps/www/app`
-- Index and listing pages such as `/blog` and `/customers`
+- Index and listing pages such as `/blog` and `/customers`, for the page suite.
+  The global-element suite covers them.
 - Link checking
-- Shared chrome: header, footer, and anything else outside the article wrapper
+
+Shared chrome — the nav, the footer, and everything else outside the article
+wrapper — belongs to the global-element suite described in
+[Scan global elements](#scan-global-elements).
 
 ### Limits
 
@@ -174,8 +178,60 @@ Event articles are short enough that a scan can fall under the 20-element floor 
 warn that a clean result proves nothing. That reflects the template, not a broken
 run.
 
-Not covered: shared chrome, listing pages, and most of WCAG. Keyboard navigation,
-focus management, and screen reader behavior need manual testing.
+Not covered by the page scan: shared chrome, listing pages, and most of WCAG.
+Keyboard navigation, focus management, and screen reader behavior need manual
+testing.
+
+### Scan global elements
+
+The page scan stops at the article wrapper. The global-element suite covers the
+other half — the nav, the footer, and the rest of the page scaffolding:
+
+```bash
+PLAYWRIGHT_BASE_URL=https://supabase.com pnpm e2e:www:global-elements
+```
+
+It scans a fixed list of eight pages, one per layout, at both a 1280x800 desktop
+and a 390x844 mobile viewport, plus one pass with the mobile menu open. The list
+lives in `utils/www-global-elements.ts` and resolves nothing from your git diff,
+so the same chrome gets scanned no matter what you changed.
+
+Each scan covers the document with that page's article wrapper excluded. Listing
+pages and `/` render no article, so they declare `articleSelector: null` rather
+than excluding a selector that matches nothing — excluding nothing would
+silently widen the scan back to the whole page.
+
+Chrome ships on every page, so the enforced set is stricter here than for
+content. `GLOBAL_ELEMENTS_ENFORCED_RULES` holds the WCAG 2.1 A/AA rules that
+apply to every page in the list and pass today; a failure there is a regression
+in markup every visitor sees. Rules that apply to only some pages, and rules
+with findings today, stay reported.
+
+This inverts the page scan's exclusions. `document-title`, `html-has-lang`,
+`html-lang-valid`, and `meta-viewport` are unreachable from an article-scoped
+scan and become enforceable here. `color-contrast` is reachable too, and it is
+about three quarters of axe's runtime — worth paying, because this is the only
+suite that checks www contrast at all.
+
+`GLOBAL_ELEMENTS_EXTRA_REPORTED_RULES` holds `heading-order` and
+`landmark-unique`. Both are axe best-practice rules rather than WCAG, so they
+need a pass of their own, and both are reported and never blocking:
+
+- The footer's `h6` headings sit under a screen-reader-only `h2`, which is a
+  `heading-order` skip on every www page. Enforcing it would fail nearly every
+  content pull request.
+- The event template nests a `<main>` inside the layout's `<main id="main">`,
+  which `landmark-unique` reports on every event page.
+
+`dedupeViolations` collapses repeats, so a finding in shared chrome reports once
+per worker instead of once per page per viewport.
+
+Element presence is asserted softly, so a missing nav still reports its scan
+instead of hiding it behind a hard failure.
+
+Point this suite at your pull request's preview, not production, whenever you
+change chrome — the `data-testid` hooks it looks for only exist on branches that
+carry them.
 
 ## Debug failures
 

--- a/e2e/www/README.md
+++ b/e2e/www/README.md
@@ -241,12 +241,18 @@ carry them.
    pnpm -C e2e/www exec playwright show-report
    ```
 
-2. Inspect traces and screenshots under `test-results/` for failed runs.
+2. Inspect traces and screenshots under `test-results/` for failed runs. The
+   global-element suite writes to `test-results-global-elements/` and
+   `playwright-report-global-elements/` instead, so the two runs never overwrite
+   each other's output.
 
 ## How CI uses this suite
 
-The workflow at `.github/workflows/www-e2e.yml` runs on pull requests that touch
-owned www content, `e2e/www`, or `e2e/shared`.
+The workflow at `.github/workflows/www-e2e.yml` runs both suites in one job, each
+behind its own paths filter.
+
+The page suite runs on pull requests that touch owned www content, `e2e/www`, or
+`e2e/shared`.
 
 1. Diff the pull request against its base branch and resolve in-scope page paths.
 2. Skip Playwright when nothing in scope changed.
@@ -255,9 +261,20 @@ owned www content, `e2e/www`, or `e2e/shared`.
    than test against production, which does not have pages the pull request adds.
 4. Run the suite with `WWW_E2E_PAGE_PATHS` set to the resolved list.
 
+The global-element suite runs on pull requests that touch `apps/www/components`,
+`apps/www/layouts`, the app shell, or the harness. A content-only pull request
+never reaches it.
+
+1. Reuse the same preview when one resolved.
+2. Fall back to production when no preview resolved and the pull request changes
+   no `apps/www` files. A harness-only change ships no markup, so production is
+   the same surface.
+3. Skip when no preview resolved and the pull request does change `apps/www`,
+   because production would not have those chrome changes.
+
 Draft pull requests stay skipped until you mark them ready for review. Manual
-`workflow_dispatch` runs require a `page_paths` input and accept an optional
-`base_url`, which defaults to production.
+`workflow_dispatch` runs accept an optional `base_url`, which defaults to
+production, and require a `page_paths` input for the page suite only.
 
 ## Shared helpers
 

--- a/e2e/www/README.md
+++ b/e2e/www/README.md
@@ -215,7 +215,11 @@ suite that checks www contrast at all.
 
 `GLOBAL_ELEMENTS_EXTRA_REPORTED_RULES` holds `heading-order` and
 `landmark-unique`. Both are axe best-practice rules rather than WCAG, so they
-need a pass of their own, and both are reported and never blocking:
+need a pass of their own. That pass keeps the article in, because heading order
+and landmark uniqueness are properties of the whole document. Scoping it would
+hide the event template's nested `<main>`, which is the article wrapper itself.
+
+Both rules are reported and never blocking:
 
 - The footer's `h6` headings sit under a screen-reader-only `h2`, which is a
   `heading-order` skip on every www page. Enforcing it would fail nearly every

--- a/e2e/www/global-elements/www-global-elements.spec.ts
+++ b/e2e/www/global-elements/www-global-elements.spec.ts
@@ -1,0 +1,173 @@
+import { expect, test, type Page, type TestInfo } from '@playwright/test'
+
+import { renderedLocator, VIEWPORTS, type ViewportName } from '../../shared/viewports.ts'
+import {
+  annotate,
+  attachScanReport,
+  blockingGlobalElementViolations,
+  dedupeViolations,
+  formatViolations,
+  GLOBAL_ELEMENTS_ENFORCED_RULES,
+  scanGlobalElements,
+  scanLooksEmpty,
+  settleForAxe,
+  shouldEnforceAll,
+  unloadedGlobalElementsResult,
+} from '../utils/axe-helpers.ts'
+import {
+  GLOBAL_ELEMENT_PAGES,
+  GLOBAL_ELEMENTS,
+  globalElementsForViewport,
+  MOBILE_MENU_SELECTOR,
+  type GlobalElement,
+} from '../utils/www-global-elements.ts'
+
+// One footer finding would otherwise report once per page per viewport.
+const seenFindings = new Set<string>()
+
+async function load(
+  page: Page,
+  testInfo: TestInfo,
+  path: string,
+  surface: string
+): Promise<number | null> {
+  let response
+  try {
+    response = await page.goto(path)
+  } catch (error) {
+    await attachScanReport(testInfo, unloadedGlobalElementsResult(surface, path, null))
+    throw error
+  }
+
+  const status = response?.status() ?? null
+
+  if (!response?.ok()) {
+    await attachScanReport(testInfo, unloadedGlobalElementsResult(surface, page.url(), status))
+    expect(response?.ok(), `Expected a successful response for ${path}, got ${status}`).toBeTruthy()
+  }
+
+  return status
+}
+
+async function assertElementsRender(
+  page: Page,
+  surface: string,
+  elements: readonly GlobalElement[],
+  viewport: ViewportName
+): Promise<void> {
+  // Visible, not attached: axe skips hidden subtrees.
+  // Soft, so a missing element still reports its scan.
+  for (const { selector, label } of globalElementsForViewport(elements, viewport)) {
+    await expect
+      .soft(renderedLocator(page, selector), `${surface} should render the ${label} (${selector})`)
+      .toBeVisible()
+  }
+}
+
+async function scanAndAssert(
+  page: Page,
+  testInfo: TestInfo,
+  surface: string,
+  status: number | null,
+  exclude: string[]
+): Promise<void> {
+  const result = await scanGlobalElements(page, surface, exclude)
+  result.status = status
+  result.violations = dedupeViolations(result.violations, seenFindings)
+
+  await attachScanReport(testInfo, result)
+
+  if (scanLooksEmpty(result)) {
+    annotate(
+      testInfo,
+      `${surface} scanned only ${result.elementCount} element(s) outside the article, so a clean ` +
+        'result here proves nothing. Most likely the page had not finished rendering.'
+    )
+  }
+
+  const blocking = blockingGlobalElementViolations(result)
+
+  const reported = result.violations.filter((violation) => !blocking.includes(violation))
+  if (reported.length) {
+    annotate(
+      testInfo,
+      `${surface} has ${reported.length} non-blocking accessibility finding(s) outside the ` +
+        `article: ${reported.map((v) => `${v.id} (${v.nodes.length})`).join(', ')}`
+    )
+  }
+
+  const enforced = shouldEnforceAll()
+    ? 'all WCAG 2.1 A/AA rules'
+    : GLOBAL_ELEMENTS_ENFORCED_RULES.join(', ')
+
+  expect(
+    blocking.map((violation) => violation.id).sort(),
+    `${surface} has blocking a11y violations outside the article (${enforced}):\n` +
+      formatViolations(blocking)
+  ).toEqual([])
+}
+
+test.describe('WWW global elements', () => {
+  for (const { path, layout, elements, articleSelector } of GLOBAL_ELEMENT_PAGES) {
+    for (const viewport of Object.keys(VIEWPORTS) as ViewportName[]) {
+      const surface = `${path} at ${viewport}`
+
+      test(`${surface} (${layout}) has no blocking accessibility violations outside the article @global-elements`, async ({
+        page,
+      }, testInfo) => {
+        await page.setViewportSize(VIEWPORTS[viewport])
+
+        const status = await load(page, testInfo, path, surface)
+
+        await settleForAxe(page)
+
+        if (articleSelector) {
+          await expect
+            .soft(
+              page.locator(articleSelector),
+              `${surface} should render the article wrapper (${articleSelector}). Without it the ` +
+                'scan widens into content the page suite already covers.'
+            )
+            .toBeAttached()
+        }
+
+        await assertElementsRender(page, surface, elements, viewport)
+
+        await scanAndAssert(
+          page,
+          testInfo,
+          surface,
+          status,
+          articleSelector ? [articleSelector] : []
+        )
+      })
+    }
+  }
+
+  // Same overlay on every page, and its markup only exists once opened.
+  test('the mobile menu overlay has no blocking accessibility violations @global-elements', async ({
+    page,
+  }, testInfo) => {
+    const path = '/'
+    const surface = '/ with the mobile menu open'
+
+    await page.setViewportSize(VIEWPORTS.mobile)
+
+    const status = await load(page, testInfo, path, surface)
+
+    const trigger = renderedLocator(page, GLOBAL_ELEMENTS.menuTrigger.selector)
+    await expect.soft(trigger, `${surface} should render the mobile menu trigger`).toBeVisible()
+
+    // Clicking a trigger that never rendered burns the timeout and reports nothing.
+    if (await trigger.count()) {
+      await trigger.click()
+      await expect
+        .soft(page.locator(MOBILE_MENU_SELECTOR), `${surface} should open the mobile menu overlay`)
+        .toBeVisible()
+    }
+
+    await settleForAxe(page)
+
+    await scanAndAssert(page, testInfo, surface, status, [])
+  })
+})

--- a/e2e/www/global-elements/www-global-elements.spec.ts
+++ b/e2e/www/global-elements/www-global-elements.spec.ts
@@ -1,0 +1,176 @@
+import { expect, test, type Page, type TestInfo } from '@playwright/test'
+
+import { renderedLocator, VIEWPORTS, type ViewportName } from '../../shared/viewports.ts'
+import {
+  annotate,
+  attachScanReport,
+  blockingGlobalElementViolations,
+  dedupeViolations,
+  formatViolations,
+  GLOBAL_ELEMENTS_ENFORCED_RULES,
+  scanGlobalElements,
+  scanLooksEmpty,
+  settleForAxe,
+  shouldEnforceAll,
+  unloadedGlobalElementsResult,
+} from '../utils/axe-helpers.ts'
+import {
+  GLOBAL_ELEMENT_PAGES,
+  GLOBAL_ELEMENTS,
+  globalElementsForViewport,
+  MOBILE_MENU_SELECTOR,
+  type GlobalElement,
+} from '../utils/www-global-elements.ts'
+
+// The same chrome renders on every page, so one footer finding would otherwise
+// report once per page per viewport. Module scope, so it outlives each test.
+const seenFindings = new Set<string>()
+
+async function load(
+  page: Page,
+  testInfo: TestInfo,
+  path: string,
+  surface: string
+): Promise<number | null> {
+  let response
+  try {
+    response = await page.goto(path)
+  } catch (error) {
+    await attachScanReport(testInfo, unloadedGlobalElementsResult(surface, path, null))
+    throw error
+  }
+
+  const status = response?.status() ?? null
+
+  if (!response?.ok()) {
+    await attachScanReport(testInfo, unloadedGlobalElementsResult(surface, page.url(), status))
+    expect(response?.ok(), `Expected a successful response for ${path}, got ${status}`).toBeTruthy()
+  }
+
+  return status
+}
+
+async function assertElementsRender(
+  page: Page,
+  surface: string,
+  elements: readonly GlobalElement[],
+  viewport: ViewportName
+): Promise<void> {
+  // Visible, not attached: axe skips hidden subtrees, so scanning an
+  // attached-but-invisible copy would pass while scanning nothing. Soft, so a
+  // missing element still reports its scan.
+  for (const { selector, label } of globalElementsForViewport(elements, viewport)) {
+    await expect
+      .soft(renderedLocator(page, selector), `${surface} should render the ${label} (${selector})`)
+      .toBeVisible()
+  }
+}
+
+async function scanAndAssert(
+  page: Page,
+  testInfo: TestInfo,
+  surface: string,
+  status: number | null,
+  exclude: string[]
+): Promise<void> {
+  const result = await scanGlobalElements(page, surface, exclude)
+  result.status = status
+  result.violations = dedupeViolations(result.violations, seenFindings)
+
+  await attachScanReport(testInfo, result)
+
+  if (scanLooksEmpty(result)) {
+    annotate(
+      testInfo,
+      `${surface} scanned only ${result.elementCount} element(s) outside the article, so a clean ` +
+        'result here proves nothing. Most likely the page had not finished rendering.'
+    )
+  }
+
+  const blocking = blockingGlobalElementViolations(result)
+
+  const reported = result.violations.filter((violation) => !blocking.includes(violation))
+  if (reported.length) {
+    annotate(
+      testInfo,
+      `${surface} has ${reported.length} non-blocking accessibility finding(s) outside the ` +
+        `article: ${reported.map((v) => `${v.id} (${v.nodes.length})`).join(', ')}`
+    )
+  }
+
+  const enforced = shouldEnforceAll()
+    ? 'all WCAG 2.1 A/AA rules'
+    : GLOBAL_ELEMENTS_ENFORCED_RULES.join(', ')
+
+  expect(
+    blocking.map((violation) => violation.id).sort(),
+    `${surface} has blocking a11y violations outside the article (${enforced}):\n` +
+      formatViolations(blocking)
+  ).toEqual([])
+}
+
+test.describe('WWW global elements', () => {
+  for (const { path, layout, elements, articleSelector } of GLOBAL_ELEMENT_PAGES) {
+    for (const viewport of Object.keys(VIEWPORTS) as ViewportName[]) {
+      const surface = `${path} at ${viewport}`
+
+      test(`${surface} (${layout}) has no blocking accessibility violations outside the article @global-elements`, async ({
+        page,
+      }, testInfo) => {
+        await page.setViewportSize(VIEWPORTS[viewport])
+
+        const status = await load(page, testInfo, path, surface)
+
+        await settleForAxe(page)
+
+        if (articleSelector) {
+          await expect
+            .soft(
+              page.locator(articleSelector),
+              `${surface} should render the article wrapper (${articleSelector}). Without it the ` +
+                'scan widens into content the page suite already covers.'
+            )
+            .toBeAttached()
+        }
+
+        await assertElementsRender(page, surface, elements, viewport)
+
+        await scanAndAssert(
+          page,
+          testInfo,
+          surface,
+          status,
+          articleSelector ? [articleSelector] : []
+        )
+      })
+    }
+  }
+
+  // Same overlay on every page, and its markup only exists once opened.
+  test('the mobile menu overlay has no blocking accessibility violations @global-elements', async ({
+    page,
+  }, testInfo) => {
+    const path = '/'
+    const surface = '/ with the mobile menu open'
+
+    await page.setViewportSize(VIEWPORTS.mobile)
+
+    const status = await load(page, testInfo, path, surface)
+
+    const trigger = renderedLocator(page, GLOBAL_ELEMENTS.menuTrigger.selector)
+    await expect.soft(trigger, `${surface} should render the mobile menu trigger`).toBeVisible()
+
+    // Clicking a trigger that never rendered would burn the whole test timeout
+    // and report nothing, so scan the page as it stands instead.
+    if (await trigger.count()) {
+      await trigger.click()
+      await expect
+        .soft(page.locator(MOBILE_MENU_SELECTOR), `${surface} should open the mobile menu overlay`)
+        .toBeVisible()
+    }
+
+    await settleForAxe(page)
+
+    await scanAndAssert(page, testInfo, surface, status, [])
+  })
+})

--- a/e2e/www/package.json
+++ b/e2e/www/package.json
@@ -7,6 +7,7 @@
     "e2e:www": "node --experimental-strip-types scripts/run-e2e-www.ts",
     "e2e:www:all": "node --experimental-strip-types scripts/run-e2e-www.ts --all",
     "e2e:www:a11y": "node --experimental-strip-types scripts/run-e2e-www.ts --grep @a11y",
+    "e2e:www:global-elements": "node --experimental-strip-types scripts/run-e2e-www-global-elements.ts",
     "resolve-www-scope": "node --experimental-strip-types scripts/resolve-www-scope.ts"
   },
   "dependencies": {

--- a/e2e/www/playwright.config.ts
+++ b/e2e/www/playwright.config.ts
@@ -10,16 +10,29 @@ const BYPASS_SECRET = isSupabaseHost(BASE_URL)
   ? process.env.VERCEL_AUTOMATION_BYPASS_SECRET
   : undefined
 
+// `maxFailures` and `reporter` are whole-run options, so the selected project has
+// to be read from argv. Every entry point passes `--project=`.
+const PROJECT = process.argv.find((arg) => arg.startsWith('--project='))?.slice('--project='.length)
+
+const IS_GLOBAL_ELEMENTS = PROJECT === 'global-elements'
+
+const REPORT_DIR = IS_GLOBAL_ELEMENTS
+  ? './playwright-report-global-elements'
+  : './playwright-report'
+
 export default defineConfig({
   testDir: './features',
   testMatch: /.*\.spec\.ts/,
   timeout: 60_000,
   forbidOnly: IS_CI,
   retries: IS_CI ? 2 : 0,
-  maxFailures: 3,
+  // One bad page must not hide the rest of the chrome.
+  maxFailures: IS_GLOBAL_ELEMENTS ? 0 : 3,
   expect: { timeout: 15_000 },
   fullyParallel: true,
-  workers: 1,
+  // Parallel navigations time out against production once the page suite resolves
+  // hundreds of pages. The global-element suite is a fixed 17 tests.
+  workers: IS_GLOBAL_ELEMENTS ? 4 : 1,
   use: {
     baseURL: BASE_URL,
     browserName: 'chromium',
@@ -39,8 +52,17 @@ export default defineConfig({
       name: 'pages',
       testDir: './features',
       testMatch: /.*\.spec\.ts/,
+      outputDir: './test-results',
+    },
+    {
+      name: 'global-elements',
+      testDir: './global-elements',
+      testMatch: /.*\.spec\.ts/,
+      timeout: 120_000,
+      fullyParallel: true,
+      outputDir: './test-results-global-elements',
     },
   ],
-  reporter: [['list'], ['html', { open: 'never', outputFolder: './playwright-report' }]],
+  reporter: [['list'], ['html', { open: 'never', outputFolder: REPORT_DIR }]],
   outputDir: './test-results',
 })

--- a/e2e/www/playwright.config.ts
+++ b/e2e/www/playwright.config.ts
@@ -10,16 +10,31 @@ const BYPASS_SECRET = isSupabaseHost(BASE_URL)
   ? process.env.VERCEL_AUTOMATION_BYPASS_SECRET
   : undefined
 
+// `maxFailures` and `reporter` are whole-run options, so the two suites can only
+// differ on them by reading the project off the command line. Every entry point
+// passes `--project=`.
+const PROJECT = process.argv.find((arg) => arg.startsWith('--project='))?.slice('--project='.length)
+
+const IS_GLOBAL_ELEMENTS = PROJECT === 'global-elements'
+
+const REPORT_DIR = IS_GLOBAL_ELEMENTS
+  ? './playwright-report-global-elements'
+  : './playwright-report'
+
 export default defineConfig({
   testDir: './features',
   testMatch: /.*\.spec\.ts/,
   timeout: 60_000,
   forbidOnly: IS_CI,
   retries: IS_CI ? 2 : 0,
-  maxFailures: 3,
+  // The global-element suite runs a fixed page list, so one bad page must not
+  // cut the run short and hide the rest of the chrome.
+  maxFailures: IS_GLOBAL_ELEMENTS ? 0 : 3,
   expect: { timeout: 15_000 },
   fullyParallel: true,
-  workers: 1,
+  // The page suite can resolve hundreds of pages, where parallel navigations
+  // against production time out. The global-element suite is a fixed 17 tests.
+  workers: IS_GLOBAL_ELEMENTS ? 4 : 1,
   use: {
     baseURL: BASE_URL,
     browserName: 'chromium',
@@ -39,8 +54,17 @@ export default defineConfig({
       name: 'pages',
       testDir: './features',
       testMatch: /.*\.spec\.ts/,
+      outputDir: './test-results',
+    },
+    {
+      name: 'global-elements',
+      testDir: './global-elements',
+      testMatch: /.*\.spec\.ts/,
+      timeout: 120_000,
+      fullyParallel: true,
+      outputDir: './test-results-global-elements',
     },
   ],
-  reporter: [['list'], ['html', { open: 'never', outputFolder: './playwright-report' }]],
+  reporter: [['list'], ['html', { open: 'never', outputFolder: REPORT_DIR }]],
   outputDir: './test-results',
 })

--- a/e2e/www/scripts/run-e2e-www-global-elements.ts
+++ b/e2e/www/scripts/run-e2e-www-global-elements.ts
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { runSuite } from '../../shared/run-suite.ts'
+
+// A fixed page list, so nothing is resolved from the git diff.
+runSuite({
+  root: join(dirname(fileURLToPath(import.meta.url)), '..'),
+  label: 'www global elements',
+  devCommand: 'pnpm dev:www',
+  defaultBaseUrl: 'http://localhost:3000',
+  project: 'global-elements',
+}).catch((error) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exit(1)
+})

--- a/e2e/www/utils/axe-helpers.ts
+++ b/e2e/www/utils/axe-helpers.ts
@@ -51,6 +51,8 @@ export async function scanArticle(
 // introduced violation. `document-title`, `html-has-lang`, `html-lang-valid`, and
 // `meta-viewport` are unreachable from an article-scoped scan.
 export const GLOBAL_ELEMENTS_ENFORCED_RULES = [
+  'heading-order',
+  'landmark-unique',
   'aria-allowed-attr',
   'aria-conditional-attr',
   'aria-deprecated-role',
@@ -75,11 +77,10 @@ export const GLOBAL_ELEMENTS_ENFORCED_RULES = [
   'svg-img-alt',
 ]
 
-// Best practice rather than WCAG, so the tag sweep never runs them. Both fire
-// today: `heading-order` on the footer `h6` under a screen-reader-only `h2`, on
-// every page, and `landmark-unique` on the event template's nested `<main>` and
-// its `<aside>`.
-export const GLOBAL_ELEMENTS_EXTRA_REPORTED_RULES = ['heading-order', 'landmark-unique']
+// Best practice rather than WCAG, so the tag sweep never runs them. They need
+// their own pass, and they appear in the enforced set above to reach the
+// blocking filter.
+export const GLOBAL_ELEMENTS_BEST_PRACTICE_RULES = ['heading-order', 'landmark-unique']
 
 // `color-contrast` and the `<html>`-level rules are only reachable once the scan
 // covers the document, so nothing is excluded here.
@@ -98,7 +99,7 @@ export async function scanGlobalElements(
 
   // Both are properties of the whole document, so this pass keeps the article in.
   // Excluding it would hide the event template's nested `<main>`.
-  const extra = await scan(page, { rules: GLOBAL_ELEMENTS_EXTRA_REPORTED_RULES })
+  const extra = await scan(page, { rules: GLOBAL_ELEMENTS_BEST_PRACTICE_RULES })
   const byRule = new Map(
     [...result.violations, ...extra].map((violation) => [violation.id, violation])
   )

--- a/e2e/www/utils/axe-helpers.ts
+++ b/e2e/www/utils/axe-helpers.ts
@@ -75,8 +75,10 @@ export const GLOBAL_ELEMENTS_ENFORCED_RULES = [
   'svg-img-alt',
 ]
 
-// Best practice rather than WCAG, so these need their own pass. Reported only:
-// the footer `h6` under the screen-reader-only `h2` is on nearly every page.
+// Best practice rather than WCAG, so the tag sweep never runs them. Both fire
+// today: `heading-order` on the footer `h6` under a screen-reader-only `h2`, on
+// every page, and `landmark-unique` on the event template's nested `<main>` and
+// its `<aside>`.
 export const GLOBAL_ELEMENTS_EXTRA_REPORTED_RULES = ['heading-order', 'landmark-unique']
 
 // `color-contrast` and the `<html>`-level rules are only reachable once the scan

--- a/e2e/www/utils/axe-helpers.ts
+++ b/e2e/www/utils/axe-helpers.ts
@@ -3,6 +3,7 @@ import type { Result } from 'axe-core'
 
 import {
   blockingViolations as blockingViolationsFor,
+  scanExcluding,
   scanRegion,
   unloadedResult as unloadedResultFor,
   type A11yScanResult,
@@ -46,6 +47,63 @@ export async function scanArticle(
   return { ...result, violations: [...result.violations, ...pageViolations] }
 }
 
+// These are clean across the page list, so enforcing them only catches a newly
+// introduced violation. `document-title`, `html-has-lang`, `html-lang-valid`, and
+// `meta-viewport` are unreachable from an article-scoped scan.
+export const GLOBAL_ELEMENTS_ENFORCED_RULES = [
+  'aria-allowed-attr',
+  'aria-conditional-attr',
+  'aria-deprecated-role',
+  'aria-hidden-body',
+  'aria-prohibited-attr',
+  'aria-required-attr',
+  'aria-roles',
+  'aria-valid-attr',
+  'aria-valid-attr-value',
+  'avoid-inline-spacing',
+  'button-name',
+  'bypass',
+  'document-title',
+  'form-field-multiple-labels',
+  'html-has-lang',
+  'html-lang-valid',
+  'image-alt',
+  'label',
+  'list',
+  'listitem',
+  'meta-viewport',
+  'svg-img-alt',
+]
+
+// Best practice rather than WCAG, so these need their own pass. Reported only:
+// the footer `h6` under the screen-reader-only `h2` is on nearly every page.
+export const GLOBAL_ELEMENTS_EXTRA_REPORTED_RULES = ['heading-order', 'landmark-unique']
+
+// `color-contrast` and the `<html>`-level rules are only reachable once the scan
+// covers the document, so nothing is excluded here.
+export const GLOBAL_ELEMENTS_EXCLUDED_RULES: string[] = []
+
+export async function scanGlobalElements(
+  page: Page,
+  surface: string,
+  exclude: string[]
+): Promise<A11yScanResult> {
+  const result = await scanExcluding(page, {
+    surface,
+    exclude,
+    excludeRules: GLOBAL_ELEMENTS_EXCLUDED_RULES,
+  })
+
+  // Both are properties of the whole document, so this pass keeps the article in.
+  // Excluding it would hide the event template's nested `<main>`.
+  const extra = await scan(page, { rules: GLOBAL_ELEMENTS_EXTRA_REPORTED_RULES })
+  const byRule = new Map(
+    [...result.violations, ...extra].map((violation) => [violation.id, violation])
+  )
+
+  return { ...result, violations: [...byRule.values()] }
+}
+
 export function unloadedResult(
   surface: string,
   url: string,
@@ -53,6 +111,18 @@ export function unloadedResult(
   include: string
 ): A11yScanResult {
   return unloadedResultFor(surface, url, status, include, EXCLUDED_RULES)
+}
+
+export function unloadedGlobalElementsResult(
+  surface: string,
+  url: string,
+  status: number | null
+): A11yScanResult {
+  return unloadedResultFor(surface, url, status, 'document', GLOBAL_ELEMENTS_EXCLUDED_RULES)
+}
+
+export function blockingGlobalElementViolations(result: A11yScanResult): Result[] {
+  return blockingViolationsFor(result, GLOBAL_ELEMENTS_ENFORCED_RULES)
 }
 
 export function blockingViolations(result: A11yScanResult): Result[] {
@@ -63,6 +133,7 @@ export type { A11yScanResult }
 export {
   annotate,
   attachScanReport,
+  dedupeViolations,
   MIN_MEANINGFUL_ELEMENTS,
   scanLooksEmpty,
   shouldEnforceAll,

--- a/e2e/www/utils/axe-helpers.ts
+++ b/e2e/www/utils/axe-helpers.ts
@@ -3,6 +3,7 @@ import type { Result } from 'axe-core'
 
 import {
   blockingViolations as blockingViolationsFor,
+  scanExcluding,
   scanRegion,
   unloadedResult as unloadedResultFor,
   type A11yScanResult,
@@ -47,6 +48,67 @@ export async function scanArticle(
   return { ...result, violations: [...result.violations, ...pageViolations] }
 }
 
+// Chrome ships on every www page, so a rule only moves in here once it is clean
+// across the whole global-element page list. These are the WCAG 2.1 A/AA rules
+// that apply to every page in that list and pass today. `document-title`,
+// `html-has-lang`, `html-lang-valid`, and `meta-viewport` are unreachable from
+// an article-scoped scan and only become testable here.
+export const GLOBAL_ELEMENTS_ENFORCED_RULES = [
+  'aria-allowed-attr',
+  'aria-conditional-attr',
+  'aria-deprecated-role',
+  'aria-hidden-body',
+  'aria-prohibited-attr',
+  'aria-required-attr',
+  'aria-roles',
+  'aria-valid-attr',
+  'aria-valid-attr-value',
+  'avoid-inline-spacing',
+  'button-name',
+  'bypass',
+  'document-title',
+  'form-field-multiple-labels',
+  'html-has-lang',
+  'html-lang-valid',
+  'image-alt',
+  'label',
+  'list',
+  'listitem',
+  'meta-viewport',
+  'svg-img-alt',
+]
+
+// Best practice rather than WCAG, so these sit outside the tag sweep and need
+// their own pass. Reported, never blocking: www has not resolved its heading
+// hierarchy, and the footer `h6` under the screen-reader-only `h2` would fail
+// nearly every content pull request.
+export const GLOBAL_ELEMENTS_EXTRA_REPORTED_RULES = ['heading-order', 'landmark-unique']
+
+// Nothing is excluded, which inverts the article scan: `color-contrast` and the
+// `<html>`-level rules are only reachable once the scan covers the document.
+export const GLOBAL_ELEMENTS_EXCLUDED_RULES: string[] = []
+
+// The document minus the article wrapper, so findings land on chrome and page
+// scaffolding rather than on content the page scan already covers.
+export async function scanGlobalElements(
+  page: Page,
+  surface: string,
+  exclude: string[]
+): Promise<A11yScanResult> {
+  const result = await scanExcluding(page, {
+    surface,
+    exclude,
+    excludeRules: GLOBAL_ELEMENTS_EXCLUDED_RULES,
+  })
+
+  const extra = await scan(page, { rules: GLOBAL_ELEMENTS_EXTRA_REPORTED_RULES, exclude })
+  const byRule = new Map(
+    [...result.violations, ...extra].map((violation) => [violation.id, violation])
+  )
+
+  return { ...result, violations: [...byRule.values()] }
+}
+
 export function unloadedResult(
   surface: string,
   url: string,
@@ -54,6 +116,18 @@ export function unloadedResult(
   include: string
 ): A11yScanResult {
   return unloadedResultFor(surface, url, status, include, EXCLUDED_RULES)
+}
+
+export function unloadedGlobalElementsResult(
+  surface: string,
+  url: string,
+  status: number | null
+): A11yScanResult {
+  return unloadedResultFor(surface, url, status, 'document', GLOBAL_ELEMENTS_EXCLUDED_RULES)
+}
+
+export function blockingGlobalElementViolations(result: A11yScanResult): Result[] {
+  return blockingViolationsFor(result, GLOBAL_ELEMENTS_ENFORCED_RULES)
 }
 
 export function blockingViolations(result: A11yScanResult): Result[] {
@@ -64,6 +138,7 @@ export type { A11yScanResult }
 export {
   annotate,
   attachScanReport,
+  dedupeViolations,
   MIN_MEANINGFUL_ELEMENTS,
   scanLooksEmpty,
   shouldEnforceAll,

--- a/e2e/www/utils/axe-helpers.ts
+++ b/e2e/www/utils/axe-helpers.ts
@@ -101,7 +101,10 @@ export async function scanGlobalElements(
     excludeRules: GLOBAL_ELEMENTS_EXCLUDED_RULES,
   })
 
-  const extra = await scan(page, { rules: GLOBAL_ELEMENTS_EXTRA_REPORTED_RULES, exclude })
+  // Heading order and landmark uniqueness are properties of the whole document,
+  // so this pass keeps the article in. Scoping it would hide the event
+  // template's nested `<main>`, which is the article wrapper itself.
+  const extra = await scan(page, { rules: GLOBAL_ELEMENTS_EXTRA_REPORTED_RULES })
   const byRule = new Map(
     [...result.violations, ...extra].map((violation) => [violation.id, violation])
   )

--- a/e2e/www/utils/www-global-elements.ts
+++ b/e2e/www/utils/www-global-elements.ts
@@ -1,0 +1,99 @@
+import {
+  elementsForViewport,
+  type ViewportName,
+  type ViewportScopedElement,
+} from '../../shared/viewports.ts'
+import { wwwArticleSelectorForPagePath } from './www-selectors.ts'
+
+export interface GlobalElementConfig extends ViewportScopedElement {
+  selector: string
+  label: string
+}
+
+export const GLOBAL_ELEMENTS = {
+  nav: { selector: '[data-testid="sb-www-nav"]', label: 'site navigation' },
+  footer: { selector: 'footer', label: 'site footer' },
+  menuTrigger: {
+    selector: '[data-testid="sb-www-mobile-menu-trigger"]',
+    label: 'mobile menu trigger',
+    // `lg:hidden`, so it is out of reach at the 1280px desktop viewport.
+    viewports: ['mobile'],
+  },
+} as const satisfies Record<string, GlobalElementConfig>
+
+export type GlobalElement = keyof typeof GLOBAL_ELEMENTS
+
+export const MOBILE_MENU_SELECTOR = '[data-testid="sb-www-mobile-menu"]'
+
+export function globalElementsForViewport(
+  names: readonly GlobalElement[],
+  viewport: ViewportName
+): GlobalElementConfig[] {
+  return elementsForViewport(
+    names.map((name): GlobalElementConfig => GLOBAL_ELEMENTS[name]),
+    viewport
+  )
+}
+
+export interface GlobalElementPage {
+  path: string
+  layout: string
+  elements: readonly GlobalElement[]
+  // Listing pages and the home page render no article wrapper. Excluding a
+  // selector that matches nothing would silently widen the scan.
+  articleSelector: string | null
+}
+
+const CHROME: readonly GlobalElement[] = ['nav', 'footer', 'menuTrigger']
+
+// A second page on a covered layout would scan the same chrome.
+export const GLOBAL_ELEMENT_PAGES: readonly GlobalElementPage[] = [
+  {
+    path: '/',
+    layout: 'marketing home',
+    elements: CHROME,
+    articleSelector: null,
+  },
+  {
+    path: '/blog',
+    layout: 'blog index',
+    elements: CHROME,
+    articleSelector: null,
+  },
+  {
+    path: '/blog/supabase-steve-chavez',
+    layout: 'blog post',
+    elements: CHROME,
+    articleSelector: wwwArticleSelectorForPagePath('/blog/supabase-steve-chavez'),
+  },
+  {
+    path: '/events',
+    layout: 'events index',
+    elements: CHROME,
+    articleSelector: null,
+  },
+  {
+    path: '/events/vibe-to-live-datadog',
+    layout: 'event',
+    elements: CHROME,
+    articleSelector: wwwArticleSelectorForPagePath('/events/vibe-to-live-datadog'),
+  },
+  {
+    path: '/customers',
+    layout: 'customers index',
+    elements: CHROME,
+    articleSelector: null,
+  },
+  {
+    path: '/customers/chatbase',
+    layout: 'customer story',
+    elements: CHROME,
+    articleSelector: wwwArticleSelectorForPagePath('/customers/chatbase'),
+  },
+  {
+    path: '/alternatives/supabase-vs-firebase',
+    layout: 'alternatives comparison',
+    elements: CHROME,
+    articleSelector: wwwArticleSelectorForPagePath('/alternatives/supabase-vs-firebase'),
+  },
+]

--- a/e2e/www/utils/www-global-elements.ts
+++ b/e2e/www/utils/www-global-elements.ts
@@ -1,0 +1,99 @@
+import {
+  elementsForViewport,
+  type ViewportName,
+  type ViewportScopedElement,
+} from '../../shared/viewports.ts'
+import { wwwArticleSelectorForPagePath } from './www-selectors.ts'
+
+export interface GlobalElementConfig extends ViewportScopedElement {
+  selector: string
+  label: string
+}
+
+export const GLOBAL_ELEMENTS = {
+  nav: { selector: '[data-testid="sb-www-nav"]', label: 'site navigation' },
+  footer: { selector: 'footer', label: 'site footer' },
+  menuTrigger: {
+    selector: '[data-testid="sb-www-mobile-menu-trigger"]',
+    label: 'mobile menu trigger',
+    // `lg:hidden`, so it is out of reach at the 1280px desktop viewport.
+    viewports: ['mobile'],
+  },
+} as const satisfies Record<string, GlobalElementConfig>
+
+export type GlobalElement = keyof typeof GLOBAL_ELEMENTS
+
+export const MOBILE_MENU_SELECTOR = '[data-testid="sb-www-mobile-menu"]'
+
+export function globalElementsForViewport(
+  names: readonly GlobalElement[],
+  viewport: ViewportName
+): GlobalElementConfig[] {
+  return elementsForViewport(
+    names.map((name): GlobalElementConfig => GLOBAL_ELEMENTS[name]),
+    viewport
+  )
+}
+
+export interface GlobalElementPage {
+  path: string
+  layout: string
+  elements: readonly GlobalElement[]
+  // Listing pages and the home page render no article wrapper. Excluding a
+  // selector that matches nothing would silently widen the scan, so say so.
+  articleSelector: string | null
+}
+
+const CHROME: readonly GlobalElement[] = ['nav', 'footer', 'menuTrigger']
+
+// One page per layout. A second page on a covered layout scans the same chrome.
+export const GLOBAL_ELEMENT_PAGES: readonly GlobalElementPage[] = [
+  {
+    path: '/',
+    layout: 'marketing home',
+    elements: CHROME,
+    articleSelector: null,
+  },
+  {
+    path: '/blog',
+    layout: 'blog index',
+    elements: CHROME,
+    articleSelector: null,
+  },
+  {
+    path: '/blog/supabase-steve-chavez',
+    layout: 'blog post',
+    elements: CHROME,
+    articleSelector: wwwArticleSelectorForPagePath('/blog/supabase-steve-chavez'),
+  },
+  {
+    path: '/events',
+    layout: 'events index',
+    elements: CHROME,
+    articleSelector: null,
+  },
+  {
+    path: '/events/vibe-to-live-datadog',
+    layout: 'event',
+    elements: CHROME,
+    articleSelector: wwwArticleSelectorForPagePath('/events/vibe-to-live-datadog'),
+  },
+  {
+    path: '/customers',
+    layout: 'customers index',
+    elements: CHROME,
+    articleSelector: null,
+  },
+  {
+    path: '/customers/chatbase',
+    layout: 'customer story',
+    elements: CHROME,
+    articleSelector: wwwArticleSelectorForPagePath('/customers/chatbase'),
+  },
+  {
+    path: '/alternatives/supabase-vs-firebase',
+    layout: 'alternatives comparison',
+    elements: CHROME,
+    articleSelector: wwwArticleSelectorForPagePath('/alternatives/supabase-vs-firebase'),
+  },
+]

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "e2e:docs:local-smoke": "pnpm --prefix e2e/docs run e2e:docs:local-smoke",
     "e2e:www": "pnpm --prefix e2e/www run e2e:www",
     "e2e:www:all": "pnpm --prefix e2e/www run e2e:www:all",
+    "e2e:www:global-elements": "pnpm --prefix e2e/www run e2e:www:global-elements",
     "perf:kong": "ab -t 5 -c 20 -T application/json http://localhost:8000/",
     "perf:meta": "ab -t 5 -c 20 -T application/json http://localhost:5555/tables",
     "setup:cli": "supabase start -x studio && supabase status --output json > keys.json && node scripts/generateLocalEnv.js",


### PR DESCRIPTION
Closes FE-4173

Stack: #49077 → #49081 → #49078 → this → #49079. Review in that order.

## Problem

The www page scan stops at the article wrapper, so nothing checks the nav or the footer. The footer's heading skip is on nearly every www page and no suite reports it.

## Solution

- Add a `global-elements` Playwright project that scans the document with the article excluded, across a fixed list of one page per layout plus the listing pages and `/`.
- Trigger it from a `www_components` paths filter. No new workflow file, and a content-only pull request never runs it.
- Add `data-testid` hooks to `Nav`, `HamburgerMenu`, and `MobileMenu`.
- Declare `articleSelector: null` on pages that render no article, rather than excluding a selector that matches nothing. Excluding nothing would silently widen the scan back to the whole page.
- Keep the article in the best-practice pass. Heading order and landmark uniqueness are properties of the whole document, and excluding the article would hide the event template's nested `<main>`, which is the article wrapper itself.
- Report the footer `h6` and the nested `<main>` as warnings rather than failures. FE-4135 owns the footer.

## Manual testing

1. Run the scan against this pull request's Vercel preview. Production has no `data-testid` hooks yet, so the article assertion fails there before the scan runs.

   ```bash
   PLAYWRIGHT_BASE_URL=https://zone-www-dot-com-git-mirandalimonczenko-fe-4173-453032-supabase.vercel.app \
     pnpm -C e2e/www run e2e:www:global-elements
   ```

2. Confirm the run reports `heading-order` as a warning, not a failure.

3. Open the report and confirm `landmark-unique` appears on `/events/vibe-to-live-datadog`.

   ```bash
   pnpm -C e2e/www exec playwright show-report playwright-report-global-elements
   ```

