### PR TITLE
chore: update vendor DepthFirst

### DIFF
--- a/apps/www/app/api-v2/ticket-og/route.tsx
+++ b/apps/www/app/api-v2/ticket-og/route.tsx
@@ -27,7 +27,6 @@ const LW_MATERIALIZED_VIEW = 'tickets_view'
 export async function GET(req: Request) {
   const url = new URL(req.url)
 
-  // Just here to silence snyk false positives
   // Verify that req.url is from an allowed domain
   const username = url.searchParams.get('username') ?? url.searchParams.get('amp;username')
   const userAgent = req.headers.get('user-agent')

--- a/apps/www/pages/security.mdx
+++ b/apps/www/pages/security.mdx
@@ -194,7 +194,7 @@ Read more about [fine-grained access controls](/docs/guides/platform/access-cont
 
 Supabase works with industry experts to conduct regular penetration tests.
 
-In addition to internal security reviews, we use various tools to scan our code for vulnerabilities including [GitHub](https://github.com), [Vanta](https://www.vanta.com/), and [Snyk](https://snyk.io/).
+In addition to internal security reviews, we use various tools to scan our code for vulnerabilities including [GitHub](https://github.com), [Vanta](https://www.vanta.com/), and [DepthFirst](https://depthfirst.com/).
 
 </Section>
 

--- a/supa-mdx-lint/Rule003Spelling.toml
+++ b/supa-mdx-lint/Rule003Spelling.toml
@@ -217,6 +217,7 @@ allow_list = [
     "Datadog",
     "Deadpool",
     "Dependabot",
+    "DepthFirst"
     "DDoS",
     "Deno",
     "Dependabot",


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

www update



## Additional context

Snyk is no longer used, we use DepthFirst


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Security page to identify DepthFirst as the code-vulnerability scanning tool.

* **Chores**
  * Added “DepthFirst” to the documentation spelling allow list.
  * Removed an obsolete internal comment with no user-visible behavior change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->