### PR TITLE
fix(studio): clarify MFA backup authenticator copy

### DIFF
--- a/apps/studio/components/interfaces/Account/TOTPFactors/index.tsx
+++ b/apps/studio/components/interfaces/Account/TOTPFactors/index.tsx
@@ -1,6 +1,16 @@
 import dayjs from 'dayjs'
 import { useState } from 'react'
-import { Button } from 'ui'
+import { Button, Card, CardContent } from 'ui'
+import { Admonition } from 'ui-patterns/Admonition'
+import {
+  PageSection,
+  PageSectionAside,
+  PageSectionContent,
+  PageSectionDescription,
+  PageSectionMeta,
+  PageSectionSummary,
+  PageSectionTitle,
+} from 'ui-patterns/PageSection'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 
 import { AddNewFactorModal } from './AddNewFactorModal'
@@ -14,54 +24,86 @@ export const TOTPFactors = () => {
   const [factorToBeDeleted, setFactorToBeDeleted] = useState<string | null>(null)
   const { data, isPending: isLoading, isError, isSuccess, error } = useMfaListFactorsQuery()
 
+  const totpFactors = data?.totp ?? []
+  const canAddApp = isSuccess && totpFactors.length < 2
+  const shouldShowLockoutWarning = isSuccess && totpFactors.length === 1
+
+  const handleAddNewApp = () => setIsAddNewFactorOpen(true)
+
   return (
     <>
-      <section className="space-y-3">
-        <p className="text-sm text-foreground-light">
-          Use an authenticator app (like Google Authenticator or 1Password) to protect your account.
-        </p>
-        <div>
-          {isLoading && <GenericSkeletonLoader />}
+      <PageSection>
+        <PageSectionMeta>
+          <PageSectionSummary>
+            <PageSectionTitle>Multi-factor authentication</PageSectionTitle>
+            <PageSectionDescription>
+              Use an authenticator app (like Google Authenticator or 1Password) to protect your
+              account.
+            </PageSectionDescription>
+          </PageSectionSummary>
+          {canAddApp && (
+            <PageSectionAside>
+              <Button variant="default" onClick={handleAddNewApp}>
+                Add app
+              </Button>
+            </PageSectionAside>
+          )}
+        </PageSectionMeta>
+        <PageSectionContent className="flex flex-col gap-4">
+          {shouldShowLockoutWarning && (
+            <Admonition
+              type="danger"
+              layout="horizontal"
+              title="Avoid being locked out"
+              description="Add a backup authenticator app now. Losing access to your only app will permanently lock you out of your account."
+              actions={
+                <Button variant="default" onClick={handleAddNewApp}>
+                  Add another app
+                </Button>
+              }
+            />
+          )}
+          {isLoading && (
+            <Card>
+              <CardContent>
+                <GenericSkeletonLoader />
+              </CardContent>
+            </Card>
+          )}
           {isError && (
             <AlertError error={error} subject="Failed to retrieve account security information" />
           )}
           {isSuccess && (
-            <>
-              <div>
-                {data.totp.map((factor) => {
-                  return (
-                    <div key={factor.id} className="flex flex-row justify-between py-2">
-                      <p className="text-sm text-foreground flex items-center space-x-2">
-                        <span className="text-foreground-light">Name:</span>{' '}
-                        <span>{factor.friendly_name ?? 'No name provided'}</span>
-                      </p>
-                      <div className="flex items-center gap-4">
-                        <p className="text-sm text-foreground-light">
+            <Card>
+              {totpFactors.length === 0 ? (
+                <CardContent>
+                  <p className="text-sm text-foreground-lighter">No authenticator apps yet.</p>
+                </CardContent>
+              ) : (
+                <div className="divide-y">
+                  {totpFactors.map((factor) => (
+                    <CardContent key={factor.id} className="flex justify-between items-center py-4">
+                      <div>
+                        <p className="text-sm">{factor.friendly_name ?? 'No name provided'}</p>
+                        <p className="text-sm text-foreground-lighter">
                           Added on {dayjs(factor.created_at).format(DATETIME_FORMAT)}
                         </p>
-                        <Button
-                          size="tiny"
-                          variant="default"
-                          onClick={() => setFactorToBeDeleted(factor.id)}
-                        >
-                          Remove
-                        </Button>
                       </div>
-                    </div>
-                  )
-                })}
-              </div>
-              {data.totp.length < 2 ? (
-                <>
-                  <div className="pt-2">
-                    <Button onClick={() => setIsAddNewFactorOpen(true)}>Add new app</Button>
-                  </div>
-                </>
-              ) : null}
-            </>
+                      <Button
+                        size="tiny"
+                        variant="default"
+                        onClick={() => setFactorToBeDeleted(factor.id)}
+                      >
+                        Remove
+                      </Button>
+                    </CardContent>
+                  ))}
+                </div>
+              )}
+            </Card>
           )}
-        </div>
-      </section>
+        </PageSectionContent>
+      </PageSection>
       <AddNewFactorModal
         visible={isAddNewFactorOpen}
         onClose={() => setIsAddNewFactorOpen(false)}
@@ -69,7 +111,7 @@ export const TOTPFactors = () => {
       <DeleteFactorModal
         visible={factorToBeDeleted !== null}
         factorId={factorToBeDeleted}
-        lastFactorToBeDeleted={data?.totp.length === 1}
+        lastFactorToBeDeleted={totpFactors.length === 1}
         onClose={() => setFactorToBeDeleted(null)}
       />
     </>

--- a/apps/studio/components/interfaces/Account/TOTPFactors/index.tsx
+++ b/apps/studio/components/interfaces/Account/TOTPFactors/index.tsx
@@ -1,4 +1,5 @@
 import dayjs from 'dayjs'
+import { Plus } from 'lucide-react'
 import { useState } from 'react'
 import { Button, Card, CardContent } from 'ui'
 import { Admonition } from 'ui-patterns/Admonition'
@@ -43,7 +44,7 @@ export const TOTPFactors = () => {
           </PageSectionSummary>
           {canAddApp && (
             <PageSectionAside>
-              <Button variant="default" onClick={handleAddNewApp}>
+              <Button variant="primary" icon={<Plus />} onClick={handleAddNewApp}>
                 Add app
               </Button>
             </PageSectionAside>
@@ -53,11 +54,11 @@ export const TOTPFactors = () => {
           {shouldShowLockoutWarning && (
             <Admonition
               type="danger"
-              layout="horizontal"
+              layout="responsive"
               title="Avoid being locked out"
               description="Add a backup authenticator app now. Losing access to your only app will permanently lock you out of your account."
               actions={
-                <Button variant="default" onClick={handleAddNewApp}>
+                <Button variant="default" icon={<Plus />} onClick={handleAddNewApp}>
                   Add another app
                 </Button>
               }
@@ -94,7 +95,7 @@ export const TOTPFactors = () => {
                         variant="default"
                         onClick={() => setFactorToBeDeleted(factor.id)}
                       >
-                        Remove
+                        Delete{' '}
                       </Button>
                     </CardContent>
                   ))}

--- a/apps/studio/pages/account/security.tsx
+++ b/apps/studio/pages/account/security.tsx
@@ -1,6 +1,3 @@
-import { Lock } from 'lucide-react'
-import { Badge, Card, CardContent, CardHeader } from 'ui'
-import { Admonition } from 'ui-patterns/Admonition'
 import { PageContainer } from 'ui-patterns/PageContainer'
 import {
   PageHeader,
@@ -15,14 +12,11 @@ import AccountLayout from '@/components/layouts/AccountLayout/AccountLayout'
 import { AppLayout } from '@/components/layouts/AppLayout/AppLayout'
 import { DefaultLayout } from '@/components/layouts/DefaultLayout'
 import { UnknownInterface } from '@/components/ui/UnknownInterface'
-import { useMfaListFactorsQuery } from '@/data/profile/mfa-list-factors-query'
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
 import type { NextPageWithLayout } from '@/types'
 
 const Security: NextPageWithLayout = () => {
   const showSecuritySettings = useIsFeatureEnabled('account:show_security_settings')
-
-  const { data } = useMfaListFactorsQuery({ enabled: showSecuritySettings })
 
   if (!showSecuritySettings) {
     return <UnknownInterface urlBack={`/account/me`} />
@@ -41,32 +35,7 @@ const Security: NextPageWithLayout = () => {
         </PageHeaderMeta>
       </PageHeader>
       <PageContainer size="small">
-        {data?.totp.length === 1 && (
-          <Admonition
-            className="mt-8"
-            type="danger"
-            layout="horizontal"
-            title="Avoid being locked out"
-            description="Add a backup sign-in method now. Otherwise, losing access to your authenticator app will permanently lock you out of your account."
-          />
-        )}
-        <Card className="mt-8">
-          <CardHeader className="py-3 flex flex-row items-center justify-between">
-            <div className="flex flex-row gap-4 items-center py-1 mb-0">
-              <Lock size={18} strokeWidth={1.5} />
-              <span className="text-sm">Multi-factor authentication (MFA)</span>
-            </div>
-
-            {data ? (
-              <Badge variant={data.totp.length === 0 ? 'default' : 'success'}>
-                {data.totp.length} app{data.totp.length === 1 ? '' : 's'} configured
-              </Badge>
-            ) : null}
-          </CardHeader>
-          <CardContent>
-            <TOTPFactors />
-          </CardContent>
-        </Card>
+        <TOTPFactors />
       </PageContainer>
     </>
   )


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (copy and layout)

## What is the current behavior?

After setting up a single MFA factor, Account > Security warns you to add a "backup sign-in method". That reads like another account identity (email / Google / SSO), not a second authenticator app. The add action also sits at the bottom of the MFA card, so the callout has no nearby control.

Fixes [FE-4171](https://linear.app/supabase/issue/FE-4171/clarify-backup-sign-in-method-after-mfa-setup)

## What is the new behavior?

The MFA block is a `PageSection` with **Add app** in the aside. When one factor is configured, a danger callout above the card tells you to add a backup authenticator app, with **Add another app** opening the same modal.

| Before | After |
| --- | --- |
| <img width="1482" height="896" alt="CleanShot 2026-08-14 at 10 27 33@2x" src="https://github.com/user-attachments/assets/7a8f3737-8e11-49c4-8f8e-3fda527a8c40" /> | <img width="1468" height="802" alt="CleanShot 2026-08-14 at 10 57 06@2x" src="https://github.com/user-attachments/assets/b2f6060e-b6c1-49e4-ae5c-99553ea3e60a" /> |

## To test

1. Open **Account > Security** (`/account/security`).
2. **0 apps:** empty card, **Add app** in the section aside. Click it. The add-factor modal should open.
3. **1 app:** danger callout under the section title. Copy should mention a backup authenticator app, not a sign-in method. **Add another app** and **Add app** should both open the same modal.
4. **2 apps:** callout and add buttons gone. Remove still works.

Add or remove an authenticator app on that page to hit each state. If you already have one factor, step 3 is the important check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the multi-factor authentication interface with clearer sections, cards, and guidance.
  * Added an empty state when no authenticator apps are configured.
  * Added a warning when only one authenticator remains to help prevent account lockout.
  * Limited authenticator app setup to two configured factors.

* **Bug Fixes**
  * Improved loading and error-state presentation for authentication factor management.
  * Simplified the security page to provide a more consistent MFA experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->