### PR TITLE
fix(www): point the JS auth-api redirects at the pages their comments name

### DIFF
--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -1440,70 +1440,70 @@ module.exports = [
   {
     permanent: true,
     source: '/docs/reference/javascript/auth-api-getuser',
-    destination: '/docs/reference/javascript/v1/auth-api-getuser',
+    destination: '/docs/reference/javascript/auth-getuser',
   },
   // v1: /auth-api-resetpasswordforemail
   // v2: /auth-resetpasswordforemail
   {
     permanent: true,
     source: '/docs/reference/javascript/auth-api-resetpasswordforemail',
-    destination: '/docs/reference/javascript/v1/auth-api-resetpasswordforemail',
+    destination: '/docs/reference/javascript/auth-resetpasswordforemail',
   },
   // v1: /auth-api-verifyotp
   // v2: /auth-verifyotp
   {
     permanent: true,
     source: '/docs/reference/javascript/auth-api-verifyotp',
-    destination: '/docs/reference/javascript/v1/auth-api-verifyotp',
+    destination: '/docs/reference/javascript/auth-verifyotp',
   },
   // v1: /auth-api-listusers
   // v2: /auth-admin-listusers
   {
     permanent: true,
     source: '/docs/reference/javascript/auth-api-listusers',
-    destination: '/docs/reference/javascript/v1/auth-api-listusers',
+    destination: '/docs/reference/javascript/auth-admin-listusers',
   },
   // v1: /auth-api-createuser
   // v2: /auth-admin-createuser
   {
     permanent: true,
     source: '/docs/reference/javascript/auth-api-createuser',
-    destination: '/docs/reference/javascript/v1/auth-api-createuser',
+    destination: '/docs/reference/javascript/auth-admin-createuser',
   },
   // v1: /auth-api-deleteuser
   // v2: /auth-admin-deleteuser
   {
     permanent: true,
     source: '/docs/reference/javascript/auth-api-deleteuser',
-    destination: '/docs/reference/javascript/v1/auth-api-deleteuser',
+    destination: '/docs/reference/javascript/auth-admin-deleteuser',
   },
   // v1: /auth-api-generatelink
   // v2: /auth-admin-generatelink
   {
     permanent: true,
     source: '/docs/reference/javascript/auth-api-generatelink',
-    destination: '/docs/reference/javascript/v1/auth-api-generatelink',
+    destination: '/docs/reference/javascript/auth-admin-generatelink',
   },
   // v1: /auth-api-inviteuserbyemail
   // v2: /auth-admin-inviteuserbyemail
   {
     permanent: true,
     source: '/docs/reference/javascript/auth-api-inviteuserbyemail',
-    destination: '/docs/reference/javascript/v1/auth-api-inviteuserbyemail',
+    destination: '/docs/reference/javascript/auth-admin-inviteuserbyemail',
   },
   // v1: /auth-api-getuserbyid
   // v2: /auth-admin-getuserbyid
   {
     permanent: true,
     source: '/docs/reference/javascript/auth-api-getuserbyid',
-    destination: '/docs/reference/javascript/v1/auth-api-getuserbyid',
+    destination: '/docs/reference/javascript/auth-admin-getuserbyid',
   },
   // v1: /auth-api-updateuserbyid
   // v2: /auth-admin-updateuserbyid
   {
     permanent: true,
     source: '/docs/reference/javascript/auth-api-updateuserbyid',
-    destination: '/docs/reference/javascript/v1/auth-api-updateuserbyid',
+    destination: '/docs/reference/javascript/auth-admin-updateuserbyid',
   },
   // signIn method is now split into signInWithPassword ,signInWithOtp ,signInWithOAuth
   // send traffic to v1 docs instead
@@ -1524,7 +1524,7 @@ module.exports = [
   {
     permanent: true,
     source: '/docs/reference/javascript/auth-api-sendmobileotp',
-    destination: '/docs/reference/javascript/v1/auth-api-sendmobileotp',
+    destination: '/docs/reference/javascript/auth-signinwithotp',
   },
 
   // realtime methods been replaced with new names


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix. Eleven redirects send JavaScript auth reference traffic to pages that no longer exist.

## What is the current behavior?

Each of the `auth-api-*` redirects points into the JS `v1` archive, and every one of those eleven destinations 404s:

```js
{ source: '/docs/reference/javascript/auth-api-deleteuser',
  destination: '/docs/reference/javascript/v1/auth-api-deleteuser' },  // 404
```

The v1 archive itself is still up, which is what makes this easy to miss. `/docs/reference/javascript/v1/upgrade-guide`, `/v1/removesubscription` and `/v1/auth-signin` all return 200. It is specifically the `v1/auth-api-*` pages that are gone, so these eleven permanent redirects land users on a 404 instead of the method they asked for.

## What is the new behavior?

Each one points at the page the file already says it should.

This is the part worth checking first: every entry already carries a comment naming its v2 target, and the destinations simply never caught up with them.

```js
// v1: /auth-api-resetpasswordforemail
// v2: /auth-resetpasswordforemail
```

So the mapping here is not my inference, it is the existing comments. I wrote the eleven destinations, then diffed each against its own `// v2:` line and they match exactly, including `auth-api-sendmobileotp` to `auth-signinwithotp`, which was the one I would otherwise have hesitated on.

| source | new destination |
| --- | --- |
| `auth-api-getuser` | `auth-getuser` |
| `auth-api-resetpasswordforemail` | `auth-resetpasswordforemail` |
| `auth-api-verifyotp` | `auth-verifyotp` |
| `auth-api-listusers` | `auth-admin-listusers` |
| `auth-api-createuser` | `auth-admin-createuser` |
| `auth-api-deleteuser` | `auth-admin-deleteuser` |
| `auth-api-generatelink` | `auth-admin-generatelink` |
| `auth-api-inviteuserbyemail` | `auth-admin-inviteuserbyemail` |
| `auth-api-getuserbyid` | `auth-admin-getuserbyid` |
| `auth-api-updateuserbyid` | `auth-admin-updateuserbyid` |
| `auth-api-sendmobileotp` | `auth-signinwithotp` |

All eleven confirmed 200 against production. The admin ones line up with the spec too: `deleteUser` in `supabase_js_v2.yml` resolves to `@supabase/auth-js.GoTrueAdminApi.deleteUser`, so the `auth-admin-` pages are the right home for the old `auth.api.*` server-side methods.

## Additional context

Two nearby entries have the same comment mismatch but I left them alone, because they are not broken: `auth-update` and `auth-session` point at `/v1/auth-update` and `/v1/auth-session`, which both still return 200. Their comments say `/auth-updateuser` and `/auth-getsession`, so they serve v1 docs rather than current ones, but that reads like a deliberate "keep sending these to v1" choice rather than a defect, and it is your call rather than mine.

One thing I did not do unilaterally: these have been `permanent: true` for a long time, so clients that already followed one hold a cached 301 to the removed page and a destination change alone will not reach them. In #48560 the fix for that was a set of non-permanent bridges from the dead paths. Adding eleven more entries here felt like a bigger call about table size than I should make on my own, so say the word and I will add them.

How I found it: I extracted all 510 static destinations from `redirects.js` and status checked them, which turned up 78 that do not resolve. This is the cleanest family of those. The rest need their own decisions (some are removed partner pages, some are consolidated reference methods) so they are not in this PR.

Verification: every URL above checked against production, with a deliberate nonsense URL in the run to prove the check reports failures, and the flagged ones re-checked serially afterwards so the result is not a rate-limit artifact. Gates: `test:prettier` passes repo wide, `typecheck --filter=www --force` passes 8/8, and the www vitest suite passes (6 files, 75 tests) including the `next.config.test.ts` redirect coverage.

Freshman contributor, put this together with Claude Code's help and checked the status codes and the spec entries myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Supabase JavaScript authentication documentation redirects to point to v2 guides.
  - Updated routes for user management, password resets, OTP sign-in, administrative actions, invitations, and magic links.
  - Corrected the mobile OTP redirect to the current v2 documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->