### PR TITLE
fix(Search): Add server sources for search

### DIFF
--- a/apps/docs/scripts/search/sources/index.ts
+++ b/apps/docs/scripts/search/sources/index.ts
@@ -51,6 +51,18 @@ export async function fetchJsLibReferenceSource() {
   })
 }
 
+export async function fetchServerLibReferenceSource() {
+  // Server SDK is driven by the new reference pipeline. Ingest search sources
+  // from the generated `content/reference/server/v1/` outputs so embeddings
+  // never drift from what the renderer shows.
+  return loadClientLibReferenceFromNewPipeline({
+    source: 'server-lib',
+    path: '/reference/server',
+    meta: { title: 'Server Reference', language: 'TypeScript' },
+    contentDir: 'content/reference/server/v1',
+  })
+}
+
 export async function fetchDartLibReferenceSource() {
   // Dart v2 is driven by the new reference pipeline. Ingest search sources from
   // the generated `content/reference/dart/v2/` outputs so embeddings never
@@ -132,6 +144,7 @@ export async function fetchAllSources(fullIndex: boolean) {
   const lintWarningsGuideSources = fetchLintWarningsGuideSources()
   const openApiReferenceSource = fetchOpenApiReferenceSource()
   const jsLibReferenceSource = fetchJsLibReferenceSource()
+  const serverLibReferenceSource = fullIndex ? fetchServerLibReferenceSource() : []
   const dartLibReferenceSource = fullIndex ? fetchDartLibReferenceSource() : []
   const pythonLibReferenceSource = fullIndex ? fetchPythonLibReferenceSource() : []
   const cSharpLibReferenceSource = fullIndex ? fetchCSharpLibReferenceSource() : []
@@ -165,6 +178,7 @@ export async function fetchAllSources(fullIndex: boolean) {
       lintWarningsGuideSources,
       openApiReferenceSource,
       jsLibReferenceSource,
+      serverLibReferenceSource,
       dartLibReferenceSource,
       pythonLibReferenceSource,
       cSharpLibReferenceSource,


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Fix for Server SDK discoverability in search.

When the new SDK was added its source wasn't added to the search embeddings generation script. This adds the Server SDK sources following the newer SDK approach.

_Sadly we can only replicate on production so for testing we need to deploy and test on production. Something we could potentially improve in a future Search improvements project._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server SDK reference content to documentation search results.
  * Server SDK references are now available when building the complete search index.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->