### PR TITLE
feat(studio): focus column name input after adding a column

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/Column.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/Column.tsx
@@ -59,6 +59,7 @@ interface ColumnProps {
   isNewRecord: boolean
   hasForeignKeys: boolean
   hasImportContent: boolean
+  shouldAutoFocusName?: boolean
   onUpdateColumn: (changes: Partial<ColumnField>) => void
   onRemoveColumn: () => void
   onEditForeignKey: (relation?: ForeignKey) => void
@@ -71,6 +72,7 @@ export const Column = ({
   isNewRecord = false,
   hasForeignKeys = false,
   hasImportContent = false,
+  shouldAutoFocusName = false,
   onUpdateColumn,
   onRemoveColumn,
   onEditForeignKey,
@@ -137,6 +139,7 @@ export const Column = ({
         <div className="flex w-[95%] items-center justify-between">
           <div className="h-4 w-px bg-border" />
           <Input
+            autoFocus={shouldAutoFocusName}
             aria-label="Column name"
             size="small"
             value={column.name}

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ColumnManagement.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ColumnManagement.tsx
@@ -69,6 +69,7 @@ export const ColumnManagement = ({
   const [open, setOpen] = useState(false)
   const [selectedColumn, setSelectedColumn] = useState<ColumnField>()
   const [selectedFk, setSelectedFk] = useState<ForeignKey>()
+  const [columnIdToFocus, setColumnIdToFocus] = useState<string | null>(null)
 
   const hasImportContent = !isEmpty(importContent)
   const [primaryKeyColumns, otherColumns] = partition(
@@ -109,6 +110,7 @@ export const ColumnManagement = ({
   const onAddColumn = () => {
     const defaultColumn = generateColumnField()
     const updatedColumns = columns.concat(defaultColumn)
+    setColumnIdToFocus(defaultColumn.id)
     onColumnsUpdated(updatedColumns)
   }
 
@@ -285,6 +287,7 @@ export const ColumnManagement = ({
                       hasForeignKeys={checkIfHaveForeignKeys(column)}
                       isNewRecord={isNewRecord}
                       hasImportContent={hasImportContent}
+                      shouldAutoFocusName={column.id === columnIdToFocus}
                       onUpdateColumn={(changes) => onUpdateColumn(column, changes)}
                       onRemoveColumn={() => onRemoveColumn(column)}
                       onEditForeignKey={(fk) => {
@@ -316,6 +319,7 @@ export const ColumnManagement = ({
                     isNewRecord={isNewRecord}
                     hasForeignKeys={checkIfHaveForeignKeys(column)}
                     hasImportContent={hasImportContent}
+                    shouldAutoFocusName={column.id === columnIdToFocus}
                     onUpdateColumn={(changes) => onUpdateColumn(column, changes)}
                     onRemoveColumn={() => onRemoveColumn(column)}
                     onEditForeignKey={(fk) => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When creating a new table and clicking **Add column**, the new column row appears but the name input is not focused. Users have to click into the field before typing.

Closes [DEPR-641](https://linear.app/supabase/issue/DEPR-641/focus-column-name-input-after-adding-a-column)

## What is the new behavior?

Clicking **Add column** while creating a table focuses the new column's name input so you can start typing immediately.

| After |
| --- |
| <img width="1492" height="728" alt="CleanShot 2026-08-18 at 17 22 15@2x" src="https://github.com/user-attachments/assets/df84f771-7b6f-445a-a457-cb3b69d291aa" /> |

## To test

1. Open Studio and go to **[Table Editor](https://studio-self-hosted-git-dannywhite-depr-641-focu-77d0cd-supabase.vercel.app/project/default/editor)** (Database → Tables in the sidebar)
2. Click **New table** in the table list
3. Scroll to the **Columns** section and click **Add column**
4. Confirm the name input on the new row is focused and ready to type
5. Add another column and confirm focus moves to the latest row's name input

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Usability Improvements**
  * Newly added column name fields are automatically focused, allowing immediate naming without an extra click.
  * Focus handling works consistently for both standard and primary-key columns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->