### PR TITLE
Joshenlim/fe 4174 project creation ignores selected us east 1 region

### DIFF
--- a/apps/studio/components/interfaces/ProjectCreation/ProjectCreationForm.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/ProjectCreationForm.tsx
@@ -443,13 +443,9 @@ export const ProjectCreationForm = ({
       extractPostgresVersionDetails(postgresVersionSelection)
 
     const { smartGroup = [], specific = [] } = availableRegionsData?.all ?? {}
-    const selectedRegion =
-      highAvailability && highAvailabilityRegionCode !== undefined
-        ? specific.find((region) => region.code === highAvailabilityRegionCode)
-        : smartRegionEnabled
-          ? (smartGroup.find((x) => x.name === dbRegion) ??
-            specific.find((x) => x.name === dbRegion))
-          : undefined
+    const selectedRegion = smartRegionEnabled
+      ? (smartGroup.find((x) => x.name === dbRegion) ?? specific.find((x) => x.name === dbRegion))
+      : undefined
 
     if (highAvailability && highAvailabilityRegionCode !== undefined && !selectedRegion) {
       return toast.error(

--- a/apps/studio/tests/pages/new/[slug].test.tsx
+++ b/apps/studio/tests/pages/new/[slug].test.tsx
@@ -792,6 +792,37 @@ describe('project creation wizard', () => {
       expect(body.custom_supabase_internal_requests).toBeUndefined()
     })
 
+    // Regression (FE-4174): in local dev, region choice isn't restricted to the fixed HA
+    // region (unlike staging), so a manual selection should be respected. onSubmit used to
+    // resolve the HA region purely from highAvailabilityRegionCode without that same
+    // exception, silently sending the fixed region regardless of what was displayed.
+    test('submits the manually selected region in local dev instead of the fixed HA default', async () => {
+      vi.stubEnv('NEXT_PUBLIC_ENVIRONMENT', 'local')
+      try {
+        mockWizardEndpoints({ availableRegions: AVAILABLE_REGIONS_WITH_FRANKFURT })
+        const onRequest = vi.fn()
+        mockCreateProject(onRequest)
+
+        await renderWizard()
+
+        await fillProjectName('Local HA Region Project')
+        await generateAndWaitForStrongPassword()
+
+        await user.click(await screen.findByRole('switch', { name: 'Enable high availability' }))
+        // Local dev stacks aren't restricted to the fixed HA region, so the user can still
+        // pick a different one from the (unrestricted) list.
+        await selectRegion(/East US/)
+        expect(getSelectTriggerByLabel('Region')).toHaveTextContent('East US (North Virginia)')
+
+        fireEvent.click(screen.getByRole('button', { name: 'Create new project' }))
+
+        await waitFor(() => expect(onRequest).toHaveBeenCalled())
+        expect(onRequest.mock.calls[0][0].region_selection).toMatchObject({ code: 'us-east-1' })
+      } finally {
+        vi.unstubAllEnvs()
+      }
+    })
+
     test('forces the high availability region over a manually selected region and restores it', async () => {
       vi.stubEnv('NEXT_PUBLIC_ENVIRONMENT', 'staging')
       try {


### PR DESCRIPTION
## Context

Addresses a bug on local only whereby when toggling HA in the project creation form, the database region was getting fixed to eu-central-1 irregardless of the region that was chosen on the UI. Was a result of old code that wasn't cleaned up when we introduced region selection for HA locally.

Added regression test to cover this case as well 🙏 

## To test
Can only be tested locally
- [ ] On the project creation form, toggle HA and create a project in us-east-1 - the project should be created in the selected region, and not eu-central-1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed project creation so high-availability settings no longer replace a manually selected database region.
  - Smart-region providers continue using the selected smart or specific region.

- **Tests**
  - Added regression coverage to verify that manually selected regions are submitted correctly in local high-availability environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->