### PR TITLE
fix(log-drains): add UK1 and US2-FED Datadog regions

### DIFF
--- a/apps/docs/content/guides/monitoring-and-debugging/log-drains.mdx
+++ b/apps/docs/content/guides/monitoring-and-debugging/log-drains.mdx
@@ -191,7 +191,7 @@ Logs are batched and sent to Datadog with Gzip compression. Each event's log sou
 **Required configuration:**
 
 - API Key — from [Datadog Organization Settings](https://app.datadoghq.com/organization-settings/api-keys)
-- Region — the Datadog site your account uses (US1, US3, US5, EU, AP1, AP2, US1-FED)
+- Region — the Datadog site your account uses (US1, US3, US5, EU, AP1, AP2, UK1, US1-FED, US2-FED)
 
 **Steps:**
 

--- a/apps/studio/components/interfaces/LogDrains/LogDrains.constants.tsx
+++ b/apps/studio/components/interfaces/LogDrains/LogDrains.constants.tsx
@@ -86,12 +86,20 @@ export const DATADOG_REGIONS = [
     value: 'EU',
   },
   {
+    label: 'UK1',
+    value: 'UK1',
+  },
+  {
     label: 'US1',
     value: 'US1',
   },
   {
     label: 'US1-FED',
     value: 'US1-FED',
+  },
+  {
+    label: 'US2-FED',
+    value: 'US2-FED',
   },
   {
     label: 'US3',


### PR DESCRIPTION
## Summary
- Add `UK1` and `US2-FED` to the Datadog region dropdown in the log drains studio UI
- Add the same two regions to the Datadog region list in the log-drains docs page

The Logflare backend added support for these two Datadog regions in [Logflare/logflare#3790](https://github.com/Logflare/logflare/pull/3790) (shipped in v1.50.1), but the studio dropdown and docs were never updated, so customers on UK1 or US2-FED couldn't actually select their region when setting up a Datadog log drain.

## Test plan
- [ ] Open Project Settings → Log Drains → add a Datadog destination and confirm UK1 and US2-FED appear in the Region dropdown
- [ ] Confirm a log drain configured with `UK1`/`US2-FED` saves and sends events successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring Datadog log drains in the UK1 and US2-FED regions.

* **Documentation**
  * Updated the monitoring and debugging guide with the UK1 Datadog region.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->