### PR TITLE
feat(www): add client-side trace propagation to Logs & Analytics

### DIFF
--- a/apps/www/data/features.tsx
+++ b/apps/www/data/features.tsx
@@ -32,7 +32,6 @@ import {
   UploadCloud,
   Users,
   UserX,
-  Waypoints,
   Zap,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
@@ -2344,6 +2343,8 @@ The Logs & Analytics feature in Supabase provides users with comprehensive loggi
 
 OpenTelemetry integration allows you to export logs, metrics, and traces to any OTel-compatible tool—Datadog, Honeycomb, Grafana, or your preferred monitoring platform. The Metrics API exposes ~200 Prometheus-compatible Postgres metrics, including CPU, IO, WAL, connections, and query statistics.
 
+Trace propagation also works inbound. supabase-js, Swift, Flutter, and Python can propagate W3C Trace Context to Supabase, so a client-side trace and the corresponding Supabase logs share the same trace_id. It is opt-in and works with any W3C-compliant tracer, including OpenTelemetry, Sentry, Datadog, Honeycomb, and Grafana. See the [client-side tracing guide](https://supabase.com/docs/guides/monitoring-and-debugging/client-side-tracing).
+
 ## Key benefits
 1. Real-Time Monitoring: Access live data on application performance and user interactions to make informed decisions.
 2. Comprehensive Log Management: Ingest and store logs from multiple sources, allowing for centralized management of application events.
@@ -2352,6 +2353,7 @@ OpenTelemetry integration allows you to export logs, metrics, and traces to any 
 5. Scalability: Handle large volumes of log data with a robust infrastructure designed for high availability and performance.
 6. OpenTelemetry Support: Export telemetry data to vendor-agnostic monitoring platforms for unified observability.
 7. Metrics API: Stream Postgres performance metrics for CPU, IO, WAL, connections, and query statistics.
+8. Client-Side Trace Propagation: correlate a browser request with the matching API Gateway and Edge Function log under one shared trace_id.
 
 This feature is particularly valuable for teams looking to enhance their application's reliability and performance by gaining deeper insights into usage patterns and potential issues.
 `,
@@ -2677,28 +2679,6 @@ $60 per drain per project, plus $0.20 per million events and $0.09 per GB egress
     status: {
       stage: PRODUCT_STAGES.GA,
       availableOnSelfHosted: true,
-    },
-  },
-  {
-    title: 'Client-Side Trace Propagation',
-    subtitle: 'Follow a request from your client into your Supabase logs with a shared trace_id.',
-    description: `
-supabase-js, Swift, Flutter, and Python can now propagate W3C Trace Context to Supabase, so a client-side trace and the corresponding Supabase logs share the same trace_id.
-
-## Key benefits
-1. End-to-end debugging: follow a single request from the browser through Supabase's API Gateway and Edge Function logs under one trace_id, instead of matching timestamps by hand.
-2. Works with your existing tracer: any W3C-compliant tracer, including OpenTelemetry, Sentry, Datadog, Honeycomb, and Grafana, picks up the trace server-side.
-3. More value from Log Drains: every log you already export carries the shared trace_id, so it joins your traces in the tool you already run.
-4. Opt-in, zero bundle cost: nothing is added to your app until you turn it on.
-`,
-    icon: Waypoints,
-    products: [ADDITIONAL_PRODUCTS.STUDIO],
-    heroImage: '',
-    docsUrl: 'https://supabase.com/docs/guides/monitoring-and-debugging/client-side-tracing',
-    slug: 'client-side-trace-propagation',
-    status: {
-      stage: PRODUCT_STAGES.GA,
-      availableOnSelfHosted: false,
     },
   },
   {

--- a/apps/www/data/features.tsx
+++ b/apps/www/data/features.tsx
@@ -2343,7 +2343,7 @@ The Logs & Analytics feature in Supabase provides users with comprehensive loggi
 
 OpenTelemetry integration allows you to export logs, metrics, and traces to any OTel-compatible tool—Datadog, Honeycomb, Grafana, or your preferred monitoring platform. The Metrics API exposes ~200 Prometheus-compatible Postgres metrics, including CPU, IO, WAL, connections, and query statistics.
 
-Trace propagation also works inbound. supabase-js, Swift, Flutter, and Python can propagate W3C Trace Context to Supabase, so a client-side trace and the corresponding Supabase logs share the same trace_id. It is opt-in and works with any W3C-compliant tracer, including OpenTelemetry, Sentry, Datadog, Honeycomb, and Grafana. See the [client-side tracing guide](https://supabase.com/docs/guides/monitoring-and-debugging/client-side-tracing).
+Trace propagation also works inbound. supabase-js, Swift, Flutter, and Python can propagate W3C Trace Context to Supabase, so a client-side trace and the corresponding Supabase logs share the same trace_id. It is opt-in and works with any W3C-compliant tracer, including OTLP, Sentry, Datadog, Honeycomb, and Grafana. See the [client-side tracing guide](https://supabase.com/docs/guides/monitoring-and-debugging/client-side-tracing) for the latest on supported SDKs and target platforms.
 
 ## Key benefits
 1. Real-Time Monitoring: Access live data on application performance and user interactions to make informed decisions.

--- a/apps/www/data/features.tsx
+++ b/apps/www/data/features.tsx
@@ -32,6 +32,7 @@ import {
   UploadCloud,
   Users,
   UserX,
+  Waypoints,
   Zap,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
@@ -2671,11 +2672,33 @@ $60 per drain per project, plus $0.20 per million events and $0.09 per GB egress
     icon: Activity,
     products: [ADDITIONAL_PRODUCTS.STUDIO],
     heroImage: 'https://www.youtube-nocookie.com/embed/A4GFmvgxS-E',
-    docsUrl: 'https://supabase.com/docs/guides/telemetry/log-drains',
+    docsUrl: 'https://supabase.com/docs/guides/monitoring-and-debugging/log-drains',
     slug: 'log-drains',
     status: {
       stage: PRODUCT_STAGES.GA,
       availableOnSelfHosted: true,
+    },
+  },
+  {
+    title: 'Client-Side Trace Propagation',
+    subtitle: 'Follow a request from your client into your Supabase logs with a shared trace_id.',
+    description: `
+supabase-js, Swift, Flutter, and Python can now propagate W3C Trace Context to Supabase, so a client-side trace and the corresponding Supabase logs share the same trace_id.
+
+## Key benefits
+1. End-to-end debugging: follow a single request from the browser through Supabase's API Gateway and Edge Function logs under one trace_id, instead of matching timestamps by hand.
+2. Works with your existing tracer: any W3C-compliant tracer, including OpenTelemetry, Sentry, Datadog, Honeycomb, and Grafana, picks up the trace server-side.
+3. More value from Log Drains: every log you already export carries the shared trace_id, so it joins your traces in the tool you already run.
+4. Opt-in, zero bundle cost: nothing is added to your app until you turn it on.
+`,
+    icon: Waypoints,
+    products: [ADDITIONAL_PRODUCTS.STUDIO],
+    heroImage: '',
+    docsUrl: 'https://supabase.com/docs/guides/monitoring-and-debugging/client-side-tracing',
+    slug: 'client-side-trace-propagation',
+    status: {
+      stage: PRODUCT_STAGES.GA,
+      availableOnSelfHosted: false,
     },
   },
   {

--- a/apps/www/data/features.tsx
+++ b/apps/www/data/features.tsx
@@ -2353,7 +2353,7 @@ Trace propagation also works inbound. supabase-js, Swift, Flutter, and Python ca
 5. Scalability: Handle large volumes of log data with a robust infrastructure designed for high availability and performance.
 6. OpenTelemetry Support: Export telemetry data to vendor-agnostic monitoring platforms for unified observability.
 7. Metrics API: Stream Postgres performance metrics for CPU, IO, WAL, connections, and query statistics.
-8. Client-Side Trace Propagation: correlate a browser request with the matching API Gateway and Edge Function log under one shared trace_id.
+8. Client-Side Trace Propagation: correlate a trace from your client app — web, mobile, or server-side — with the matching API Gateway and Edge Function log under one shared 'trace_id'.
 
 This feature is particularly valuable for teams looking to enhance their application's reliability and performance by gaining deeper insights into usage patterns and potential issues.
 `,


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- Feature page content update (`apps/www/data/features.tsx`)
- Docs link fix

## What is the current behavior?

The Logs & Analytics feature page entry covers Supabase exporting its own telemetry outward (OpenTelemetry export, Metrics API) but does not mention client-side trace propagation. The Log Drains entry links a stale docs URL.

## What is the new behavior?

- Logs & Analytics entry now also covers client-side trace propagation: supabase-js, Swift, Flutter, and Python can propagate W3C Trace Context to Supabase so a client trace and the corresponding Supabase logs share a `trace_id`, added as a new paragraph and Key benefit
- Log Drains entry's `docsUrl` fixed from `/guides/telemetry/log-drains` to `/guides/monitoring-and-debugging/log-drains`

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added information about W3C trace-context propagation for Logs & Analytics.
  * Documented supported client libraries, tracer integrations, opt-in behavior, and shared `trace_id` correlation.

* **Documentation**
  * Updated the Log Drains documentation link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->