### PR TITLE
fix(realtime): add pg changes pool to realtime settings

### DIFF
--- a/apps/docs/content/guides/realtime/concepts.mdx
+++ b/apps/docs/content/guides/realtime/concepts.mdx
@@ -64,7 +64,9 @@ The number of connections varies based on your compute add-on size and configura
 
 <Admonition type="note">
 
-You can customize `Authorization Pool Size` through the `Database connection pool size` parameter in your Realtime configuration. If not specified, the default values shown in the table will be used.
+You can customize `Authorization Pool Size` through the `Database connection pool size` parameter, and `Subscription management` through the `Postgres Changes connection pool size` parameter, in your Realtime configuration. If not specified, the default values shown in the table are used.
+
+Both pools open connections against the same database, so size them together. Raising `Subscription management` increases how many Postgres Changes subscriptions Realtime can create at once, which helps when many clients subscribe simultaneously, such as after a deployment or a network reconnect.
 
 </Admonition>
 

--- a/apps/docs/content/guides/realtime/postgres-changes.mdx
+++ b/apps/docs/content/guides/realtime/postgres-changes.mdx
@@ -3631,6 +3631,7 @@ For most applications this is plenty. To get the best performance:
 
 - Use [filters](#available-filters) and [column selection](#selecting-specific-columns) to send each client only the events and columns it needs.
 - Keep authorization cheap by writing , indexed [RLS policies](/docs/guides/database/postgres/row-level-security).
+- Raise `Postgres Changes connection pool size` in [Realtime Settings](/docs/guides/realtime/settings) if many clients subscribe at the same time. Realtime uses this pool to write subscriptions to your database, so a pool that's too small makes subscriptions queue and eventually time out.
 
 Use the estimator below to gauge the maximum throughput for your instance, and run your own benchmarks to confirm it fits your use case:
 

--- a/apps/docs/content/guides/realtime/settings.mdx
+++ b/apps/docs/content/guides/realtime/settings.mdx
@@ -28,6 +28,7 @@ You can set the following settings using the Realtime Settings screen in your Da
 - Enable Realtime service: Determines if the Realtime service is enabled or disabled for your project.
 - Channel Restrictions: You can toggle this settings to set Realtime to allow public channels or set it to use only private channels with [Realtime Authorization](/docs/guides/realtime/authorization).
 - Database connection pool size: Determines the number of connections used for Realtime Authorization RLS checking
+- Postgres Changes connection pool size: Determines the number of connections used to create Postgres Changes subscriptions when clients subscribe. This pool is separate from the Realtime Authorization pool, and Realtime only opens it if your project uses [Postgres Changes](/docs/guides/realtime/postgres-changes)
   {/* supa-mdx-lint-disable-next-line Rule004ExcludeWords */}
 - Max concurrent clients: Determines the maximum number of clients that can be connected
 - Max events per second: Determines the maximum number of events per second that can be sent

--- a/apps/studio/components/interfaces/Realtime/RealtimeSettings.test.tsx
+++ b/apps/studio/components/interfaces/Realtime/RealtimeSettings.test.tsx
@@ -1,0 +1,137 @@
+import { fireEvent, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { components } from 'api-types'
+import { mockAnimationsApi } from 'jsdom-testing-mocks'
+import { HttpResponse } from 'msw'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { RealtimeSettings } from './RealtimeSettings'
+import { customRender } from '@/tests/lib/custom-render'
+import { addAPIMock } from '@/tests/lib/msw'
+
+mockAnimationsApi()
+
+const {
+  mockUseAsyncCheckPermissions,
+  mockUseMaxConnectionsQuery,
+  mockUseSelectedOrganizationQuery,
+  mockUseSelectedProjectQuery,
+  mockUseDatabasePoliciesQuery,
+} = vi.hoisted(() => ({
+  mockUseAsyncCheckPermissions: vi.fn(),
+  mockUseMaxConnectionsQuery: vi.fn(),
+  mockUseSelectedOrganizationQuery: vi.fn(),
+  mockUseSelectedProjectQuery: vi.fn(),
+  mockUseDatabasePoliciesQuery: vi.fn(),
+}))
+
+vi.mock('@/hooks/misc/useCheckPermissions', () => ({
+  useAsyncCheckPermissions: mockUseAsyncCheckPermissions,
+}))
+
+vi.mock('@/hooks/misc/useSelectedProject', () => ({
+  useSelectedProjectQuery: mockUseSelectedProjectQuery,
+}))
+
+vi.mock('@/hooks/misc/useSelectedOrganization', () => ({
+  useSelectedOrganizationQuery: mockUseSelectedOrganizationQuery,
+}))
+
+vi.mock('@/data/database/max-connections-query', () => ({
+  useMaxConnectionsQuery: mockUseMaxConnectionsQuery,
+}))
+
+vi.mock('@/data/database-policies/database-policies-query', () => ({
+  useDatabasePoliciesQuery: mockUseDatabasePoliciesQuery,
+}))
+
+const REALTIME_CONFIG: components['schemas']['RealtimeConfigResponse'] = {
+  connection_pool: 2,
+  postgres_changes_pool: 2,
+  max_bytes_per_second: 100000,
+  max_channels_per_client: 100,
+  max_concurrent_users: 200,
+  max_events_per_second: 100,
+  max_joins_per_second: 100,
+  max_payload_size_in_kb: 100,
+  max_presence_events_per_second: 100,
+  presence_enabled: true,
+  private_only: false,
+  suspend: false,
+}
+
+describe('RealtimeSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockUseAsyncCheckPermissions.mockReturnValue({ can: true, isSuccess: true })
+    mockUseSelectedProjectQuery.mockReturnValue({
+      data: { ref: 'default', connectionString: 'postgresql://example' },
+    })
+    mockUseSelectedOrganizationQuery.mockReturnValue({ data: undefined, isSuccess: false })
+    mockUseMaxConnectionsQuery.mockReturnValue({ data: { maxConnections: 20 } })
+    mockUseDatabasePoliciesQuery.mockReturnValue({ data: [], isSuccess: true })
+
+    addAPIMock({
+      method: 'get',
+      path: '/platform/projects/:ref/config/realtime',
+      response: () =>
+        HttpResponse.json<components['schemas']['RealtimeConfigResponse']>(REALTIME_CONFIG),
+    })
+  })
+
+  test('renders the fetched pool value and warns when the combined pool size exceeds 50% of max connections', async () => {
+    customRender(<RealtimeSettings />)
+
+    const postgresChangesPoolInput = await screen.findByLabelText(
+      'Postgres Changes connection pool size'
+    )
+    expect(postgresChangesPoolInput).toHaveValue(2)
+    expect(
+      screen.queryByText(/Both pools combined are greater than 50% of the max connections/)
+    ).not.toBeInTheDocument()
+
+    await userEvent.clear(postgresChangesPoolInput)
+    await userEvent.type(postgresChangesPoolInput, '8')
+
+    expect(
+      screen.queryByText(/Both pools combined are greater than 50% of the max connections/)
+    ).not.toBeInTheDocument()
+
+    await userEvent.clear(postgresChangesPoolInput)
+    await userEvent.type(postgresChangesPoolInput, '9')
+
+    expect(
+      await screen.findByText(/Both pools combined are greater than 50% of the max connections/)
+    ).toBeInTheDocument()
+    expect(screen.getByText(/Realtime opens 11 connections across both pools/)).toBeInTheDocument()
+  })
+
+  test('submits the postgres changes pool value when saving', async () => {
+    const requests: components['schemas']['UpdateRealtimeConfigBody'][] = []
+    addAPIMock({
+      method: 'patch',
+      path: '/platform/projects/:ref/config/realtime',
+      response: async ({ request }) => {
+        requests.push((await request.json()) as components['schemas']['UpdateRealtimeConfigBody'])
+        return HttpResponse.json({}, { status: 204 })
+      },
+    })
+
+    customRender(<RealtimeSettings />)
+
+    const postgresChangesPoolInput = await screen.findByLabelText(
+      'Postgres Changes connection pool size'
+    )
+    await userEvent.clear(postgresChangesPoolInput)
+    await userEvent.type(postgresChangesPoolInput, '5')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }))
+
+    const dialog = await screen.findByRole('dialog')
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Save changes' }))
+
+    await waitFor(() => expect(requests).toHaveLength(1))
+    expect(requests[0]).toMatchObject({ postgres_changes_pool: 5 })
+  })
+})

--- a/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
+++ b/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
@@ -41,6 +41,8 @@ import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 
 const formId = 'realtime-configuration-form'
 
+const MAX_POSTGRES_CHANGES_POOL = 20
+
 export const RealtimeSettings = () => {
   const { ref: projectRef } = useParams()
   const { data: project } = useSelectedProjectQuery()
@@ -93,6 +95,7 @@ export const RealtimeSettings = () => {
         .min(1)
         .max(maxConn?.maxConnections ?? 100)
         .optional(),
+      postgres_changes_pool: z.coerce.number().min(1).max(MAX_POSTGRES_CHANGES_POOL).optional(),
       max_concurrent_users: z.coerce.number().min(1).max(50000).optional(),
       max_events_per_second: z.coerce.number().min(1).max(50000).optional(),
       max_presence_events_per_second: z.coerce.number().min(1).max(5000).optional(),
@@ -110,6 +113,7 @@ export const RealtimeSettings = () => {
         .number()
         .min(1)
         .max(maxConn?.maxConnections ?? 100),
+      postgres_changes_pool: z.coerce.number().min(1).max(MAX_POSTGRES_CHANGES_POOL),
       max_concurrent_users: z.coerce.number().min(1).max(50000),
       max_events_per_second: z.coerce.number().min(1).max(50000),
       max_presence_events_per_second: z.coerce.number().min(1).max(5000),
@@ -135,10 +139,12 @@ export const RealtimeSettings = () => {
     } as any,
   })
 
-  const [allow_public, suspend] = useWatch({
+  const [allow_public, suspend, connection_pool, postgres_changes_pool] = useWatch({
     control: form.control,
-    name: ['allow_public', 'suspend'],
+    name: ['allow_public', 'suspend', 'connection_pool', 'postgres_changes_pool'],
   })
+  const totalPoolSize = Number(connection_pool ?? 0) + Number(postgres_changes_pool ?? 0)
+  const isTotalPoolSizeExcessive = !!maxConn && totalPoolSize > maxConn.maxConnections * 0.5
   const isSettingToPrivate = !data?.private_only && !allow_public
   const isDisablingRealtime = !isRealtimeDisabled && suspend
   const isEnablingRealtime = isRealtimeDisabled && !suspend
@@ -159,6 +165,11 @@ export const RealtimeSettings = () => {
       private_only: !values.allow_public,
       connection_pool: Number(
         values.connection_pool ?? data?.connection_pool ?? REALTIME_DEFAULT_CONFIG.connection_pool
+      ),
+      postgres_changes_pool: Number(
+        values.postgres_changes_pool ??
+          data?.postgres_changes_pool ??
+          REALTIME_DEFAULT_CONFIG.postgres_changes_pool
       ),
       max_concurrent_users: Number(
         values.max_concurrent_users ??
@@ -309,41 +320,66 @@ export const RealtimeSettings = () => {
                       control={form.control}
                       name="connection_pool"
                       render={({ field }) => (
-                        <>
-                          <FormItemLayout
-                            id="connection_pool"
-                            layout="flex-row-reverse"
-                            label="Database connection pool size"
-                            description="Realtime Authorization uses this database pool to check client access"
-                          >
-                            <FormControl>
-                              <InputGroup>
-                                <FormInputGroupInput
-                                  {...field}
-                                  id="connection_pool"
-                                  type="number"
-                                  disabled={!canUpdateConfig}
-                                  value={field.value || ''}
-                                />
-                                <InputGroupAddon align="inline-end">
-                                  <InputGroupText>connections</InputGroupText>
-                                </InputGroupAddon>
-                              </InputGroup>
-                            </FormControl>
-                          </FormItemLayout>
-                          {!!maxConn &&
-                            field.value &&
-                            field.value > maxConn.maxConnections * 0.5 && (
-                              <Admonition
-                                showIcon={false}
-                                type="warning"
-                                title={`Pool size is greater than 50% of the max connections (${maxConn.maxConnections}) on your database`}
-                                description="This may result in instability and unreliability with your database connections."
+                        <FormItemLayout
+                          id="connection_pool"
+                          layout="flex-row-reverse"
+                          label="Database connection pool size"
+                          description="Realtime Authorization uses this database pool to check client access"
+                        >
+                          <FormControl>
+                            <InputGroup>
+                              <FormInputGroupInput
+                                {...field}
+                                id="connection_pool"
+                                type="number"
+                                disabled={!canUpdateConfig}
+                                value={field.value || ''}
                               />
-                            )}
-                        </>
+                              <InputGroupAddon align="inline-end">
+                                <InputGroupText>connections</InputGroupText>
+                              </InputGroupAddon>
+                            </InputGroup>
+                          </FormControl>
+                        </FormItemLayout>
                       )}
                     />
+                  </CardContent>
+                  <CardContent className="space-y-2">
+                    <FormField
+                      control={form.control}
+                      name="postgres_changes_pool"
+                      render={({ field }) => (
+                        <FormItemLayout
+                          id="postgres_changes_pool"
+                          layout="flex-row-reverse"
+                          label="Postgres Changes connection pool size"
+                          description="Postgres Changes uses this database pool to create subscriptions when clients subscribe"
+                        >
+                          <FormControl>
+                            <InputGroup>
+                              <FormInputGroupInput
+                                {...field}
+                                id="postgres_changes_pool"
+                                type="number"
+                                disabled={!canUpdateConfig}
+                                value={field.value || ''}
+                              />
+                              <InputGroupAddon align="inline-end">
+                                <InputGroupText>connections</InputGroupText>
+                              </InputGroupAddon>
+                            </InputGroup>
+                          </FormControl>
+                        </FormItemLayout>
+                      )}
+                    />
+                    {isTotalPoolSizeExcessive && (
+                      <Admonition
+                        showIcon={false}
+                        type="warning"
+                        title={`Both pools combined are greater than 50% of the max connections (${maxConn?.maxConnections}) on your database`}
+                        description={`Realtime opens ${totalPoolSize} connections across both pools. This may result in instability and unreliability with your database connections.`}
+                      />
+                    )}
                   </CardContent>
                   <CardContent>
                     <FormField

--- a/apps/studio/data/realtime/realtime-config-mutation.ts
+++ b/apps/studio/data/realtime/realtime-config-mutation.ts
@@ -14,6 +14,7 @@ export async function updateRealtimeConfiguration({
   ref,
   private_only,
   connection_pool,
+  postgres_changes_pool,
   max_concurrent_users,
   max_events_per_second,
   max_bytes_per_second,
@@ -30,6 +31,7 @@ export async function updateRealtimeConfiguration({
     body: {
       private_only,
       connection_pool,
+      postgres_changes_pool,
       max_concurrent_users,
       max_events_per_second,
       max_bytes_per_second,

--- a/apps/studio/data/realtime/realtime-config-query.ts
+++ b/apps/studio/data/realtime/realtime-config-query.ts
@@ -12,6 +12,7 @@ export type RealtimeConfigurationVariables = {
 export const REALTIME_DEFAULT_CONFIG = {
   private_only: false,
   connection_pool: 2,
+  postgres_changes_pool: 2,
   max_concurrent_users: 200,
   max_events_per_second: 100,
   max_bytes_per_second: 100000,


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

add pg changes pool to realtime settings

https://linear.app/supabase/issue/REAL-973/add-pg-changes-pool-documentation
https://linear.app/supabase/issue/REAL-950/add-settings-to-realtime-settings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a separate Postgres Changes connection pool setting in Realtime configuration.
  * Added validation, save support, and a default pool size of 2 connections.
  * Added warnings when Authorization and Postgres Changes pools together exceed half of the database connection limit.

* **Documentation**
  * Documented pool sizing, shared database usage, and scaling guidance for concurrent subscriptions.
  * Clarified that undersized pools may queue subscriptions or cause timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->