### PR TITLE
fix(studio): stop the HA region guard rejecting AWS_NIMBUS projects

### DIFF
--- a/apps/studio/components/interfaces/ProjectCreation/ProjectCreationForm.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/ProjectCreationForm.tsx
@@ -447,7 +447,15 @@ export const ProjectCreationForm = ({
       ? (smartGroup.find((x) => x.name === dbRegion) ?? specific.find((x) => x.name === dbRegion))
       : undefined
 
-    if (highAvailability && highAvailabilityRegionCode !== undefined && !selectedRegion) {
+    // Only meaningful when smart regions are in play. For AWS_NIMBUS `selectedRegion` is
+    // intentionally left undefined and the payload sends `dbRegion` instead, so without this
+    // the guard would reject every high availability NIMBUS project.
+    if (
+      smartRegionEnabled &&
+      highAvailability &&
+      highAvailabilityRegionCode !== undefined &&
+      !selectedRegion
+    ) {
       return toast.error(
         `High Availability projects are not available in the required region (${highAvailabilityRegionCode})`
       )


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix. High availability project creation is blocked for AWS_NIMBUS orgs by a guard that cannot pass for them.

## What is the current behavior?

`onSubmit` resolves the selected region only when smart regions apply, then checks it:

```ts
const selectedRegion = smartRegionEnabled
  ? (smartGroup.find((x) => x.name === dbRegion) ?? specific.find((x) => x.name === dbRegion))
  : undefined

if (highAvailability && highAvailabilityRegionCode !== undefined && !selectedRegion) {
  return toast.error(`High Availability projects are not available in the required region (...)`)
}
```

`smartRegionEnabled` is `cloudProvider !== 'AWS_NIMBUS'`, so for a NIMBUS org `selectedRegion` is always `undefined` and that guard always fires. Creating a high availability project on NIMBUS therefore fails with "High Availability projects are not available in the required region", regardless of which region was picked.

The guard's premise does not apply on that path at all. Twelve lines further down the payload is built as:

```ts
...(smartRegionEnabled ? { regionSelection: selectedRegion } : { dbRegion }),
```

so for NIMBUS the region is sent as `dbRegion` and `selectedRegion` is never used for anything except this check.

This came in with #49092, which correctly removed the old HA branch from the `selectedRegion` expression but left the guard below it untouched.

## What is the new behavior?

The guard only runs when smart regions are actually in play, which is the only case where `selectedRegion` is meaningful.

## Scope, and one thing to weigh

I want to be straight about the blast radius rather than overstate it. `getHighAvailabilityRegionCode()` only returns a code when `NEXT_PUBLIC_ENVIRONMENT` is `staging` or `local`, and `undefined` otherwise, so `highAvailabilityRegionCode !== undefined` is false in production and the guard short circuits there. This is not breaking project creation for customers.

Where it does bite is staging and local stacks, so anyone testing high availability against a NIMBUS org, which is presumably how this would get exercised in the first place. I sat on this for a few days for exactly that reason and decided it was worth sending after #49131 showed NIMBUS is a live surface you are fixing bugs against.

I could not write a failing test for it: `tests/pages/new/[slug].test.tsx` has no way to select a cloud provider, so reproducing it needs NIMBUS plumbed into the wizard harness first, which felt like more than this one line warrants. The existing suite still passes (34 tests), including the two high availability region cases, so the smart region path is unchanged. If you would rather have the test than the fix, say so and I will add the harness support instead.

Gates: `test:prettier` passes repo wide, `typecheck --filter=studio --force` passes 9/9, `--filter studio run lint:ratchet` passes, and the project creation wizard suite passes 34/34.

Freshman contributor. Found this with Claude Code's help while reading what #49092 changed, and I traced the payload construction and the environment gate myself before deciding how to scope it.
