### PR TITLE
fix(docs): point the Management API nav entry at the Management API reference

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -3365,7 +3365,7 @@ export const reference = {
         },
         {
           name: 'Management API',
-          url: '/reference/javascript',
+          url: '/reference/api/introduction',
           icon: '/img/icons/menu/reference-api' as `/${string}`,
         },
       ],


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix. The "Management API" navigation entry points at the JavaScript client library reference, and at a url that 404s.

## What is the current behavior?

In `NavigationMenu.constants.ts`:

```ts
{
  name: 'Supabase CLI',
  url: '/reference/cli/introduction',
  icon: '/img/icons/menu/reference-cli',
},
{
  name: 'Management API',
  url: '/reference/javascript',        // <-- the JS client library reference
  icon: '/img/icons/menu/reference-api',
},
```

Two things are wrong with that one line. It is the wrong reference entirely, and `/docs/reference/javascript` returns 404 on its own, so the entry does not even land on the JavaScript docs it names.

Three signals say the url is the odd one out rather than the label being wrong:

- the entry is called "Management API"
- it already carries the `reference-api` icon, not the javascript one
- its sibling immediately above pairs label, icon and url consistently

## What is the new behavior?

It points at `/reference/api/introduction`, confirmed 200, which is the Management API reference and is the form already used elsewhere in this same file.

## Additional context

I have another nav PR open, #49157, which fixes a separate problem in this file: seventeen entries still using the pre-rename `/reference/<lang>/start` form. This one is a different defect (wrong destination rather than a stale slug), so I kept it separate. I checked that the two do not conflict: `git merge-tree` across both branches reports zero conflict markers, so they can land in either order.

Verification: `/docs/reference/javascript` confirmed 404 and `/docs/reference/api/introduction` confirmed 200 against production, with a nonsense URL in the same namespace first to confirm the check reports failures (`/docs/reference/javascript/zzz-canary` returns 404, so status codes are meaningful here, which is not true in every docs namespace).

Found by sweeping all 657 distinct `url:` values in the nav constants rather than by reading around, which is also how #49157 surfaced.

Gates: `test:prettier` passes repo wide and `typecheck --filter=docs --force` passes 8/8. Nothing covers the nav constants in tests, so there is no test to update.

Freshman contributor, put this together with Claude Code's help and checked the two urls and the sibling pattern myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Management API navigation link to direct users to the API introduction page instead of the JavaScript reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->