### PR TITLE
feat(studio): add NotebookPreview diff component

### DIFF
--- a/apps/studio/components/interfaces/Explorer/NotebookPreview/NotebookPreview.test.tsx
+++ b/apps/studio/components/interfaces/Explorer/NotebookPreview/NotebookPreview.test.tsx
@@ -14,6 +14,21 @@ const wireMarkdownCell = (id: string, text: string): CellWire => ({
 
 const agentMarkdownCell = (text: string): AgentCell => ({ _tag: 'markdown_cell', text })
 
+const wireDatabaseCell = (id: string, database_identifier?: string): CellWire => ({
+  _tag: 'database_cell',
+  id,
+  sql: 'select 1',
+  row_limit: 100,
+  database_identifier,
+})
+
+const agentDatabaseCell = (database_identifier?: string): AgentCell => ({
+  _tag: 'database_cell',
+  sql: 'select 1',
+  row_limit: 100,
+  database_identifier,
+})
+
 describe('NotebookPreview', () => {
   // The whole safety argument for this feature reduces to this: agent-authored markdown text
   // is rendered as literal source (via CodeBlock), never interpreted into real DOM nodes. A
@@ -41,6 +56,21 @@ describe('NotebookPreview', () => {
     render(<NotebookPreview entries={entries} mode="create" />)
 
     expect(screen.getByText('2 cells')).toBeInTheDocument()
+  })
+
+  it('surfaces a metadata-only change on a replaced cell even when the sql is unchanged', () => {
+    const entries: NotebookCellDiffEntry[] = [
+      {
+        _tag: 'replaced',
+        before: wireDatabaseCell('cell-1', 'primary'),
+        after: agentDatabaseCell('replica-3'),
+        operationIndex: 0,
+      },
+    ]
+
+    render(<NotebookPreview entries={entries} mode="update" />)
+
+    expect(screen.getByText('Database: primary → Database: replica-3')).toBeInTheDocument()
   })
 
   it('hides entries past the limit behind a "Show N more" button', async () => {

--- a/apps/studio/components/interfaces/Explorer/NotebookPreview/NotebookPreview.test.tsx
+++ b/apps/studio/components/interfaces/Explorer/NotebookPreview/NotebookPreview.test.tsx
@@ -1,0 +1,56 @@
+import { screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { NotebookPreview } from './NotebookPreview'
+import type { NotebookCellDiffEntry } from '@/data/content/notebooks/notebook-operations'
+import type { AgentCell, CellWire } from '@/data/content/notebooks/notebook-schema'
+import { customRender as render } from '@/tests/lib/custom-render'
+
+const wireMarkdownCell = (id: string, text: string): CellWire => ({
+  _tag: 'markdown_cell',
+  id,
+  text,
+})
+
+const agentMarkdownCell = (text: string): AgentCell => ({ _tag: 'markdown_cell', text })
+
+describe('NotebookPreview', () => {
+  // The whole safety argument for this feature reduces to this: agent-authored markdown text
+  // is rendered as literal source (via CodeBlock), never interpreted into real DOM nodes. A
+  // future refactor that swaps in <Markdown> would break this silently.
+  it('never renders agent-authored cell content as real img/link/src DOM nodes', () => {
+    const adversarialText =
+      '![x](https://evil.example/) [y](https://evil.example/) <img src=x onerror=1>'
+    const entries: NotebookCellDiffEntry[] = [
+      { _tag: 'added', cell: agentMarkdownCell(adversarialText), operationIndex: 0 },
+    ]
+
+    const { container } = render(<NotebookPreview entries={entries} mode="update" />)
+
+    expect(container.querySelectorAll('img')).toHaveLength(0)
+    expect(container.querySelectorAll('[href]')).toHaveLength(0)
+    expect(container.querySelectorAll('[src]')).toHaveLength(0)
+  })
+
+  it('renders the create-mode header summary', () => {
+    const entries: NotebookCellDiffEntry[] = [
+      { _tag: 'unchanged', cell: wireMarkdownCell('a', 'one') },
+      { _tag: 'unchanged', cell: wireMarkdownCell('b', 'two') },
+    ]
+
+    render(<NotebookPreview entries={entries} mode="create" />)
+
+    expect(screen.getByText('2 cells')).toBeInTheDocument()
+  })
+
+  it('hides entries past the limit behind a "Show N more" button', async () => {
+    const entries: NotebookCellDiffEntry[] = Array.from({ length: 7 }, (_, index) => ({
+      _tag: 'unchanged' as const,
+      cell: wireMarkdownCell(`cell-${index}`, `text-${index}`),
+    }))
+
+    render(<NotebookPreview entries={entries} mode="create" />)
+
+    expect(screen.getByText('Show 2 more cells')).toBeInTheDocument()
+  })
+})

--- a/apps/studio/components/interfaces/Explorer/NotebookPreview/NotebookPreview.tsx
+++ b/apps/studio/components/interfaces/Explorer/NotebookPreview/NotebookPreview.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react'
+import { Button } from 'ui'
+
+import {
+  formatNotebookDiffSummary,
+  getEntryKey,
+  summarizeNotebookDiff,
+} from './NotebookPreview.utils'
+import { NotebookPreviewCell } from './NotebookPreviewCell'
+import type { NotebookCellDiffEntry } from '@/data/content/notebooks/notebook-operations'
+
+export interface NotebookPreviewProps {
+  entries: NotebookCellDiffEntry[]
+  mode: 'create' | 'update'
+}
+
+// Long notebooks stay skimmable behind a "show more" affordance rather than a fixed scroll
+// area, mirroring AdvisorPanelBody's "Show N more issues" pattern.
+const VISIBLE_ENTRY_LIMIT = 5
+
+/**
+ * Read-only preview of a proposed notebook create/update, rendered from a pre-computed diff.
+ * Pure presentational component: no data fetching, no approval or notebook-editor state — see
+ * `deriveNotebookDiff` for how `entries` is produced.
+ */
+export const NotebookPreview = ({ entries, mode }: NotebookPreviewProps) => {
+  const [isExpanded, setIsExpanded] = useState(false)
+
+  const summary = summarizeNotebookDiff(entries, mode)
+  const visibleEntries = isExpanded ? entries : entries.slice(0, VISIBLE_ENTRY_LIMIT)
+  const hiddenCount = entries.length - visibleEntries.length
+
+  return (
+    <div className="flex flex-col gap-2">
+      <p className="text-xs text-foreground-light font-mono">
+        {formatNotebookDiffSummary(summary)}
+      </p>
+      <div className="flex flex-col gap-1.5">
+        {visibleEntries.map((entry) => (
+          <NotebookPreviewCell key={getEntryKey(entry)} entry={entry} />
+        ))}
+      </div>
+      {hiddenCount > 0 && (
+        <Button variant="text" className="w-full" onClick={() => setIsExpanded(true)}>
+          Show {hiddenCount} more cell{hiddenCount === 1 ? '' : 's'}
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/apps/studio/components/interfaces/Explorer/NotebookPreview/NotebookPreview.tsx
+++ b/apps/studio/components/interfaces/Explorer/NotebookPreview/NotebookPreview.tsx
@@ -14,8 +14,6 @@ export interface NotebookPreviewProps {
   mode: 'create' | 'update'
 }
 
-// Long notebooks stay skimmable behind a "show more" affordance rather than a fixed scroll
-// area, mirroring AdvisorPanelBody's "Show N more issues" pattern.
 const VISIBLE_ENTRY_LIMIT = 5
 
 /**

--- a/apps/studio/components/interfaces/Explorer/NotebookPreview/NotebookPreview.utils.test.ts
+++ b/apps/studio/components/interfaces/Explorer/NotebookPreview/NotebookPreview.utils.test.ts
@@ -1,9 +1,11 @@
+import dayjs from 'dayjs'
 import { describe, expect, it } from 'vitest'
 
 import {
   formatNotebookDiffSummary,
   formatTimeRange,
   getCellLabel,
+  getCellMetadataLine,
   getEntryKey,
   summarizeNotebookDiff,
 } from './NotebookPreview.utils'
@@ -19,12 +21,20 @@ const wireMarkdownCell = (id: string, text = 'hello'): CellWire => ({
 
 const agentMarkdownCell = (text = 'hello'): AgentCell => ({ _tag: 'markdown_cell', text })
 
-const wireDatabaseCell = (id: string, title?: string): CellWire => ({
+const wireDatabaseCell = (id: string, title?: string, database_identifier?: string): CellWire => ({
   _tag: 'database_cell',
   id,
   title,
   sql: 'select 1',
   row_limit: 100,
+  database_identifier,
+})
+
+const wireLogCell = (id: string): CellWire => ({
+  _tag: 'log_cell',
+  id,
+  sql: 'select 1',
+  time_range: { _tag: 'relative_time_range', unit: 'day', amount: 7 },
 })
 
 describe('getEntryKey', () => {
@@ -86,13 +96,35 @@ describe('formatTimeRange', () => {
   })
 
   it('formats an absolute range as a start → end pair', () => {
-    const formatted = formatTimeRange({
-      _tag: 'absolute_time_range',
-      start: isoDateTimeString('2026-01-01T00:00:00.000Z')!,
-      end: isoDateTimeString('2026-01-02T00:00:00.000Z')!,
-    })
-    expect(formatted).toContain('→')
-    expect(formatted).toContain('2026')
+    const start = isoDateTimeString('2026-01-01T13:00:00.000Z')!
+    const end = isoDateTimeString('2026-01-02T09:30:00.000Z')!
+
+    const formatted = formatTimeRange({ _tag: 'absolute_time_range', start, end })
+
+    // Bounds are asserted via dayjs rather than a hardcoded string so this doesn't depend on
+    // the test runner's local timezone (formatTimeRange formats in local time).
+    const expectedBound = (value: string) => dayjs(value).format('MMM D, YYYY h:mm A')
+    expect(formatted).toBe(`${expectedBound(start)} → ${expectedBound(end)}`)
+  })
+})
+
+describe('getCellMetadataLine', () => {
+  it('returns null for markdown cells', () => {
+    expect(getCellMetadataLine(wireMarkdownCell('cell-1'))).toBeNull()
+  })
+
+  it('returns null for a database cell with no database_identifier', () => {
+    expect(getCellMetadataLine(wireDatabaseCell('cell-1'))).toBeNull()
+  })
+
+  it('labels a database cell with a database_identifier', () => {
+    expect(getCellMetadataLine(wireDatabaseCell('cell-1', 'Signups', 'replica-3'))).toBe(
+      'Database: replica-3'
+    )
+  })
+
+  it('labels a log cell with its formatted time range', () => {
+    expect(getCellMetadataLine(wireLogCell('cell-1'))).toBe('Time range: Last 7 days')
   })
 })
 

--- a/apps/studio/components/interfaces/Explorer/NotebookPreview/NotebookPreview.utils.test.ts
+++ b/apps/studio/components/interfaces/Explorer/NotebookPreview/NotebookPreview.utils.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  formatNotebookDiffSummary,
+  formatTimeRange,
+  getCellLabel,
+  getEntryKey,
+  summarizeNotebookDiff,
+} from './NotebookPreview.utils'
+import type { NotebookCellDiffEntry } from '@/data/content/notebooks/notebook-operations'
+import type { AgentCell, CellWire } from '@/data/content/notebooks/notebook-schema'
+import { isoDateTimeString } from '@/lib/iso-datetime'
+
+const wireMarkdownCell = (id: string, text = 'hello'): CellWire => ({
+  _tag: 'markdown_cell',
+  id,
+  text,
+})
+
+const agentMarkdownCell = (text = 'hello'): AgentCell => ({ _tag: 'markdown_cell', text })
+
+const wireDatabaseCell = (id: string, title?: string): CellWire => ({
+  _tag: 'database_cell',
+  id,
+  title,
+  sql: 'select 1',
+  row_limit: 100,
+})
+
+describe('getEntryKey', () => {
+  it('keys unchanged, removed, and moved entries off the cell id', () => {
+    expect(getEntryKey({ _tag: 'unchanged', cell: wireMarkdownCell('cell-1') })).toBe('cell-1')
+    expect(
+      getEntryKey({ _tag: 'removed', cell: wireMarkdownCell('cell-2'), operationIndex: 0 })
+    ).toBe('cell-2')
+    expect(
+      getEntryKey({
+        _tag: 'moved',
+        cell: wireMarkdownCell('cell-3'),
+        fromIndex: 1,
+        operationIndex: 0,
+      })
+    ).toBe('cell-3')
+  })
+
+  it('keys added and replaced entries off the operation index', () => {
+    expect(getEntryKey({ _tag: 'added', cell: agentMarkdownCell(), operationIndex: 2 })).toBe(
+      'op-2'
+    )
+    expect(
+      getEntryKey({
+        _tag: 'replaced',
+        before: wireMarkdownCell('cell-4'),
+        after: agentMarkdownCell(),
+        operationIndex: 3,
+      })
+    ).toBe('op-3')
+  })
+})
+
+describe('getCellLabel', () => {
+  it('labels markdown cells', () => {
+    expect(getCellLabel(wireMarkdownCell('cell-1'))).toBe('Markdown cell')
+  })
+
+  it('labels query cells with their title', () => {
+    expect(getCellLabel(wireDatabaseCell('cell-1', 'Signups'))).toBe('Query: Signups')
+  })
+
+  it('falls back to "Untitled query" when a query cell has no title', () => {
+    expect(getCellLabel(wireDatabaseCell('cell-1'))).toBe('Query: Untitled query')
+  })
+})
+
+describe('formatTimeRange', () => {
+  it('formats a relative range, pluralizing the unit', () => {
+    expect(formatTimeRange({ _tag: 'relative_time_range', unit: 'day', amount: 7 })).toBe(
+      'Last 7 days'
+    )
+  })
+
+  it('does not pluralize a relative range with amount 1', () => {
+    expect(formatTimeRange({ _tag: 'relative_time_range', unit: 'hour', amount: 1 })).toBe(
+      'Last 1 hour'
+    )
+  })
+
+  it('formats an absolute range as a start → end pair', () => {
+    const formatted = formatTimeRange({
+      _tag: 'absolute_time_range',
+      start: isoDateTimeString('2026-01-01T00:00:00.000Z')!,
+      end: isoDateTimeString('2026-01-02T00:00:00.000Z')!,
+    })
+    expect(formatted).toContain('→')
+    expect(formatted).toContain('2026')
+  })
+})
+
+describe('summarizeNotebookDiff / formatNotebookDiffSummary', () => {
+  it('formats create mode with pluralized cell count', () => {
+    const entries: NotebookCellDiffEntry[] = [
+      { _tag: 'unchanged', cell: wireMarkdownCell('a') },
+      { _tag: 'unchanged', cell: wireMarkdownCell('b') },
+    ]
+
+    expect(formatNotebookDiffSummary(summarizeNotebookDiff(entries, 'create'))).toBe('2 cells')
+  })
+
+  it('formats create mode singular for a single cell', () => {
+    const entries: NotebookCellDiffEntry[] = [{ _tag: 'unchanged', cell: wireMarkdownCell('a') }]
+
+    expect(formatNotebookDiffSummary(summarizeNotebookDiff(entries, 'create'))).toBe('1 cell')
+  })
+
+  it('formats update mode with a mix of categories, ignoring unchanged', () => {
+    const entries: NotebookCellDiffEntry[] = [
+      { _tag: 'unchanged', cell: wireMarkdownCell('a') },
+      { _tag: 'added', cell: agentMarkdownCell(), operationIndex: 0 },
+      { _tag: 'added', cell: agentMarkdownCell(), operationIndex: 1 },
+      { _tag: 'removed', cell: wireMarkdownCell('d'), operationIndex: 2 },
+      {
+        _tag: 'replaced',
+        before: wireMarkdownCell('e'),
+        after: agentMarkdownCell(),
+        operationIndex: 3,
+      },
+      { _tag: 'moved', cell: wireMarkdownCell('f'), fromIndex: 0, operationIndex: 4 },
+    ]
+
+    expect(formatNotebookDiffSummary(summarizeNotebookDiff(entries, 'update'))).toBe('+2 −1 ~1 ↕1')
+  })
+
+  it('omits zero categories from the update summary', () => {
+    const entries: NotebookCellDiffEntry[] = [
+      { _tag: 'unchanged', cell: wireMarkdownCell('a') },
+      { _tag: 'added', cell: agentMarkdownCell(), operationIndex: 0 },
+    ]
+
+    expect(formatNotebookDiffSummary(summarizeNotebookDiff(entries, 'update'))).toBe('+1')
+  })
+
+  it('falls back to "No changes" when every entry is unchanged', () => {
+    const entries: NotebookCellDiffEntry[] = [
+      { _tag: 'unchanged', cell: wireMarkdownCell('a') },
+      { _tag: 'unchanged', cell: wireMarkdownCell('b') },
+    ]
+
+    expect(formatNotebookDiffSummary(summarizeNotebookDiff(entries, 'update'))).toBe('No changes')
+  })
+})

--- a/apps/studio/components/interfaces/Explorer/NotebookPreview/NotebookPreview.utils.ts
+++ b/apps/studio/components/interfaces/Explorer/NotebookPreview/NotebookPreview.utils.ts
@@ -1,0 +1,125 @@
+import dayjs from 'dayjs'
+import type { CodeBlockLang } from 'ui-patterns/CodeBlock'
+
+import type { NotebookCellDiffEntry } from '@/data/content/notebooks/notebook-operations'
+import type { AgentCell, CellWire, TimeRange } from '@/data/content/notebooks/notebook-schema'
+
+/** React key for a diff entry. Added/replaced cells have no `id`, so they key off the operation. */
+export function getEntryKey(entry: NotebookCellDiffEntry): string {
+  switch (entry._tag) {
+    case 'unchanged':
+    case 'removed':
+    case 'moved':
+      return entry.cell.id
+    case 'added':
+    case 'replaced':
+      return `op-${entry.operationIndex}`
+  }
+}
+
+/** Human label for a collapsed/badge row. */
+export function getCellLabel(cell: CellWire | AgentCell): string {
+  switch (cell._tag) {
+    case 'markdown_cell':
+      return 'Markdown cell'
+    case 'database_cell':
+    case 'log_cell':
+      return `Query: ${cell.title ?? 'Untitled query'}`
+  }
+}
+
+/** The cell's underlying source text, regardless of backend. */
+export function getCellSourceText(cell: CellWire | AgentCell): string {
+  switch (cell._tag) {
+    case 'markdown_cell':
+      return cell.text
+    case 'database_cell':
+    case 'log_cell':
+      return cell.sql
+  }
+}
+
+/** Language for rendering the cell's source via `CodeBlock`. */
+export function getCellCodeBlockLanguage(cell: CellWire | AgentCell): CodeBlockLang {
+  switch (cell._tag) {
+    case 'markdown_cell':
+      return 'markdown'
+    case 'database_cell':
+    case 'log_cell':
+      return 'sql'
+  }
+}
+
+/** Monaco language id for rendering the cell's source via `DiffEditor`. */
+export function getCellMonacoLanguage(cell: CellWire | AgentCell): string {
+  switch (cell._tag) {
+    case 'markdown_cell':
+      return 'markdown'
+    case 'database_cell':
+    case 'log_cell':
+      return 'pgsql'
+  }
+}
+
+/** Formats a `TimeRange` as plain text, e.g. "Last 7 days" or an absolute bound pair. */
+export function formatTimeRange(range: TimeRange): string {
+  if (range._tag === 'relative_time_range') {
+    return `Last ${range.amount} ${range.unit}${range.amount === 1 ? '' : 's'}`
+  }
+
+  const format = (value: string) => dayjs(value).format('MMM D, YYYY h:mm A')
+  return `${format(range.start)} → ${format(range.end)}`
+}
+
+export type NotebookDiffSummary =
+  | { mode: 'create'; cellCount: number }
+  | { mode: 'update'; counts: { added: number; removed: number; replaced: number; moved: number } }
+
+/** Summarizes a set of diff entries into counts suitable for a header line. */
+export function summarizeNotebookDiff(
+  entries: NotebookCellDiffEntry[],
+  mode: 'create' | 'update'
+): NotebookDiffSummary {
+  if (mode === 'create') {
+    return { mode: 'create', cellCount: entries.length }
+  }
+
+  const counts = { added: 0, removed: 0, replaced: 0, moved: 0 }
+  for (const entry of entries) {
+    switch (entry._tag) {
+      case 'added':
+        counts.added++
+        break
+      case 'removed':
+        counts.removed++
+        break
+      case 'replaced':
+        counts.replaced++
+        break
+      case 'moved':
+        counts.moved++
+        break
+      case 'unchanged':
+        break
+    }
+  }
+
+  return { mode: 'update', counts }
+}
+
+/** Formats a `NotebookDiffSummary` into the header string. */
+export function formatNotebookDiffSummary(summary: NotebookDiffSummary): string {
+  if (summary.mode === 'create') {
+    const { cellCount } = summary
+    return `${cellCount} cell${cellCount === 1 ? '' : 's'}`
+  }
+
+  const { added, removed, replaced, moved } = summary.counts
+  const parts: string[] = []
+  if (added > 0) parts.push(`+${added}`)
+  if (removed > 0) parts.push(`−${removed}`)
+  if (replaced > 0) parts.push(`~${replaced}`)
+  if (moved > 0) parts.push(`↕${moved}`)
+
+  return parts.length > 0 ? parts.join(' ') : 'No changes'
+}

--- a/apps/studio/components/interfaces/Explorer/NotebookPreview/NotebookPreview.utils.ts
+++ b/apps/studio/components/interfaces/Explorer/NotebookPreview/NotebookPreview.utils.ts
@@ -71,6 +71,22 @@ export function formatTimeRange(range: TimeRange): string {
   return `${format(range.start)} → ${format(range.end)}`
 }
 
+/**
+ * Plain-text metadata line for a query cell (its source parameters, not its SQL) — `null`
+ * when the cell has none. A `replace_cell` can change only this and leave `sql` identical,
+ * so it's compared independently of the source text rather than folded into it.
+ */
+export function getCellMetadataLine(cell: CellWire | AgentCell): string | null {
+  switch (cell._tag) {
+    case 'markdown_cell':
+      return null
+    case 'database_cell':
+      return cell.database_identifier ? `Database: ${cell.database_identifier}` : null
+    case 'log_cell':
+      return `Time range: ${formatTimeRange(cell.time_range)}`
+  }
+}
+
 export type NotebookDiffSummary =
   | { mode: 'create'; cellCount: number }
   | { mode: 'update'; counts: { added: number; removed: number; replaced: number; moved: number } }

--- a/apps/studio/components/interfaces/Explorer/NotebookPreview/NotebookPreviewCell.tsx
+++ b/apps/studio/components/interfaces/Explorer/NotebookPreview/NotebookPreviewCell.tsx
@@ -3,9 +3,9 @@ import { Badge, Button, cn } from 'ui'
 import { CodeBlock, type CodeBlockLang } from 'ui-patterns/CodeBlock'
 
 import {
-  formatTimeRange,
   getCellCodeBlockLanguage,
   getCellLabel,
+  getCellMetadataLine,
   getCellMonacoLanguage,
   getCellSourceText,
 } from './NotebookPreview.utils'
@@ -83,35 +83,42 @@ const AddedCell = ({ cell }: { cell: AgentCell }) => (
       language={getCellCodeBlockLanguage(cell)}
       value={getCellSourceText(cell)}
     />
-    <CellMetadata cell={cell} />
+    <MetadataLine text={getCellMetadataLine(cell)} />
   </ContentCell>
 )
 
-const ReplacedCell = ({ before, after }: { before: CellWire; after: AgentCell }) => (
-  <ContentCell badge={{ variant: 'warning', label: 'Replaced' }} label={getCellLabel(after)}>
-    <DiffEditor
-      original={getCellSourceText(before)}
-      modified={getCellSourceText(after)}
-      language={getCellMonacoLanguage(after)}
-      height={240}
-    />
-  </ContentCell>
-)
+/**
+ * A `replace_cell` can change only the source parameters (`database_identifier`,
+ * `time_range`) and leave `sql`/`text` identical — the `DiffEditor` above would then show no
+ * change at all, so the metadata is compared independently and rendered as its own
+ * before → after line whenever it differs.
+ */
+const ReplacedCell = ({ before, after }: { before: CellWire; after: AgentCell }) => {
+  const beforeMetadata = getCellMetadataLine(before)
+  const afterMetadata = getCellMetadataLine(after)
 
-/** Plain-text metadata lines for query cells — never rendered as a link or attribute. */
-const CellMetadata = ({ cell }: { cell: AgentCell }) => {
-  if (cell._tag === 'database_cell' && cell.database_identifier) {
-    return <p className="text-xs text-foreground-lighter">Database: {cell.database_identifier}</p>
-  }
-  if (cell._tag === 'log_cell') {
-    return (
-      <p className="text-xs text-foreground-lighter">
-        Time range: {formatTimeRange(cell.time_range)}
-      </p>
-    )
-  }
-  return null
+  return (
+    <ContentCell badge={{ variant: 'warning', label: 'Replaced' }} label={getCellLabel(after)}>
+      <DiffEditor
+        original={getCellSourceText(before)}
+        modified={getCellSourceText(after)}
+        language={getCellMonacoLanguage(after)}
+        height={240}
+      />
+      {beforeMetadata !== afterMetadata ? (
+        <MetadataLine
+          text={`${beforeMetadata ?? 'No metadata'} → ${afterMetadata ?? 'No metadata'}`}
+        />
+      ) : (
+        <MetadataLine text={afterMetadata} />
+      )}
+    </ContentCell>
+  )
 }
+
+/** A plain-text metadata line for a query cell — never rendered as a link or attribute. */
+const MetadataLine = ({ text }: { text: string | null }) =>
+  text ? <p className="text-xs text-foreground-lighter">{text}</p> : null
 
 interface ExpandableCodeBlockProps {
   language: CodeBlockLang

--- a/apps/studio/components/interfaces/Explorer/NotebookPreview/NotebookPreviewCell.tsx
+++ b/apps/studio/components/interfaces/Explorer/NotebookPreview/NotebookPreviewCell.tsx
@@ -1,0 +1,147 @@
+import { useState, type ReactNode } from 'react'
+import { Badge, Button, cn } from 'ui'
+import { CodeBlock, type CodeBlockLang } from 'ui-patterns/CodeBlock'
+
+import {
+  formatTimeRange,
+  getCellCodeBlockLanguage,
+  getCellLabel,
+  getCellMonacoLanguage,
+  getCellSourceText,
+} from './NotebookPreview.utils'
+import { DiffEditor } from '@/components/ui/DiffEditor'
+import type { NotebookCellDiffEntry } from '@/data/content/notebooks/notebook-operations'
+import type { AgentCell, CellWire } from '@/data/content/notebooks/notebook-schema'
+
+export interface NotebookPreviewCellProps {
+  entry: NotebookCellDiffEntry
+}
+
+/** Renders a single diff entry, dispatching on its tag. */
+export const NotebookPreviewCell = ({ entry }: NotebookPreviewCellProps) => {
+  switch (entry._tag) {
+    case 'unchanged':
+      return <CollapsedRow label={getCellLabel(entry.cell)} />
+    case 'removed':
+      return (
+        <CollapsedRow
+          label={getCellLabel(entry.cell)}
+          strikethrough
+          badge={{ variant: 'destructive', label: 'Removed' }}
+        />
+      )
+    case 'moved':
+      return (
+        <CollapsedRow
+          label={getCellLabel(entry.cell)}
+          badge={{ variant: 'secondary', label: 'Moved' }}
+        />
+      )
+    case 'added':
+      return <AddedCell cell={entry.cell} />
+    case 'replaced':
+      return <ReplacedCell before={entry.before} after={entry.after} />
+  }
+}
+
+interface CollapsedRowProps {
+  label: string
+  strikethrough?: boolean
+  badge?: { variant: 'destructive' | 'secondary'; label: string }
+}
+
+/** A single muted row with no content — used for unchanged, removed, and moved entries. */
+const CollapsedRow = ({ label, strikethrough, badge }: CollapsedRowProps) => (
+  <div className="flex items-center gap-2 px-3 py-1.5 text-sm text-foreground-light">
+    {badge && <Badge variant={badge.variant}>{badge.label}</Badge>}
+    <span className={cn('truncate', strikethrough && 'line-through text-foreground-lighter')}>
+      {label}
+    </span>
+  </div>
+)
+
+interface ContentCellProps {
+  badge: { variant: 'success' | 'warning'; label: string }
+  label: string
+  children: ReactNode
+}
+
+/** Shared frame for entries that show full cell content — added and replaced cells. */
+const ContentCell = ({ badge, label, children }: ContentCellProps) => (
+  <div className="flex flex-col gap-2 px-3 py-2 border rounded-md bg-surface-75">
+    <div className="flex items-center gap-2 text-sm">
+      <Badge variant={badge.variant}>{badge.label}</Badge>
+      <span className="text-foreground truncate">{label}</span>
+    </div>
+    {children}
+  </div>
+)
+
+const AddedCell = ({ cell }: { cell: AgentCell }) => (
+  <ContentCell badge={{ variant: 'success', label: 'Added' }} label={getCellLabel(cell)}>
+    <ExpandableCodeBlock
+      language={getCellCodeBlockLanguage(cell)}
+      value={getCellSourceText(cell)}
+    />
+    <CellMetadata cell={cell} />
+  </ContentCell>
+)
+
+const ReplacedCell = ({ before, after }: { before: CellWire; after: AgentCell }) => (
+  <ContentCell badge={{ variant: 'warning', label: 'Replaced' }} label={getCellLabel(after)}>
+    <DiffEditor
+      original={getCellSourceText(before)}
+      modified={getCellSourceText(after)}
+      language={getCellMonacoLanguage(after)}
+      height={240}
+    />
+  </ContentCell>
+)
+
+/** Plain-text metadata lines for query cells — never rendered as a link or attribute. */
+const CellMetadata = ({ cell }: { cell: AgentCell }) => {
+  if (cell._tag === 'database_cell' && cell.database_identifier) {
+    return <p className="text-xs text-foreground-lighter">Database: {cell.database_identifier}</p>
+  }
+  if (cell._tag === 'log_cell') {
+    return (
+      <p className="text-xs text-foreground-lighter">
+        Time range: {formatTimeRange(cell.time_range)}
+      </p>
+    )
+  }
+  return null
+}
+
+interface ExpandableCodeBlockProps {
+  language: CodeBlockLang
+  value: string
+}
+
+/**
+ * `CodeBlock` clipped to a fixed height with a "Show more/less" toggle. `CodeBlock`'s
+ * wrapper already scrolls (`overflow-auto`), so clipping just changes what's visible.
+ */
+const ExpandableCodeBlock = ({ language, value }: ExpandableCodeBlockProps) => {
+  const [isExpanded, setIsExpanded] = useState(false)
+
+  return (
+    <div>
+      <CodeBlock
+        language={language}
+        value={value}
+        hideLineNumbers
+        className="text-xs"
+        wrapperClassName={cn(!isExpanded && 'max-h-56')}
+      />
+      <Button
+        variant="text"
+        size="tiny"
+        className="mt-1"
+        onClick={() => setIsExpanded((prev) => !prev)}
+      >
+        {isExpanded ? 'Show less' : 'Show more'}
+      </Button>
+    </div>
+  )
+}

--- a/packages/ui-patterns/src/CodeBlock/CodeBlock.tsx
+++ b/packages/ui-patterns/src/CodeBlock/CodeBlock.tsx
@@ -16,6 +16,7 @@ import ini from 'react-syntax-highlighter/dist/cjs/languages/hljs/ini'
 import js from 'react-syntax-highlighter/dist/cjs/languages/hljs/javascript'
 import json from 'react-syntax-highlighter/dist/cjs/languages/hljs/json'
 import kotlin from 'react-syntax-highlighter/dist/cjs/languages/hljs/kotlin'
+import markdown from 'react-syntax-highlighter/dist/cjs/languages/hljs/markdown'
 import pgsql from 'react-syntax-highlighter/dist/cjs/languages/hljs/pgsql'
 import php from 'react-syntax-highlighter/dist/cjs/languages/hljs/php'
 import {
@@ -52,6 +53,7 @@ const codeBlockLangs = [
   'yaml',
   'toml',
   'html',
+  'markdown',
 ] as const
 
 export type CodeBlockLang = (typeof codeBlockLangs)[number]
@@ -175,6 +177,7 @@ export const CodeBlock = ({
   SyntaxHighlighter.registerLanguage('html', xml)
   SyntaxHighlighter.registerLanguage('toml', ini)
   SyntaxHighlighter.registerLanguage('yaml', yaml)
+  SyntaxHighlighter.registerLanguage('markdown', markdown)
 
   const large = false
   // don't show line numbers if bash == lang


### PR DESCRIPTION
## Summary

Stacked on #49109 (PR 1 — `deriveNotebookDiff`). This is PR 3 of the notebook approval-preview stack: a pure presentational component that renders the cell-level diff for a proposed notebook create/update, for use in the assistant approval UI (wired in a later PR).

- `NotebookPreview` — header summary (`"6 cells"` for create, `"+2 −1 ~1 ↕1"` for update) + entry list + "Show N more cells" for long notebooks.
- `NotebookPreviewCell` — dispatches per entry tag: `unchanged`/`removed`/`moved` collapse to a muted badge row; `added` renders source via `CodeBlock` (with a max-height/expand toggle); `replaced` renders a `DiffEditor` diff, plus a before → after metadata line when only `database_identifier`/`time_range` changed (SQL/text identical).
- `NotebookPreview.utils` — pure helpers (labels, source/metadata extraction, language mapping, summary formatting), unit tested.
- **Safety property**: cell content only ever renders through `CodeBlock`/`DiffEditor` (literal source), never through a markdown renderer — agent-authored text can't trigger image loads or link navigation before the user approves. Covered by an adversarial test (`![x](evil)`, `[y](evil)`, `<img onerror>` → zero `img`/`[href]`/`[src]` DOM nodes).
- Adds `'markdown'` as a supported `CodeBlock` language (small, additive change to `packages/ui-patterns`).

Towards FE-4143

## Test plan

- [x] `pnpm --filter studio test` — NotebookPreview suite (21 tests) passes
- [x] `pnpm --filter studio exec eslint components/interfaces/Explorer/NotebookPreview` — clean
- [x] `pnpm --filter studio exec tsc --noEmit` — no new errors
- [x] `pnpm exec prettier --check` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added notebook previews showing create and update summaries.
  * Displayed added, removed, moved, unchanged, and replaced cells with metadata and source diffs.
  * Added expandable previews with truncation and a “Show more cells” option.
  * Added Markdown syntax highlighting to code blocks.

* **Bug Fixes**
  * Safely render adversarial agent-authored Markdown as literal content.

* **Tests**
  * Added comprehensive coverage for notebook previews, summaries, metadata, formatting, and truncation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->