### PR TITLE
[FE-4186] fix(studio): endless region selector loading for AWS_NIMBUS orgs

### DIFF
--- a/apps/studio/components/interfaces/ProjectCreation/RegionSelector.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/RegionSelector.tsx
@@ -181,9 +181,7 @@ export const RegionSelector = ({
           const selectedRegionLabel = selectedRegion?.name
             ? getDisplayNameForSmartRegion(selectedRegion.name)
             : dbRegion
-          const triggerLabel = isLoadingAvailableRegions
-            ? 'Loading available regions...'
-            : selectedRegionLabel
+          const triggerLabel = isLoading ? 'Loading available regions...' : selectedRegionLabel
 
           const affectingIncidents = incidents.filter((incident) => {
             const affectedRegions = incident.cache?.affected_regions ?? []
@@ -247,9 +245,7 @@ export const RegionSelector = ({
                       >
                         {dbRegion !== undefined && (
                           <div className="flex items-center gap-x-3">
-                            {isLoadingAvailableRegions && (
-                              <Loader2 size={14} className="animate-spin" />
-                            )}
+                            {isLoading && <Loader2 size={14} className="animate-spin" />}
                             {selectedRegion?.code && (
                               // For some reason, Safari considered the empty string alt text on this icon as misspelled (with VoiceOver)
                               // Only way to fix it is to set the role. Not needed for the combobox options


### PR DESCRIPTION
On the new-project form, the Region select's trigger label and inline spinner were driven by `isLoadingAvailableRegions` — the `isPending` state of `useOrganizationAvailableRegionsQuery`. For `AWS_NIMBUS` orgs that query is permanently disabled (`smartRegionEnabled` is false), and a disabled query stays `isPending` forever, so the trigger showed "Loading available regions..." with a spinner indefinitely even though the default region was actually selected underneath and the form still worked.

**Changed:**
- The trigger label and spinner now use the provider-aware `isLoading` (`smartRegionEnabled ? isLoadingAvailableRegions : isLoadingDefaultRegion`), which the component already used for the select's `disabled` state and placeholder. For non-Nimbus providers the two values are identical, so the normal path is unaffected.

## To test

- Emulate a Nimbus deployment locally by setting `"infra:cloud_providers": ["AWS_NIMBUS"]` in `apps/studio/hooks/custom-content/custom-content.json`, then open the new-project form: the Region field should show the default region (name + flag) within a moment — not an endless "Loading available regions..." spinner — and the dropdown should open with the specific-regions list
- Restore the normal provider list and reload: the field should briefly load, then show smart regions ("General regions") plus specific regions with Recommended badges, as before
- Toggle High Availability on/off in either config: the selector should transition between region lists without getting stuck loading

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading indicators in the region selector.
  * The selector now consistently shows the correct loading state while regions are being loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->