### PR TITLE
test(studio): allow scoped token creation in CI

### DIFF
--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/NewScopedTokenSheet.test.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/NewScopedTokenSheet.test.tsx
@@ -204,7 +204,7 @@ describe('NewScopedTokenSheet', () => {
     fireEvent.click(await screen.findByRole('button', { name: 'Done' }))
     // Dialog has been closed
     await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
-  })
+  }, 10_000)
 
   // Organization scope tests
   test('requires an organization when scope is Organization', async () => {
@@ -254,7 +254,7 @@ describe('NewScopedTokenSheet', () => {
     fireEvent.click(await screen.findByRole('button', { name: 'Done' }))
     // Dialog has been closed
     await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
-  })
+  }, 10_000)
 
   test('opens the experimental API dialog from the dropdown', async () => {
     renderSheet()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Test reliability fix.

## What is the current behavior?

The two longest scoped access token creation tests can exceed Vitest's default five-second timeout when they run under the full Studio CI shard, despite passing locally.

## What is the new behavior?

The project-scoped and organisation-scoped token creation tests each use a targeted ten-second timeout. The global timeout and production code remain unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased test timeouts for project- and organization-scoped token creation scenarios to improve test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->