### PR TITLE
feat(studio): polish PrivateLink connection UI

### DIFF
--- a/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLink.utils.test.ts
+++ b/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLink.utils.test.ts
@@ -60,6 +60,7 @@ describe('getConnectionsAttentionCopy', () => {
     const copy = getConnectionsAttentionCopy({ waitingCount: 1, expiredCount: 0 })
     expect(copy?.type).toBe('warning')
     expect(copy?.title).toBe('Waiting for the AWS account owner')
+    expect(copy?.description).toBe('Accept the resource share in AWS within 12 hours.')
     expect(copy?.shouldShowAcceptLink).toBe(true)
   })
 
@@ -67,7 +68,7 @@ describe('getConnectionsAttentionCopy', () => {
     const copy = getConnectionsAttentionCopy({ waitingCount: 0, expiredCount: 2 })
     expect(copy?.type).toBe('destructive')
     expect(copy?.title).toBe('Connection requests expired')
-    expect(copy?.description).toBe('AWS can no longer accept the expired shares below.')
+    expect(copy?.description).toBe('AWS can no longer accept these shares.')
     expect(copy?.shouldShowAcceptLink).toBe(false)
   })
 

--- a/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLink.utils.test.ts
+++ b/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLink.utils.test.ts
@@ -60,14 +60,15 @@ describe('getConnectionsAttentionCopy', () => {
     const copy = getConnectionsAttentionCopy({ waitingCount: 1, expiredCount: 0 })
     expect(copy?.type).toBe('warning')
     expect(copy?.title).toBe('Waiting for the AWS account owner')
-    expect(copy?.showAcceptLink).toBe(true)
+    expect(copy?.shouldShowAcceptLink).toBe(true)
   })
 
   it('uses destructive copy when only expired', () => {
     const copy = getConnectionsAttentionCopy({ waitingCount: 0, expiredCount: 2 })
     expect(copy?.type).toBe('destructive')
     expect(copy?.title).toBe('Connection requests expired')
-    expect(copy?.showAcceptLink).toBe(false)
+    expect(copy?.description).toBe('AWS can no longer accept the expired shares below.')
+    expect(copy?.shouldShowAcceptLink).toBe(false)
   })
 
   it('counts statuses from a list', () => {

--- a/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLink.utils.ts
+++ b/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLink.utils.ts
@@ -82,7 +82,7 @@ export function getConnectionsAttentionCopy(attention: ConnectionsAttention): {
     return {
       type: 'destructive',
       title: expiredCount === 1 ? 'A connection request expired' : 'Connection requests expired',
-      description: `AWS can no longer accept the expired share${expiredCount === 1 ? '' : 's'} below.`,
+      description: `AWS can no longer accept ${expiredCount === 1 ? 'this share' : 'these shares'}.`,
       shouldShowAcceptLink: false,
     }
   }

--- a/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLink.utils.ts
+++ b/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLink.utils.ts
@@ -73,7 +73,7 @@ export function getConnectionsAttentionCopy(attention: ConnectionsAttention): {
   type: 'warning' | 'destructive'
   title: string
   description: string
-  showAcceptLink: boolean
+  shouldShowAcceptLink: boolean
 } | null {
   const { waitingCount, expiredCount } = attention
   if (waitingCount === 0 && expiredCount === 0) return null
@@ -82,8 +82,8 @@ export function getConnectionsAttentionCopy(attention: ConnectionsAttention): {
     return {
       type: 'destructive',
       title: expiredCount === 1 ? 'A connection request expired' : 'Connection requests expired',
-      description: 'Add a new connection to try again. AWS can no longer accept this share.',
-      showAcceptLink: false,
+      description: `AWS can no longer accept the expired share${expiredCount === 1 ? '' : 's'} below.`,
+      shouldShowAcceptLink: false,
     }
   }
 
@@ -91,9 +91,8 @@ export function getConnectionsAttentionCopy(attention: ConnectionsAttention): {
     return {
       type: 'warning',
       title: 'Some connections need attention',
-      description:
-        'Accept waiting resource shares in AWS within 12 hours. Expired requests need a new connection.',
-      showAcceptLink: true,
+      description: `Accept the waiting resource share${waitingCount === 1 ? '' : 's'} in AWS within 12 hours.`,
+      shouldShowAcceptLink: true,
     }
   }
 
@@ -101,7 +100,7 @@ export function getConnectionsAttentionCopy(attention: ConnectionsAttention): {
     type: 'warning',
     title:
       waitingCount === 1 ? 'Waiting for the AWS account owner' : 'Waiting for AWS account owners',
-    description: 'Accept the resource share in AWS within 12 hours.',
-    showAcceptLink: true,
+    description: `Accept the resource share${waitingCount === 1 ? '' : 's'} in AWS within 12 hours.`,
+    shouldShowAcceptLink: true,
   }
 }

--- a/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLinkAttentionAdmonition.tsx
+++ b/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLinkAttentionAdmonition.tsx
@@ -25,7 +25,7 @@ export function AWSPrivateLinkAttentionAdmonition({
       description={copy.description}
       className={className}
       actions={
-        copy.showAcceptLink && (
+        copy.shouldShowAcceptLink && (
           <Button variant="default" className="w-min" icon={<SquareArrowOutUpRight />} asChild>
             <Link
               target="_blank"

--- a/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLinkForm.tsx
+++ b/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLinkForm.tsx
@@ -206,11 +206,16 @@ export const AWSPrivateLinkForm = ({
                 control={form.control}
                 name="accountName"
                 render={({ field }) => (
-                  <FormItemLayout label="Description" labelOptional="Optional">
+                  <FormItemLayout
+                    label="Name"
+                    labelOptional="Optional"
+                    description="Shown on the connections list. Defaults to the AWS account ID if left blank."
+                  >
                     <FormControl>
                       <Input
                         {...field}
                         readOnly={!isNew}
+                        placeholder="Production VPC"
                         onFocus={(e) => {
                           if (!isNew) e.target.blur()
                         }}

--- a/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLinkSection.tsx
+++ b/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLinkSection.tsx
@@ -25,6 +25,7 @@ import {
 } from 'ui-patterns/PageSection'
 
 import { IntegrationSectionIcon } from '../IntegrationsSettings'
+import { getConnectionTitle } from './AWSPrivateLink.utils'
 import { AWSPrivateLinkAccountItem } from './AWSPrivateLinkAccountItem'
 import { AWSPrivateLinkAttentionAdmonition } from './AWSPrivateLinkAttentionAdmonition'
 import { AWSPrivateLinkForm } from './AWSPrivateLinkForm'
@@ -46,7 +47,7 @@ export const AWSPrivateLinkSection = () => {
   const [showForm, setShowForm] = useState(false)
   const [showDeleteModal, setShowDeleteModal] = useState(false)
 
-  const { mutate: deleteAccount, isPending: isDeleting } = useAWSAccountDeleteMutation({
+  const { mutateAsync: deleteAccount, isPending: isDeleting } = useAWSAccountDeleteMutation({
     onSuccess: () => {
       toast.success('Connection will be deleted shortly')
       setShowDeleteModal(false)
@@ -68,25 +69,34 @@ export const AWSPrivateLinkSection = () => {
     setShowForm(true)
   }
 
-  const onConfirmDelete = () => {
-    if (selectedAccount && project) {
-      deleteAccount({
-        projectRef: project.ref,
-        awsAccountId: selectedAccount.aws_account_id,
-        databaseIdentifier:
-          selectedAccount.database_type === 'READ_REPLICA'
-            ? selectedAccount.database_identifier
-            : undefined,
-      })
-    }
+  const onConfirmDelete = async () => {
+    if (!selectedAccount || !project) return
+
+    await deleteAccount({
+      projectRef: project.ref,
+      awsAccountId: selectedAccount.aws_account_id,
+      databaseIdentifier:
+        selectedAccount.database_type === 'READ_REPLICA'
+          ? selectedAccount.database_identifier
+          : undefined,
+    })
   }
 
-  const deleteDatabaseCopy =
-    selectedAccount?.database_type === 'READ_REPLICA'
-      ? selectedAccount.database_identifier
-        ? `the read replica (ID: ${formatDatabaseID(selectedAccount.database_identifier)})`
-        : 'a read replica'
-      : 'the primary database'
+  let deleteDatabaseCopy = 'the primary database'
+  if (selectedAccount?.database_type === 'READ_REPLICA') {
+    deleteDatabaseCopy = selectedAccount.database_identifier
+      ? `the read replica (ID: ${formatDatabaseID(selectedAccount.database_identifier)})`
+      : 'the read replica (ID: Unknown identifier)'
+  }
+
+  const deleteConnectionTitle = selectedAccount
+    ? getConnectionTitle({
+        account_name: selectedAccount.account_name,
+        aws_account_id: selectedAccount.aws_account_id,
+      })
+    : ''
+  const showDeleteConnectionId =
+    !!selectedAccount && deleteConnectionTitle === selectedAccount.aws_account_id
 
   return (
     <>
@@ -161,8 +171,12 @@ export const AWSPrivateLinkSection = () => {
             <AlertDialogTitle>Delete connection</AlertDialogTitle>
             <AlertDialogDescription>
               This removes the PrivateLink connection for{' '}
-              <code className="text-code-inline">{selectedAccount?.aws_account_id}</code> on{' '}
-              {deleteDatabaseCopy}. Applications using this private path will lose access.
+              {showDeleteConnectionId ? (
+                <code className="text-code-inline">{deleteConnectionTitle}</code>
+              ) : (
+                deleteConnectionTitle
+              )}{' '}
+              on {deleteDatabaseCopy}. Applications using this private path will lose access.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Polish for the AWS PrivateLink integrations UI.

## What is the current behavior?

The add/view sheet labels the optional nickname field as "Description", delete confirmation always shows the AWS account ID, list admonitions use generic copy, and delete uses a fire-and-forget mutation.

## What is the new behavior?

- Rename the optional nickname field to **Name**, with helper copy explaining it appears on the connections list
- Tighten list admonition copy to reference connections below and pluralise share wording
- Rename `showAcceptLink` to `shouldShowAcceptLink`
- Delete confirmation uses the connection name (or account ID when unnamed) and clearer read replica fallback copy
- Delete uses `mutateAsync` so the dialog can await the mutation

| Before | After | 
| --- | --- |
| <img width="828" height="515" alt="Integrations  Settings  Chisel  Toolshed  Supabase" src="https://github.com/user-attachments/assets/9e255d4b-a048-459c-87ff-ee1b65f42f9a" /> | <img width="828" height="515" alt="Integrations  Settings  Chisel  Toolshed  Supabase" src="https://github.com/user-attachments/assets/500e3922-912f-4e3b-a875-295ac7bd689e" /> |

## To test

1. Open **Project settings → Integrations → AWS PrivateLink** on a project with PrivateLink access
2. Click **Add connection** and confirm the optional field is labelled **Name** with helper copy underneath
3. Add a connection with a name (e.g. `Production VPC`) and confirm the list row shows that title
4. If you have a waiting or expired connection, confirm the list admonition copy references shares below
5. Open a named connection, click **Delete**, and confirm the dialog uses the connection name rather than always showing the raw account ID
6. Cancel delete and confirm the sheet stays open

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated AWS PrivateLink connection messages with clearer singular and plural wording.
  * Improved guidance for expired and pending connections, including acceptance-instruction links.
  * Renamed the account field to “Name,” marked it optional, and clarified its purpose and default behavior.
  * Enhanced deletion confirmations with clearer connection names and AWS account identifiers.
  * Improved deletion handling to provide more reliable feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->