### PR TITLE
fix(www): point Edge Functions redirects at their post-move docs paths

### DIFF
--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -2894,17 +2894,17 @@ module.exports = [
   {
     permanent: true,
     source: '/docs/guides/functions/debugging',
-    destination: '/docs/functions/logging',
+    destination: '/docs/guides/functions/logging',
   },
   {
     permanent: true,
     source: '/docs/guides/functions/log-drains',
-    destination: '/docs/platform/log-drains',
+    destination: '/docs/guides/monitoring-and-debugging/log-drains',
   },
   {
     permanent: true,
     source: '/docs/guides/functions/functions-headers',
-    destination: '/docs/functions/logging',
+    destination: '/docs/guides/functions/logging',
   },
   {
     permanent: true,


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix. Three Edge Functions redirects point at pre-reorganization docs paths that no longer exist.

## What is the current behavior?

All three land on a 404, so the source URLs are dead ends for anyone following an old link:

| you visit | you get redirected to | result |
| --- | --- | --- |
| `/docs/guides/functions/debugging` | `/docs/functions/logging` | 404 |
| `/docs/guides/functions/functions-headers` | `/docs/functions/logging` | 404 |
| `/docs/guides/functions/log-drains` | `/docs/platform/log-drains` | 404 |

I checked the three source URLs directly, not just the destinations, and all three 404 for a real visitor today.

`/docs/functions/*` and `/docs/platform/*` are from the docs layout before guides moved under `/docs/guides/`, so these destinations were left behind by that move.

## What is the new behavior?

- Both `/docs/functions/logging` destinations become `/docs/guides/functions/logging`, which is the same page under its current path. `apps/docs/content/guides/functions/logging.mdx` is "How to access logs for your Edge Functions", so the page these were always pointing at still exists and just moved.
- `/docs/platform/log-drains` becomes `/docs/guides/monitoring-and-debugging/log-drains`, which is the Log Drains feature guide.

On that last one, `/docs/guides/platform/log-drains` also resolves, but only by redirecting onward to `/docs/guides/monitoring-and-debugging/log-drains`, so I pointed straight at the final page rather than adding a hop. Worth noting there is a second, different log drains page at `guides/platform/manage-your-usage/log-drains`, but that one is about what you are charged, not about the feature, so it is not the right destination for someone arriving from a functions URL.

## Additional context

I only corrected the paths, not the mappings. `functions-headers` pointing at the logging page is a slightly surprising pairing and there is an `auth-headers.mdx` sitting right next to `logging.mdx` that may be what was actually meant, but changing where a redirect sends people is a different decision from fixing a path that moved, and that one is yours. Happy to repoint it if you want.

Verification: every URL above checked against production, sources as well as destinations, with a nonsense URL in the same namespace each time to confirm the check actually reports failures (`/docs/guides/functions/zzz` returns 404, so status codes are meaningful here, which is not true everywhere in the docs).

Found while working through a scan of all 510 static destinations in `redirects.js`, of which 78 do not resolve. This is the third family from that scan after #49121 and #49122. The remainder need individual judgement rather than a mechanical fix, so they are not here.

Gates: `test:prettier` passes repo wide, `typecheck --filter=www --force` passes 8/8, and the www vitest suite passes (6 files, 75 tests) including the `next.config.test.ts` redirect coverage.

Freshman contributor, put this together with Claude Code's help and verified the status codes and the target pages myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated function documentation redirects to point to the latest logging, log drains, and function headers guides.
  * Improved navigation from legacy debugging documentation routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->