### PR TITLE
fix(ui-patterns): restore Warp's MCP setup instructions

### DIFF
--- a/packages/ui-patterns/src/McpUrlBuilder/clients.instructions.md.tsx
+++ b/packages/ui-patterns/src/McpUrlBuilder/clients.instructions.md.tsx
@@ -188,6 +188,22 @@ export const MCP_CLIENT_INSTRUCTIONS: Record<string, McpClientInstructions> = {
       </>
     ),
   },
+  warp: {
+    alternate: () => (
+      <>
+        <paragraph>
+          Warp supports remote MCP servers natively, so no local proxy is needed. You can also add
+          the server from the UI: open the MCP servers page (<strong>Settings</strong> &gt;{' '}
+          <strong>Agents</strong> &gt; <strong>MCP Servers</strong>, or search for MCP in the
+          command palette), click <strong>+ Add</strong>, and paste the same JSON.
+        </paragraph>
+        <paragraph>
+          After adding the server, Warp opens a browser window to complete the Supabase OAuth flow
+          and stores the credentials securely on your device.
+        </paragraph>
+      </>
+    ),
+  },
   goose: {
     primary: ({ url }) => (
       <>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix. Warp's MCP setup instructions were removed by an unrelated change and no longer render.

## What is the current behavior?

#49048 rebranded the Windsurf client entry to Devin Desktop, which also meant dropping the old Windsurf instructions block (it carried a "Windsurf version 0.1.37 or higher" note that no longer applies). That part looks intended.

The `warp` block sat directly underneath it in `clients.instructions.md.tsx` and was deleted in the same hunk. Nothing else about that change touches Warp: `key: 'warp'` is still a client in `clients.data.ts`, its icons are still registered, and it is still listed in the IDE group.

`McpConfigPanel.md.tsx` looks instructions up as `MCP_CLIENT_INSTRUCTIONS[client.key]`, so with no `warp` key the lookup returns undefined and the panel just renders the config block without the guidance. It fails quietly rather than erroring, which is probably why it slipped through.

What readers lose is the part that explains the config they are looking at:

- that Warp supports remote MCP servers natively, so no local proxy is needed
- how to add the server from the UI instead, and that Warp then opens a browser to finish the Supabase OAuth flow

That first point matters more than usual here, because the Warp entry deliberately has no `transformConfig`. Every neighbouring client that needs `mcp-remote` gets a transformed config, so without the note there is nothing on the page explaining why Warp's looks different.

## What is the new behavior?

The `warp` block is restored exactly as #48838 added it, byte for byte. I diffed the restored block against `ececf6c003^` to confirm.

I deliberately did not touch anything else:

- the Windsurf block stays deleted, since that removal goes with the rename
- I did not write a new instructions block for Devin Desktop. There isn't one now, and inventing setup steps for a client I cannot test would be guessing. Worth a follow up by someone who can check it against the app.

## Additional context

Eight other clients have no instructions entry and render fine, so this is not a crash, just content that used to be there and now isn't.

How I found it: I was re-checking the MCP client icon contract after the Devin icons landed, noticed `windsurf` had become an orphaned asset, and followed that into the commit. The instructions deletion was 31 removed lines with none added, which is what made me look at the hunk rather than just the data file.

Gates on this branch: `test:prettier` passes repo wide, `typecheck --filter=ui-patterns...` passes 4/4, and the McpUrlBuilder vitest suite passes (5 tests). I did not run `pnpm build`, which cannot finish in my environment because the docs `build:federated-content` step needs `DOCS_GITHUB_APP_PRIVATE_KEY`.

Freshman contributor. Found this with Claude Code's help while auditing the client icon registry, and I verified the restored block against the pre-deletion file myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added setup guidance for connecting remote MCP servers through Warp.
  * Documented Warp’s UI configuration flow, JSON server setup, and Supabase OAuth credential storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->