### PR TITLE
feat(studio): mark PrivateLink waiting as a warning

### DIFF
--- a/apps/docs/content/guides/platform/privatelink.mdx
+++ b/apps/docs/content/guides/platform/privatelink.mdx
@@ -51,9 +51,9 @@ Navigate to your project's Integrations section to set up PrivateLink:
 
 Each database, whether the primary or a read replica, needs its own connection. Create a separate connection for every database you want to reach over PrivateLink.
 
-After submission, Supabase creates a VPC Lattice Resource Configuration for your project and sends an AWS Resource Share to the specified AWS account ID. This process may take a few moments. Once complete, the connection will show a "Ready" status, indicating that the resource share has been sent to your AWS account and is ready to be accepted. You must accept the resource share within 12 hours, or the request expires and can no longer be accepted in AWS. You'll need to create a new connection to try again.
+After submission, Supabase creates a VPC Lattice Resource Configuration for your project and sends an AWS Resource Share to the specified AWS account ID. This process may take a few moments. Once complete, the connection will show a "Waiting" status, indicating that the resource share has been sent to your AWS account and still needs to be accepted. You must accept the resource share within 12 hours, or the request expires and can no longer be accepted in AWS. You'll need to create a new connection to try again.
 
-Once ready, select **View connection** to see the VPC Lattice resource configuration ID and ARNs for the connection. This is useful for confirming which resource configuration corresponds to which database when a project has multiple connections, for example one for the primary database and one for each read replica.
+Select **View connection** to see the VPC Lattice resource configuration ID and ARNs for the connection. This is useful for confirming which resource configuration corresponds to which database when a project has multiple connections, for example one for the primary database and one for each read replica.
 
 ### Step 2: Accept resource share
 

--- a/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLink.utils.test.ts
+++ b/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLink.utils.test.ts
@@ -15,8 +15,8 @@ describe('getConnectionStatusUi', () => {
     [
       'READY',
       {
-        badge: 'Ready',
-        badgeVariant: 'success',
+        badge: 'Waiting',
+        badgeVariant: 'warning',
         title: 'Waiting for the AWS account owner to accept',
         description: 'This request expires after 12 hours.',
       },
@@ -25,7 +25,7 @@ describe('getConnectionStatusUi', () => {
       'CREATING',
       {
         badge: 'Creating',
-        badgeVariant: 'warning',
+        badgeVariant: 'default',
         title: 'This connection is being created',
       },
     ],
@@ -33,7 +33,7 @@ describe('getConnectionStatusUi', () => {
       'DELETING',
       {
         badge: 'Deleting',
-        badgeVariant: 'destructive',
+        badgeVariant: 'warning',
         title: 'This connection is being deleted',
       },
     ],

--- a/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLink.utils.ts
+++ b/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLink.utils.ts
@@ -21,20 +21,20 @@ const CONNECTION_STATUS_UI: Record<PrivateLinkConnectionStatus, ConnectionStatus
   READY: {
     title: 'Waiting for the AWS account owner to accept',
     description: 'This request expires after 12 hours.',
-    badge: 'Ready',
-    badgeVariant: 'success',
+    badge: 'Waiting',
+    badgeVariant: 'warning',
   },
   CREATING: {
     title: 'This connection is being created',
     description: '',
     badge: 'Creating',
-    badgeVariant: 'warning',
+    badgeVariant: 'default',
   },
   DELETING: {
     title: 'This connection is being deleted',
     description: '',
     badge: 'Deleting',
-    badgeVariant: 'destructive',
+    badgeVariant: 'warning',
   },
   ASSOCIATION_REQUEST_EXPIRED: {
     title: 'This request has expired',


### PR DESCRIPTION
## What kind of change does this PR introduce?

UI

## What is the current behavior?

Waiting (still labelled Ready in #49085) is green. Creating is orange. Deleting is red.

## What is the new behavior?

Waiting is orange. Creating is grey. Deleting is orange. Connected stays the only green state.

| Before | After |
| --- | --- |
| <img width="1448" height="492" alt="CleanShot 2026-08-14 at 12 43 59@2x" src="https://github.com/user-attachments/assets/c0d95b51-7841-4714-a01b-47e5587c3efb" /> | <img width="1434" height="470" alt="CleanShot 2026-08-14 at 12 44 59@2x" src="https://github.com/user-attachments/assets/3ba10dc5-5fdd-464a-a748-5085d2d65df3" /> |
| <img width="842" height="440" alt="CleanShot 2026-08-14 at 12 44 21@2x" src="https://github.com/user-attachments/assets/757db647-4b7c-4f77-8dcf-1eb289c40cc1" /> | <img width="842" height="432" alt="CleanShot 2026-08-14 at 12 44 49@2x" src="https://github.com/user-attachments/assets/1311a6d2-4712-4cb9-a6f2-f39387f0a953" /> |

## Additional context

Stacked on #49085. See #49030 for the end state, as it may already include fixes you might propose.

## To test

- **Project Settings → Integrations → AWS PrivateLink.** A connection that AWS has not accepted yet should show an orange **Waiting** badge, not green Ready.
- Creating should be grey. Deleting orange. Expired and Failed stay red.
- **Docs preview → Platform → PrivateLink.** Should say Waiting, not Ready.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated AWS PrivateLink connection statuses to accurately show “Waiting” while the AWS Resource Share is pending acceptance.
  * Refined status badge styling for creating, waiting, and deleting connections.
  * Clarified that Resource Shares must be accepted within 12 hours.

* **Documentation**
  * Updated PrivateLink setup instructions to reflect the revised connection status flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->