### PR TITLE
fix(www): point Vue framework links at the live quickstart page

### DIFF
--- a/apps/www/app/(home)/_components/FrameworksSection.tsx
+++ b/apps/www/app/(home)/_components/FrameworksSection.tsx
@@ -208,7 +208,7 @@ onMounted(async () => {
 })
 </script>`,
     lang: 'vue' as const,
-    docsUrl: '/docs/guides/getting-started/quickstarts/vuejs',
+    docsUrl: '/docs/guides/getting-started/quickstarts/vue',
   },
   {
     name: 'Nuxt',
@@ -307,7 +307,7 @@ const frameworkExamples: Record<
     {
       title: 'Auth with Vue',
       description: 'Email and OAuth authentication.',
-      url: '/docs/guides/getting-started/quickstarts/vuejs',
+      url: '/docs/guides/getting-started/quickstarts/vue',
       icon: 'KeyRound',
     },
   ],


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix (broken link on the homepage).

## What is the current behavior?

On the homepage, the "Use Supabase with Vue" code window links its docs button to `/docs/guides/getting-started/quickstarts/vuejs`, which 404s. The quickstart file is `apps/docs/content/guides/getting-started/quickstarts/vue.mdx`, so the live page is `/docs/guides/getting-started/quickstarts/vue` and there is no redirect for the `vuejs` spelling.

The same dead path appears twice in `FrameworksSection.tsx`: the `docsUrl` of the Vue snippet and the "Auth with Vue" card below it.

Fixes #49142

## What is the new behavior?

Both links point at `/docs/guides/getting-started/quickstarts/vue`, confirmed 200. The sibling `nuxtjs` spelling is left alone because `nuxtjs.mdx` really is the file name there.

## Additional context

While checking the rest of the file I found one more dead link I did not touch: `/docs/guides/auth/server-side/nuxt` on the Nuxt "Server-Side Auth" card also 404s. Unlike the Vue one it has no obvious replacement, since `apps/docs/content/guides/auth/server-side/` only holds `creating-a-client`, `advanced-guide` and the migration page, so picking a target is a call for someone who knows what that card is meant to show.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Vue documentation links to use the correct `/vue` URL path.
  * Fixed the Vue authentication example link to point to the updated documentation location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->