### PR TITLE
fix(www): stop redirecting Dart realtime pages into the removed v0 archive

### DIFF
--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -1596,12 +1596,25 @@ module.exports = [
   {
     permanent: true,
     source: '/docs/reference/dart/removesubscription',
-    destination: '/docs/reference/dart/v0/removesubscription',
+    destination: '/docs/reference/dart/removechannel',
   },
   {
     permanent: true,
     source: '/docs/reference/dart/getsubscriptions',
-    destination: '/docs/reference/dart/v0/getsubscriptions',
+    destination: '/docs/reference/dart/getchannels',
+  },
+  // The Dart reference kept no v0 archive, so anything already pointing into
+  // /v0/ needs bridging to the renamed page the way auth-signinwithprovider is
+  // above. Non-permanent so a cached 301 to the removed page can recover.
+  {
+    permanent: false,
+    source: '/docs/reference/dart/v0/removesubscription',
+    destination: '/docs/reference/dart/removechannel',
+  },
+  {
+    permanent: false,
+    source: '/docs/reference/dart/v0/getsubscriptions',
+    destination: '/docs/reference/dart/getchannels',
   },
   {
     permanent: true,


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix. Two redirects send Dart reference traffic to pages that no longer exist.

## What is the current behavior?

`redirects.js` has a pair of realtime redirects under the comment "realtime methods been replaced with new names":

```js
{ source: '/docs/reference/dart/removesubscription', destination: '/docs/reference/dart/v0/removesubscription' },
{ source: '/docs/reference/dart/getsubscriptions',   destination: '/docs/reference/dart/v0/getsubscriptions' },
```

Both destinations 404. The Dart reference no longer keeps a `v0` archive: `apps/docs/spec/reference/dart/` contains only `v2`. So these are permanent redirects that land users on a 404 rather than on the renamed method.

This is Dart-specific, which is what makes it easy to miss. The JavaScript block just above does the same thing (`/docs/reference/javascript/removesubscription` to `/docs/reference/javascript/v1/removesubscription`) and those are fine, because the JS `v1` archive is still published. I checked all three JS ones and they return 200.

## What is the new behavior?

Each points at the current method page instead:

| source | new destination | status |
| --- | --- | --- |
| `dart/removesubscription` | `dart/removechannel` | 200 |
| `dart/getsubscriptions` | `dart/getchannels` | 200 |

I matched these on what the pages actually say, not just that they resolve. From `supabase_dart_v2.yml`, `removeChannel()` is "Unsubscribes and removes Realtime channel from Realtime client" and `getChannels()` is "Returns all Realtime channels", which are the renamed forms of the two subscription methods the redirects are about.

I also added two non-permanent bridges from the `/v0/` paths themselves. Those redirects have been `permanent: true` for a long time, so clients that already followed them have a cached 301 pointing at the removed page and a destination change alone will not reach them. This mirrors what already exists a few lines above for `/docs/reference/dart/v0/auth-signinwithprovider`, and the same cache-bridge approach was used in #48560.

## Additional context

There is a third redirect in the same block with the same problem, `/docs/reference/dart/auth-signin` to `/docs/reference/dart/v0/auth-signin`, and I deliberately left it alone. The v0 `signIn()` split into `signInWithPassword()`, `signInWithOtp()` and `signInWithOAuth()`, so there is no single obvious successor. The OAuth case already has its own entry just above. Picking one of the three for everyone else is a product call rather than something I should guess at, so it seemed better to flag it than to pick.

Placement: all four entries are exact paths, and there is no `:path*` or `:slug` catch-all anywhere under `/docs/reference` in this file, so nothing shadows them and they shadow nothing.

Verification: every URL above was checked against production, including a deliberate nonsense URL to confirm the check was actually reporting failures. Gates on this branch: `test:prettier` passes repo wide, `typecheck --filter=www --force` passes 8/8, and the www vitest suite passes (6 files, 75 tests), which includes the `next.config.test.ts` redirect coverage. I did not run `pnpm build`, which cannot finish in my environment because the docs `build:federated-content` step needs `DOCS_GITHUB_APP_PRIVATE_KEY`.

Freshman contributor. Found this while chasing a dead Dart link in a blog post, with Claude Code's help, and I verified the status codes and read the destination pages myself before matching them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Dart realtime documentation links to point to the current `removechannel` and `getchannels` pages.
  * Added fallback redirects for legacy `/v0/` documentation URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->