### PR TITLE
fix(docs/oauth-server): add `plain` for code_challenge_method

### DIFF
--- a/apps/docs/content/guides/auth/oauth-server/oauth-flows.mdx
+++ b/apps/docs/content/guides/auth/oauth-server/oauth-flows.mdx
@@ -152,13 +152,13 @@ https://<project-ref>.supabase.co/auth/v1/oauth/authorize?
 
 #### Required parameters
 
-| Parameter               | Description                                  |
-| ----------------------- | -------------------------------------------- |
-| `response_type`         | Must be `code` for authorization code flow   |
-| `client_id`             | The client ID from registration              |
-| `redirect_uri`          | Must exactly match a registered redirect URI |
-| `code_challenge`        | The generated code challenge                 |
-| `code_challenge_method` | Must be `S256` (SHA-256)                     |
+| Parameter               | Description                                        |
+| ----------------------- | -------------------------------------------------- |
+| `response_type`         | Must be `code` for authorization code flow         |
+| `client_id`             | The client ID from registration                    |
+| `redirect_uri`          | Must exactly match a registered redirect URI       |
+| `code_challenge`        | The generated code challenge                       |
+| `code_challenge_method` | `S256` (SHA-256) or `plain`. `S256` is recommended |
 
 #### Optional parameters
 

--- a/apps/docs/content/guides/auth/oauth-server/oauth-flows.mdx
+++ b/apps/docs/content/guides/auth/oauth-server/oauth-flows.mdx
@@ -152,13 +152,13 @@ https://<project-ref>.supabase.co/auth/v1/oauth/authorize?
 
 #### Required parameters
 
-| Parameter               | Description                                        |
-| ----------------------- | -------------------------------------------------- |
-| `response_type`         | Must be `code` for authorization code flow         |
-| `client_id`             | The client ID from registration                    |
-| `redirect_uri`          | Must exactly match a registered redirect URI       |
-| `code_challenge`        | The generated code challenge                       |
-| `code_challenge_method` | `S256` (SHA-256, recommended) or `plain` |
+| Parameter               | Description                                  |
+| ----------------------- | -------------------------------------------- |
+| `response_type`         | Must be `code` for authorization code flow   |
+| `client_id`             | The client ID from registration              |
+| `redirect_uri`          | Must exactly match a registered redirect URI |
+| `code_challenge`        | The generated code challenge                 |
+| `code_challenge_method` | `S256` (SHA-256, recommended) or `plain`     |
 
 #### Optional parameters
 

--- a/apps/docs/content/guides/auth/oauth-server/oauth-flows.mdx
+++ b/apps/docs/content/guides/auth/oauth-server/oauth-flows.mdx
@@ -158,7 +158,7 @@ https://<project-ref>.supabase.co/auth/v1/oauth/authorize?
 | `client_id`             | The client ID from registration                    |
 | `redirect_uri`          | Must exactly match a registered redirect URI       |
 | `code_challenge`        | The generated code challenge                       |
-| `code_challenge_method` | `S256` (SHA-256) or `plain`. `S256` is recommended |
+| `code_challenge_method` | `S256` (SHA-256, recommended) or `plain` |
 
 #### Optional parameters
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?
docs update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that OAuth authorization requests support both `S256` and `plain` code challenge methods.
  * Recommends `S256` for improved security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->