### PR TITLE
fix(examples): update slack clone Next.js Link usage

### DIFF
--- a/examples/slack-clone/nextjs-slack-clone-dotenvx/components/Layout.js
+++ b/examples/slack-clone/nextjs-slack-clone-dotenvx/components/Layout.js
@@ -75,8 +75,11 @@ export default function Layout(props) {
 const SidebarItem = ({ channel, isActiveChannel, user }) => (
   <>
     <li className="flex items-center justify-between">
-      <Link href="/channels/[id]" as={`/channels/${channel.id}`}>
-        <a className={isActiveChannel ? 'font-bold' : ''}>{channel.slug}</a>
+      <Link
+        href={`/channels/${channel.id}`}
+        className={isActiveChannel ? 'font-bold' : ''}
+      >
+        {channel.slug}
       </Link>
       {channel.id !== 1 && (channel.created_by === user?.id || user?.appRole === 'admin') && (
         <button onClick={() => deleteChannel(channel.id)}>

--- a/examples/slack-clone/nextjs-slack-clone/components/Layout.js
+++ b/examples/slack-clone/nextjs-slack-clone/components/Layout.js
@@ -75,8 +75,11 @@ export default function Layout(props) {
 const SidebarItem = ({ channel, isActiveChannel, user }) => (
   <>
     <li className="flex items-center justify-between">
-      <Link href="/channels/[id]" as={`/channels/${channel.id}`}>
-        <a className={isActiveChannel ? 'font-bold' : ''}>{channel.slug}</a>
+      <Link
+        href={`/channels/${channel.id}`}
+        className={isActiveChannel ? 'font-bold' : ''}
+      >
+        {channel.slug}
       </Link>
       {channel.id !== 1 && (channel.created_by === user?.id || user?.appRole === 'admin') && (
         <button onClick={() => deleteChannel(channel.id)}>


### PR DESCRIPTION
## Summary
- Fixes channel navigation in the slack clone examples by using the modern `next/link` API (no nested `<a>`, no legacy `as` prop).
- Applies the same change to both `nextjs-slack-clone` and `nextjs-slack-clone-dotenvx`.

Closes #31116

## Test plan
- [ ] Open `examples/slack-clone/nextjs-slack-clone`, install deps, run `next dev`
- [ ] Confirm channel links in the sidebar navigate without requiring `legacyBehavior`
- [ ] Repeat for `nextjs-slack-clone-dotenvx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated channel navigation links to use the current routing format.
  * Preserved active-channel styling and dynamic channel URLs.
  * Improved compatibility with the latest Next.js link behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->