### PR TITLE
fix(studio): guard SignInPartner redirect against unmount race

### DIFF
--- a/apps/studio/components/interfaces/SignIn/SignInPartner.tsx
+++ b/apps/studio/components/interfaces/SignIn/SignInPartner.tsx
@@ -9,6 +9,8 @@ export const SignInPartner = () => {
   const router = useRouter()
 
   useEffect(() => {
+    let isMounted = true
+
     ;(async () => {
       const params = new URLSearchParams(window.location.hash.substring(1))
 
@@ -21,12 +23,16 @@ export const SignInPartner = () => {
         try {
           await auth.signInWithIdToken({ provider: partner, token })
         } finally {
-          router.replace({ pathname: '/sign-in-mfa' })
+          if (isMounted) router.replace({ pathname: '/sign-in-mfa' })
         }
       } else {
-        router.replace({ pathname: '/sign-in' })
+        if (isMounted) router.replace({ pathname: '/sign-in' })
       }
     })()
+
+    return () => {
+      isMounted = false
+    }
   }, [])
 
   return (

--- a/apps/studio/tests/components/SignIn/SignInPartner.test.tsx
+++ b/apps/studio/tests/components/SignIn/SignInPartner.test.tsx
@@ -1,0 +1,46 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import { SignInPartner } from '@/components/interfaces/SignIn/SignInPartner'
+import { customRender } from '@/tests/lib/custom-render'
+
+const routerReplaceMock = vi.fn()
+
+vi.mock('next/router', () => ({
+  useRouter: () => ({
+    replace: routerReplaceMock,
+  }),
+}))
+
+vi.mock('@/lib/gotrue', () => ({
+  auth: {
+    getSession: vi.fn(),
+    signInWithIdToken: vi.fn(),
+  },
+}))
+
+describe('SignInPartner', () => {
+  test('does not navigate after unmounting before sign-in resolves', async () => {
+    const { auth } = await import('@/lib/gotrue')
+
+    let resolveSignIn: () => void = () => {}
+    vi.mocked(auth.getSession).mockResolvedValue({ data: { session: null } } as any)
+    vi.mocked(auth.signInWithIdToken).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveSignIn = () => resolve({} as any)
+        })
+    )
+
+    window.location.hash = '#partner=google&id_token=test-token'
+
+    const { unmount } = customRender(<SignInPartner />)
+
+    unmount()
+    resolveSignIn()
+
+    // flush the pending microtasks from the resolved sign-in promise
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(routerReplaceMock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- `SignInPartner.tsx` fires an unguarded async IIFE in a `useEffect` that calls `auth.getSession()` and possibly `auth.signInWithIdToken()`, then unconditionally calls `router.replace()` once the promise resolves.
- If the component unmounts before that promise settles (e.g. the user navigates away), the redirect still fires, yanking the user back to `/sign-in-mfa` or `/sign-in` regardless of where they've navigated to.
- Added an `isMounted` guard set in the effect's cleanup function so the redirect is skipped once the component has unmounted.

Fixes #46593

## Test plan
- [x] Added a regression test (`tests/components/SignIn/SignInPartner.test.tsx`) that unmounts the component while the sign-in promise is still pending, then resolves it and asserts `router.replace` is never called.
- [ ] CI: typecheck, lint, and Studio unit tests (could not run `pnpm install`/vitest locally in this environment — happy to address any CI failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented sign-in redirects from occurring after the sign-in screen has been closed or unmounted.
  * Improved stability when partner authentication completes after navigation.

* **Tests**
  * Added coverage for unresolved partner sign-ins and unmount scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->