### PR TITLE
Centralize empty state + error handling for query results

### DIFF
--- a/apps/studio/components/interfaces/Explorer/QueryEditor.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryEditor.tsx
@@ -21,8 +21,7 @@ import {
   ExplorerToolbarTitle,
 } from './ExplorerToolbar'
 import { DisplaySettingsButton } from './QueryCell/DisplaySettingsButton'
-import { QueryResultChart } from './QueryCell/QueryResultChart'
-import { QueryResultTable } from './QueryResultTable'
+import { QueryResultRenderer } from './QueryResultRenderer'
 import { type QueryDisplay, type QueryResult } from './types'
 import { CodeEditor } from '@/components/ui/CodeEditor/CodeEditor'
 import { isValidConnString } from '@/data/fetchers'
@@ -227,13 +226,10 @@ export const QueryEditor = ({
 
       <ExplorerQueryResults
         className={cn(
-          (result?.rows ?? []).length === 0 && view === 'table'
-            ? 'items-center justify-center'
-            : 'overflow-x-auto'
+          (result?.rows ?? []).length === 0 ? 'items-center justify-center' : 'overflow-x-auto'
         )}
       >
-        {view === 'table' && <QueryResultTable result={result} />}
-        {view === 'chart' && <QueryResultChart chart={display?.chart} result={result} />}
+        <QueryResultRenderer view={view} result={result} chart={display?.chart} />
       </ExplorerQueryResults>
 
       <ExplorerQueryFooter className="flex items-center gap-x-2">

--- a/apps/studio/components/interfaces/Explorer/QueryResultChart.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryResultChart.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import { Chart, ChartBar, ChartCard, ChartContent, ChartLine } from 'ui-patterns/Chart'
 
-import { type QueryChartConfig, type QueryResult } from '../types'
+import { type QueryChartConfig, type QueryResult } from './types'
 import NoDataPlaceholder from '@/components/ui/Charts/NoDataPlaceholder'
 import { formatLogTick, getCumulativeResults } from '@/components/ui/QueryBlock/QueryBlock.utils'
 

--- a/apps/studio/components/interfaces/Explorer/QueryResultError.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryResultError.tsx
@@ -7,7 +7,6 @@ import { subscriptionHasHipaaAddon } from '../Billing/Subscription/Subscription.
 import { type QueryResult } from './types'
 import { AiAssistantDropdown } from '@/components/ui/AiAssistantDropdown'
 import CopyButton from '@/components/ui/CopyButton'
-import { DataGridResults } from '@/components/ui/DataGridResults'
 import { InlineLink, InlineLinkClassName } from '@/components/ui/InlineLink'
 import { useProjectSettingsV2Query } from '@/data/config/project-settings-v2-query'
 import { getSqlErrorLines } from '@/data/sql/utils'
@@ -15,37 +14,7 @@ import { useOrgSubscriptionQuery } from '@/data/subscriptions/org-subscription-q
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 import { DOCS_URL } from '@/lib/constants'
 
-interface QueryResultTableProps {
-  result?: QueryResult
-}
-
-// [Joshen] This is essentially a duplicate of UtilityTabResults from the SQL Editor
-// I'll eventually migrate the Results component over - just trying to avoid bloating
-// changes wherever possible
-
-// [Joshen] Should be shifted into QueryCell folder
-
-export const QueryResultTable = ({ result }: QueryResultTableProps) => {
-  const { rows, error, autoLimit } = result ?? {}
-
-  if (!result) {
-    return <p className="text-xs text-foreground-light">Run the query to see results</p>
-  }
-
-  if (error) {
-    return <QueryError error={error} autoLimit={autoLimit} />
-  }
-
-  if ((rows ?? []).length === 0) {
-    return <p className="text-xs text-foreground-light">Success. No rows returned</p>
-  }
-
-  if (rows && rows.length > 0) {
-    return <QueryResults rows={rows} />
-  }
-}
-
-const QueryError = ({
+export const QueryResultError = ({
   error,
   autoLimit,
 }: {
@@ -182,9 +151,4 @@ const QueryError = ({
       </div>
     </div>
   )
-}
-
-// [Joshen] Eventually migrate the Results component here from SQL Editor
-const QueryResults = ({ rows }: { rows: NonNullable<QueryResult['rows']> }) => {
-  return <DataGridResults rows={rows} />
 }

--- a/apps/studio/components/interfaces/Explorer/QueryResultError.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryResultError.tsx
@@ -44,7 +44,7 @@ export const QueryResultError = ({
   )
 
   return (
-    <div className="bg-table-header-light in-data-[theme*=dark]:bg-table-header-dark overflow-y-auto">
+    <div className="w-full bg-table-header-light in-data-[theme*=dark]:bg-table-header-dark overflow-y-auto">
       <div className="flex flex-row justify-between items-start py-4 px-6 gap-x-4">
         {isTimeout ? (
           <div className="flex flex-col gap-y-1">

--- a/apps/studio/components/interfaces/Explorer/QueryResultRenderer.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryResultRenderer.tsx
@@ -1,0 +1,33 @@
+import { QueryResultChart } from './QueryResultChart'
+import { QueryResultError } from './QueryResultError'
+import { type QueryChartConfig, type QueryResult } from './types'
+import { DataGridResults } from '@/components/ui/DataGridResults'
+
+interface QueryResultRendererProps {
+  result?: QueryResult
+  view?: 'table' | 'chart'
+  chart?: QueryChartConfig
+}
+
+export const QueryResultRenderer = ({ result, view, chart }: QueryResultRendererProps) => {
+  const { rows, error, autoLimit } = result ?? {}
+
+  if (!result) {
+    return <p className="text-xs text-foreground-lighter">Run the query to see results</p>
+  }
+
+  if (error) {
+    return <QueryResultError error={error} autoLimit={autoLimit} />
+  }
+
+  if ((rows ?? []).length === 0) {
+    return <p className="text-xs text-foreground-lighter">Success. No rows returned</p>
+  }
+
+  if (rows && rows.length > 0) {
+    if (view === 'table') return <DataGridResults rows={rows} />
+    if (view === 'chart') return <QueryResultChart chart={chart} result={result} />
+  }
+
+  return null
+}


### PR DESCRIPTION
## Context

Related to Explorer/Notebook - currently with the chart view, if the query has any errors, there's no error UI being shown
Mainly because the error UI handlers are all within the table view

Changes here hence opt to extract the empty state + error UI into a centralized renderer

<img width="936" height="366" alt="image" src="https://github.com/user-attachments/assets/437891dc-241e-4c43-97a6-6eef52472ee7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unified query result display for prompts, errors, empty results, tables, and charts.
  * Query results now switch consistently between table and chart views.

* **Bug Fixes**
  * Improved empty-result layout centering across views.
  * Expanded error display to use the available width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->