### PR TITLE
chore(studio): lighten FormLayout descriptions and tighten GitHub copy

### DIFF
--- a/apps/studio/components/interfaces/ProjectCreation/ProjectCreationForm.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/ProjectCreationForm.tsx
@@ -680,8 +680,8 @@ export const ProjectCreationForm = ({
                           label="GitHub (optional)"
                           description={
                             <>
-                              Ideal for agent-first workflows: update your schema in code, push it
-                              to GitHub, and Supabase deploys the changes automatically.{' '}
+                              Ideal for agent-first workflows. Update your schema in code, push it
+                              to GitHub, Supabase deploys the changes.{' '}
                               <a
                                 href="https://supabase.com/docs/guides/deployment/branching/github-integration"
                                 target="_blank"

--- a/apps/studio/components/interfaces/ProjectCreation/ProjectCreationForm.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/ProjectCreationForm.tsx
@@ -680,8 +680,8 @@ export const ProjectCreationForm = ({
                           label="GitHub (optional)"
                           description={
                             <>
-                              Ideal for agent-first workflows. Update your schema in code, push it
-                              to GitHub, Supabase deploys the changes.{' '}
+                              Ideal for agent-first workflows. Update your schema in code and push
+                              it to GitHub. Supabase deploys the changes.{' '}
                               <a
                                 href="https://supabase.com/docs/guides/deployment/branching/github-integration"
                                 target="_blank"

--- a/packages/ui-patterns/src/form/Layout/FormLayout.tsx
+++ b/packages/ui-patterns/src/form/Layout/FormLayout.tsx
@@ -342,7 +342,7 @@ export const FormLayout = React.forwardRef<
         // Rendered as a div rather than a p as descriptions can be arbitrary JSX
         // which may contain block-level elements (invalid HTML inside a p)
         <div
-          className={cn(DescriptionVariants({ size, layout }), 'text-sm text-foreground-lighter')}
+          className={cn(DescriptionVariants({ size, layout }))}
           data-formlayout-id={'description'}
         >
           {description}

--- a/packages/ui-patterns/src/form/Layout/FormLayout.tsx
+++ b/packages/ui-patterns/src/form/Layout/FormLayout.tsx
@@ -342,7 +342,7 @@ export const FormLayout = React.forwardRef<
         // Rendered as a div rather than a p as descriptions can be arbitrary JSX
         // which may contain block-level elements (invalid HTML inside a p)
         <div
-          className={cn(DescriptionVariants({ size, layout }), 'text-sm text-foreground-light')}
+          className={cn(DescriptionVariants({ size, layout }), 'text-sm text-foreground-lighter')}
           data-formlayout-id={'description'}
         >
           {description}


### PR DESCRIPTION
## What kind of change does this PR introduce?

UI nits

## What is the current behavior?

`FormLayout` descriptions that are not in a react-hook-form field use `text-foreground-light`, which fights the component’s `text-foreground-lighter` variant. New-project GitHub helper copy is one long colon sentence.

## What is the new behavior?

Those `FormLayout` descriptions use the shared description variant (`foreground-lighter`). New-project GitHub copy is two short sentences.

| Figure |
| --- |
| <img width="820" height="798" alt="CleanShot 2026-08-14 at 14 33 32@2x" src="https://github.com/user-attachments/assets/7703a01d-efcb-41c2-8f6a-e96fc8a7187d" /> |
| _Example call site of **before** the `FormLayout` fix._ |
| <img width="1384" height="582" alt="CleanShot 2026-08-14 at 14 53 39@2x" src="https://github.com/user-attachments/assets/1bce1ee7-befd-4f53-881c-bbc7a87dd467" /> |
| _**After** New-project copy shortening._ |

## To test

- **Organization → New project.** GitHub (optional): “Ideal for agent-first workflows. Update your schema in code and push it to GitHub. Supabase deploys the changes.”
- **Project Settings → Database → SSL configuration.** “Reject non-SSL connections to your database” should look more muted (`foreground-lighter`), not the brighter `foreground-light`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified the GitHub repository field description while preserving deployment guidance and the “Learn more” link.

* **Style**
  * Lightened the color of descriptive text in form layouts for improved visual hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->