### PR TITLE
refactor(studio): derive notebook diff entries

### DIFF
--- a/apps/studio/data/content/notebooks/notebook-operations.test.ts
+++ b/apps/studio/data/content/notebooks/notebook-operations.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { applyNotebookOperations, type NotebookOperation } from './notebook-operations'
+import {
+  applyNotebookOperations,
+  deriveNotebookDiff,
+  type NotebookOperation,
+} from './notebook-operations'
 import type { NotebookWire } from './notebook-schema'
 
 const NOTEBOOK: NotebookWire = {
@@ -255,5 +259,263 @@ describe('applyNotebookOperations', () => {
     const result = applyNotebookOperations(NOTEBOOK, ops)
 
     expect(result).toEqual({ success: false, error: { _tag: 'empty_result' } })
+  })
+
+  it('anchors an insert on a cell that an earlier operation replaced', () => {
+    const ops: NotebookOperation[] = [
+      { _tag: 'replace_cell', cell_id: 'cell-2', cell: NEW_MARKDOWN_CELL },
+      { _tag: 'insert_cell', after_cell_id: 'cell-2', cell: { _tag: 'markdown_cell', text: 'x' } },
+    ]
+
+    const result = applyNotebookOperations(NOTEBOOK, ops)
+
+    expect(result).toEqual({
+      success: true,
+      notebook: {
+        schema_version: 1,
+        cells: [
+          NOTEBOOK.cells[0],
+          NEW_MARKDOWN_CELL,
+          { _tag: 'markdown_cell', text: 'x' },
+          NOTEBOOK.cells[2],
+        ],
+      },
+    })
+  })
+
+  it('anchors a move on a cell that an earlier operation replaced', () => {
+    const ops: NotebookOperation[] = [
+      { _tag: 'replace_cell', cell_id: 'cell-2', cell: NEW_MARKDOWN_CELL },
+      { _tag: 'move_cell', cell_id: 'cell-3', after_cell_id: 'cell-2' },
+    ]
+
+    const result = applyNotebookOperations(NOTEBOOK, ops)
+
+    expect(result).toEqual({
+      success: true,
+      notebook: {
+        schema_version: 1,
+        cells: [NOTEBOOK.cells[0], NEW_MARKDOWN_CELL, NOTEBOOK.cells[2]],
+      },
+    })
+  })
+
+  it('still rejects an operation targeting a cell that an earlier operation replaced', () => {
+    // A replaced cell can be anchored on, but not targeted — the conflict pre-pass rejects
+    // the batch before any operation runs.
+    const ops: NotebookOperation[] = [
+      { _tag: 'replace_cell', cell_id: 'cell-2', cell: NEW_MARKDOWN_CELL },
+      { _tag: 'delete_cell', cell_id: 'cell-2' },
+    ]
+
+    const result = applyNotebookOperations(NOTEBOOK, ops)
+
+    expect(result).toEqual({
+      success: false,
+      error: { _tag: 'conflicting_operations', cell_id: 'cell-2' },
+    })
+  })
+})
+
+describe('deriveNotebookDiff', () => {
+  it('annotates every cell as unchanged when there are no operations', () => {
+    const result = deriveNotebookDiff(NOTEBOOK, [])
+
+    expect(result).toEqual({
+      success: true,
+      entries: [
+        { _tag: 'unchanged', cell: NOTEBOOK.cells[0] },
+        { _tag: 'unchanged', cell: NOTEBOOK.cells[1] },
+        { _tag: 'unchanged', cell: NOTEBOOK.cells[2] },
+      ],
+    })
+  })
+
+  it('annotates an inserted cell as added in its resulting position', () => {
+    const ops: NotebookOperation[] = [
+      { _tag: 'insert_cell', after_cell_id: 'cell-1', cell: NEW_MARKDOWN_CELL },
+    ]
+
+    const result = deriveNotebookDiff(NOTEBOOK, ops)
+
+    expect(result).toEqual({
+      success: true,
+      entries: [
+        { _tag: 'unchanged', cell: NOTEBOOK.cells[0] },
+        { _tag: 'added', cell: NEW_MARKDOWN_CELL, operationIndex: 0 },
+        { _tag: 'unchanged', cell: NOTEBOOK.cells[1] },
+        { _tag: 'unchanged', cell: NOTEBOOK.cells[2] },
+      ],
+    })
+  })
+
+  it('annotates a replaced cell in place, keeping both sides', () => {
+    const ops: NotebookOperation[] = [
+      { _tag: 'replace_cell', cell_id: 'cell-2', cell: NEW_MARKDOWN_CELL },
+    ]
+
+    const result = deriveNotebookDiff(NOTEBOOK, ops)
+
+    expect(result).toEqual({
+      success: true,
+      entries: [
+        { _tag: 'unchanged', cell: NOTEBOOK.cells[0] },
+        {
+          _tag: 'replaced',
+          before: NOTEBOOK.cells[1],
+          after: NEW_MARKDOWN_CELL,
+          operationIndex: 0,
+        },
+        { _tag: 'unchanged', cell: NOTEBOOK.cells[2] },
+      ],
+    })
+  })
+
+  it('keeps a deleted cell in the position it used to hold', () => {
+    const ops: NotebookOperation[] = [{ _tag: 'delete_cell', cell_id: 'cell-2' }]
+
+    const result = deriveNotebookDiff(NOTEBOOK, ops)
+
+    expect(result).toEqual({
+      success: true,
+      entries: [
+        { _tag: 'unchanged', cell: NOTEBOOK.cells[0] },
+        { _tag: 'removed', cell: NOTEBOOK.cells[1], operationIndex: 0 },
+        { _tag: 'unchanged', cell: NOTEBOOK.cells[2] },
+      ],
+    })
+  })
+
+  it('annotates a moved cell with the position it started from', () => {
+    const ops: NotebookOperation[] = [
+      { _tag: 'move_cell', cell_id: 'cell-1', after_cell_id: 'cell-3' },
+    ]
+
+    const result = deriveNotebookDiff(NOTEBOOK, ops)
+
+    expect(result).toEqual({
+      success: true,
+      entries: [
+        { _tag: 'unchanged', cell: NOTEBOOK.cells[1] },
+        { _tag: 'unchanged', cell: NOTEBOOK.cells[2] },
+        { _tag: 'moved', cell: NOTEBOOK.cells[0], fromIndex: 0, operationIndex: 0 },
+      ],
+    })
+  })
+
+  it('reports fromIndex against the original notebook, not the shifted working order', () => {
+    const ops: NotebookOperation[] = [
+      { _tag: 'delete_cell', cell_id: 'cell-1' },
+      { _tag: 'move_cell', cell_id: 'cell-3', after_cell_id: 'start' },
+    ]
+
+    const result = deriveNotebookDiff(NOTEBOOK, ops)
+
+    expect(result).toEqual({
+      success: true,
+      entries: [
+        { _tag: 'moved', cell: NOTEBOOK.cells[2], fromIndex: 2, operationIndex: 1 },
+        { _tag: 'removed', cell: NOTEBOOK.cells[0], operationIndex: 0 },
+        { _tag: 'unchanged', cell: NOTEBOOK.cells[1] },
+      ],
+    })
+  })
+
+  it('downgrades moves that cancel out to unchanged', () => {
+    // Same operations as the applyNotebookOperations case that lands back on the original
+    // order: nothing actually moved, so nothing should be badged as moved.
+    const ops: NotebookOperation[] = [
+      { _tag: 'move_cell', cell_id: 'cell-1', after_cell_id: 'cell-2' },
+      { _tag: 'move_cell', cell_id: 'cell-2', after_cell_id: 'cell-1' },
+    ]
+
+    const result = deriveNotebookDiff(NOTEBOOK, ops)
+
+    expect(result).toEqual({
+      success: true,
+      entries: [
+        { _tag: 'unchanged', cell: NOTEBOOK.cells[0] },
+        { _tag: 'unchanged', cell: NOTEBOOK.cells[1] },
+        { _tag: 'unchanged', cell: NOTEBOOK.cells[2] },
+      ],
+    })
+  })
+
+  it('keeps reporting moves that do change the order', () => {
+    const ops: NotebookOperation[] = [
+      { _tag: 'move_cell', cell_id: 'cell-1', after_cell_id: 'cell-3' },
+      { _tag: 'move_cell', cell_id: 'cell-2', after_cell_id: 'cell-1' },
+    ]
+
+    const result = deriveNotebookDiff(NOTEBOOK, ops)
+
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    expect(result.entries.map((entry) => entry._tag)).toEqual(['unchanged', 'moved', 'moved'])
+  })
+
+  it('leaves removed entries out of the way of inserts anchored at the same cell', () => {
+    const ops: NotebookOperation[] = [
+      { _tag: 'delete_cell', cell_id: 'cell-2' },
+      {
+        _tag: 'insert_cell',
+        after_cell_id: 'cell-1',
+        cell: { _tag: 'markdown_cell', text: '1st' },
+      },
+      {
+        _tag: 'insert_cell',
+        after_cell_id: 'cell-1',
+        cell: { _tag: 'markdown_cell', text: '2nd' },
+      },
+    ]
+
+    const result = deriveNotebookDiff(NOTEBOOK, ops)
+
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    expect(result.entries.map((entry) => entry._tag)).toEqual([
+      'unchanged',
+      'added',
+      'added',
+      'removed',
+      'unchanged',
+    ])
+    // The removed entry sits in the middle of the entry list but must not affect the order
+    // the surviving cells end up in.
+    expect(applyNotebookOperations(NOTEBOOK, ops)).toEqual({
+      success: true,
+      notebook: {
+        schema_version: 1,
+        cells: [
+          NOTEBOOK.cells[0],
+          { _tag: 'markdown_cell', text: '1st' },
+          { _tag: 'markdown_cell', text: '2nd' },
+          NOTEBOOK.cells[2],
+        ],
+      },
+    })
+  })
+
+  it('reports the same errors as applyNotebookOperations', () => {
+    expect(deriveNotebookDiff(NOTEBOOK, [{ _tag: 'delete_cell', cell_id: 'missing' }])).toEqual({
+      success: false,
+      error: { _tag: 'unknown_cell_id', cell_id: 'missing' },
+    })
+    expect(
+      deriveNotebookDiff(NOTEBOOK, [
+        { _tag: 'delete_cell', cell_id: 'cell-2' },
+        { _tag: 'replace_cell', cell_id: 'cell-2', cell: NEW_MARKDOWN_CELL },
+      ])
+    ).toEqual({
+      success: false,
+      error: { _tag: 'conflicting_operations', cell_id: 'cell-2' },
+    })
+    expect(
+      deriveNotebookDiff(NOTEBOOK, [
+        { _tag: 'delete_cell', cell_id: 'cell-1' },
+        { _tag: 'delete_cell', cell_id: 'cell-2' },
+        { _tag: 'delete_cell', cell_id: 'cell-3' },
+      ])
+    ).toEqual({ success: false, error: { _tag: 'empty_result' } })
   })
 })

--- a/apps/studio/data/content/notebooks/notebook-operations.ts
+++ b/apps/studio/data/content/notebooks/notebook-operations.ts
@@ -67,6 +67,33 @@ export type ApplyNotebookOperationsResult =
   | { success: true; notebook: NotebookOperationsResult }
   | { success: false; error: NotebookOperationError }
 
+/**
+ * One entry per cell position in the notebook that a set of operations produces, annotated
+ * with what the operations did to it. `removed` entries are kept in the position the cell
+ * held before its deletion so the list reads as a diff; every other entry sits where the
+ * cell ends up.
+ *
+ * `operationIndex` is the index of the operation that produced the entry. Its main job is
+ * giving `added` and `replaced` entries a stable React key: their cells have no `id` by
+ * construction (`agentCellSchema` omits it — the backend assigns one on write).
+ */
+export type NotebookCellDiffEntry =
+  | { _tag: 'unchanged'; cell: CellWire }
+  | { _tag: 'added'; cell: AgentCell; operationIndex: number }
+  | { _tag: 'removed'; cell: CellWire; operationIndex: number }
+  | { _tag: 'replaced'; before: CellWire; after: AgentCell; operationIndex: number }
+  | {
+      _tag: 'moved'
+      cell: CellWire
+      /** The cell's zero-based position in the notebook before any operation ran. */
+      fromIndex: number
+      operationIndex: number
+    }
+
+export type DeriveNotebookDiffResult =
+  | { success: true; entries: NotebookCellDiffEntry[] }
+  | { success: false; error: NotebookOperationError }
+
 export function describeNotebookOperationError(error: NotebookOperationError): string {
   switch (error._tag) {
     case 'unknown_cell_id':
@@ -89,10 +116,97 @@ function targetCellId(operation: NotebookOperation): string | undefined {
   }
 }
 
-export function applyNotebookOperations(
+/**
+ * The position an operation can anchor at, by cell id. A replaced cell still anchors: the
+ * replacement holds the same position, so the old id remains a meaningful address for it
+ * even though the new cell carries no `id` of its own until the backend assigns one on
+ * write. Without this, an agent replacing a cell and inserting after it in the same batch
+ * gets a spurious `unknown_cell_id`.
+ */
+function findAnchorIndex(entries: NotebookCellDiffEntry[], cellId: string): number {
+  return entries.findIndex((entry) => {
+    switch (entry._tag) {
+      case 'unchanged':
+      case 'moved':
+        return entry.cell.id === cellId
+      case 'replaced':
+        return entry.before.id === cellId
+      // A removed cell is no longer in the notebook, and an inserted cell has no id to be
+      // addressed by until the backend assigns one.
+      case 'added':
+      case 'removed':
+        return false
+    }
+  })
+}
+
+/**
+ * The cell an operation can target by id — one still holding its original identity.
+ * Replaced and removed entries are excluded because `deriveNotebookDiff` rejects two
+ * operations targeting the same cell before any of them run, so those entries can never be
+ * a legitimate target.
+ */
+function findTargetCell(
+  entries: NotebookCellDiffEntry[],
+  cellId: string
+): { index: number; cell: CellWire } | undefined {
+  for (let index = 0; index < entries.length; index++) {
+    const entry = entries[index]
+    if (entry._tag !== 'unchanged' && entry._tag !== 'moved') continue
+    if (entry.cell.id === cellId) return { index, cell: entry.cell }
+  }
+  return undefined
+}
+
+/**
+ * A cell targeted by `move_cell` has not necessarily changed position — two moves can
+ * anchor on each other and cancel out. Compares each moved cell's predecessors among the
+ * surviving original cells and downgrades the entry to `unchanged` when that set is
+ * unchanged, so a review UI doesn't badge a cell as moved when it sits exactly where it
+ * started.
+ */
+function downgradeNoOpMoves(
+  entries: NotebookCellDiffEntry[],
+  notebook: NotebookWire
+): NotebookCellDiffEntry[] {
+  if (!entries.some((entry) => entry._tag === 'moved')) return entries
+
+  const finalOrder = entries.flatMap((entry) =>
+    entry._tag === 'unchanged' || entry._tag === 'moved' ? [entry.cell.id] : []
+  )
+  const survivingIds = new Set(finalOrder)
+  const originalOrder = notebook.cells
+    .map((cell) => cell.id)
+    .filter((cellId) => survivingIds.has(cellId))
+
+  // Both sequences are permutations of the same id set, so equal predecessor counts plus
+  // containment is enough to prove the predecessor sets match.
+  const hasSamePredecessors = (cellId: string) => {
+    const finalPredecessors = new Set(finalOrder.slice(0, finalOrder.indexOf(cellId)))
+    const originalPredecessors = originalOrder.slice(0, originalOrder.indexOf(cellId))
+    return (
+      originalPredecessors.length === finalPredecessors.size &&
+      originalPredecessors.every((predecessor) => finalPredecessors.has(predecessor))
+    )
+  }
+
+  return entries.map((entry) =>
+    entry._tag === 'moved' && hasSamePredecessors(entry.cell.id)
+      ? { _tag: 'unchanged', cell: entry.cell }
+      : entry
+  )
+}
+
+/**
+ * Resolves an ordered list of operations against a notebook into one annotated entry per
+ * cell position. This is the only interpreter of notebook operations —
+ * `applyNotebookOperations` projects its result — so the diff a user approves cannot
+ * disagree with the cells that get written.
+ */
+export function deriveNotebookDiff(
   notebook: NotebookWire,
   operations: NotebookOperation[]
-): ApplyNotebookOperationsResult {
+): DeriveNotebookDiffResult {
   const targetedIds = new Set<string>()
   for (const operation of operations) {
     const cellId = targetCellId(operation)
@@ -104,53 +218,71 @@ export function applyNotebookOperations(
     targetedIds.add(cellId)
   }
 
-  const cells: OperationResultCell[] = [...notebook.cells]
-  const indexOfCellId = (cellId: string) =>
-    cells.findIndex((cell) => 'id' in cell && cell.id === cellId)
+  const originalIndexById = new Map(notebook.cells.map((cell, index) => [cell.id, index]))
+  const entries: NotebookCellDiffEntry[] = notebook.cells.map((cell) => ({
+    _tag: 'unchanged',
+    cell,
+  }))
 
   const insertedAfter = new Map<string, number>()
   const insertAfter = (
     anchor: string,
-    item: OperationResultCell
+    entry: NotebookCellDiffEntry
   ): NotebookOperationError | undefined => {
-    const anchorIndex = anchor === CELL_ANCHOR_START ? -1 : indexOfCellId(anchor)
+    const anchorIndex = anchor === CELL_ANCHOR_START ? -1 : findAnchorIndex(entries, anchor)
     if (anchor !== CELL_ANCHOR_START && anchorIndex === -1) {
       return { _tag: 'unknown_cell_id', cell_id: anchor }
     }
 
+    // Inserts anchored at the same cell land in the order they were issued. Removed
+    // entries left in place don't disturb this: prior inserts still sit immediately after
+    // the anchor, so the offset lands after them.
     const offset = insertedAfter.get(anchor) ?? 0
-    cells.splice(anchorIndex + 1 + offset, 0, item)
+    entries.splice(anchorIndex + 1 + offset, 0, entry)
     insertedAfter.set(anchor, offset + 1)
     return undefined
   }
 
-  for (const operation of operations) {
+  for (let operationIndex = 0; operationIndex < operations.length; operationIndex++) {
+    const operation = operations[operationIndex]
+
     switch (operation._tag) {
       case 'insert_cell': {
-        const error = insertAfter(operation.after_cell_id, operation.cell)
+        const error = insertAfter(operation.after_cell_id, {
+          _tag: 'added',
+          cell: operation.cell,
+          operationIndex,
+        })
         if (error) return { success: false, error }
         break
       }
       case 'replace_cell': {
-        const index = indexOfCellId(operation.cell_id)
-        if (index === -1) {
+        const found = findTargetCell(entries, operation.cell_id)
+        if (found === undefined) {
           return {
             success: false,
             error: { _tag: 'unknown_cell_id', cell_id: operation.cell_id },
           }
         }
-        cells[index] = operation.cell
+        entries[found.index] = {
+          _tag: 'replaced',
+          before: found.cell,
+          after: operation.cell,
+          operationIndex,
+        }
         break
       }
       case 'delete_cell': {
-        const index = indexOfCellId(operation.cell_id)
-        if (index === -1) {
+        const found = findTargetCell(entries, operation.cell_id)
+        if (found === undefined) {
           return {
             success: false,
             error: { _tag: 'unknown_cell_id', cell_id: operation.cell_id },
           }
         }
-        cells.splice(index, 1)
+        // Marked in place rather than spliced out, so the diff can show the deletion where
+        // the cell used to be.
+        entries[found.index] = { _tag: 'removed', cell: found.cell, operationIndex }
         break
       }
       case 'move_cell': {
@@ -161,28 +293,63 @@ export function applyNotebookOperations(
           }
         }
 
-        const fromIndex = indexOfCellId(operation.cell_id)
-        if (fromIndex === -1) {
+        const found = findTargetCell(entries, operation.cell_id)
+        if (found === undefined) {
           return {
             success: false,
             error: { _tag: 'unknown_cell_id', cell_id: operation.cell_id },
           }
         }
 
-        const [movedCell] = cells.splice(fromIndex, 1)
-        const error = insertAfter(operation.after_cell_id, movedCell)
+        entries.splice(found.index, 1)
+        const error = insertAfter(operation.after_cell_id, {
+          _tag: 'moved',
+          cell: found.cell,
+          // An addressable entry only ever holds a cell from `notebook.cells`, so the
+          // lookup can't miss; the current index is a harmless fallback.
+          fromIndex: originalIndexById.get(found.cell.id) ?? found.index,
+          operationIndex,
+        })
         if (error) return { success: false, error }
         break
       }
     }
   }
 
-  if (cells.length === 0) {
+  if (!entries.some((entry) => entry._tag !== 'removed')) {
     return { success: false, error: { _tag: 'empty_result' } }
   }
 
+  return { success: true, entries: downgradeNoOpMoves(entries, notebook) }
+}
+
+function resultingCells(entries: NotebookCellDiffEntry[]): OperationResultCell[] {
+  return entries.flatMap((entry) => {
+    switch (entry._tag) {
+      case 'unchanged':
+      case 'moved':
+      case 'added':
+        return [entry.cell]
+      case 'replaced':
+        return [entry.after]
+      case 'removed':
+        return []
+    }
+  })
+}
+
+export function applyNotebookOperations(
+  notebook: NotebookWire,
+  operations: NotebookOperation[]
+): ApplyNotebookOperationsResult {
+  const result = deriveNotebookDiff(notebook, operations)
+  if (!result.success) return result
+
   return {
     success: true,
-    notebook: { schema_version: notebook.schema_version, cells },
+    notebook: {
+      schema_version: notebook.schema_version,
+      cells: resultingCells(result.entries),
+    },
   }
 }

--- a/apps/studio/data/content/notebooks/notebook-operations.ts
+++ b/apps/studio/data/content/notebooks/notebook-operations.ts
@@ -67,16 +67,6 @@ export type ApplyNotebookOperationsResult =
   | { success: true; notebook: NotebookOperationsResult }
   | { success: false; error: NotebookOperationError }
 
-/**
- * One entry per cell position in the notebook that a set of operations produces, annotated
- * with what the operations did to it. `removed` entries are kept in the position the cell
- * held before its deletion so the list reads as a diff; every other entry sits where the
- * cell ends up.
- *
- * `operationIndex` is the index of the operation that produced the entry. Its main job is
- * giving `added` and `replaced` entries a stable React key: their cells have no `id` by
- * construction (`agentCellSchema` omits it — the backend assigns one on write).
- */
 export type NotebookCellDiffEntry =
   | { _tag: 'unchanged'; cell: CellWire }
   | { _tag: 'added'; cell: AgentCell; operationIndex: number }
@@ -85,7 +75,6 @@ export type NotebookCellDiffEntry =
   | {
       _tag: 'moved'
       cell: CellWire
-      /** The cell's zero-based position in the notebook before any operation ran. */
       fromIndex: number
       operationIndex: number
     }
@@ -116,13 +105,6 @@ function targetCellId(operation: NotebookOperation): string | undefined {
   }
 }
 
-/**
- * The position an operation can anchor at, by cell id. A replaced cell still anchors: the
- * replacement holds the same position, so the old id remains a meaningful address for it
- * even though the new cell carries no `id` of its own until the backend assigns one on
- * write. Without this, an agent replacing a cell and inserting after it in the same batch
- * gets a spurious `unknown_cell_id`.
- */
 function findAnchorIndex(entries: NotebookCellDiffEntry[], cellId: string): number {
   return entries.findIndex((entry) => {
     switch (entry._tag) {
@@ -131,8 +113,6 @@ function findAnchorIndex(entries: NotebookCellDiffEntry[], cellId: string): numb
         return entry.cell.id === cellId
       case 'replaced':
         return entry.before.id === cellId
-      // A removed cell is no longer in the notebook, and an inserted cell has no id to be
-      // addressed by until the backend assigns one.
       case 'added':
       case 'removed':
         return false
@@ -140,12 +120,6 @@ function findAnchorIndex(entries: NotebookCellDiffEntry[], cellId: string): numb
   })
 }
 
-/**
- * The cell an operation can target by id — one still holding its original identity.
- * Replaced and removed entries are excluded because `deriveNotebookDiff` rejects two
- * operations targeting the same cell before any of them run, so those entries can never be
- * a legitimate target.
- */
 function findTargetCell(
   entries: NotebookCellDiffEntry[],
   cellId: string
@@ -158,13 +132,6 @@ function findTargetCell(
   return undefined
 }
 
-/**
- * A cell targeted by `move_cell` has not necessarily changed position — two moves can
- * anchor on each other and cancel out. Compares each moved cell's predecessors among the
- * surviving original cells and downgrades the entry to `unchanged` when that set is
- * unchanged, so a review UI doesn't badge a cell as moved when it sits exactly where it
- * started.
- */
 function downgradeNoOpMoves(
   entries: NotebookCellDiffEntry[],
   notebook: NotebookWire
@@ -179,8 +146,6 @@ function downgradeNoOpMoves(
     .map((cell) => cell.id)
     .filter((cellId) => survivingIds.has(cellId))
 
-  // Both sequences are permutations of the same id set, so equal predecessor counts plus
-  // containment is enough to prove the predecessor sets match.
   const hasSamePredecessors = (cellId: string) => {
     const finalPredecessors = new Set(finalOrder.slice(0, finalOrder.indexOf(cellId)))
     const originalPredecessors = originalOrder.slice(0, originalOrder.indexOf(cellId))
@@ -197,12 +162,6 @@ function downgradeNoOpMoves(
   )
 }
 
-/**
- * Resolves an ordered list of operations against a notebook into one annotated entry per
- * cell position. This is the only interpreter of notebook operations —
- * `applyNotebookOperations` projects its result — so the diff a user approves cannot
- * disagree with the cells that get written.
- */
 export function deriveNotebookDiff(
   notebook: NotebookWire,
   operations: NotebookOperation[]
@@ -234,9 +193,6 @@ export function deriveNotebookDiff(
       return { _tag: 'unknown_cell_id', cell_id: anchor }
     }
 
-    // Inserts anchored at the same cell land in the order they were issued. Removed
-    // entries left in place don't disturb this: prior inserts still sit immediately after
-    // the anchor, so the offset lands after them.
     const offset = insertedAfter.get(anchor) ?? 0
     entries.splice(anchorIndex + 1 + offset, 0, entry)
     insertedAfter.set(anchor, offset + 1)
@@ -280,8 +236,6 @@ export function deriveNotebookDiff(
             error: { _tag: 'unknown_cell_id', cell_id: operation.cell_id },
           }
         }
-        // Marked in place rather than spliced out, so the diff can show the deletion where
-        // the cell used to be.
         entries[found.index] = { _tag: 'removed', cell: found.cell, operationIndex }
         break
       }
@@ -305,8 +259,6 @@ export function deriveNotebookDiff(
         const error = insertAfter(operation.after_cell_id, {
           _tag: 'moved',
           cell: found.cell,
-          // An addressable entry only ever holds a cell from `notebook.cells`, so the
-          // lookup can't miss; the current index is a harmless fallback.
           fromIndex: originalIndexById.get(found.cell.id) ?? found.index,
           operationIndex,
         })


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Refactor, plus one bug fix.

Groundwork for showing the user a preview of what they are approving when the AI Assistant creates or edits a notebook. No UI in this PR.

Towards FE-4143

## What is the current behavior?

`applyNotebookOperations` resolves an ordered list of notebook operations into the resulting cells and nothing else. Rendering a diff for the approval gate needs to know *what happened* to each cell position, not just where things landed, so there is no way to build the preview on top of it.

Separately, replacing a cell dropped its id, so `[replace cell-2, insert after cell-2]` failed with a spurious `unknown_cell_id`.

## What is the new behavior?

`deriveNotebookDiff` resolves operations into one annotated entry per cell position (`unchanged`, `added`, `removed`, `replaced`, `moved`). `applyNotebookOperations` becomes a thin projection over its result, so there is a single interpreter of notebook operations and the diff a user approves cannot disagree with the cells that get written. The pre-existing tests pass untouched, which is the evidence that the projection is faithful.

Notes on the annotations:

- `removed` entries stay in the position the cell used to hold so the list reads as a diff. This does not perturb insert-anchor arithmetic: prior inserts still sit contiguously after their anchor.
- Moves that cancel out are downgraded to `unchanged`, since two moves can anchor on each other and leave every cell where it started. Badging those as moved would make the preview lie.
- `fromIndex` is the cell's position in the original notebook rather than in the shifted working order, so `was #3` means what a reader expects.

A replaced cell now stays addressable as an anchor. Anchoring and targeting are separate lookups: a replaced cell can be anchored on, but is never a legitimate target.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notebook changes now provide a structured view of added, removed, replaced, moved, and unchanged cells.
  * Replaced cells can be used as insertion anchors, while invalid or duplicate targets are rejected.
  * No-op moves are handled as unchanged cells.
  * Notebook edits preserve operation ordering and original cell positions for more predictable results.

* **Bug Fixes**
  * Improved notebook operation handling and error reporting for complex cell edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->