### PR TITLE
docs(blog): point the Dart v0 migration guide links at their live page

### DIFF
--- a/apps/www/_blog/2022-10-21-supabase-flutter-sdk-v1-released.mdx
+++ b/apps/www/_blog/2022-10-21-supabase-flutter-sdk-v1-released.mdx
@@ -13,7 +13,7 @@ date: '2022-10-21'
 toc_depth: 3
 ---
 
-A few months ago, we announced a [developer preview version of supabase-flutter SDK](https://supabase.com/blog/supabase-flutter-sdk-1-developer-preview). Since then, we have heard a lot of amazing feedback from the community, and have been improving it. Today, we are happy to announce the stable v1 of [supabase-flutter](https://pub.dev/packages/supabase_flutter). You can also find the updated [quick start guide](https://supabase.com/docs/guides/with-flutter), [documentation](https://supabase.com/docs/reference/dart) and a [migration guide from v0](https://supabase.com/docs/reference/dart/v0/upgrade-guide).
+A few months ago, we announced a [developer preview version of supabase-flutter SDK](https://supabase.com/blog/supabase-flutter-sdk-1-developer-preview). Since then, we have heard a lot of amazing feedback from the community, and have been improving it. Today, we are happy to announce the stable v1 of [supabase-flutter](https://pub.dev/packages/supabase_flutter). You can also find the updated [quick start guide](https://supabase.com/docs/guides/with-flutter), [documentation](https://supabase.com/docs/reference/dart) and a [migration guide from v0](https://supabase.com/docs/reference/dart/upgrade-guide).
 
 ## What is new in v1?
 
@@ -99,7 +99,7 @@ It required massive support from the community to bring the supabase-flutter to 
 
 - [Install supabase-flutter v1.0](https://pub.dev/packages/supabase_flutter)
 - [supabase-flutter documentation](https://supabase.com/docs/reference/dart/)
-- [v0 to v1 migration guide](https://supabase.com/docs/reference/dart/v0/upgrade-guide)
+- [v0 to v1 migration guide](https://supabase.com/docs/reference/dart/upgrade-guide)
 - [Flutter Tutorial: building a Flutter chat app](https://supabase.com/blog/flutter-tutorial-building-a-chat-app)
 - [Flutter Tutorial - Part 2: Authentication and Authorization with RLS](https://supabase.com/blog/flutter-authentication-and-authorization-with-rls)
 - [How to build a real-time multiplayer game with Flutter Flame](https://supabase.com/blog/flutter-real-time-multiplayer-game)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs fix (two dead links in the supabase-flutter v1 announcement post).

## What is the current behavior?

`2022-10-21-supabase-flutter-sdk-v1-released.mdx` links the v0 to v1 migration guide twice, once in the intro paragraph and once under Resources, and both point at `/docs/reference/dart/v0/upgrade-guide`, which returns 404.

The Dart reference has no `v0` archive anymore. That is specific to Dart, and it is what makes this easy to miss: the JavaScript equivalents in `redirects.js` point at `/docs/reference/javascript/v1/...` and those pages are still live, so the same shape of link is fine over there.

## What is the new behavior?

Both point at `/docs/reference/dart/upgrade-guide`, confirmed 200.

That is the right destination rather than just a live one: `apps/docs/spec/reference/dart/v2/config.json` lists `"partialsOrder": ["introduction", "installing", "initializing", "upgrade-guide"]`, so `upgrade-guide` is the Dart reference's own upgrade page, which is what "migration guide from v0" and "v0 to v1 migration guide" are describing.

## Additional context

Two lines, one file, and only that one link changed.

I left the `[documentation](https://supabase.com/docs/reference/dart)` links in the same post alone on purpose. `/docs/reference/dart` also 404s today, but there is already a redirect for it in `redirects.js` and #48562 fixes that redirect's destination, so it will resolve once that lands. Changing it here too would duplicate the fix in a second place.

Separately, while checking this I noticed three redirects in `redirects.js` still send Dart traffic to that removed v0 archive (`auth-signin`, `removesubscription`, `getsubscriptions` all 301 to `/docs/reference/dart/v0/...` which 404s). That is a different file and a different concern, so it is not in this PR.

Verification: both old URLs confirmed 404 against production and the new one confirmed 200, along with a deliberate nonsense URL to prove the check was actually reporting failures. Gates on this branch: `test:prettier` passes repo wide, `typecheck --filter=www --force` passes 8/8, and the www vitest suite passes (6 files, 75 tests). I did not run `pnpm build`, which cannot finish in my environment because the docs `build:federated-content` step needs `DOCS_GITHUB_APP_PRIVATE_KEY`.

Freshman contributor. Found this working through a backlog of dead links I had verified but not yet matched to a target, with Claude Code's help, and I checked the status codes and the Dart reference's own page list myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Supabase Flutter SDK v1 announcement with the current migration guide link.
  * Removed outdated URL paths from the Resources section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->