### PR TITLE
[FE-4193] fix(studio): show proper names for custom identity providers

### DIFF
--- a/apps/studio/components/interfaces/SignIn/SignInWithCustom.tsx
+++ b/apps/studio/components/interfaces/SignIn/SignInWithCustom.tsx
@@ -4,18 +4,16 @@ import { Button } from 'ui'
 
 import { BASE_PATH } from '@/lib/constants'
 import { captureCriticalError } from '@/lib/error-reporting'
+import { getProviderDisplay } from '@/lib/external-identity-providers'
 import { auth, buildPathWithParams } from '@/lib/gotrue'
 
 interface SignInWithCustomProps {
   providerName: string
 }
 
-const formatProviderName = (name: string) => {
-  return name.replace('custom:', '')
-}
-
 export const SignInWithCustom = ({ providerName }: SignInWithCustomProps) => {
   const [loading, setLoading] = useState(false)
+  const displayName = getProviderDisplay(providerName).displayName
 
   async function handleCustomSignIn() {
     setLoading(true)
@@ -38,7 +36,7 @@ export const SignInWithCustom = ({ providerName }: SignInWithCustomProps) => {
 
       if (error) throw error
     } catch (error: any) {
-      toast.error(`Failed to sign in via ${providerName}: ${error.message}`)
+      toast.error(`Failed to sign in via ${displayName}: ${error.message}`)
       captureCriticalError(error, `sign in via ${providerName}`)
       setLoading(false)
     }
@@ -46,7 +44,7 @@ export const SignInWithCustom = ({ providerName }: SignInWithCustomProps) => {
 
   return (
     <Button block onClick={handleCustomSignIn} size="large" variant="default" loading={loading}>
-      Continue with <span className="capitalize">{formatProviderName(providerName)}</span>
+      Continue with {displayName}
     </Button>
   )
 }

--- a/apps/studio/lib/external-identity-providers.test.ts
+++ b/apps/studio/lib/external-identity-providers.test.ts
@@ -30,6 +30,7 @@ describe('external identity providers', () => {
     expect(getProviderDisplay('custom:acme').displayName).toBe('Acme')
     expect(getProviderDisplay('Custom:Acme').displayName).toBe('Acme')
     expect(getProviderDisplay('custom:my_provider').displayName).toBe('My Provider')
+    expect(getProviderDisplay('custom:MY_PROVIDER').displayName).toBe('My Provider')
     // registered custom providers keep their configured display name
     expect(getProviderDisplay('custom:openai').displayName).toBe('ChatGPT')
   })

--- a/apps/studio/lib/external-identity-providers.test.ts
+++ b/apps/studio/lib/external-identity-providers.test.ts
@@ -26,6 +26,14 @@ describe('external identity providers', () => {
     expect(getProviderDisplay('my_provider').displayName).toBe('my provider')
   })
 
+  test('derives a title-cased name for unregistered custom providers', () => {
+    expect(getProviderDisplay('custom:acme').displayName).toBe('Acme')
+    expect(getProviderDisplay('Custom:Acme').displayName).toBe('Acme')
+    expect(getProviderDisplay('custom:my_provider').displayName).toBe('My Provider')
+    // registered custom providers keep their configured display name
+    expect(getProviderDisplay('custom:openai').displayName).toBe('ChatGPT')
+  })
+
   test('marks static provider icons as monochrome but not built-in or fallback icons', () => {
     expect(getProviderDisplay('github').hasMonochromeIcon).toBe(true)
     expect(getProviderDisplay('email').hasMonochromeIcon).toBeUndefined()

--- a/apps/studio/lib/external-identity-providers.ts
+++ b/apps/studio/lib/external-identity-providers.ts
@@ -69,6 +69,24 @@ export function normalizeIconPath(iconPath: string): string {
   return `${BASE_PATH}/${iconPath}`
 }
 
+const CUSTOM_PROVIDER_PREFIX = 'custom:'
+
+/**
+ * Derives a human-readable name from a `custom:*` provider id, e.g. `custom:acme` -> "Acme" and
+ * `custom:my_provider` -> "My Provider". Returns undefined for non-custom providers.
+ */
+function getCustomProviderName(provider: string): string | undefined {
+  if (!provider.toLowerCase().startsWith(CUSTOM_PROVIDER_PREFIX)) return undefined
+
+  return provider
+    .slice(CUSTOM_PROVIDER_PREFIX.length)
+    .replaceAll('_', ' ')
+    .split(' ')
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+}
+
 export function getProviderDisplay(provider: string): IdentityProviderDisplay {
   const config = IDENTITY_PROVIDERS.find(
     ({ id, authProvider }) => provider === id || provider === authProvider
@@ -87,6 +105,17 @@ export function getProviderDisplay(provider: string): IdentityProviderDisplay {
     return {
       id: provider,
       displayName: 'SSO',
+      iconPath: `${BASE_PATH}/img/icons/saml-icon.svg`,
+    }
+  }
+
+  // Unregistered `custom:*` providers (e.g. white-label deployments' own OAuth providers) fall
+  // back to a title-cased name derived from the id: `custom:acme` -> "Acme".
+  const customProviderName = getCustomProviderName(provider)
+  if (customProviderName) {
+    return {
+      id: provider,
+      displayName: customProviderName,
       iconPath: `${BASE_PATH}/img/icons/saml-icon.svg`,
     }
   }

--- a/apps/studio/lib/external-identity-providers.ts
+++ b/apps/studio/lib/external-identity-providers.ts
@@ -83,7 +83,7 @@ function getCustomProviderName(provider: string): string | undefined {
     .replaceAll('_', ' ')
     .split(' ')
     .filter(Boolean)
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
     .join(' ')
 }
 


### PR DESCRIPTION
Unregistered `custom:*` identity providers (e.g. white-label deployments' own OAuth providers) rendered their raw id — the account preferences "Sign-in methods" list showed something like `Custom:Acme` instead of `Acme`. `getProviderDisplay()` now derives a proper title-cased name from any `custom:*` id, so this works generically for every custom provider.

**Changed:**
- `getProviderDisplay()` derives a title-cased display name for unregistered `custom:*` providers (`custom:acme` → "Acme", `custom:my_provider` → "My Provider"), case-insensitively. Registered ones (e.g. `custom:openai` → ChatGPT) are unaffected.
- `SignInWithCustom` reuses `getProviderDisplay()` instead of its own `formatProviderName`, which only stripped a lowercase `custom:` prefix — the display name also now flows into its error toast.
- Added unit tests for the new fallback branch.

## To test

- On a deployment with a custom provider (or by temporarily hardcoding an identity with `provider: 'custom:acme'` in `AccountIdentities`), check `/account/me` → Sign-in methods shows "Acme", not "Custom:Acme"
- Unlink dialog/toast for that identity should also say "Acme"
- Sign-in page with a custom provider configured should show "Continue with Acme"
- `pnpm vitest run lib/external-identity-providers.test.ts` in `apps/studio` passes

Addresses [FE-4193](https://linear.app/supabase/issue/FE-4193)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for unregistered custom identity providers.
  * Custom provider names are now displayed in a clearer, title-cased format with underscores converted to spaces.
  * Matching providers use the SAML icon while preserving their configured display names.

* **Bug Fixes**
  * Improved sign-in error messages and button labels for custom providers.
  * Provider identifiers are now handled case-insensitively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->