### PR TITLE
fix(www): point three redirects at pages that were renamed or moved

### DIFF
--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -366,7 +366,7 @@ module.exports = [
   {
     permanent: false,
     source: '/docs/client/generating-types',
-    destination: '/docs/reference/javascript/generating-types',
+    destination: '/docs/guides/api/rest/generating-types',
   },
   {
     permanent: false,
@@ -2372,7 +2372,7 @@ module.exports = [
   {
     permanent: true,
     source: '/docs/guides/cli/using-environment-variables-in-config',
-    destination: '/docs/guides/cli/managing-config',
+    destination: '/docs/guides/local-development/managing-config',
   },
   {
     permanent: true,
@@ -2679,7 +2679,7 @@ module.exports = [
   {
     permanent: true,
     source: '/docs/reference/dart/sign-in-with-apple',
-    destination: '/docs/reference/dart/sign-in-with-id-token',
+    destination: '/docs/reference/dart/auth-signinwithidtoken',
   },
   {
     permanent: true,


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix. Three redirects point at pages that were renamed or moved, so all three send visitors to a 404.

## What is the current behavior?

| you visit | you get sent to | result |
| --- | --- | --- |
| `/docs/client/generating-types` | `/docs/reference/javascript/generating-types` | 404 |
| `/docs/guides/cli/using-environment-variables-in-config` | `/docs/guides/cli/managing-config` | 404 |
| `/docs/reference/dart/sign-in-with-apple` | `/docs/reference/dart/sign-in-with-id-token` | 404 |

I checked the source URLs, not just the destinations, so those three are what a visitor actually experiences today.

## What is the new behavior?

Each points at where its page lives now. I confirmed each target by reading it rather than by trusting a status code:

- **generating-types** goes to `/docs/guides/api/rest/generating-types`. That file's front matter is `title: 'Generating TypeScript Types'`, which is what the old client page was.
- **managing-config** goes to `/docs/guides/local-development/managing-config`. The page moved out of the `cli` namespace into `local-development`; its front matter is "Managing config and secrets, managing local configuration using config.toml", which matches a source about environment variables in config.
- **sign-in-with-apple** goes to `/docs/reference/dart/auth-signinwithidtoken`. `signInWithIdToken()` is in `supabase_dart_v2.yml`, and the Dart upgrade guide points at that same page when it describes native Google and Apple sign in, so it is the documented home for the Apple flow.

## Additional context

One I left out on purpose. `/docs/guides/database/connecting/direct-connections` points at `/docs/guides/database/connection-pooling`, which also 404s, but there is no single obvious successor: `connecting-to-postgres`, `connection-management` and `database/supavisor` all resolve and all cover part of it, and there is no dedicated pooling guide anymore. Picking one is a docs decision rather than a path repair, so I would rather flag it than guess.

A note on verification, because it bit me earlier in this series. A 200 is not proof on its own: `/docs/reference/cli/` returns 200 for literally any slug, so status codes are meaningless in that namespace. For each namespace here I checked a deliberate nonsense URL first (`/docs/guides/api/rest/zzz`, `/docs/guides/local-development/zzz`, `/docs/reference/dart/nope`) and confirmed it 404s, so the 200s in this PR mean something. Then I read each target page to confirm it is about the thing the source promises.

These came out of a scan of all 510 static destinations in `redirects.js`, of which 78 do not resolve. Earlier families from the same scan are #49121 (JS auth-api), #49122 (CLI reference) and #49123 (Edge Functions). I grouped these three together rather than opening three more PRs against the same file, since there are already several in flight against `redirects.js` and they touch separate, non-adjacent entries.

Gates: `test:prettier` passes repo wide, `typecheck --filter=www --force` passes 8/8, and the www vitest suite passes (6 files, 75 tests) including the `next.config.test.ts` redirect coverage.

Freshman contributor. Put this together with Claude Code's help, and I verified the status codes, the canaries and the target pages myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated redirects for type generation, environment variable configuration, and Dart Sign in with Apple documentation.
  - Existing links now lead to the relevant, reorganized documentation pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->