### PR TITLE
fix(studio): restrict geolocated default region to provider regions

### DIFF
--- a/apps/studio/components/interfaces/ProjectCreation/ProjectCreation.utils.test.ts
+++ b/apps/studio/components/interfaces/ProjectCreation/ProjectCreation.utils.test.ts
@@ -1,3 +1,4 @@
+import { AWS_REGIONS } from 'shared-data'
 import { describe, expect, it } from 'vitest'
 
 import {
@@ -6,8 +7,24 @@ import {
 } from './ProjectCreation.constants'
 import {
   filterHighAvailabilityRegions,
+  getAvailableRegions,
   getHighAvailabilityRegionCode,
 } from './ProjectCreation.utils'
+
+describe('getAvailableRegions', () => {
+  it.each(['local', 'staging', 'prod'])('returns all AWS regions for AWS on %s', (environment) => {
+    expect(getAvailableRegions('AWS', environment)).toEqual(AWS_REGIONS)
+    expect(getAvailableRegions('AWS_K8S', environment)).toEqual(AWS_REGIONS)
+  })
+
+  it.each([
+    ['local', { SOUTHEAST_ASIA: AWS_REGIONS.SOUTHEAST_ASIA }],
+    ['staging', { SOUTHEAST_ASIA: AWS_REGIONS.SOUTHEAST_ASIA }],
+    ['prod', { EAST_US: AWS_REGIONS.EAST_US }],
+  ])('returns the single AWS_NIMBUS region on %s', (environment, expectedRegions) => {
+    expect(getAvailableRegions('AWS_NIMBUS', environment)).toEqual(expectedRegions)
+  })
+})
 
 describe('High Availability project creation constraints', () => {
   it('pins the Alpha Postgres engine and release channel', () => {

--- a/apps/studio/components/interfaces/ProjectCreation/ProjectCreation.utils.test.ts
+++ b/apps/studio/components/interfaces/ProjectCreation/ProjectCreation.utils.test.ts
@@ -9,7 +9,64 @@ import {
   filterHighAvailabilityRegions,
   getAvailableRegions,
   getHighAvailabilityRegionCode,
+  resolveDefaultDbRegion,
 } from './ProjectCreation.utils'
+
+describe('resolveDefaultDbRegion', () => {
+  const base = {
+    cloudProvider: 'AWS_NIMBUS',
+    isHighAvailabilityRestricted: false,
+    highAvailabilityRegionName: undefined,
+    isSmartRegionEnabled: false,
+    recommendedSmartRegion: undefined,
+    autoDefaultRegion: undefined,
+    fixedDefaultRegion: AWS_REGIONS.EAST_US.displayName,
+    environment: 'prod',
+  } as const
+
+  it('prefers the high availability region when restricted, even while it is still loading', () => {
+    expect(
+      resolveDefaultDbRegion({
+        ...base,
+        isHighAvailabilityRestricted: true,
+        highAvailabilityRegionName: AWS_REGIONS.EAST_US.displayName,
+      })
+    ).toBe(AWS_REGIONS.EAST_US.displayName)
+    expect(resolveDefaultDbRegion({ ...base, isHighAvailabilityRestricted: true })).toBeUndefined()
+  })
+
+  it('uses the recommended smart region when smart regions are enabled', () => {
+    expect(
+      resolveDefaultDbRegion({
+        ...base,
+        cloudProvider: 'AWS',
+        isSmartRegionEnabled: true,
+        recommendedSmartRegion: 'Americas',
+        autoDefaultRegion: AWS_REGIONS.SOUTHEAST_ASIA.displayName,
+      })
+    ).toBe('Americas')
+  })
+
+  it('uses the geolocated region when the provider offers it', () => {
+    expect(
+      resolveDefaultDbRegion({
+        ...base,
+        cloudProvider: 'AWS',
+        autoDefaultRegion: AWS_REGIONS.SOUTHEAST_ASIA.displayName,
+      })
+    ).toBe(AWS_REGIONS.SOUTHEAST_ASIA.displayName)
+  })
+
+  it('falls back to the fixed default when the provider does not offer the geolocated region', () => {
+    expect(
+      resolveDefaultDbRegion({ ...base, autoDefaultRegion: AWS_REGIONS.SOUTHEAST_ASIA.displayName })
+    ).toBe(AWS_REGIONS.EAST_US.displayName)
+  })
+
+  it('falls back to the fixed default when no geolocated region resolved', () => {
+    expect(resolveDefaultDbRegion(base)).toBe(AWS_REGIONS.EAST_US.displayName)
+  })
+})
 
 describe('getAvailableRegions', () => {
   it.each(['local', 'staging', 'prod'])('returns all AWS regions for AWS on %s', (environment) => {

--- a/apps/studio/components/interfaces/ProjectCreation/ProjectCreation.utils.ts
+++ b/apps/studio/components/interfaces/ProjectCreation/ProjectCreation.utils.ts
@@ -8,13 +8,16 @@ export function smartRegionToExactRegion(smartOrExactRegion: string) {
   return SMART_REGION_TO_EXACT_REGION_MAP.get(smartOrExactRegion) ?? smartOrExactRegion
 }
 
-export function getAvailableRegions(cloudProvider: CloudProvider): Region {
+export function getAvailableRegions(
+  cloudProvider: CloudProvider,
+  environment = process.env.NEXT_PUBLIC_ENVIRONMENT
+): Region {
   switch (cloudProvider) {
     case 'AWS':
     case 'AWS_K8S':
       return AWS_REGIONS
     case 'AWS_NIMBUS':
-      if (process.env.NEXT_PUBLIC_ENVIRONMENT !== 'prod') {
+      if (environment !== 'prod') {
         // Only allow Southeast Asia for Nimbus (local/staging)
         return {
           SOUTHEAST_ASIA: AWS_REGIONS.SOUTHEAST_ASIA,

--- a/apps/studio/components/interfaces/ProjectCreation/ProjectCreation.utils.ts
+++ b/apps/studio/components/interfaces/ProjectCreation/ProjectCreation.utils.ts
@@ -33,6 +33,41 @@ export function getAvailableRegions(
   }
 }
 
+type ResolveDefaultDbRegionArgs = {
+  cloudProvider: CloudProvider
+  isHighAvailabilityRestricted: boolean
+  highAvailabilityRegionName: string | undefined
+  isSmartRegionEnabled: boolean
+  recommendedSmartRegion: string | undefined
+  autoDefaultRegion: string | undefined
+  fixedDefaultRegion: string
+  environment?: string
+}
+
+export function resolveDefaultDbRegion({
+  cloudProvider,
+  isHighAvailabilityRestricted,
+  highAvailabilityRegionName,
+  isSmartRegionEnabled,
+  recommendedSmartRegion,
+  autoDefaultRegion,
+  fixedDefaultRegion,
+  environment = process.env.NEXT_PUBLIC_ENVIRONMENT,
+}: ResolveDefaultDbRegionArgs): string | undefined {
+  if (isHighAvailabilityRestricted) return highAvailabilityRegionName
+  if (isSmartRegionEnabled) return recommendedSmartRegion
+
+  // The geolocated default is only usable if the provider actually offers that region
+  // (e.g. AWS_NIMBUS is restricted to a single region)
+  const isAutoDefaultRegionAvailable = Object.entries(
+    getAvailableRegions(cloudProvider, environment)
+  ).some(([, region]) => region.displayName === autoDefaultRegion)
+
+  return isAutoDefaultRegionAvailable && autoDefaultRegion !== undefined
+    ? autoDefaultRegion
+    : fixedDefaultRegion
+}
+
 /**
  * When launching new projects, they only get assigned a compute size once successfully launched,
  * this might assume wrong compute size, but only for projects being rapidly launched after one another on non-default compute sizes.

--- a/apps/studio/components/interfaces/ProjectCreation/ProjectCreationForm.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/ProjectCreationForm.tsx
@@ -30,6 +30,7 @@ import {
 } from './ProjectCreation.constants'
 import { FormSchema } from './ProjectCreation.schema'
 import {
+  getAvailableRegions,
   getHighAvailabilityRegionCode,
   instanceLabel,
   monthlyInstancePrice,
@@ -284,12 +285,18 @@ export const ProjectCreationForm = ({
 
   const fixedDefaultRegion = PROVIDERS[selectedCloudProvider].default_region.displayName
   const regionError = smartRegionEnabled ? availableRegionsError : defaultRegionError
+  // The geolocated default is only usable if the provider actually offers that region
+  // (e.g. AWS_NIMBUS is restricted to a single region)
+  const isAutoDefaultRegionAvailable = Object.entries(
+    getAvailableRegions(selectedCloudProvider)
+  ).some(([, region]) => region.displayName === autoDefaultRegion)
+  const validatedAutoDefaultRegion = isAutoDefaultRegionAvailable ? autoDefaultRegion : undefined
   const defaultRegion =
     highAvailability && highAvailabilityRegionCode !== undefined
       ? highAvailabilityRegion?.name
       : smartRegionEnabled
         ? recommendedSmartRegion
-        : (autoDefaultRegion ?? fixedDefaultRegion)
+        : (validatedAutoDefaultRegion ?? fixedDefaultRegion)
 
   const canCreateProject = isAdmin && !freePlanWithExceedingLimits && !hasOutstandingInvoices
   const canConfigureGitHubOnCreate =

--- a/apps/studio/components/interfaces/ProjectCreation/ProjectCreationForm.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/ProjectCreationForm.tsx
@@ -30,10 +30,10 @@ import {
 } from './ProjectCreation.constants'
 import { FormSchema } from './ProjectCreation.schema'
 import {
-  getAvailableRegions,
   getHighAvailabilityRegionCode,
   instanceLabel,
   monthlyInstancePrice,
+  resolveDefaultDbRegion,
   smartRegionToExactRegion,
 } from './ProjectCreation.utils'
 import { ProjectCreationFooter } from './ProjectCreationFooter'
@@ -285,18 +285,16 @@ export const ProjectCreationForm = ({
 
   const fixedDefaultRegion = PROVIDERS[selectedCloudProvider].default_region.displayName
   const regionError = smartRegionEnabled ? availableRegionsError : defaultRegionError
-  // The geolocated default is only usable if the provider actually offers that region
-  // (e.g. AWS_NIMBUS is restricted to a single region)
-  const isAutoDefaultRegionAvailable = Object.entries(
-    getAvailableRegions(selectedCloudProvider)
-  ).some(([, region]) => region.displayName === autoDefaultRegion)
-  const validatedAutoDefaultRegion = isAutoDefaultRegionAvailable ? autoDefaultRegion : undefined
-  const defaultRegion =
-    highAvailability && highAvailabilityRegionCode !== undefined
-      ? highAvailabilityRegion?.name
-      : smartRegionEnabled
-        ? recommendedSmartRegion
-        : (validatedAutoDefaultRegion ?? fixedDefaultRegion)
+  const defaultRegion = resolveDefaultDbRegion({
+    cloudProvider: selectedCloudProvider,
+    isHighAvailabilityRestricted:
+      highAvailability === true && highAvailabilityRegionCode !== undefined,
+    highAvailabilityRegionName: highAvailabilityRegion?.name,
+    isSmartRegionEnabled: smartRegionEnabled,
+    recommendedSmartRegion,
+    autoDefaultRegion,
+    fixedDefaultRegion,
+  })
 
   const canCreateProject = isAdmin && !freePlanWithExceedingLimits && !hasOutstandingInvoices
   const canConfigureGitHubOnCreate =

--- a/apps/studio/data/misc/get-default-region-query.test.ts
+++ b/apps/studio/data/misc/get-default-region-query.test.ts
@@ -1,0 +1,41 @@
+import { AWS_REGIONS } from 'shared-data'
+import { describe, expect, it } from 'vitest'
+
+import { getDefaultRegionCandidateKeys } from './get-default-region-query'
+
+describe('getDefaultRegionCandidateKeys', () => {
+  it('returns all AWS regions for the AWS provider', () => {
+    expect(getDefaultRegionCandidateKeys('AWS', undefined, 'prod')).toEqual(
+      Object.keys(AWS_REGIONS)
+    )
+  })
+
+  it.each([
+    ['prod', ['EAST_US']],
+    ['staging', ['SOUTHEAST_ASIA']],
+    ['local', ['SOUTHEAST_ASIA']],
+  ])('restricts AWS_NIMBUS to its only available region on %s', (environment, expectedKeys) => {
+    expect(getDefaultRegionCandidateKeys('AWS_NIMBUS', undefined, environment)).toEqual(
+      expectedKeys
+    )
+  })
+
+  it('narrows the provider regions to the restricted pool', () => {
+    expect(getDefaultRegionCandidateKeys('AWS', ['EAST_US', 'SOUTHEAST_ASIA'], 'prod')).toEqual([
+      'EAST_US',
+      'SOUTHEAST_ASIA',
+    ])
+  })
+
+  it('never returns a region the provider does not offer, even if the restricted pool contains it', () => {
+    expect(
+      getDefaultRegionCandidateKeys('AWS_NIMBUS', ['EAST_US', 'SOUTHEAST_ASIA'], 'prod')
+    ).toEqual(['EAST_US'])
+  })
+
+  it('ignores a restricted pool that excludes every provider region', () => {
+    expect(getDefaultRegionCandidateKeys('AWS_NIMBUS', ['SOUTHEAST_ASIA'], 'prod')).toEqual([
+      'EAST_US',
+    ])
+  })
+})

--- a/apps/studio/data/misc/get-default-region-query.ts
+++ b/apps/studio/data/misc/get-default-region-query.ts
@@ -5,6 +5,7 @@ import { AWS_REGIONS } from 'shared-data'
 
 import { miscKeys } from './keys'
 import { COUNTRY_LAT_LON } from '@/components/interfaces/ProjectCreation/ProjectCreation.constants'
+import { getAvailableRegions } from '@/components/interfaces/ProjectCreation/ProjectCreation.utils'
 import { AWS_REGIONS_COORDINATES } from '@/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.constants'
 import { fetchHandler } from '@/data/fetchers'
 import { getDistanceLatLonKM, tryParseJson } from '@/lib/helpers'
@@ -14,6 +15,21 @@ export type DefaultRegionVariables = {
   cloudProvider?: CloudProvider
   restrictedPool?: string[]
   useRestrictedPool?: boolean
+}
+
+// The geolocation-based default may only ever pick a region the selected cloud provider
+// actually offers (e.g. AWS_NIMBUS is restricted to a single region). The flag-based
+// restricted pool narrows within that set, and is ignored if it would leave no candidates.
+export function getDefaultRegionCandidateKeys(
+  cloudProvider: CloudProvider,
+  restrictedPool?: string[],
+  environment = process.env.NEXT_PUBLIC_ENVIRONMENT
+) {
+  const providerRegionKeys = Object.keys(getAvailableRegions(cloudProvider, environment))
+  const pooledRegionKeys = restrictedPool
+    ? providerRegionKeys.filter((key) => restrictedPool.includes(key))
+    : providerRegionKeys
+  return pooledRegionKeys.length > 0 ? pooledRegionKeys : providerRegionKeys
 }
 
 export async function getDefaultRegionOption({
@@ -34,17 +50,18 @@ export async function getDefaultRegionOption({
 
     if (locLatLon === undefined) return undefined
 
-    const locations =
-      useRestrictedPool && restrictedPool
-        ? Object.entries(AWS_REGIONS_COORDINATES)
-            .filter((x) => restrictedPool.includes(x[0]))
-            .reduce((o, val) => ({ ...o, [val[0]]: val[1] }), {})
-        : AWS_REGIONS_COORDINATES
+    const candidateKeys = getDefaultRegionCandidateKeys(
+      cloudProvider,
+      useRestrictedPool ? restrictedPool : undefined
+    )
+    const locations = Object.fromEntries(
+      Object.entries(AWS_REGIONS_COORDINATES).filter(([key]) => candidateKeys.includes(key))
+    )
 
     const distances = Object.keys(locations).map((reg) => {
       const region: { lat: number; lon: number } = {
-        lat: locations[reg as keyof typeof locations][1],
-        lon: locations[reg as keyof typeof locations][0],
+        lat: locations[reg][1],
+        lon: locations[reg][0],
       }
       return getDistanceLatLonKM(locLatLon.lat, locLatLon.lon, region.lat, region.lon)
     })


### PR DESCRIPTION
Follow-up to #49131. For `AWS_NIMBUS` orgs, the new-project form's Region trigger could show a region that wasn't in the dropdown at all (e.g. "Southeast Asia (Singapore)" while the list only offered "East US (North Virginia)"). The geolocation-based default region (`useDefaultRegionQuery`) picked the nearest region from **all** AWS regions and seeded it into `dbRegion` unvalidated, ignoring the provider's restricted region list.

**Changed:**

- `getDefaultRegionOption` now computes the nearest region only over the provider's available regions (new `getDefaultRegionCandidateKeys` helper). The flag-based restricted pool (`defaultRegionRestrictedPool`) narrows within that set and is ignored if the intersection would be empty.
- The form's default-region selection is extracted into `resolveDefaultDbRegion` (`ProjectCreation.utils.ts`): High Availability region first, then the recommended smart region, then the geolocated default — used only when the provider actually offers that region — falling back to the provider's static default.
- `getAvailableRegions` takes an injectable `environment` param (same pattern as `getHighAvailabilityRegionCode`) so the prod-only Nimbus region list is unit-testable.

**Added:**

- Unit tests for `getDefaultRegionCandidateKeys` (provider clamping incl. Nimbus on prod, restricted-pool intersection, empty-intersection fallback), `getAvailableRegions` across environments, and `resolveDefaultDbRegion` (branch priority plus the fallback when the geolocated region isn't offered).

## To test

- Emulate a Nimbus org locally by setting `"infra:cloud_providers": ["AWS_NIMBUS"]` in `apps/studio/hooks/custom-content/custom-content.json`, then open the new-project form: the Region trigger must show the same region the dropdown offers (locally that's only Southeast Asia (Singapore)). To reproduce the original mismatch path, stub `https://www.cloudflare.com/cdn-cgi/trace` to return `loc=US` — the trigger should still be clamped to the provider's region rather than showing a US region
- Block or fail the Cloudflare trace request: the trigger should fall back to the provider's static default region, not sit blank or loading
- Restore the normal provider list: the smart-region flow ("General regions" + "Specific regions" with Recommended badges) is unaffected — the geolocation request doesn't even fire on that path — and toggling High Availability still transitions the region list cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Region suggestions now respect the selected cloud provider and deployment environment.
  - Project creation avoids unavailable geolocated regions and falls back to a supported provider default.
  - Restricted region pools now fall back reliably to available provider regions.
  - AWS Nimbus selection reflects the active environment while preserving high-availability and smart-region behavior.

- **Tests**
  - Added coverage for provider-specific, environment-specific, restricted, and fallback region selection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->