### PR TITLE
fix(www): restore the /cli/ segment on CLI reference redirect destinations

### DIFF
--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -1306,52 +1306,52 @@ module.exports = [
   {
     permanent: true,
     source: '/docs/reference/cli/supabase-db-branch-list',
-    destination: '/docs/reference/supabase-branches-list',
+    destination: '/docs/reference/cli/supabase-branches-list',
   },
   {
     permanent: true,
     source: '/docs/reference/cli/supabase-db-branch-create',
-    destination: '/docs/reference/supabase-branches-create',
+    destination: '/docs/reference/cli/supabase-branches-create',
   },
   {
     permanent: true,
     source: '/docs/reference/cli/supabase-db-branch-delete',
-    destination: '/docs/reference/supabase-branches-delete',
+    destination: '/docs/reference/cli/supabase-branches-delete',
   },
   {
     permanent: true,
     source: '/docs/reference/cli/supabase-db-switch',
-    destination: '/docs/reference/supabase-branches-create',
+    destination: '/docs/reference/cli/supabase-branches-create',
   },
   {
     permanent: true,
     source: '/docs/reference/cli/supabase-db-changes',
-    destination: '/docs/reference/supabase-db-diff',
+    destination: '/docs/reference/cli/supabase-db-diff',
   },
   {
     permanent: true,
     source: '/docs/reference/cli/supabase-db-commit',
-    destination: '/docs/reference/supabase-db-pull',
+    destination: '/docs/reference/cli/supabase-db-pull',
   },
   {
     permanent: true,
     source: '/docs/reference/cli/supabase-db-remote-set',
-    destination: '/docs/reference/supabase-link',
+    destination: '/docs/reference/cli/supabase-link',
   },
   {
     permanent: true,
     source: '/docs/reference/cli/supabase-db-remote-changes',
-    destination: '/docs/reference/supabase-db-diff',
+    destination: '/docs/reference/cli/supabase-db-diff',
   },
   {
     permanent: true,
     source: '/docs/reference/cli/supabase-db-remote-commit',
-    destination: '/docs/reference/supabase-db-pull',
+    destination: '/docs/reference/cli/supabase-db-pull',
   },
   {
     permanent: true,
     source: '/docs/reference/cli/supabase-gen-types-typescript',
-    destination: '/docs/reference/supabase-gen-types',
+    destination: '/docs/reference/cli/supabase-gen-types',
   },
 
   {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix. Ten CLI reference redirects drop the `/cli/` segment from their destination and land on a 404.

## What is the current behavior?

The sources all sit under `/docs/reference/cli/`, but their destinations do not:

```js
{ source: '/docs/reference/cli/supabase-db-branch-list',
  destination: '/docs/reference/supabase-branches-list' },   // 404
```

`/docs/reference/supabase-branches-list` and its nine siblings all 404. The CLI reference lives at `/docs/reference/cli/<command>`, so these permanent redirects send anyone following an old CLI docs link to a dead page instead of the renamed command.

## What is the new behavior?

Each destination gets the `/cli/` segment it is missing. Ten entries, seven distinct target commands:

| destination before | after |
| --- | --- |
| `/docs/reference/supabase-branches-list` | `/docs/reference/cli/supabase-branches-list` |
| `/docs/reference/supabase-branches-create` | `/docs/reference/cli/supabase-branches-create` |
| `/docs/reference/supabase-branches-delete` | `/docs/reference/cli/supabase-branches-delete` |
| `/docs/reference/supabase-db-diff` | `/docs/reference/cli/supabase-db-diff` |
| `/docs/reference/supabase-db-pull` | `/docs/reference/cli/supabase-db-pull` |
| `/docs/reference/supabase-link` | `/docs/reference/cli/supabase-link` |
| `/docs/reference/supabase-gen-types` | `/docs/reference/cli/supabase-gen-types` |

The command renames themselves are untouched. `supabase db branch list` to `supabase branches list`, `db changes` to `db diff`, `db commit` to `db pull`, `db remote set` to `link`, and so on are all preserved exactly as they were, since those mappings were already correct. The only thing wrong was the path prefix.

## Additional context

A note on how I verified these, because the obvious check does not work here. `/docs/reference/cli/` returns 200 for any slug at all, including nonsense: I checked `/docs/reference/cli/zzz-canary` and got 200. So a status code cannot tell you whether a CLI command page really exists, and I would have "confirmed" seven targets that could equally have been fabricated.

Instead I checked the seven target ids against `apps/docs/spec/cli_v1_commands.yaml`, which is what the reference is generated from. All seven are present, and a deliberately fake id returns zero matches, so the control works. The ten current destinations were separately confirmed as real 404s, since `/docs/reference/` outside `/cli/` does return 404 properly.

Found while scanning all 510 static destinations in `redirects.js` for the first time, which turned up 78 that do not resolve. This is the second family from that scan, after #49121. The remaining ones (removed partner catalog pages, reference methods that were consolidated into other pages) each need their own judgement rather than a mechanical fix, so they are not here.

Gates: `test:prettier` passes repo wide, `typecheck --filter=www --force` passes 8/8, and the www vitest suite passes (6 files, 75 tests) including the `next.config.test.ts` redirect coverage.

Freshman contributor. Put this together with Claude Code's help, and the canary that caught the 200-for-anything behaviour was the thing that made me go check the spec instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated ten CLI documentation redirects to point to the correct reference documentation paths.
  * Existing source URLs and permanent redirect behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->