### PR TITLE
docs(functions): update Pro and Team function limits

### DIFF
--- a/apps/docs/content/guides/functions/limits.mdx
+++ b/apps/docs/content/guides/functions/limits.mdx
@@ -20,8 +20,8 @@ subtitle: "Limits applied Edge Functions in Supabase's hosted platform."
 - Maximum Function Size: 20MB (bundled locally via the CLI) or 5MB (bundled server-side, e.g. via the Management API or Dashboard)
 - Maximum no. of Functions per project:
   - Free: 100
-  - Pro: 500
-  - Team: 1000
+  - Pro: 1000
+  - Team: 2000
   - Enterprise: Unlimited
 - Maximum log message length: 10,000 characters
 - Log event threshold: 100 events per 10 seconds


### PR DESCRIPTION
Pro plan increased from 500 to 1000 functions per project, Team from 1000 to 2000.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update for function limits

## What is the current behavior?

The function limits for Pro and Team plans are 500 and 1000 respectively in the docs.

## What is the new behavior?

The function limits are updated to 1000 and 2000 for Pro and Team plans in the docs to match the updated
limits in the backend. 


## Additional context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated platform limits for Pro plans to support up to 1,000 functions per project.
  * Updated platform limits for Team plans to support up to 2,000 functions per project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->