### PR TITLE
feat(studio): show PrivateLink accept guidance on the list

### DIFF
--- a/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLink.utils.test.ts
+++ b/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLink.utils.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { getConnectionStatusUi, type PrivateLinkConnectionStatus } from './AWSPrivateLink.utils'
+import {
+  getConnectionsAttentionCopy,
+  getConnectionStatusUi,
+  type PrivateLinkConnectionStatus,
+} from './AWSPrivateLink.utils'
 
 describe('getConnectionStatusUi', () => {
   it.each([
@@ -65,5 +69,27 @@ describe('getConnectionStatusUi', () => {
     expect(ui.badge).toBe('Unknown')
     expect(ui.badgeVariant).toBe('default')
     expect(ui.title).toBe("Couldn't determine this connection's status")
+  })
+})
+
+describe('getConnectionsAttentionCopy', () => {
+  it('returns null when nothing needs attention', () => {
+    expect(getConnectionsAttentionCopy({ waitingCount: 0, expiredCount: 0 })).toBeNull()
+  })
+
+  it('returns waiting copy for a single ready connection', () => {
+    const copy = getConnectionsAttentionCopy({ waitingCount: 1, expiredCount: 0 })
+
+    expect(copy?.type).toBe('warning')
+    expect(copy?.title).toBe('Waiting for the AWS account owner')
+    expect(copy?.showAcceptLink).toBe(true)
+  })
+
+  it('returns expired copy when only expired connections remain', () => {
+    const copy = getConnectionsAttentionCopy({ waitingCount: 0, expiredCount: 2 })
+
+    expect(copy?.type).toBe('destructive')
+    expect(copy?.title).toBe('Connection requests expired')
+    expect(copy?.showAcceptLink).toBe(false)
   })
 })

--- a/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLink.utils.test.ts
+++ b/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLink.utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  getConnectionsAttention,
   getConnectionsAttentionCopy,
   getConnectionStatusUi,
   type PrivateLinkConnectionStatus,
@@ -8,67 +9,20 @@ import {
 
 describe('getConnectionStatusUi', () => {
   it.each([
-    [
-      'ASSOCIATION_ACCEPTED',
-      {
-        badge: 'Connected',
-        badgeVariant: 'success',
-        title: 'This connection is active',
-      },
-    ],
-    [
-      'READY',
-      {
-        badge: 'Waiting',
-        badgeVariant: 'warning',
-        title: 'Waiting for the AWS account owner to accept',
-        description: 'This request expires after 12 hours.',
-      },
-    ],
-    [
-      'CREATING',
-      {
-        badge: 'Creating',
-        badgeVariant: 'default',
-        title: 'This connection is being created',
-      },
-    ],
-    [
-      'DELETING',
-      {
-        badge: 'Deleting',
-        badgeVariant: 'warning',
-        title: 'This connection is being deleted',
-      },
-    ],
-    [
-      'ASSOCIATION_REQUEST_EXPIRED',
-      {
-        badge: 'Expired',
-        badgeVariant: 'destructive',
-        title: 'This request has expired',
-      },
-    ],
-    [
-      'CREATION_FAILED',
-      {
-        badge: 'Failed',
-        badgeVariant: 'destructive',
-        title: "Couldn't create this connection",
-      },
-    ],
+    ['ASSOCIATION_ACCEPTED', { badge: 'Connected', badgeVariant: 'success' }],
+    ['READY', { badge: 'Waiting', badgeVariant: 'warning' }],
+    ['CREATING', { badge: 'Creating', badgeVariant: 'default' }],
+    ['DELETING', { badge: 'Deleting', badgeVariant: 'warning' }],
+    ['ASSOCIATION_REQUEST_EXPIRED', { badge: 'Expired', badgeVariant: 'destructive' }],
+    ['CREATION_FAILED', { badge: 'Failed', badgeVariant: 'destructive' }],
   ] as const satisfies ReadonlyArray<
-    [PrivateLinkConnectionStatus, Partial<ReturnType<typeof getConnectionStatusUi>>]
+    [PrivateLinkConnectionStatus, ReturnType<typeof getConnectionStatusUi>]
   >)('maps %s', (status, expected) => {
-    expect(getConnectionStatusUi(status)).toMatchObject(expected)
+    expect(getConnectionStatusUi(status)).toEqual(expected)
   })
 
   it('returns unknown copy when status is missing', () => {
-    const ui = getConnectionStatusUi()
-
-    expect(ui.badge).toBe('Unknown')
-    expect(ui.badgeVariant).toBe('default')
-    expect(ui.title).toBe("Couldn't determine this connection's status")
+    expect(getConnectionStatusUi()).toEqual({ badge: 'Unknown', badgeVariant: 'default' })
   })
 })
 
@@ -77,19 +31,27 @@ describe('getConnectionsAttentionCopy', () => {
     expect(getConnectionsAttentionCopy({ waitingCount: 0, expiredCount: 0 })).toBeNull()
   })
 
-  it('returns waiting copy for a single ready connection', () => {
+  it('warns when a connection is waiting', () => {
     const copy = getConnectionsAttentionCopy({ waitingCount: 1, expiredCount: 0 })
-
     expect(copy?.type).toBe('warning')
     expect(copy?.title).toBe('Waiting for the AWS account owner')
     expect(copy?.showAcceptLink).toBe(true)
   })
 
-  it('returns expired copy when only expired connections remain', () => {
+  it('uses destructive copy when only expired', () => {
     const copy = getConnectionsAttentionCopy({ waitingCount: 0, expiredCount: 2 })
-
     expect(copy?.type).toBe('destructive')
     expect(copy?.title).toBe('Connection requests expired')
     expect(copy?.showAcceptLink).toBe(false)
+  })
+
+  it('counts statuses from a list', () => {
+    expect(
+      getConnectionsAttention([
+        { status: 'READY' },
+        { status: 'ASSOCIATION_ACCEPTED' },
+        { status: 'ASSOCIATION_REQUEST_EXPIRED' },
+      ])
+    ).toEqual({ waitingCount: 1, expiredCount: 1 })
   })
 })

--- a/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLink.utils.ts
+++ b/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLink.utils.ts
@@ -5,54 +5,38 @@ export type PrivateLinkConnectionStatus = AWSAccount['status']
 type BadgeVariant = 'success' | 'warning' | 'destructive' | 'default'
 
 export type ConnectionStatusUi = {
-  title: string
-  description: string
   badge: string
   badgeVariant: BadgeVariant
 }
 
 const CONNECTION_STATUS_UI: Record<PrivateLinkConnectionStatus, ConnectionStatusUi> = {
   ASSOCIATION_ACCEPTED: {
-    title: 'This connection is active',
-    description: 'The AWS account owner has accepted the resource share.',
     badge: 'Connected',
     badgeVariant: 'success',
   },
   READY: {
-    title: 'Waiting for the AWS account owner to accept',
-    description: 'This request expires after 12 hours.',
     badge: 'Waiting',
     badgeVariant: 'warning',
   },
   CREATING: {
-    title: 'This connection is being created',
-    description: '',
     badge: 'Creating',
     badgeVariant: 'default',
   },
   DELETING: {
-    title: 'This connection is being deleted',
-    description: '',
     badge: 'Deleting',
     badgeVariant: 'warning',
   },
   ASSOCIATION_REQUEST_EXPIRED: {
-    title: 'This request has expired',
-    description: 'Add a new connection to try again.',
     badge: 'Expired',
     badgeVariant: 'destructive',
   },
   CREATION_FAILED: {
-    title: "Couldn't create this connection",
-    description: 'Add a new connection to try again.',
     badge: 'Failed',
     badgeVariant: 'destructive',
   },
 }
 
 const UNKNOWN_STATUS_UI: ConnectionStatusUi = {
-  title: "Couldn't determine this connection's status",
-  description: '',
   badge: 'Unknown',
   badgeVariant: 'default',
 }

--- a/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLink.utils.ts
+++ b/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLink.utils.ts
@@ -61,3 +61,55 @@ export function getConnectionStatusUi(status?: PrivateLinkConnectionStatus): Con
   if (!status) return UNKNOWN_STATUS_UI
   return CONNECTION_STATUS_UI[status] ?? UNKNOWN_STATUS_UI
 }
+
+export type ConnectionsAttention = {
+  waitingCount: number
+  expiredCount: number
+}
+
+export function getConnectionsAttention(
+  accounts: Array<Pick<AWSAccount, 'status'>> | undefined
+): ConnectionsAttention {
+  const waitingCount = accounts?.filter((account) => account.status === 'READY').length ?? 0
+  const expiredCount =
+    accounts?.filter((account) => account.status === 'ASSOCIATION_REQUEST_EXPIRED').length ?? 0
+
+  return { waitingCount, expiredCount }
+}
+
+export function getConnectionsAttentionCopy(attention: ConnectionsAttention): {
+  type: 'warning' | 'destructive'
+  title: string
+  description: string
+  showAcceptLink: boolean
+} | null {
+  const { waitingCount, expiredCount } = attention
+  if (waitingCount === 0 && expiredCount === 0) return null
+
+  if (expiredCount > 0 && waitingCount === 0) {
+    return {
+      type: 'destructive',
+      title: expiredCount === 1 ? 'A connection request expired' : 'Connection requests expired',
+      description: 'Add a new connection to try again. AWS can no longer accept this share.',
+      showAcceptLink: false,
+    }
+  }
+
+  if (waitingCount > 0 && expiredCount > 0) {
+    return {
+      type: 'warning',
+      title: 'Some connections need attention',
+      description:
+        'Accept waiting resource shares in AWS within 12 hours. Expired requests need a new connection.',
+      showAcceptLink: true,
+    }
+  }
+
+  return {
+    type: 'warning',
+    title:
+      waitingCount === 1 ? 'Waiting for the AWS account owner' : 'Waiting for AWS account owners',
+    description: 'Accept the resource share in AWS within 12 hours.',
+    showAcceptLink: true,
+  }
+}

--- a/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLinkAttentionAdmonition.tsx
+++ b/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLinkAttentionAdmonition.tsx
@@ -1,0 +1,42 @@
+import { SquareArrowOutUpRight } from 'lucide-react'
+import Link from 'next/link'
+import { Button } from 'ui'
+import { Admonition } from 'ui-patterns/Admonition'
+
+import { getConnectionsAttention, getConnectionsAttentionCopy } from './AWSPrivateLink.utils'
+import type { AWSAccount } from '@/data/aws-accounts/aws-accounts-query'
+import { DOCS_URL } from '@/lib/constants'
+
+export function AWSPrivateLinkAttentionAdmonition({
+  accounts,
+  className,
+}: {
+  accounts: Array<Pick<AWSAccount, 'status'>> | undefined
+  className?: string
+}) {
+  const copy = getConnectionsAttentionCopy(getConnectionsAttention(accounts))
+  if (!copy) return null
+
+  return (
+    <Admonition
+      type={copy.type}
+      layout="responsive"
+      title={copy.title}
+      description={copy.description}
+      className={className}
+      actions={
+        copy.showAcceptLink && (
+          <Button variant="default" className="w-min" icon={<SquareArrowOutUpRight />} asChild>
+            <Link
+              target="_blank"
+              rel="noopener noreferrer"
+              href={`${DOCS_URL}/guides/platform/privatelink#step-2-accept-resource-share`}
+            >
+              View instructions
+            </Link>
+          </Button>
+        )
+      }
+    />
+  )
+}

--- a/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLinkForm.tsx
+++ b/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLinkForm.tsx
@@ -1,11 +1,8 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useFlag } from 'common'
-import { ExternalLink } from 'lucide-react'
-import Link from 'next/link'
 import { useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 import {
-  Badge,
   Button,
   Form,
   FormControl,
@@ -24,12 +21,11 @@ import {
   SheetSection,
   SheetTitle,
 } from 'ui'
-import { Admonition } from 'ui-patterns/Admonition'
 import { Input as CopyableInput } from 'ui-patterns/DataInputs/Input'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { z } from 'zod'
 
-import { getConnectionStatusUi } from './AWSPrivateLink.utils'
+import { AWSPrivateLinkAttentionAdmonition } from './AWSPrivateLinkAttentionAdmonition'
 import { InlineLink } from '@/components/ui/InlineLink'
 import { useAWSAccountCreateMutation } from '@/data/aws-accounts/aws-account-create-mutation'
 import type { AWSAccount } from '@/data/aws-accounts/aws-accounts-query'
@@ -78,7 +74,6 @@ export const AWSPrivateLinkForm = ({
 
   const readReplicas = databases.filter((database) => database.identifier !== project?.ref)
   const showDatabaseTarget = showPrivateLinkReadReplica || !isNew
-  const statusUi = getConnectionStatusUi(account?.status)
   const formValues: FormValues = {
     awsAccountId: account?.aws_account_id ?? '',
     databaseIdentifier: account?.database_identifier ?? project?.ref ?? '',
@@ -144,36 +139,7 @@ export const AWSPrivateLinkForm = ({
             className="flex flex-col flex-1 min-h-0"
           >
             <SheetSection className="space-y-4 flex-1 overflow-y-auto">
-              {!isNew && account && (
-                <Admonition
-                  showIcon={false}
-                  type="default"
-                  childProps={{ title: { className: 'flex-row gap-x-2 items-center' } }}
-                  // @ts-ignore
-                  title={
-                    <>
-                      <span>{statusUi.title}</span>
-                      <Badge className="ml-2" variant={statusUi.badgeVariant}>
-                        {statusUi.badge}
-                      </Badge>
-                    </>
-                  }
-                  description={statusUi.description}
-                  actions={
-                    account.status === 'READY' && (
-                      <Button variant="default" className="w-min" icon={<ExternalLink />}>
-                        <Link
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          href={`${DOCS_URL}/guides/platform/privatelink#step-2-accept-resource-share`}
-                        >
-                          How to accept
-                        </Link>
-                      </Button>
-                    )
-                  }
-                />
-              )}
+              {!isNew && account && <AWSPrivateLinkAttentionAdmonition accounts={[account]} />}
               <FormField
                 control={form.control}
                 name="awsAccountId"

--- a/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLinkForm.tsx
+++ b/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLinkForm.tsx
@@ -55,9 +55,15 @@ interface AWSPrivateLinkFormProps {
   account?: AWSAccount
   open: boolean
   onOpenChange: (open: boolean) => void
+  onDelete?: () => void
 }
 
-export const AWSPrivateLinkForm = ({ account, open, onOpenChange }: AWSPrivateLinkFormProps) => {
+export const AWSPrivateLinkForm = ({
+  account,
+  open,
+  onOpenChange,
+  onDelete,
+}: AWSPrivateLinkFormProps) => {
   const isNew = !account
   const { data: project } = useSelectedProjectQuery()
   const showPrivateLinkReadReplica = useFlag('privatelinkReadReplica')
@@ -272,19 +278,30 @@ export const AWSPrivateLinkForm = ({ account, open, onOpenChange }: AWSPrivateLi
               )}
             </SheetSection>
 
-            <SheetFooter>
-              <Button
-                type="button"
-                variant="default"
-                disabled={isPending}
-                onClick={() => handleOpenChange(false)}
-              >
-                Cancel
-              </Button>
-              {isNew && (
-                <Button form={FORM_ID} type="submit" loading={isPending}>
-                  Add connection
-                </Button>
+            <SheetFooter className={!isNew ? 'sm:justify-between' : undefined}>
+              {!isNew ? (
+                <>
+                  <Button type="button" variant="danger" onClick={onDelete}>
+                    Delete
+                  </Button>
+                  <Button type="button" variant="default" onClick={() => handleOpenChange(false)}>
+                    Close
+                  </Button>
+                </>
+              ) : (
+                <>
+                  <Button
+                    type="button"
+                    variant="default"
+                    disabled={isPending}
+                    onClick={() => handleOpenChange(false)}
+                  >
+                    Cancel
+                  </Button>
+                  <Button form={FORM_ID} type="submit" loading={isPending}>
+                    Add connection
+                  </Button>
+                </>
               )}
             </SheetFooter>
           </form>

--- a/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLinkForm.tsx
+++ b/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLinkForm.tsx
@@ -55,9 +55,15 @@ interface AWSPrivateLinkFormProps {
   account?: AWSAccount
   open: boolean
   onOpenChange: (open: boolean) => void
+  onDelete?: () => void
 }
 
-export const AWSPrivateLinkForm = ({ account, open, onOpenChange }: AWSPrivateLinkFormProps) => {
+export const AWSPrivateLinkForm = ({
+  account,
+  open,
+  onOpenChange,
+  onDelete,
+}: AWSPrivateLinkFormProps) => {
   const isNew = !account
   const { data: project } = useSelectedProjectQuery()
   const showPrivateLinkReadReplica = useFlag('privatelinkReadReplica')
@@ -271,19 +277,30 @@ export const AWSPrivateLinkForm = ({ account, open, onOpenChange }: AWSPrivateLi
               )}
             </SheetSection>
 
-            <SheetFooter>
-              <Button
-                type="button"
-                variant="default"
-                disabled={isPending}
-                onClick={() => handleOpenChange(false)}
-              >
-                Cancel
-              </Button>
-              {isNew && (
-                <Button form={FORM_ID} type="submit" loading={isPending}>
-                  Add connection
-                </Button>
+            <SheetFooter className={!isNew ? 'sm:justify-between' : undefined}>
+              {!isNew ? (
+                <>
+                  <Button type="button" variant="danger" onClick={onDelete}>
+                    Delete
+                  </Button>
+                  <Button type="button" variant="default" onClick={() => handleOpenChange(false)}>
+                    Close
+                  </Button>
+                </>
+              ) : (
+                <>
+                  <Button
+                    type="button"
+                    variant="default"
+                    disabled={isPending}
+                    onClick={() => handleOpenChange(false)}
+                  >
+                    Cancel
+                  </Button>
+                  <Button form={FORM_ID} type="submit" loading={isPending}>
+                    Add connection
+                  </Button>
+                </>
               )}
             </SheetFooter>
           </form>

--- a/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLinkForm.tsx
+++ b/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLinkForm.tsx
@@ -1,11 +1,8 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useFlag } from 'common'
-import { ExternalLink } from 'lucide-react'
-import Link from 'next/link'
 import { useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 import {
-  Badge,
   Button,
   Form,
   FormControl,
@@ -24,12 +21,11 @@ import {
   SheetSection,
   SheetTitle,
 } from 'ui'
-import { Admonition } from 'ui-patterns/Admonition'
 import { Input as CopyableInput } from 'ui-patterns/DataInputs/Input'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { z } from 'zod'
 
-import { getConnectionStatusUi } from './AWSPrivateLink.utils'
+import { AWSPrivateLinkAttentionAdmonition } from './AWSPrivateLinkAttentionAdmonition'
 import { InlineLink } from '@/components/ui/InlineLink'
 import { useAWSAccountCreateMutation } from '@/data/aws-accounts/aws-account-create-mutation'
 import type { AWSAccount } from '@/data/aws-accounts/aws-accounts-query'
@@ -78,7 +74,6 @@ export const AWSPrivateLinkForm = ({
 
   const readReplicas = databases.filter((database) => database.identifier !== project?.ref)
   const showDatabaseTarget = showPrivateLinkReadReplica || !isNew
-  const statusUi = getConnectionStatusUi(account?.status)
 
   const form = useForm<FormValues>({
     resolver: zodResolver(FormSchema),
@@ -143,36 +138,7 @@ export const AWSPrivateLinkForm = ({
             className="flex flex-col flex-1 min-h-0"
           >
             <SheetSection className="space-y-4 flex-1 overflow-y-auto">
-              {!isNew && account && (
-                <Admonition
-                  showIcon={false}
-                  type="default"
-                  childProps={{ title: { className: 'flex-row gap-x-2 items-center' } }}
-                  // @ts-ignore
-                  title={
-                    <>
-                      <span>{statusUi.title}</span>
-                      <Badge className="ml-2" variant={statusUi.badgeVariant}>
-                        {statusUi.badge}
-                      </Badge>
-                    </>
-                  }
-                  description={statusUi.description}
-                  actions={
-                    account.status === 'READY' && (
-                      <Button variant="default" className="w-min" icon={<ExternalLink />}>
-                        <Link
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          href={`${DOCS_URL}/guides/platform/privatelink#step-2-accept-resource-share`}
-                        >
-                          How to accept
-                        </Link>
-                      </Button>
-                    )
-                  }
-                />
-              )}
+              {!isNew && account && <AWSPrivateLinkAttentionAdmonition accounts={[account]} />}
               <FormField
                 control={form.control}
                 name="awsAccountId"

--- a/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLinkSection.tsx
+++ b/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLinkSection.tsx
@@ -1,7 +1,19 @@
 import { useState } from 'react'
 import { toast } from 'sonner'
-import { Button, Card, CardContent, cn } from 'ui'
-import { ConfirmationModal } from 'ui-patterns/Dialogs/ConfirmationModal'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  Button,
+  Card,
+  CardContent,
+  cn,
+} from 'ui'
 import {
   PageSection,
   PageSectionContent,
@@ -13,6 +25,7 @@ import {
 
 import { IntegrationSectionIcon } from '../IntegrationsSettings'
 import { AWSPrivateLinkAccountItem } from './AWSPrivateLinkAccountItem'
+import { AWSPrivateLinkAttentionAdmonition } from './AWSPrivateLinkAttentionAdmonition'
 import { AWSPrivateLinkForm } from './AWSPrivateLinkForm'
 import { ResourceList } from '@/components/ui/Resource/ResourceList'
 import { UpgradeToPro } from '@/components/ui/UpgradeToPro'
@@ -36,6 +49,7 @@ export const AWSPrivateLinkSection = () => {
     onSuccess: () => {
       toast.success('Connection will be deleted shortly')
       setShowDeleteModal(false)
+      setShowForm(false)
       setSelectedAccount(undefined)
     },
   })
@@ -71,6 +85,13 @@ export const AWSPrivateLinkSection = () => {
     }
   }
 
+  const deleteDatabaseCopy =
+    selectedAccount?.database_type === 'READ_REPLICA'
+      ? selectedAccount.database_identifier
+        ? `the read replica (ID: ${formatDatabaseID(selectedAccount.database_identifier)})`
+        : 'a read replica'
+      : 'the primary database'
+
   return (
     <>
       <PageSection>
@@ -103,6 +124,7 @@ export const AWSPrivateLinkSection = () => {
                   Add connection
                 </Button>
               </div>
+              <AWSPrivateLinkAttentionAdmonition accounts={accounts} className="mb-3" />
               {(accounts?.length ?? 0) > 0 ? (
                 <ResourceList>
                   {accounts?.map((account) => (
@@ -126,31 +148,36 @@ export const AWSPrivateLinkSection = () => {
         </PageSectionContent>
       </PageSection>
 
-      <AWSPrivateLinkForm account={selectedAccount} open={showForm} onOpenChange={setShowForm} />
+      <AWSPrivateLinkForm
+        account={selectedAccount}
+        open={showForm}
+        onOpenChange={setShowForm}
+        onDelete={() => setShowDeleteModal(true)}
+      />
 
-      <ConfirmationModal
-        variant="destructive"
-        visible={showDeleteModal}
-        title="Delete connection"
-        confirmLabel="Delete"
-        loading={isDeleting}
-        onCancel={() => setShowDeleteModal(false)}
-        onConfirm={onConfirmDelete}
+      <AlertDialog
+        open={showDeleteModal}
+        onOpenChange={(open) => {
+          if (!open && !isDeleting) setShowDeleteModal(false)
+        }}
       >
-        <p className="text-sm text-foreground-light">
-          This removes the PrivateLink connection for {selectedAccount?.aws_account_id}.
-          Applications using this private path will lose access.
-        </p>
-        <p className="text-sm text-foreground-lighter mt-1">
-          Database:{' '}
-          {selectedAccount &&
-            ` ${
-              selectedAccount.database_type === 'READ_REPLICA'
-                ? `Read replica (ID: ${selectedAccount.database_identifier ? formatDatabaseID(selectedAccount.database_identifier) : 'Unknown identifier'})`
-                : 'Primary database'
-            }`}
-        </p>
-      </ConfirmationModal>
+        <AlertDialogContent size="small">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete connection</AlertDialogTitle>
+            <AlertDialogDescription>
+              This removes the PrivateLink connection for{' '}
+              <code className="text-code-inline">{selectedAccount?.aws_account_id}</code> on{' '}
+              {deleteDatabaseCopy}. Applications using this private path will lose access.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction variant="danger" loading={isDeleting} onClick={onConfirmDelete}>
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   )
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Accept-in-AWS guidance lives only in the view sheet, as a per-status essay with a nested button/link. Delete is easy to miss and does not name the database.

## What is the new behavior?

The list warns when any connection is Waiting or Expired. View connection uses that same admonition. Delete uses a confirm dialog that names the database, including from **View connection**.

| Before | After |
| --- | --- |
| <img width="1444" height="480" alt="CleanShot 2026-08-14 at 12 46 23@2x" src="https://github.com/user-attachments/assets/015b261b-0bee-48f4-8f2d-d0d23293e120" /> | <img width="1456" height="676" alt="CleanShot 2026-08-14 at 12 47 17@2x" src="https://github.com/user-attachments/assets/0a12371b-553a-4e52-b042-7498af722f4a" /> |
| <img width="844" height="560" alt="CleanShot 2026-08-14 at 12 46 49@2x" src="https://github.com/user-attachments/assets/f664b165-d351-4572-8536-27f4a9749975" /> | <img width="842" height="452" alt="CleanShot 2026-08-14 at 12 47 09@2x" src="https://github.com/user-attachments/assets/a387c294-5814-451b-9359-e70c73de2cb2" /> |

## Additional context

Stacked on #49086. See #49030 for the end state, as it may already include fixes you might propose.

## To test

- **Project Settings → Integrations → AWS PrivateLink → Add connection.** Leave it unaccepted in AWS. The list should show the 12-hour accept warning.
- **View connection** on that row. Same warning, **View instructions**, not a status essay.
- **⋯ → Delete** on a row, and **Delete** inside **View connection.** The dialog should name the database.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer AWS PrivateLink connection alerts for pending and expired connections, including guidance and acceptance links when applicable.
  * Existing PrivateLink connections can now be deleted directly from the connection form.
  * Added confirmation dialogs with loading and completion states for deletion.
  * Added more specific descriptions for primary databases and read replicas.

* **Bug Fixes**
  * Improved connection status messaging and handling for AWS PrivateLink integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->