### PR TITLE
chore(studio): scoped pat mcp tool ui improvement

### DIFF
--- a/apps/studio/components/interfaces/Account/AccessTokens/AccessToken.permissions.test.ts
+++ b/apps/studio/components/interfaces/Account/AccessTokens/AccessToken.permissions.test.ts
@@ -11,7 +11,6 @@ import {
   getEnabledEndpoints,
   getEnabledEndpointsForCapability,
   getEnabledMcpTools,
-  getEnabledMcpToolsForCapability,
   normalizePermissionScopeMap,
   type PermissionScopeMap,
 } from '@/data/scoped-access-tokens/permission-scope-map-query'
@@ -308,66 +307,5 @@ describe('getEnabledEndpointsForCapability', () => {
         })
       )
     ).toEqual(['PUT /api/upgrade'])
-  })
-})
-
-describe('getEnabledMcpToolsForCapability', () => {
-  it('attributes a tool to each capability whose scope is in a fully-granted group', () => {
-    const permissionScopeMap = scopeMap({
-      mcp_tools: {
-        list_branches: [['branching_development_read'], ['branching_production_read']],
-      },
-    })
-    const allGrantedScopes = ['branching_development_read', 'branching_production_read']
-
-    expect(
-      getEnabledMcpToolsForCapability({
-        capabilityScopes: ['branching_development_read'],
-        allGrantedScopes,
-        permissionScopeMap,
-      })
-    ).toEqual(['list_branches'])
-    expect(
-      getEnabledMcpToolsForCapability({
-        capabilityScopes: ['branching_production_read'],
-        allGrantedScopes,
-        permissionScopeMap,
-      })
-    ).toEqual(['list_branches'])
-  })
-
-  it('does not attribute a tool to a capability whose own group is unsatisfied', () => {
-    const enabled = getEnabledMcpToolsForCapability({
-      capabilityScopes: ['branching_production_read'],
-      allGrantedScopes: ['branching_development_read'],
-      permissionScopeMap: scopeMap({
-        mcp_tools: {
-          list_branches: [['branching_development_read'], ['branching_production_read']],
-        },
-      }),
-    })
-
-    expect(enabled).toEqual([])
-  })
-
-  it('requires every scope of the capability group to be granted', () => {
-    const permissionScopeMap = scopeMap({
-      mcp_tools: { upgrade_project: [['project_admin_read', 'database_read']] },
-    })
-
-    expect(
-      getEnabledMcpToolsForCapability({
-        capabilityScopes: ['database_read'],
-        allGrantedScopes: ['database_read'],
-        permissionScopeMap,
-      })
-    ).toEqual([])
-    expect(
-      getEnabledMcpToolsForCapability({
-        capabilityScopes: ['database_read'],
-        allGrantedScopes: ['database_read', 'project_admin_read'],
-        permissionScopeMap,
-      })
-    ).toEqual(['upgrade_project'])
   })
 })

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/NewScopedTokenForm.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/NewScopedTokenForm.tsx
@@ -170,7 +170,6 @@ export const NewScopedTokenForm = ({
                   <PermissionsAccordion
                     selection={selection}
                     onChange={handlePermissionChange}
-                    permissionScopeMap={permissionScopeMap}
                     access={access}
                   />
                   {showMissingPermissionsWarning && (

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/NewScopedTokenFormReview.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/NewScopedTokenFormReview.tsx
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs'
 import { useMemo, useState } from 'react'
-import { cn } from 'ui'
+import { Badge, cn } from 'ui'
 import { Admonition } from 'ui-patterns/Admonition'
 
 import { PERMISSION_MODE_LABEL, selectionToScopes } from '../../AccessToken.permissions'
@@ -26,7 +26,10 @@ import {
   type CapabilityLevelFilter,
 } from '../TokenCapabilities/TokenCapabilities.utils'
 import { EXPIRY_OPTIONS, type TokenFormValues } from './NewScopedTokenForm.utils'
-import { PermissionScopeMap } from '@/data/scoped-access-tokens/permission-scope-map-query'
+import {
+  getEnabledMcpTools,
+  PermissionScopeMap,
+} from '@/data/scoped-access-tokens/permission-scope-map-query'
 
 interface ReviewStepProps {
   values: TokenFormValues
@@ -96,6 +99,11 @@ export const NewScopedTokenFormReview = ({
   })
   const capabilityTier = getCapabilityDensityTier(capabilities.length)
   const [levelFilter, setLevelFilter] = useState<CapabilityLevelFilter>('all')
+
+  const enabledMcpTools = useMemo(
+    () => getEnabledMcpTools({ grantedScopes, permissionScopeMap }).sort(),
+    [grantedScopes, permissionScopeMap]
+  )
 
   const { containerRef: pillsRef, isWrapped: isResourceAccessWrapped } = useResourceAccessWrap()
 
@@ -175,6 +183,25 @@ export const NewScopedTokenFormReview = ({
           accessEntries={access.entries}
           levelFilter={levelFilter}
         />
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <h3 className="text-sm">Available MCP tools</h3>
+        {enabledMcpTools.length === 0 ? (
+          <span className="text-sm text-foreground-lighter">No MCP tools enabled</span>
+        ) : (
+          <div className="flex flex-wrap gap-1.5">
+            {enabledMcpTools.map((tool) => (
+              <Badge
+                key={tool}
+                variant="default"
+                className="px-2.5 py-1 font-mono text-xs normal-case tracking-normal"
+              >
+                {tool}
+              </Badge>
+            ))}
+          </div>
+        )}
       </div>
     </div>
   )

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/PermissionRow.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/PermissionRow.tsx
@@ -4,23 +4,15 @@ import type { PermissionCatalogEntry, PermissionMode } from '../../AccessToken.p
 import type { EntryAccess } from '../../AccessToken.roles'
 import { ExceedsRoleBadge } from '../ExceedsRoleBadge'
 import { RiskMarker } from './RiskMarker'
-import { PermissionScopeMap } from '@/data/scoped-access-tokens/permission-scope-map-query'
 
 interface PermissionRowProps {
   entry: PermissionCatalogEntry
   mode: PermissionMode
   onChange: (mode: PermissionMode) => void
-  permissionScopeMap: PermissionScopeMap | undefined
   entryAccess?: EntryAccess
 }
 
-export const PermissionRow = ({
-  entry,
-  mode,
-  onChange,
-  permissionScopeMap,
-  entryAccess,
-}: PermissionRowProps) => {
+export const PermissionRow = ({ entry, mode, onChange, entryAccess }: PermissionRowProps) => {
   return (
     <div className="flex items-center justify-between gap-4 py-4">
       <div className="min-w-0 flex flex-col gap-1">
@@ -30,7 +22,7 @@ export const PermissionRow = ({
               {entry.name} <span className="sr-only">permissions</span>
             </span>
           </Label>
-          <RiskMarker entry={entry} permissionScopeMap={permissionScopeMap} />
+          <RiskMarker entry={entry} />
           {entryAccess?.status === 'exceeds-role' && (
             <ExceedsRoleBadge entry={entry} mode={mode} access={entryAccess} />
           )}

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/PermissionsAccordion.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/PermissionsAccordion.tsx
@@ -10,20 +10,17 @@ import {
 import type { TokenAccessEvaluation } from '../../AccessToken.roles'
 import { PermissionRow } from './PermissionRow'
 import { InlineLink } from '@/components/ui/InlineLink'
-import { PermissionScopeMap } from '@/data/scoped-access-tokens/permission-scope-map-query'
 import { DOCS_URL } from '@/lib/constants'
 
 interface PermissionsAccordionProps {
   selection: PermissionSelection
   onChange: (key: string, mode: PermissionMode) => void
-  permissionScopeMap: PermissionScopeMap | undefined
   access?: TokenAccessEvaluation
 }
 
 export const PermissionsAccordion = ({
   selection,
   onChange,
-  permissionScopeMap,
   access,
 }: PermissionsAccordionProps) => {
   const [openCategories, setOpenCategories] = useState<string[]>([])
@@ -81,7 +78,6 @@ export const PermissionsAccordion = ({
                         entry={entry}
                         mode={selection[entry.key] ?? 'none'}
                         onChange={(mode) => onChange(entry.key, mode)}
-                        permissionScopeMap={permissionScopeMap}
                         entryAccess={access?.entries[entry.key]}
                       />
                     </div>

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/RiskMarker.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/RiskMarker.tsx
@@ -5,25 +5,15 @@ import {
   RISK_TONE_VARIANT,
   type PermissionCatalogEntry,
 } from '../../AccessToken.permissions'
-import {
-  getMcpToolsForScopes,
-  PermissionScopeMap,
-} from '@/data/scoped-access-tokens/permission-scope-map-query'
 
 interface RiskMarkerProps {
   entry: PermissionCatalogEntry
   /** When false, renders the dot + label without the explanatory tooltip (used in the review list). */
   withTooltip?: boolean
   className?: string
-  permissionScopeMap: PermissionScopeMap | undefined
 }
 
-export const RiskMarker = ({
-  entry,
-  withTooltip = true,
-  className,
-  permissionScopeMap,
-}: RiskMarkerProps) => {
+export const RiskMarker = ({ entry, withTooltip = true, className }: RiskMarkerProps) => {
   const marker = (
     <Badge
       variant={RISK_TONE_VARIANT[entry.risk]}
@@ -34,11 +24,6 @@ export const RiskMarker = ({
   )
 
   if (!withTooltip) return marker
-
-  const mcpTools = getMcpToolsForScopes({
-    scopeIds: [...entry.readScopes, ...entry.writeScopes],
-    permissionScopeMap,
-  })
 
   return (
     <Tooltip>
@@ -66,18 +51,6 @@ export const RiskMarker = ({
                 {entry.allowsWrite.join(', ')}
               </span>
             )}
-          </div>
-        )}
-        {mcpTools.length > 0 && (
-          <div className="space-y-1">
-            {/* getMcpToolsForScopes is associative, not conjunctive: these scopes contribute to
-                the listed tools, but a tool may need scopes from other capabilities too — the
-                review step's enabled-tools list is the authoritative view. Keep this heading
-                distinct from the review step's "MCP tools". */}
-            <p className="text-[11px] font-mono uppercase tracking-wide text-foreground-lighter">
-              Related MCP tools
-            </p>
-            <p className="font-mono text-xs text-foreground-light">{mcpTools.join(', ')}</p>
           </div>
         )}
       </TooltipContent>

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/TokenCapabilities/CapabilityCard.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/TokenCapabilities/CapabilityCard.tsx
@@ -5,7 +5,7 @@ import type { EntryAccess } from '../../AccessToken.roles'
 import type { CapabilitySummaryEntry } from '../../hooks/useCapabilitySummary'
 import { ExceedsRoleBadge } from '../ExceedsRoleBadge'
 import { CapabilityCardBody } from './CapabilityCardBody'
-import { formatCapabilityCounts } from './TokenCapabilities.utils'
+import { pluralize } from '@/lib/helpers'
 
 interface CapabilityCardProps {
   capability: CapabilitySummaryEntry
@@ -19,7 +19,7 @@ const CapabilityCardHeader = ({
   capability,
   accessEntries,
 }: Pick<CapabilityCardProps, 'capability' | 'accessEntries'>) => {
-  const { entry, mode, endpoints, mcpTools } = capability
+  const { entry, mode, endpoints } = capability
   const entryAccess = accessEntries[entry.key]
 
   return (
@@ -32,7 +32,7 @@ const CapabilityCardHeader = ({
           )}
         </span>
         <span className="text-xs text-foreground-lighter">
-          {formatCapabilityCounts(endpoints.length, mcpTools.length)}
+          {`${endpoints.length} ${pluralize(endpoints.length, 'endpoint')}`}
         </span>
       </div>
       <Badge variant={mode === 'readwrite' ? 'warning' : 'default'} className="shrink-0">
@@ -48,13 +48,7 @@ export const CapabilityCard = ({
   isFirst = true,
   isLast = true,
 }: CapabilityCardProps) => {
-  const body = (
-    <CapabilityCardBody
-      entry={capability.entry}
-      endpoints={capability.endpoints}
-      mcpTools={capability.mcpTools}
-    />
-  )
+  const body = <CapabilityCardBody entry={capability.entry} endpoints={capability.endpoints} />
   const positionClassName = cn(
     'border',
     !isLast && 'border-b-0',

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/TokenCapabilities/CapabilityCardBody.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/TokenCapabilities/CapabilityCardBody.tsx
@@ -12,10 +12,9 @@ import type { EnabledEndpoint } from '@/data/scoped-access-tokens/permission-sco
 interface CapabilityCardBodyProps {
   entry: PermissionCatalogEntry
   endpoints: EnabledEndpoint[]
-  mcpTools: string[]
 }
 
-export const CapabilityCardBody = ({ entry, endpoints, mcpTools }: CapabilityCardBodyProps) => {
+export const CapabilityCardBody = ({ entry, endpoints }: CapabilityCardBodyProps) => {
   const sharedPrefix = getSharedPathPrefix(endpoints.map((endpoint) => endpoint.path))
   const methodColumnWidth = `${Math.max(0, ...endpoints.map((endpoint) => endpoint.method.length)) + 2}ch`
 
@@ -47,21 +46,9 @@ export const CapabilityCardBody = ({ entry, endpoints, mcpTools }: CapabilityCar
           </div>
         </div>
       )}
-      {mcpTools.length > 0 && (
-        <div className="flex flex-col gap-1.5">
-          <h3 className="text-xs tracking-wide text-foreground-lighter">MCP tools</h3>
-          <div className="flex flex-wrap gap-1.5">
-            {mcpTools.map((tool) => (
-              <Badge key={tool} variant="default">
-                {tool}
-              </Badge>
-            ))}
-          </div>
-        </div>
-      )}
-      {endpoints.length === 0 && mcpTools.length === 0 && (
+      {endpoints.length === 0 && (
         <p className="text-xs text-foreground-lighter">
-          No API endpoints or MCP tools are enabled by this capability yet.
+          No API endpoints are enabled by this capability yet.
         </p>
       )}
     </div>

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/TokenCapabilities/DenseCapabilities.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/TokenCapabilities/DenseCapabilities.tsx
@@ -1,14 +1,10 @@
 import { useState } from 'react'
-import { Accordion, Badge } from 'ui'
+import { Accordion } from 'ui'
 
 import type { EntryAccess } from '../../AccessToken.roles'
 import type { CapabilitySummaryEntry } from '../../hooks/useCapabilitySummary'
 import { CapabilityCard } from './CapabilityCard'
-import {
-  getNotGrantedCatalogEntries,
-  groupCapabilitiesByLevel,
-  type CapabilityLevelFilter,
-} from './TokenCapabilities.utils'
+import { groupCapabilitiesByLevel, type CapabilityLevelFilter } from './TokenCapabilities.utils'
 
 interface DenseCapabilitiesProps {
   capabilities: CapabilitySummaryEntry[]
@@ -26,7 +22,6 @@ export const DenseCapabilities = ({
   const [openKeys, setOpenKeys] = useState<string[]>([])
 
   const { readwrite, read } = groupCapabilitiesByLevel(capabilities)
-  const notGranted = getNotGrantedCatalogEntries(capabilities)
 
   const shown =
     levelFilter === 'readwrite'
@@ -52,21 +47,6 @@ export const DenseCapabilities = ({
           />
         ))}
       </Accordion>
-
-      {notGranted.length > 0 && (
-        <div className="flex flex-col gap-2">
-          <p className="text-[11px] font-mono uppercase tracking-wide text-foreground-lighter">
-            Not granted · {notGranted.length}
-          </p>
-          <div className="flex flex-wrap gap-1.5">
-            {notGranted.map((entry) => (
-              <Badge key={entry.key} variant="default">
-                {entry.name}
-              </Badge>
-            ))}
-          </div>
-        </div>
-      )}
     </div>
   )
 }

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/TokenCapabilities/TokenCapabilities.utils.test.ts
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/TokenCapabilities/TokenCapabilities.utils.test.ts
@@ -5,7 +5,6 @@ import type { CapabilitySummaryEntry } from '../../hooks/useCapabilitySummary'
 import {
   computeRiskBanner,
   getCapabilityDensityTier,
-  getNotGrantedCatalogEntries,
   getSharedPathPrefix,
   groupCapabilitiesByLevel,
   splitEndpointPath,
@@ -93,17 +92,6 @@ describe('groupCapabilitiesByLevel', () => {
     const { readwrite, read } = groupCapabilitiesByLevel(capabilities)
     expect(readwrite.map((c) => c.entry.key)).toEqual(['project:database'])
     expect(read.map((c) => c.entry.key)).toEqual(['project:advisors'])
-  })
-})
-
-describe('getNotGrantedCatalogEntries', () => {
-  it('returns every catalog entry when nothing is granted', () => {
-    expect(getNotGrantedCatalogEntries([]).map((e) => e.key)).toContain('project:database')
-  })
-
-  it('excludes granted entries', () => {
-    const notGranted = getNotGrantedCatalogEntries([databaseCapability('read')])
-    expect(notGranted.map((e) => e.key)).not.toContain('project:database')
   })
 })
 

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/TokenCapabilities/TokenCapabilities.utils.test.ts
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/TokenCapabilities/TokenCapabilities.utils.test.ts
@@ -4,7 +4,6 @@ import { getCatalogEntry } from '../../AccessToken.permissions'
 import type { CapabilitySummaryEntry } from '../../hooks/useCapabilitySummary'
 import {
   computeRiskBanner,
-  formatCapabilityCounts,
   getCapabilityDensityTier,
   getNotGrantedCatalogEntries,
   getSharedPathPrefix,
@@ -20,37 +19,12 @@ const databaseCapability = (
   entry: getCatalogEntry('project:database')!,
   mode,
   endpoints,
-  mcpTools: [],
 })
 
 const advisorsCapability = (mode: CapabilitySummaryEntry['mode']): CapabilitySummaryEntry => ({
   entry: getCatalogEntry('project:advisors')!,
   mode,
   endpoints: [],
-  mcpTools: [],
-})
-
-describe('formatCapabilityCounts', () => {
-  it('combines both counts when both are non-zero', () => {
-    expect(formatCapabilityCounts(3, 2)).toBe('3 endpoints and 2 MCP tools')
-  })
-
-  it('omits the endpoint side when it is zero', () => {
-    expect(formatCapabilityCounts(0, 2)).toBe('2 MCP tools')
-  })
-
-  it('omits the MCP tool side when it is zero', () => {
-    expect(formatCapabilityCounts(3, 0)).toBe('3 endpoints')
-  })
-
-  it('singularizes a count of one', () => {
-    expect(formatCapabilityCounts(1, 0)).toBe('1 endpoint')
-    expect(formatCapabilityCounts(0, 1)).toBe('1 MCP tool')
-  })
-
-  it('falls back to the endpoint count when both are zero', () => {
-    expect(formatCapabilityCounts(0, 0)).toBe('0 endpoints')
-  })
 })
 
 describe('getCapabilityDensityTier', () => {

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/TokenCapabilities/TokenCapabilities.utils.ts
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/TokenCapabilities/TokenCapabilities.utils.ts
@@ -15,17 +15,6 @@ export type CapabilityDensityTier = 'accordion' | 'dense'
 export const getCapabilityDensityTier = (count: number): CapabilityDensityTier =>
   count <= CAPABILITY_DENSITY_ACCORDION_MAX ? 'accordion' : 'dense'
 
-/** Card subheading counts — omits whichever side is zero rather than saying "and 0 ...". */
-export const formatCapabilityCounts = (endpointCount: number, mcpToolCount: number): string => {
-  const endpointText = `${endpointCount} ${pluralize(endpointCount, 'endpoint')}`
-  const mcpToolText = `${mcpToolCount} MCP ${pluralize(mcpToolCount, 'tool')}`
-
-  if (endpointCount === 0 && mcpToolCount === 0) return endpointText
-  if (endpointCount === 0) return mcpToolText
-  if (mcpToolCount === 0) return endpointText
-  return `${endpointText} and ${mcpToolText}`
-}
-
 /**
  * Longest shared leading path segments across a group of endpoint paths, so the UI can mute the
  * boilerplate prefix and highlight only the segment that distinguishes each row. Matching is

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/TokenCapabilities/TokenCapabilities.utils.ts
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/TokenCapabilities/TokenCapabilities.utils.ts
@@ -1,7 +1,5 @@
 import {
   getCatalogEntry,
-  PERMISSION_CATALOG,
-  type PermissionCatalogEntry,
   type PermissionSelection,
   type ResourceAccessMode,
   type RiskLevel,
@@ -48,14 +46,6 @@ export const groupCapabilitiesByLevel = (capabilities: CapabilitySummaryEntry[])
   readwrite: capabilities.filter((capability) => capability.mode === 'readwrite'),
   read: capabilities.filter((capability) => capability.mode === 'read'),
 })
-
-/** Catalog entries the token doesn't grant at all — dense mode's "Not granted" group. */
-export const getNotGrantedCatalogEntries = (
-  capabilities: CapabilitySummaryEntry[]
-): PermissionCatalogEntry[] => {
-  const grantedKeys = new Set(capabilities.map((capability) => capability.entry.key))
-  return PERMISSION_CATALOG.filter((entry) => !grantedKeys.has(entry.key))
-}
 
 export type CapabilityLevelFilter = 'all' | 'read' | 'readwrite'
 

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/ViewTokenSheet.test.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/ViewTokenSheet.test.tsx
@@ -140,7 +140,7 @@ describe('ViewTokenSheet', () => {
     expect(screen.queryByText('This token no longer has access')).toBeNull()
   })
 
-  test('renders capability cards with attributed endpoints, MCP tools, and a risk banner', async () => {
+  test('renders capability cards with endpoints, a token-wide MCP tools row, and a risk banner', async () => {
     mockPermissionsApi(ownerRows(MOCK_ORG.slug))
     mockToken({
       ...TOKEN_BASE,
@@ -168,12 +168,16 @@ describe('ViewTokenSheet', () => {
     })
     renderSheet()
 
-    // Capability cards are closed by default — expand both to see their endpoints and tools.
     expect(await screen.findByText('Advisors')).toBeInTheDocument()
     expect(screen.getByText('Database')).toBeInTheDocument()
     expect(screen.getByText('Read-write')).toBeInTheDocument()
     expect(screen.getByText('Read')).toBeInTheDocument()
 
+    // Enabled tools are token-wide summary rows, visible without expanding any capability card.
+    expect(screen.getByText('get_advisors')).toBeInTheDocument()
+    expect(screen.getByText('execute_sql')).toBeInTheDocument()
+
+    // Capability cards are closed by default — expand both to see their endpoints.
     fireEvent.click(screen.getByText('Advisors'))
     fireEvent.click(screen.getByText('Database'))
 
@@ -187,11 +191,7 @@ describe('ViewTokenSheet', () => {
     expect(
       screen.getByRole('button', { name: 'Copy POST /v1/projects/{ref}/database/query' })
     ).toBeInTheDocument()
-    // Every method renders as a badge; non-GET methods get the tinted warning variant.
     expect(screen.getByText('POST')).toBeInTheDocument()
-
-    expect(screen.getByText('get_advisors')).toBeInTheDocument()
-    expect(screen.getByText('execute_sql')).toBeInTheDocument()
 
     // project:database is catalog-high risk and granted read-write — max() over capabilities.
     // "High risk" appears twice: the risk banner title, and Database's own Risk Level badge.

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/ViewTokenSheet.test.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/ViewTokenSheet.test.tsx
@@ -223,7 +223,6 @@ describe('ViewTokenSheet', () => {
     renderSheet()
 
     expect(await screen.findByText('Database')).toBeInTheDocument()
-    expect(screen.getByText(/Not granted · \d+/)).toBeInTheDocument()
     // All granted capabilities render immediately — no truncation.
     expect(screen.getByText('Storage')).toBeInTheDocument()
     expect(screen.getByText('Backups')).toBeInTheDocument()

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/ViewTokenSheet.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/ViewTokenSheet.tsx
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs'
 import { useMemo, useState } from 'react'
-import { cn, ScrollArea, Sheet, SheetContent, SheetHeader } from 'ui'
+import { Badge, cn, ScrollArea, Sheet, SheetContent, SheetHeader } from 'ui'
 import { Admonition } from 'ui-patterns/Admonition'
 import { TimestampInfo } from 'ui-patterns/TimestampInfo'
 
@@ -23,7 +23,10 @@ import {
   type CapabilityLevelFilter,
 } from './TokenCapabilities/TokenCapabilities.utils'
 import { DocsButton } from '@/components/ui/DocsButton'
-import { useGetEnabledEndpointsForCapability } from '@/data/scoped-access-tokens/permission-scope-map-query'
+import {
+  getEnabledMcpTools,
+  useGetEnabledEndpointsForCapability,
+} from '@/data/scoped-access-tokens/permission-scope-map-query'
 import { useScopedAccessTokenQuery } from '@/data/scoped-access-tokens/scoped-access-token-query'
 import { DOCS_URL } from '@/lib/constants'
 import { pluralize } from '@/lib/helpers'
@@ -155,6 +158,11 @@ export function ViewTokenSheet({ visible, tokenId, onClose }: ViewTokenSheetProp
     access.inaccessibleProjectRefs,
     access.inaccessibleOrgSlugs,
   ])
+
+  const enabledMcpTools = useMemo(
+    () => getEnabledMcpTools({ grantedScopes, permissionScopeMap }).sort(),
+    [grantedScopes, permissionScopeMap]
+  )
 
   const { containerRef: pillsRef, isWrapped: isResourceAccessWrapped } = useResourceAccessWrap()
 
@@ -314,6 +322,25 @@ export function ViewTokenSheet({ visible, tokenId, onClose }: ViewTokenSheetProp
                     accessEntries={access.entries}
                     levelFilter={levelFilter}
                   />
+                </div>
+
+                <div className="flex flex-col gap-3">
+                  <h3 className="text-sm">Available MCP tools</h3>
+                  {enabledMcpTools.length === 0 ? (
+                    <span className="text-sm text-foreground-lighter">No MCP tools enabled</span>
+                  ) : (
+                    <div className="flex flex-wrap gap-1.5">
+                      {enabledMcpTools.map((tool) => (
+                        <Badge
+                          key={tool}
+                          variant="default"
+                          className="px-2.5 py-1 font-mono text-xs normal-case tracking-normal"
+                        >
+                          {tool}
+                        </Badge>
+                      ))}
+                    </div>
+                  )}
                 </div>
               </>
             )}

--- a/apps/studio/components/interfaces/Account/AccessTokens/hooks/useCapabilitySummary.ts
+++ b/apps/studio/components/interfaces/Account/AccessTokens/hooks/useCapabilitySummary.ts
@@ -9,7 +9,6 @@ import {
 } from '../AccessToken.permissions'
 import {
   getEnabledEndpointsForCapability,
-  getEnabledMcpToolsForCapability,
   type EnabledEndpoint,
   type PermissionScopeMap,
 } from '@/data/scoped-access-tokens/permission-scope-map-query'
@@ -24,12 +23,11 @@ export interface CapabilitySummaryEntry {
   entry: PermissionCatalogEntry
   mode: PermissionMode
   endpoints: EnabledEndpoint[]
-  mcpTools: string[]
 }
 
 /**
  * Selection-derived summary data for the token view sheet: every granted catalog entry paired with
- * the Management API endpoints and MCP tools it enables.
+ * the Management API endpoints it enables.
  */
 export const useCapabilitySummary = ({
   selection,
@@ -48,12 +46,7 @@ export const useCapabilitySummary = ({
         allGrantedScopes: grantedScopes,
         permissionScopeMap,
       })
-      const mcpTools = getEnabledMcpToolsForCapability({
-        capabilityScopes,
-        allGrantedScopes: grantedScopes,
-        permissionScopeMap,
-      })
-      result.push({ entry, mode, endpoints, mcpTools })
+      result.push({ entry, mode, endpoints })
     }
     return result
   }, [selection, grantedScopes, permissionScopeMap])

--- a/apps/studio/data/scoped-access-tokens/permission-scope-map-query.ts
+++ b/apps/studio/data/scoped-access-tokens/permission-scope-map-query.ts
@@ -155,55 +155,6 @@ export const getEnabledEndpointsForCapability = ({
 }
 
 /**
- * MCP-tool counterpart to getEnabledEndpointsForCapability: the MCP tools enabled by the complete
- * granted-scope set that owe that to `capabilityScopes`, for grouping enabled tools under the
- * capability that contributes them.
- */
-export const getEnabledMcpToolsForCapability = ({
-  capabilityScopes,
-  allGrantedScopes,
-  permissionScopeMap,
-}: {
-  capabilityScopes: Iterable<string>
-  allGrantedScopes: Iterable<string>
-  permissionScopeMap: PermissionScopeMap | undefined
-}): string[] => {
-  if (permissionScopeMap == null) return []
-
-  const granted = new Set(allGrantedScopes)
-  const capability = new Set(capabilityScopes)
-  return Object.entries(permissionScopeMap.mcp_tools)
-    .filter(([, groups]) =>
-      groups.some(
-        (group) =>
-          group.some((scope) => capability.has(scope)) && group.every((scope) => granted.has(scope))
-      )
-    )
-    .map(([tool]) => tool)
-}
-
-/**
- * Informational lookup for the per-permission risk tooltip: the MCP tools associated with any of
- * the given scopes. Unlike getEnabledMcpTools this is not conjunctive — it surfaces every tool that
- * lists one of these scopes, so users can see what a capability relates to before granting it.
- */
-export const getMcpToolsForScopes = ({
-  scopeIds,
-  permissionScopeMap,
-}: {
-  scopeIds: Iterable<string>
-  permissionScopeMap: PermissionScopeMap | undefined
-}): string[] => {
-  if (permissionScopeMap == null) return []
-
-  const tools = new Set<string>()
-  for (const id of scopeIds) {
-    permissionScopeMap.scopes[id]?.mcp_tools.forEach((tool) => tools.add(tool))
-  }
-  return Array.from(tools)
-}
-
-/**
  * The endpoint's payload changed endpoint/tool requirements from a flat conjunctive scope list
  * (string[]) to alternative groups (string[][], ScopeGroupAlternatives) at the same URL, and the
  * response is CDN-cached (s-maxage + stale-while-revalidate). Right after a deploy a new client


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Follow on from view permissions sheet and review step tidy up to show a clear list of available mcp tools. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Available MCP tools” section to scoped token reviews and token details.
  * Displays enabled tools as badges, with a clear empty state when none are available.
* **Improvements**
  * Simplified capability cards to focus on enabled API endpoints.
  * Removed per-permission MCP tool details and ungranted capability listings.
  * Updated endpoint count formatting for clearer singular and plural labels.
* **Tests**
  * Updated capability and token detail tests to reflect the new MCP tool summary presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->