### PR TITLE
feat(studio): extract PrivateLink status copy

### DIFF
--- a/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLink.utils.test.ts
+++ b/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLink.utils.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+
+import { getConnectionStatusUi, type PrivateLinkConnectionStatus } from './AWSPrivateLink.utils'
+
+describe('getConnectionStatusUi', () => {
+  it.each([
+    [
+      'ASSOCIATION_ACCEPTED',
+      {
+        badge: 'Connected',
+        badgeVariant: 'success',
+        title: 'This connection is active',
+      },
+    ],
+    [
+      'READY',
+      {
+        badge: 'Ready',
+        badgeVariant: 'success',
+        title: 'Waiting for the AWS account owner to accept',
+        description: 'This request expires after 12 hours.',
+      },
+    ],
+    [
+      'CREATING',
+      {
+        badge: 'Creating',
+        badgeVariant: 'warning',
+        title: 'This connection is being created',
+      },
+    ],
+    [
+      'DELETING',
+      {
+        badge: 'Deleting',
+        badgeVariant: 'destructive',
+        title: 'This connection is being deleted',
+      },
+    ],
+    [
+      'ASSOCIATION_REQUEST_EXPIRED',
+      {
+        badge: 'Expired',
+        badgeVariant: 'destructive',
+        title: 'This request has expired',
+      },
+    ],
+    [
+      'CREATION_FAILED',
+      {
+        badge: 'Failed',
+        badgeVariant: 'destructive',
+        title: "Couldn't create this connection",
+      },
+    ],
+  ] as const satisfies ReadonlyArray<
+    [PrivateLinkConnectionStatus, Partial<ReturnType<typeof getConnectionStatusUi>>]
+  >)('maps %s', (status, expected) => {
+    expect(getConnectionStatusUi(status)).toMatchObject(expected)
+  })
+
+  it('returns unknown copy when status is missing', () => {
+    const ui = getConnectionStatusUi()
+
+    expect(ui.badge).toBe('Unknown')
+    expect(ui.badgeVariant).toBe('default')
+    expect(ui.title).toBe("Couldn't determine this connection's status")
+  })
+})

--- a/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLink.utils.ts
+++ b/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLink.utils.ts
@@ -1,0 +1,63 @@
+import type { AWSAccount } from '@/data/aws-accounts/aws-accounts-query'
+
+export type PrivateLinkConnectionStatus = AWSAccount['status']
+
+type BadgeVariant = 'success' | 'warning' | 'destructive' | 'default'
+
+export type ConnectionStatusUi = {
+  title: string
+  description: string
+  badge: string
+  badgeVariant: BadgeVariant
+}
+
+const CONNECTION_STATUS_UI: Record<PrivateLinkConnectionStatus, ConnectionStatusUi> = {
+  ASSOCIATION_ACCEPTED: {
+    title: 'This connection is active',
+    description: 'The AWS account owner has accepted the resource share.',
+    badge: 'Connected',
+    badgeVariant: 'success',
+  },
+  READY: {
+    title: 'Waiting for the AWS account owner to accept',
+    description: 'This request expires after 12 hours.',
+    badge: 'Ready',
+    badgeVariant: 'success',
+  },
+  CREATING: {
+    title: 'This connection is being created',
+    description: '',
+    badge: 'Creating',
+    badgeVariant: 'warning',
+  },
+  DELETING: {
+    title: 'This connection is being deleted',
+    description: '',
+    badge: 'Deleting',
+    badgeVariant: 'destructive',
+  },
+  ASSOCIATION_REQUEST_EXPIRED: {
+    title: 'This request has expired',
+    description: 'Add a new connection to try again.',
+    badge: 'Expired',
+    badgeVariant: 'destructive',
+  },
+  CREATION_FAILED: {
+    title: "Couldn't create this connection",
+    description: 'Add a new connection to try again.',
+    badge: 'Failed',
+    badgeVariant: 'destructive',
+  },
+}
+
+const UNKNOWN_STATUS_UI: ConnectionStatusUi = {
+  title: "Couldn't determine this connection's status",
+  description: '',
+  badge: 'Unknown',
+  badgeVariant: 'default',
+}
+
+export function getConnectionStatusUi(status?: PrivateLinkConnectionStatus): ConnectionStatusUi {
+  if (!status) return UNKNOWN_STATUS_UI
+  return CONNECTION_STATUS_UI[status] ?? UNKNOWN_STATUS_UI
+}

--- a/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLinkAccountItem.tsx
+++ b/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLinkAccountItem.tsx
@@ -13,6 +13,7 @@ import {
   TooltipTrigger,
 } from 'ui'
 
+import { getConnectionStatusUi } from './AWSPrivateLink.utils'
 import { formatDatabaseID } from '@/data/read-replicas/replicas.utils'
 
 interface AWSPrivateLinkAccountItemProps {
@@ -51,25 +52,7 @@ export const AWSPrivateLinkAccountItem = ({
     database_type === 'READ_REPLICA'
       ? `Read replica (ID: ${database_identifier ? formatDatabaseID(database_identifier) : 'Unknown identifier'})`
       : 'Primary database'
-
-  const getStatusBadge = () => {
-    switch (status) {
-      case 'ASSOCIATION_ACCEPTED':
-        return <Badge variant="success">Connected</Badge>
-      case 'READY':
-        return <Badge variant="success">Ready</Badge>
-      case 'CREATING':
-        return <Badge variant="warning">Creating</Badge>
-      case 'DELETING':
-        return <Badge variant="destructive">Deleting</Badge>
-      case 'ASSOCIATION_REQUEST_EXPIRED':
-        return <Badge variant="destructive">Expired</Badge>
-      case 'CREATION_FAILED':
-        return <Badge variant="destructive">Failed</Badge>
-      default:
-        return <Badge>Unknown</Badge>
-    }
-  }
+  const statusUi = getConnectionStatusUi(status)
 
   return (
     <CardContent className="flex items-center justify-between text-sm gap-4">
@@ -100,7 +83,7 @@ export const AWSPrivateLinkAccountItem = ({
         )}
       </div>
 
-      {getStatusBadge()}
+      <Badge variant={statusUi.badgeVariant}>{statusUi.badge}</Badge>
 
       <DropdownMenu>
         <DropdownMenuTrigger asChild>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactor

## What is the current behavior?

Status labels and sheet copy are inline switches in the list and form.

## What is the new behavior?

One status lookup drives the badge and the view-sheet copy. No intended visual change. Ready is still green.

| Before and After |
| --- |
| <img width="1460" height="486" alt="CleanShot 2026-08-14 at 12 37 13@2x" src="https://github.com/user-attachments/assets/0c6c0b03-25f7-4e64-a0cd-72e7ef966454" /> |
| _No visual changes_ |

## Additional context

Stacked on #48967. See https://github.com/supabase/supabase/pull/49030 for the end state, as it may already include fixes you might propose.

## To test

- **Project Settings → Integrations → AWS PrivateLink.** Look at a connection row badge, then **View** it. Labels should match today’s statuses. Ready should still be green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear status messaging for AWS PrivateLink connections, including accepted, ready, creating, deleting, expired, and failed states.
  * Added fallback messaging for unavailable or unrecognized connection statuses.

* **Bug Fixes**
  * Improved consistency of PrivateLink status badges, labels, descriptions, and visual styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->