### PR TITLE
fix(docs): drop the stale pg_partman temp redirect shadowing its page

### DIFF
--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -2355,11 +2355,6 @@ module.exports = [
     destination: '/docs/guides/database/extensions/pg_repack',
   },
   {
-    permanent: false,
-    source: '/docs/guides/database/extensions/pg_partman',
-    destination: '/docs/guides/database/extensions',
-  },
-  {
     permanent: true,
     source: '/docs/guides/ai/structured-unstructured-embeddings',
     destination: '/docs/guides/ai/structured-unstructured',


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix. A temporary redirect outlived the page it was covering and now makes that page unreachable.

## What is the current behavior?

The sidebar has an entry for pg_partman:

```ts
{ name: 'pg_partman: Partition management',
  url: '/guides/database/extensions/pg_partman' },
```

Clicking it does not open that page. `/docs/guides/database/extensions/pg_partman` redirects to the generic extensions index, so the pg_partman guide cannot be reached at all, even though `apps/docs/content/guides/database/extensions/pg_partman.mdx` is a full 95 line page with sections on enabling the extension, creating a partitioned table, time and integer based partitioning, and running maintenance.

The history explains it, and it is a tidy sequence:

1. #29206 added the pg_partman docs
2. #30109 reverted them
3. #30149 added **temp** redirects for `pgmq` and `pg_partman`, both `permanent: false`, because the pages were gone
4. #40037 brought the pg_partman page back

Step 4 never removed the step 3 redirect, so the restored page has been shadowed ever since.

## What is the new behavior?

The stale redirect entry is deleted, which makes the page reachable again and the sidebar link work.

This is the same cleanup you already did for the other half of that pair: #33170 removed the `pgmq` temp redirect from the same commit, and `pgmq` resolves to its own page today. Only `pg_partman` was left behind. There is exactly one `pg_partman` entry in `redirects.js` and zero `pgmq` entries, so this brings the two back in line.

## Additional context

Nothing else in the file needed touching, and I checked rather than assumed:

- I looked for any other redirect whose source shadows a real content page. There are three others, and all three look deliberate rather than stale, so I left them: `/docs/guides/getting-started/features` goes to the marketing `/features` page, `/docs/guides/cli` goes to `local-development`, and `connecting-to-postgres/serverless-drivers` goes to its parent. Those are consolidations, not reverts that got stranded, and the pg_partman one is the only one whose own commit message says "temp".
- I also checked whether any redirect is swallowed by an earlier pattern, since first match wins. Zero. The only duplicate sources are three pairs that share a destination, so they are harmless.

Verified live before and after reasoning about it: `/docs/guides/database/extensions/pg_partman` currently returns 200 but lands on `/docs/guides/database/extensions`, while `/docs/guides/database/extensions/pgmq` returns 200 on itself. That contrast is what pointed at the missing cleanup.

Gates: `test:prettier` passes repo wide, `typecheck --filter=www --force` passes 8/8, and the www vitest suite passes (6 files, 75 tests) including the `next.config.test.ts` redirect coverage.

Freshman contributor. Found this with Claude Code's help by checking whether any redirect source also has a content page behind it, and I traced the four commits and the pgmq precedent myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the redirect from the pg_partman documentation page to the general database extensions page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->