### PR TITLE
feat(studio): CLI deploy instructions for workers (FE-4191)

### DIFF
--- a/apps/studio/components/interfaces/Sidebar.tsx
+++ b/apps/studio/components/interfaces/Sidebar.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { ComponentProps, ComponentPropsWithoutRef, FC, ReactNode, useEffect } from 'react'
 import {
+  Badge,
   Button,
   cn,
   DropdownMenu,
@@ -195,6 +196,14 @@ export function SideBarNavLink({
     <>
       {route.icon}
       <span>{route.label}</span>
+      {route.isNew && (
+        <Badge
+          variant="success"
+          className="ml-auto shrink-0 px-1.5 py-0.5 text-[9px] uppercase tracking-wider"
+        >
+          New
+        </Badge>
+      )}
     </>
   )
 

--- a/apps/studio/components/interfaces/Workers/DeployWorkerDialog.tsx
+++ b/apps/studio/components/interfaces/Workers/DeployWorkerDialog.tsx
@@ -1,6 +1,4 @@
-import Link from 'next/link'
 import {
-  Button,
   Dialog,
   DialogContent,
   DialogFooter,
@@ -13,7 +11,7 @@ import {
 import { EXAMPLE_WORKER } from './workerSnippets'
 import { WorkerSnippetTabs } from './WorkerSnippetTabs'
 import CopyButton from '@/components/ui/CopyButton'
-import { WORKERS_DOCS_URL, WORKERS_SKILL_MARKDOWN } from '@/lib/constants/workers'
+import { WORKERS_SKILL_MARKDOWN } from '@/lib/constants/workers'
 
 interface DeployWorkerDialogProps {
   open: boolean
@@ -72,11 +70,6 @@ export const DeployWorkerDialog = ({ open, onOpenChange }: DeployWorkerDialogPro
         <CopyButton text={WORKERS_SKILL_MARKDOWN} variant="default" copyLabel="Copy SKILL.md">
           Copy SKILL.md
         </CopyButton>
-        <Button asChild variant="primary">
-          <Link href={WORKERS_DOCS_URL} target="_blank" rel="noreferrer">
-            View docs
-          </Link>
-        </Button>
       </DialogFooter>
     </DialogContent>
   </Dialog>

--- a/apps/studio/components/interfaces/Workers/DeployWorkerDialog.tsx
+++ b/apps/studio/components/interfaces/Workers/DeployWorkerDialog.tsx
@@ -1,0 +1,83 @@
+import Link from 'next/link'
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogSection,
+  DialogSectionSeparator,
+  DialogTitle,
+} from 'ui'
+
+import { EXAMPLE_WORKER } from './workerSnippets'
+import { WorkerSnippetTabs } from './WorkerSnippetTabs'
+import CopyButton from '@/components/ui/CopyButton'
+import { WORKERS_DOCS_URL, WORKERS_SKILL_MARKDOWN } from '@/lib/constants/workers'
+
+interface DeployWorkerDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+const STEPS = [
+  {
+    title: 'Scaffold the worker',
+    description: 'Creates supabase/workers/<name>/ with an entrypoint for the runtime you pick.',
+  },
+  {
+    title: 'Configure it',
+    description: 'Runtime, size, access, and instance count live in supabase/config.toml.',
+  },
+  {
+    title: 'Push it',
+    description: 'Builds the image and schedules it on a microVM in US West.',
+  },
+]
+
+export const DeployWorkerDialog = ({ open, onOpenChange }: DeployWorkerDialogProps) => (
+  <Dialog open={open} onOpenChange={onOpenChange}>
+    <DialogContent size="large">
+      <DialogHeader>
+        <DialogTitle>Deploy a worker</DialogTitle>
+      </DialogHeader>
+
+      <DialogSection className="space-y-4">
+        <p className="text-sm text-foreground-light">
+          Workers are deployed with the Supabase CLI. This dashboard is read-only during the private
+          alpha.
+        </p>
+        <ol className="space-y-4">
+          {STEPS.map((step, index) => (
+            <li key={step.title} className="flex gap-3">
+              <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-strong text-xs text-foreground-light">
+                {index + 1}
+              </span>
+              <div className="space-y-0.5">
+                <p className="text-sm text-foreground">{step.title}</p>
+                <p className="text-sm text-foreground-lighter">{step.description}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+      </DialogSection>
+
+      <DialogSectionSeparator />
+
+      <DialogSection>
+        <WorkerSnippetTabs input={EXAMPLE_WORKER} tabs={['cli', 'config', 'ai']} />
+      </DialogSection>
+
+      <DialogFooter>
+        <CopyButton text={WORKERS_SKILL_MARKDOWN} variant="default" copyLabel="Copy SKILL.md">
+          Copy SKILL.md
+        </CopyButton>
+        <Button asChild variant="primary">
+          <Link href={WORKERS_DOCS_URL} target="_blank" rel="noreferrer">
+            View docs
+          </Link>
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
+)

--- a/apps/studio/components/interfaces/Workers/DeployWorkerDialog.tsx
+++ b/apps/studio/components/interfaces/Workers/DeployWorkerDialog.tsx
@@ -1,7 +1,6 @@
 import {
   Dialog,
   DialogContent,
-  DialogFooter,
   DialogHeader,
   DialogSection,
   DialogSectionSeparator,
@@ -10,8 +9,6 @@ import {
 
 import { EXAMPLE_WORKER } from './workerSnippets'
 import { WorkerSnippetTabs } from './WorkerSnippetTabs'
-import CopyButton from '@/components/ui/CopyButton'
-import { WORKERS_SKILL_MARKDOWN } from '@/lib/constants/workers'
 
 interface DeployWorkerDialogProps {
   open: boolean
@@ -63,14 +60,8 @@ export const DeployWorkerDialog = ({ open, onOpenChange }: DeployWorkerDialogPro
       <DialogSectionSeparator />
 
       <DialogSection>
-        <WorkerSnippetTabs input={EXAMPLE_WORKER} tabs={['cli', 'config', 'ai']} />
+        <WorkerSnippetTabs input={EXAMPLE_WORKER} tabs={['cli', 'config']} />
       </DialogSection>
-
-      <DialogFooter>
-        <CopyButton text={WORKERS_SKILL_MARKDOWN} variant="default" copyLabel="Copy SKILL.md">
-          Copy SKILL.md
-        </CopyButton>
-      </DialogFooter>
     </DialogContent>
   </Dialog>
 )

--- a/apps/studio/components/interfaces/Workers/WorkerCommandLine.tsx
+++ b/apps/studio/components/interfaces/Workers/WorkerCommandLine.tsx
@@ -1,0 +1,23 @@
+import CopyButton from '@/components/ui/CopyButton'
+
+interface WorkerCommandLineProps {
+  command: string
+  comment?: string
+}
+
+export const WorkerCommandLine = ({ command, comment }: WorkerCommandLineProps) => (
+  <div className="space-y-1">
+    {comment && <p className="font-mono text-xs text-foreground-lighter">{`> ${comment}`}</p>}
+    <div className="flex items-center gap-2 font-mono text-sm text-foreground">
+      <span className="text-foreground-lighter">$</span>
+      <span className="flex-1">{command}</span>
+      <CopyButton
+        text={command}
+        iconOnly
+        variant="text"
+        aria-label="Copy command"
+        className="text-foreground-lighter hover:text-foreground"
+      />
+    </div>
+  </div>
+)

--- a/apps/studio/components/interfaces/Workers/WorkerSnippetTabs.tsx
+++ b/apps/studio/components/interfaces/Workers/WorkerSnippetTabs.tsx
@@ -6,10 +6,9 @@ import { buildWorkerSnippets, type WorkerSnippetInput } from './workerSnippets'
 import CopyButton from '@/components/ui/CopyButton'
 import { useProjectSettingsV2Query } from '@/data/config/project-settings-v2-query'
 
-export type WorkerSnippetTab = 'ai' | 'config' | 'cli' | 'curl' | 'js' | 'python'
+export type WorkerSnippetTab = 'config' | 'cli' | 'curl' | 'js' | 'python'
 
 const TAB_LABEL: Record<WorkerSnippetTab, string> = {
-  ai: 'AI',
   config: 'config.toml',
   cli: 'CLI',
   curl: 'cURL',
@@ -38,7 +37,6 @@ export const WorkerSnippetTabs = ({
     protocol: settings?.app_config?.protocol,
   })
   const snippetByTab: Record<WorkerSnippetTab, string> = {
-    ai: snippets.aiPrompt,
     config: snippets.configToml,
     cli: snippets.cli,
     curl: snippets.curl,

--- a/apps/studio/components/interfaces/Workers/WorkerSnippetTabs.tsx
+++ b/apps/studio/components/interfaces/Workers/WorkerSnippetTabs.tsx
@@ -21,10 +21,6 @@ interface WorkerSnippetTabsProps {
   className?: string
 }
 
-/**
- * Renders a subset of the deploy artifacts (AI prompt, config.toml, CLI, curl)
- * as a small tabbed code block that updates live from the create-worker form.
- */
 export const WorkerSnippetTabs = ({
   input,
   tabs = ['cli', 'curl'],

--- a/apps/studio/components/interfaces/Workers/WorkerSnippetTabs.tsx
+++ b/apps/studio/components/interfaces/Workers/WorkerSnippetTabs.tsx
@@ -18,7 +18,7 @@ const TAB_LABEL: Record<WorkerSnippetTab, string> = {
 
 interface WorkerSnippetTabsProps {
   input: Omit<WorkerSnippetInput, 'endpoint' | 'protocol'>
-  tabs?: WorkerSnippetTab[]
+  tabs?: [WorkerSnippetTab, ...WorkerSnippetTab[]]
   className?: string
 }
 

--- a/apps/studio/components/interfaces/Workers/WorkerSnippetTabs.tsx
+++ b/apps/studio/components/interfaces/Workers/WorkerSnippetTabs.tsx
@@ -1,0 +1,82 @@
+import { useState } from 'react'
+import { cn } from 'ui'
+
+import { buildWorkerSnippets, type WorkerSnippetInput } from './workerSnippets'
+import CopyButton from '@/components/ui/CopyButton'
+
+export type WorkerSnippetTab = 'ai' | 'config' | 'cli' | 'curl' | 'js' | 'python'
+
+const TAB_LABEL: Record<WorkerSnippetTab, string> = {
+  ai: 'AI',
+  config: 'config.toml',
+  cli: 'CLI',
+  curl: 'cURL',
+  js: 'JavaScript',
+  python: 'Python',
+}
+
+interface WorkerSnippetTabsProps {
+  input: WorkerSnippetInput
+  tabs?: WorkerSnippetTab[]
+  className?: string
+}
+
+/**
+ * Renders a subset of the deploy artifacts (AI prompt, config.toml, CLI, curl)
+ * as a small tabbed code block that updates live from the create-worker form.
+ */
+export const WorkerSnippetTabs = ({
+  input,
+  tabs = ['cli', 'curl'],
+  className,
+}: WorkerSnippetTabsProps) => {
+  const [active, setActive] = useState<WorkerSnippetTab>(tabs[0])
+
+  const snippets = buildWorkerSnippets(input)
+  const snippetByTab: Record<WorkerSnippetTab, string> = {
+    ai: snippets.aiPrompt,
+    config: snippets.configToml,
+    cli: snippets.cli,
+    curl: snippets.curl,
+    js: snippets.javascript,
+    python: snippets.python,
+  }
+  const activeTab = tabs.includes(active) ? active : tabs[0]
+  const value = snippetByTab[activeTab]
+
+  return (
+    <div className={cn('flex flex-col gap-y-2', className)}>
+      <div className="flex items-center gap-x-4 border-b border-default">
+        {tabs.map((tab) => (
+          <button
+            key={tab}
+            type="button"
+            tabIndex={0}
+            onClick={() => setActive(tab)}
+            className={cn(
+              '-mb-px border-b px-0.5 py-1.5 text-sm transition-colors',
+              tab === activeTab
+                ? 'border-foreground text-foreground'
+                : 'border-transparent text-foreground-lighter hover:text-foreground-light'
+            )}
+          >
+            {TAB_LABEL[tab]}
+          </button>
+        ))}
+      </div>
+
+      <div className="relative rounded-md border border-default bg-surface-100">
+        <CopyButton
+          text={value}
+          iconOnly
+          variant="text"
+          aria-label="Copy snippet"
+          className="absolute right-2 top-2 text-foreground-lighter hover:text-foreground"
+        />
+        <pre className="overflow-x-auto p-3 pr-10 font-mono text-xs leading-relaxed text-foreground-light">
+          {value}
+        </pre>
+      </div>
+    </div>
+  )
+}

--- a/apps/studio/components/interfaces/Workers/WorkerSnippetTabs.tsx
+++ b/apps/studio/components/interfaces/Workers/WorkerSnippetTabs.tsx
@@ -1,8 +1,10 @@
+import { useParams } from 'common'
 import { useState } from 'react'
 import { cn } from 'ui'
 
 import { buildWorkerSnippets, type WorkerSnippetInput } from './workerSnippets'
 import CopyButton from '@/components/ui/CopyButton'
+import { useProjectSettingsV2Query } from '@/data/config/project-settings-v2-query'
 
 export type WorkerSnippetTab = 'ai' | 'config' | 'cli' | 'curl' | 'js' | 'python'
 
@@ -16,7 +18,7 @@ const TAB_LABEL: Record<WorkerSnippetTab, string> = {
 }
 
 interface WorkerSnippetTabsProps {
-  input: WorkerSnippetInput
+  input: Omit<WorkerSnippetInput, 'endpoint' | 'protocol'>
   tabs?: WorkerSnippetTab[]
   className?: string
 }
@@ -26,9 +28,15 @@ export const WorkerSnippetTabs = ({
   tabs = ['cli', 'curl'],
   className,
 }: WorkerSnippetTabsProps) => {
+  const { ref } = useParams()
   const [active, setActive] = useState<WorkerSnippetTab>(tabs[0])
 
-  const snippets = buildWorkerSnippets(input)
+  const { data: settings } = useProjectSettingsV2Query({ projectRef: ref }, { enabled: !!ref })
+  const snippets = buildWorkerSnippets({
+    ...input,
+    endpoint: settings?.app_config?.endpoint,
+    protocol: settings?.app_config?.protocol,
+  })
   const snippetByTab: Record<WorkerSnippetTab, string> = {
     ai: snippets.aiPrompt,
     config: snippets.configToml,

--- a/apps/studio/components/interfaces/Workers/WorkersEmptyState.tsx
+++ b/apps/studio/components/interfaces/Workers/WorkersEmptyState.tsx
@@ -1,13 +1,8 @@
-import { ArrowRight, Sparkles, Terminal } from 'lucide-react'
-import Link from 'next/link'
-import { Button, Card, cn } from 'ui'
+import { Sparkles, Terminal } from 'lucide-react'
+import { Button, Card } from 'ui'
 
 import CopyButton from '@/components/ui/CopyButton'
-import {
-  WORKERS_CLI_DEPLOY,
-  WORKERS_DOCS_URL,
-  WORKERS_SKILL_MARKDOWN,
-} from '@/lib/constants/workers'
+import { WORKERS_CLI_DEPLOY, WORKERS_SKILL_MARKDOWN } from '@/lib/constants/workers'
 
 interface WorkersEmptyStateProps {
   onDeploy: () => void
@@ -86,29 +81,8 @@ export const WorkersEmptyState = ({ onDeploy }: WorkersEmptyStateProps) => (
           <CopyButton text={WORKERS_SKILL_MARKDOWN} variant="default" size="tiny">
             Copy SKILL.md
           </CopyButton>
-          <Link
-            href={WORKERS_DOCS_URL}
-            target="_blank"
-            rel="noreferrer"
-            className="text-sm text-foreground-light transition-colors hover:text-foreground"
-          >
-            View docs
-          </Link>
         </div>
       </div>
-
-      <Link
-        href={WORKERS_DOCS_URL}
-        target="_blank"
-        rel="noreferrer"
-        className={cn(
-          'flex items-center justify-between rounded-md border border-default px-4 py-3',
-          'text-sm text-foreground-light transition-colors hover:border-strong hover:text-foreground'
-        )}
-      >
-        Read the docs
-        <ArrowRight size={14} />
-      </Link>
     </div>
   </Card>
 )

--- a/apps/studio/components/interfaces/Workers/WorkersEmptyState.tsx
+++ b/apps/studio/components/interfaces/Workers/WorkersEmptyState.tsx
@@ -1,69 +1,41 @@
+import { PermissionAction } from '@supabase/shared-types/out/constants'
+import { BoxPlus } from 'icons'
 import { Terminal } from 'lucide-react'
-import { Button, Card } from 'ui'
+import { EmptyStatePresentational } from 'ui-patterns/EmptyStatePresentational'
 
-import { WorkerCommandLine } from './WorkerCommandLine'
-import { WORKERS_CLI_DEPLOY } from '@/lib/constants/workers'
+import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
+import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
 
 interface WorkersEmptyStateProps {
   onDeploy: () => void
 }
 
-const STEPS = [
-  {
-    title: 'Detects your stack',
-    description:
-      'The CLI inspects your project and picks the right runtime — Node, Deno, Bun, Python, or your Dockerfile.',
-  },
-  {
-    title: 'Builds & schedules',
-    description:
-      'Your worker is built and scheduled onto a microVM in US West, right next to your database.',
-  },
-  {
-    title: 'Shows up here',
-    description: 'The worker and its state appear on this page once the build finishes.',
-  },
-]
+export const WorkersEmptyState = ({ onDeploy }: WorkersEmptyStateProps) => {
+  const { can: canDeployWorkers } = useAsyncCheckPermissions(PermissionAction.FUNCTIONS_WRITE, '*')
 
-export const WorkersEmptyState = ({ onDeploy }: WorkersEmptyStateProps) => (
-  <Card className="grid grid-cols-1 divide-y divide-default lg:grid-cols-[1.6fr_1fr] lg:divide-x lg:divide-y-0">
-    <div className="flex flex-col gap-6 p-8">
-      <div className="space-y-2">
-        <h3 className="text-lg text-foreground">Deploy a worker</h3>
-        <p className="max-w-md text-sm text-foreground-light">
-          No workers yet. Run managed compute in microVMs next to your database. Deploy your first
-          worker with the Supabase CLI.
-        </p>
-      </div>
-
-      <div>
-        <Button variant="primary" icon={<Terminal />} onClick={onDeploy}>
-          Deploy a worker
-        </Button>
-      </div>
-
-      <ol className="space-y-5">
-        {STEPS.map((step, index) => (
-          <li key={step.title} className="flex gap-3">
-            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-strong text-xs text-foreground-light">
-              {index + 1}
-            </span>
-            <div className="space-y-0.5">
-              <p className="text-sm text-foreground">{step.title}</p>
-              <p className="max-w-md text-sm text-foreground-lighter">{step.description}</p>
-            </div>
-          </li>
-        ))}
-      </ol>
-    </div>
-
-    <div className="flex flex-col gap-4 p-8">
-      <p className="text-xs font-mono uppercase tracking-wider text-foreground-lighter">
-        Deploy from the terminal
-      </p>
-      <div className="rounded-md border border-default bg-surface-100 px-3 py-2">
-        <WorkerCommandLine command={WORKERS_CLI_DEPLOY} />
-      </div>
-    </div>
-  </Card>
-)
+  return (
+    <EmptyStatePresentational
+      icon={BoxPlus}
+      title="Deploy your first worker"
+      description="Run backend workers in microVMs next to your database. Dockerfile, Node.js and Deno supported at Private Alpha."
+    >
+      <ButtonTooltip
+        variant="primary"
+        size="tiny"
+        icon={<Terminal size={14} />}
+        disabled={!canDeployWorkers}
+        onClick={onDeploy}
+        tooltip={{
+          content: {
+            side: 'bottom',
+            text: canDeployWorkers
+              ? undefined
+              : 'You need additional permissions to deploy workers',
+          },
+        }}
+      >
+        Deploy a worker
+      </ButtonTooltip>
+    </EmptyStatePresentational>
+  )
+}

--- a/apps/studio/components/interfaces/Workers/WorkersEmptyState.tsx
+++ b/apps/studio/components/interfaces/Workers/WorkersEmptyState.tsx
@@ -1,6 +1,6 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { BoxPlus } from 'icons'
-import { Terminal } from 'lucide-react'
+import { Plus } from 'lucide-react'
 import { EmptyStatePresentational } from 'ui-patterns/EmptyStatePresentational'
 
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
@@ -17,12 +17,12 @@ export const WorkersEmptyState = ({ onDeploy }: WorkersEmptyStateProps) => {
     <EmptyStatePresentational
       icon={BoxPlus}
       title="Deploy your first worker"
-      description="Run backend workers in microVMs next to your database. Dockerfile, Node.js and Deno supported at Private Alpha."
+      description="Spin up and deploy a worker locally, then deploy it to the cloud. Dockerfile, Node.js and Deno supported at Private Alpha."
     >
       <ButtonTooltip
         variant="primary"
         size="tiny"
-        icon={<Terminal size={14} />}
+        icon={<Plus size={14} />}
         disabled={!canDeployWorkers}
         onClick={onDeploy}
         tooltip={{

--- a/apps/studio/components/interfaces/Workers/WorkersEmptyState.tsx
+++ b/apps/studio/components/interfaces/Workers/WorkersEmptyState.tsx
@@ -1,9 +1,8 @@
-import { Sparkles, Terminal } from 'lucide-react'
+import { Terminal } from 'lucide-react'
 import { Button, Card } from 'ui'
 
 import { WorkerCommandLine } from './WorkerCommandLine'
-import CopyButton from '@/components/ui/CopyButton'
-import { WORKERS_CLI_DEPLOY, WORKERS_SKILL_MARKDOWN } from '@/lib/constants/workers'
+import { WORKERS_CLI_DEPLOY } from '@/lib/constants/workers'
 
 interface WorkersEmptyStateProps {
   onDeploy: () => void
@@ -64,23 +63,6 @@ export const WorkersEmptyState = ({ onDeploy }: WorkersEmptyStateProps) => (
       </p>
       <div className="rounded-md border border-default bg-surface-100 px-3 py-2">
         <WorkerCommandLine command={WORKERS_CLI_DEPLOY} />
-      </div>
-
-      <div className="space-y-2 rounded-md border border-default p-4">
-        <div className="flex items-center gap-2">
-          <span className="text-sm text-foreground">SKILL.md</span>
-          <span className="inline-flex items-center gap-1 rounded-full border border-strong px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-foreground-lighter">
-            <Sparkles size={10} /> For agents
-          </span>
-        </div>
-        <p className="text-sm text-foreground-lighter">
-          Drop a skill file into your agent so it can deploy and manage workers for you.
-        </p>
-        <div className="flex items-center gap-3 pt-1">
-          <CopyButton text={WORKERS_SKILL_MARKDOWN} variant="default" size="tiny">
-            Copy SKILL.md
-          </CopyButton>
-        </div>
       </div>
     </div>
   </Card>

--- a/apps/studio/components/interfaces/Workers/WorkersEmptyState.tsx
+++ b/apps/studio/components/interfaces/Workers/WorkersEmptyState.tsx
@@ -27,7 +27,6 @@ const STEPS = [
 
 export const WorkersEmptyState = ({ onDeploy }: WorkersEmptyStateProps) => (
   <Card className="grid grid-cols-1 divide-y divide-default lg:grid-cols-[1.6fr_1fr] lg:divide-x lg:divide-y-0">
-    {/* Left: deploy hero + steps */}
     <div className="flex flex-col gap-6 p-8">
       <div className="space-y-2">
         <h3 className="text-lg text-foreground">Deploy a worker</h3>
@@ -58,7 +57,6 @@ export const WorkersEmptyState = ({ onDeploy }: WorkersEmptyStateProps) => (
       </ol>
     </div>
 
-    {/* Right rail: CLI + SKILL.md + docs */}
     <div className="flex flex-col gap-4 p-8">
       <p className="text-xs font-mono uppercase tracking-wider text-foreground-lighter">
         Prefer the CLI?

--- a/apps/studio/components/interfaces/Workers/WorkersEmptyState.tsx
+++ b/apps/studio/components/interfaces/Workers/WorkersEmptyState.tsx
@@ -1,0 +1,114 @@
+import { ArrowRight, Sparkles, Terminal } from 'lucide-react'
+import Link from 'next/link'
+import { Button, Card, cn } from 'ui'
+
+import CopyButton from '@/components/ui/CopyButton'
+import {
+  WORKERS_CLI_DEPLOY,
+  WORKERS_DOCS_URL,
+  WORKERS_SKILL_MARKDOWN,
+} from '@/lib/constants/workers'
+
+interface WorkersEmptyStateProps {
+  onDeploy: () => void
+}
+
+const STEPS = [
+  {
+    title: 'Detects your stack',
+    description:
+      'The CLI inspects your project and picks the right runtime — Node, Deno, Bun, Python, or your Dockerfile.',
+  },
+  {
+    title: 'Builds & schedules',
+    description:
+      'Your worker is built and scheduled onto a microVM in US West, right next to your database.',
+  },
+  {
+    title: 'Streams back here',
+    description: 'Lifecycle events and logs stream to Logflare and show up on this page.',
+  },
+]
+
+export const WorkersEmptyState = ({ onDeploy }: WorkersEmptyStateProps) => (
+  <Card className="grid grid-cols-1 divide-y divide-default lg:grid-cols-[1.6fr_1fr] lg:divide-x lg:divide-y-0">
+    {/* Left: deploy hero + steps */}
+    <div className="flex flex-col gap-6 p-8">
+      <div className="space-y-2">
+        <h3 className="text-lg text-foreground">Deploy a worker</h3>
+        <p className="max-w-md text-sm text-foreground-light">
+          No workers yet. Run managed compute in microVMs next to your database. Deploy your first
+          worker with the Supabase CLI.
+        </p>
+      </div>
+
+      <div>
+        <Button variant="primary" icon={<Terminal />} onClick={onDeploy}>
+          Deploy a worker
+        </Button>
+      </div>
+
+      <ol className="space-y-5">
+        {STEPS.map((step, index) => (
+          <li key={step.title} className="flex gap-3">
+            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-strong text-xs text-foreground-light">
+              {index + 1}
+            </span>
+            <div className="space-y-0.5">
+              <p className="text-sm text-foreground">{step.title}</p>
+              <p className="max-w-md text-sm text-foreground-lighter">{step.description}</p>
+            </div>
+          </li>
+        ))}
+      </ol>
+    </div>
+
+    {/* Right rail: CLI + SKILL.md + docs */}
+    <div className="flex flex-col gap-4 p-8">
+      <p className="text-xs font-mono uppercase tracking-wider text-foreground-lighter">
+        Prefer the CLI?
+      </p>
+      <div className="rounded-md border border-default bg-surface-100 px-3 py-2 font-mono text-sm text-foreground-light">
+        {WORKERS_CLI_DEPLOY}
+      </div>
+
+      <div className="space-y-2 rounded-md border border-default p-4">
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-foreground">SKILL.md</span>
+          <span className="inline-flex items-center gap-1 rounded-full border border-strong px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-foreground-lighter">
+            <Sparkles size={10} /> For agents
+          </span>
+        </div>
+        <p className="text-sm text-foreground-lighter">
+          Drop a skill file into your agent so it can deploy and manage workers for you.
+        </p>
+        <div className="flex items-center gap-3 pt-1">
+          <CopyButton text={WORKERS_SKILL_MARKDOWN} variant="default" size="tiny">
+            Copy SKILL.md
+          </CopyButton>
+          <Link
+            href={WORKERS_DOCS_URL}
+            target="_blank"
+            rel="noreferrer"
+            className="text-sm text-foreground-light transition-colors hover:text-foreground"
+          >
+            View docs
+          </Link>
+        </div>
+      </div>
+
+      <Link
+        href={WORKERS_DOCS_URL}
+        target="_blank"
+        rel="noreferrer"
+        className={cn(
+          'flex items-center justify-between rounded-md border border-default px-4 py-3',
+          'text-sm text-foreground-light transition-colors hover:border-strong hover:text-foreground'
+        )}
+      >
+        Read the docs
+        <ArrowRight size={14} />
+      </Link>
+    </div>
+  </Card>
+)

--- a/apps/studio/components/interfaces/Workers/WorkersEmptyState.tsx
+++ b/apps/studio/components/interfaces/Workers/WorkersEmptyState.tsx
@@ -1,6 +1,7 @@
 import { Sparkles, Terminal } from 'lucide-react'
 import { Button, Card } from 'ui'
 
+import { WorkerCommandLine } from './WorkerCommandLine'
 import CopyButton from '@/components/ui/CopyButton'
 import { WORKERS_CLI_DEPLOY, WORKERS_SKILL_MARKDOWN } from '@/lib/constants/workers'
 
@@ -20,8 +21,8 @@ const STEPS = [
       'Your worker is built and scheduled onto a microVM in US West, right next to your database.',
   },
   {
-    title: 'Streams back here',
-    description: 'Lifecycle events and logs stream to Logflare and show up on this page.',
+    title: 'Shows up here',
+    description: 'The worker and its state appear on this page once the build finishes.',
   },
 ]
 
@@ -59,10 +60,10 @@ export const WorkersEmptyState = ({ onDeploy }: WorkersEmptyStateProps) => (
 
     <div className="flex flex-col gap-4 p-8">
       <p className="text-xs font-mono uppercase tracking-wider text-foreground-lighter">
-        Prefer the CLI?
+        Deploy from the terminal
       </p>
-      <div className="rounded-md border border-default bg-surface-100 px-3 py-2 font-mono text-sm text-foreground-light">
-        {WORKERS_CLI_DEPLOY}
+      <div className="rounded-md border border-default bg-surface-100 px-3 py-2">
+        <WorkerCommandLine command={WORKERS_CLI_DEPLOY} />
       </div>
 
       <div className="space-y-2 rounded-md border border-default p-4">

--- a/apps/studio/components/interfaces/Workers/WorkersList.test.tsx
+++ b/apps/studio/components/interfaces/Workers/WorkersList.test.tsx
@@ -1,6 +1,6 @@
 import { screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { Worker } from './Workers.types'
 import { WorkersList } from './WorkersList'
@@ -19,7 +19,7 @@ const worker = (name: string, overrides: Partial<Worker> = {}): Worker => ({
 })
 
 const renderList = (workers: Worker[]) =>
-  customRender(<WorkersList projectRef="default" workers={workers} />)
+  customRender(<WorkersList projectRef="default" workers={workers} onDeploy={vi.fn()} />)
 
 const rowNames = () =>
   screen

--- a/apps/studio/components/interfaces/Workers/WorkersList.tsx
+++ b/apps/studio/components/interfaces/Workers/WorkersList.tsx
@@ -1,4 +1,4 @@
-import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { ChevronLeft, ChevronRight, Terminal } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useState } from 'react'
@@ -30,6 +30,7 @@ import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 interface WorkersListProps {
   projectRef: string
   workers: Worker[]
+  onDeploy: () => void
 }
 
 const STATE_FILTERS: { value: WorkerBuildState | 'all'; label: string }[] = [
@@ -53,7 +54,7 @@ const parseStateFilter = (value: string): WorkerBuildState | 'all' =>
 const parseAccessFilter = (value: string): WorkerAccess | 'all' =>
   ACCESS_FILTERS.find((option) => option.value === value)?.value ?? 'all'
 
-export const WorkersList = ({ projectRef, workers }: WorkersListProps) => {
+export const WorkersList = ({ projectRef, workers, onDeploy }: WorkersListProps) => {
   const router = useRouter()
   const [search, setSearch] = useState('')
   const [stateFilter, setStateFilter] = useState<WorkerBuildState | 'all'>('all')
@@ -125,6 +126,9 @@ export const WorkersList = ({ projectRef, workers }: WorkersListProps) => {
           <span className="text-sm text-foreground-lighter">
             {filtered.length} worker{filtered.length === 1 ? '' : 's'}
           </span>
+          <Button variant="primary" icon={<Terminal />} onClick={onDeploy}>
+            Deploy a worker
+          </Button>
         </div>
       </div>
 

--- a/apps/studio/components/interfaces/Workers/WorkersList.tsx
+++ b/apps/studio/components/interfaces/Workers/WorkersList.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router'
 import { useState } from 'react'
 import {
   Badge,
+  Button,
   Card,
   CardFooter,
   Input,

--- a/apps/studio/components/interfaces/Workers/workerSnippets.test.ts
+++ b/apps/studio/components/interfaces/Workers/workerSnippets.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+
+import { WORKERS_REGION } from './Workers.constants'
+import { buildWorkerCliCommands, buildWorkerSnippets, EXAMPLE_WORKER } from './workerSnippets'
+
+const input = (overrides: Partial<Parameters<typeof buildWorkerSnippets>[0]> = {}) => ({
+  ...EXAMPLE_WORKER,
+  endpoint: 'abcdefgh.supabase.co',
+  ...overrides,
+})
+
+describe('buildWorkerSnippets', () => {
+  it('points every call snippet at the worker URL', () => {
+    const { curl, javascript, python } = buildWorkerSnippets(input({ name: 'embed' }))
+    const url = 'https://abcdefgh.supabase.co/workers/v1/embed'
+
+    expect(curl).toContain(`'${url}'`)
+    expect(javascript).toContain(`'${url}'`)
+    expect(python).toContain(`"${url}"`)
+  })
+
+  it('leaves a placeholder URL until the project settings resolve', () => {
+    const { curl } = buildWorkerSnippets(input({ endpoint: undefined }))
+    expect(curl).toContain('[YOUR WORKER URL]')
+  })
+
+  it('asks for the anon key on a public worker and the service role key on a private one', () => {
+    expect(buildWorkerSnippets(input({ access: 'public' })).curl).toContain('[YOUR ANON KEY]')
+    expect(buildWorkerSnippets(input({ access: 'private' })).curl).toContain(
+      '[YOUR SERVICE ROLE KEY]'
+    )
+    expect(buildWorkerSnippets(input({ access: 'private' })).javascript).toContain(
+      '[YOUR SERVICE ROLE KEY]'
+    )
+  })
+
+  it('falls back to a placeholder name when the worker has none', () => {
+    expect(buildWorkerSnippets(input({ name: '   ' })).cli).toContain('my-worker')
+  })
+
+  it('trims the name before interpolating it', () => {
+    expect(buildWorkerSnippets(input({ name: '  embed  ' })).cli).toContain('new embed --runtime')
+  })
+
+  it('defaults the runtime when the API omits it', () => {
+    expect(buildWorkerSnippets(input({ runtime: undefined })).cli).toContain('--runtime node')
+  })
+
+  it('writes the worker spec into the config.toml block', () => {
+    const { configToml } = buildWorkerSnippets(
+      input({
+        name: 'embed',
+        runtime: 'python',
+        size: '4gb-2vcpu',
+        access: 'private',
+        instances: 3,
+      })
+    )
+
+    expect(configToml).toContain('[workers.embed]')
+    expect(configToml).toContain('runtime   = "python"')
+    expect(configToml).toContain('size      = "4gb-2vcpu"    # 4 GB · 2 vCPU')
+    expect(configToml).toContain('access    = "private"')
+    expect(configToml).toContain('instances = 3')
+    expect(configToml).toContain(WORKERS_REGION)
+  })
+})
+
+describe('buildWorkerCliCommands', () => {
+  it('names the worker in every command', () => {
+    const commands = buildWorkerCliCommands('embed')
+    expect(commands).not.toHaveLength(0)
+    for (const { command } of commands) {
+      expect(command).toContain('embed')
+    }
+  })
+
+  it('falls back to a placeholder name when the worker has none', () => {
+    expect(buildWorkerCliCommands('  ')[0].command).toContain('my-worker')
+  })
+})

--- a/apps/studio/components/interfaces/Workers/workerSnippets.ts
+++ b/apps/studio/components/interfaces/Workers/workerSnippets.ts
@@ -1,4 +1,4 @@
-import { workerUrl } from './Workers.constants'
+import { WORKERS_REGION, workerUrl } from './Workers.constants'
 import type { WorkerAccess } from './Workers.types'
 import { formatRuntime, formatSize } from './Workers.utils'
 import { CLI_NAME, PRODUCT_NAME } from '@/lib/constants/workers'
@@ -52,7 +52,7 @@ export function buildWorkerSnippets(input: WorkerSnippetInput): WorkerSnippets {
     `size      = "${input.size}"    # ${formatSize(input.size)}`,
     `access    = "${input.access}"`,
     `instances = ${input.instances}`,
-    `# region is locked to us-west-1 at alpha`,
+    `# region is locked to ${WORKERS_REGION} at alpha`,
   ].join('\n')
 
   const authHeader =

--- a/apps/studio/components/interfaces/Workers/workerSnippets.ts
+++ b/apps/studio/components/interfaces/Workers/workerSnippets.ts
@@ -1,0 +1,123 @@
+import { getRuntimeMeta, getSizeMeta, workerGatewayUrl } from './Workers.constants'
+import type { WorkerAccess, WorkerRuntime, WorkerSize } from './Workers.types'
+import { CLI_NAME, PRODUCT_NAME } from '@/lib/constants/workers'
+
+export interface WorkerSnippetInput {
+  name: string
+  runtime: WorkerRuntime
+  size: WorkerSize
+  access: WorkerAccess
+  instances: number
+}
+
+export interface WorkerSnippets {
+  /** Natural-language prompt a user can paste into an agent. */
+  aiPrompt: string
+  /** `supabase/config.toml` block the CLI reads. */
+  configToml: string
+  /** `supabase workers deploy` invocation. */
+  cli: string
+  /** `curl` invocation against the deployed worker. */
+  curl: string
+  /** JavaScript (fetch) invocation. */
+  javascript: string
+  /** Python (requests) invocation. */
+  python: string
+}
+
+/** Placeholder worker used by the deploy instructions, which have no form to read from. */
+export const EXAMPLE_WORKER: WorkerSnippetInput = {
+  name: 'my-worker',
+  runtime: 'node',
+  size: '2x1',
+  access: 'public',
+  instances: 1,
+}
+
+const safeName = (name: string) => (name.trim().length > 0 ? name.trim() : 'my-worker')
+
+export function buildWorkerSnippets(input: WorkerSnippetInput): WorkerSnippets {
+  const name = safeName(input.name)
+  const runtime = getRuntimeMeta(input.runtime)
+  const size = getSizeMeta(input.size)
+
+  const cli = [
+    `supabase ${CLI_NAME} new ${name} --runtime ${runtime.cli}`,
+    `supabase ${CLI_NAME} push ${name}`,
+  ].join('\n')
+
+  const configToml = [
+    `# supabase/config.toml`,
+    ``,
+    `[${CLI_NAME}.${name}]`,
+    `runtime   = "${runtime.cli}"`,
+    `size      = "${input.size}"        # ${size.memory} / ${size.vcpu}`,
+    `access    = "${input.access}"`,
+    `instances = ${input.instances}`,
+    `# region is locked to us-west-1 at alpha`,
+  ].join('\n')
+
+  const authHeader =
+    input.access === 'public'
+      ? `  -H 'Authorization: Bearer [YOUR ANON KEY]' \\`
+      : `  -H 'Authorization: Bearer [YOUR SERVICE ROLE KEY]' \\`
+
+  const curl = [
+    `curl -L -X POST '${workerGatewayUrl(name)}' \\`,
+    authHeader,
+    `  -H 'Content-Type: application/json' \\`,
+    `  --data '{"name":"world"}'`,
+  ].join('\n')
+
+  const keyPlaceholder = input.access === 'public' ? '[YOUR ANON KEY]' : '[YOUR SERVICE ROLE KEY]'
+  const url = workerGatewayUrl(name)
+
+  const javascript = [
+    `const res = await fetch('${url}', {`,
+    `  method: 'POST',`,
+    `  headers: {`,
+    `    Authorization: 'Bearer ${keyPlaceholder}',`,
+    `    'Content-Type': 'application/json',`,
+    `  },`,
+    `  body: JSON.stringify({ name: 'world' }),`,
+    `})`,
+    `const data = await res.json()`,
+  ].join('\n')
+
+  const python = [
+    `import requests`,
+    ``,
+    `res = requests.post(`,
+    `    "${url}",`,
+    `    headers={"Authorization": "Bearer ${keyPlaceholder}"},`,
+    `    json={"name": "world"},`,
+    `)`,
+    `print(res.json())`,
+  ].join('\n')
+
+  const aiPrompt = [
+    `Deploy a Supabase ${PRODUCT_NAME} worker named "${name}".`,
+    `Use the ${runtime.label} runtime on a ${input.size} instance (${size.memory} / ${size.vcpu}),`,
+    `${input.access} access, ${input.instances} instance${input.instances === 1 ? '' : 's'}.`,
+    `Write the config to supabase/config.toml and run \`supabase ${CLI_NAME} push ${name}\`.`,
+  ].join(' ')
+
+  return { aiPrompt, configToml, cli, curl, javascript, python }
+}
+
+export interface WorkerCliCommand {
+  comment: string
+  command: string
+}
+
+/** The "Develop locally" CLI commands for a worker (pull / push / logs / delete). */
+export function buildWorkerCliCommands(name: string): WorkerCliCommand[] {
+  const slug = safeName(name)
+  return [
+    { comment: 'Recreate the source locally', command: `supabase ${CLI_NAME} pull ${slug}` },
+    { comment: 'Run it locally on a port', command: `supabase ${CLI_NAME} serve ${slug}` },
+    { comment: 'Deploy a new version', command: `supabase ${CLI_NAME} push ${slug}` },
+    { comment: 'Stream logs', command: `supabase ${CLI_NAME} logs ${slug} --follow` },
+    { comment: 'Delete the worker', command: `supabase ${CLI_NAME} delete ${slug}` },
+  ]
+}

--- a/apps/studio/components/interfaces/Workers/workerSnippets.ts
+++ b/apps/studio/components/interfaces/Workers/workerSnippets.ts
@@ -1,7 +1,7 @@
 import { WORKERS_REGION, workerUrl } from './Workers.constants'
 import type { WorkerAccess } from './Workers.types'
-import { formatRuntime, formatSize } from './Workers.utils'
-import { CLI_NAME, PRODUCT_NAME } from '@/lib/constants/workers'
+import { formatSize } from './Workers.utils'
+import { CLI_NAME } from '@/lib/constants/workers'
 
 export interface WorkerSnippetInput {
   name: string
@@ -14,7 +14,6 @@ export interface WorkerSnippetInput {
 }
 
 export interface WorkerSnippets {
-  aiPrompt: string
   configToml: string
   cli: string
   curl: string
@@ -92,14 +91,7 @@ export function buildWorkerSnippets(input: WorkerSnippetInput): WorkerSnippets {
     `print(res.json())`,
   ].join('\n')
 
-  const aiPrompt = [
-    `Deploy a Supabase ${PRODUCT_NAME} worker named "${name}".`,
-    `Use the ${formatRuntime(input.runtime)} runtime on a ${formatSize(input.size)} instance,`,
-    `${input.access} access, ${input.instances} instance${input.instances === 1 ? '' : 's'}.`,
-    `Write the config to supabase/config.toml and run \`supabase ${CLI_NAME} push ${name}\`.`,
-  ].join(' ')
-
-  return { aiPrompt, configToml, cli, curl, javascript, python }
+  return { configToml, cli, curl, javascript, python }
 }
 
 export interface WorkerCliCommand {

--- a/apps/studio/components/interfaces/Workers/workerSnippets.ts
+++ b/apps/studio/components/interfaces/Workers/workerSnippets.ts
@@ -11,21 +11,14 @@ export interface WorkerSnippetInput {
 }
 
 export interface WorkerSnippets {
-  /** Natural-language prompt a user can paste into an agent. */
   aiPrompt: string
-  /** `supabase/config.toml` block the CLI reads. */
   configToml: string
-  /** `supabase workers deploy` invocation. */
   cli: string
-  /** `curl` invocation against the deployed worker. */
   curl: string
-  /** JavaScript (fetch) invocation. */
   javascript: string
-  /** Python (requests) invocation. */
   python: string
 }
 
-/** Placeholder worker used by the deploy instructions, which have no form to read from. */
 export const EXAMPLE_WORKER: WorkerSnippetInput = {
   name: 'my-worker',
   runtime: 'node',
@@ -110,7 +103,6 @@ export interface WorkerCliCommand {
   command: string
 }
 
-/** The "Develop locally" CLI commands for a worker (pull / push / logs / delete). */
 export function buildWorkerCliCommands(name: string): WorkerCliCommand[] {
   const slug = safeName(name)
   return [

--- a/apps/studio/components/interfaces/Workers/workerSnippets.ts
+++ b/apps/studio/components/interfaces/Workers/workerSnippets.ts
@@ -1,10 +1,12 @@
-import { workerGatewayUrl } from './Workers.constants'
+import { workerUrl } from './Workers.constants'
 import type { WorkerAccess } from './Workers.types'
 import { formatRuntime, formatSize } from './Workers.utils'
 import { CLI_NAME, PRODUCT_NAME } from '@/lib/constants/workers'
 
 export interface WorkerSnippetInput {
   name: string
+  endpoint: string | undefined
+  protocol?: string
   runtime: string | undefined
   size: string
   access: WorkerAccess
@@ -20,7 +22,7 @@ export interface WorkerSnippets {
   python: string
 }
 
-export const EXAMPLE_WORKER: WorkerSnippetInput = {
+export const EXAMPLE_WORKER: Omit<WorkerSnippetInput, 'endpoint' | 'protocol'> = {
   name: 'my-worker',
   runtime: 'node',
   size: '2gb-1vcpu',
@@ -33,6 +35,9 @@ const safeName = (name: string) => (name.trim().length > 0 ? name.trim() : 'my-w
 export function buildWorkerSnippets(input: WorkerSnippetInput): WorkerSnippets {
   const name = safeName(input.name)
   const runtime = input.runtime ?? 'node'
+
+  const url =
+    workerUrl({ endpoint: input.endpoint, protocol: input.protocol, name }) ?? '[YOUR WORKER URL]'
 
   const cli = [
     `supabase ${CLI_NAME} new ${name} --runtime ${runtime}`,
@@ -56,14 +61,13 @@ export function buildWorkerSnippets(input: WorkerSnippetInput): WorkerSnippets {
       : `  -H 'Authorization: Bearer [YOUR SERVICE ROLE KEY]' \\`
 
   const curl = [
-    `curl -L -X POST '${workerGatewayUrl(name)}' \\`,
+    `curl -L -X POST '${url}' \\`,
     authHeader,
     `  -H 'Content-Type: application/json' \\`,
     `  --data '{"name":"world"}'`,
   ].join('\n')
 
   const keyPlaceholder = input.access === 'public' ? '[YOUR ANON KEY]' : '[YOUR SERVICE ROLE KEY]'
-  const url = workerGatewayUrl(name)
 
   const javascript = [
     `const res = await fetch('${url}', {`,

--- a/apps/studio/components/interfaces/Workers/workerSnippets.ts
+++ b/apps/studio/components/interfaces/Workers/workerSnippets.ts
@@ -1,11 +1,12 @@
-import { getRuntimeMeta, getSizeMeta, workerGatewayUrl } from './Workers.constants'
-import type { WorkerAccess, WorkerRuntime, WorkerSize } from './Workers.types'
+import { workerGatewayUrl } from './Workers.constants'
+import type { WorkerAccess } from './Workers.types'
+import { formatRuntime, formatSize } from './Workers.utils'
 import { CLI_NAME, PRODUCT_NAME } from '@/lib/constants/workers'
 
 export interface WorkerSnippetInput {
   name: string
-  runtime: WorkerRuntime
-  size: WorkerSize
+  runtime: string | undefined
+  size: string
   access: WorkerAccess
   instances: number
 }
@@ -22,7 +23,7 @@ export interface WorkerSnippets {
 export const EXAMPLE_WORKER: WorkerSnippetInput = {
   name: 'my-worker',
   runtime: 'node',
-  size: '2x1',
+  size: '2gb-1vcpu',
   access: 'public',
   instances: 1,
 }
@@ -31,11 +32,10 @@ const safeName = (name: string) => (name.trim().length > 0 ? name.trim() : 'my-w
 
 export function buildWorkerSnippets(input: WorkerSnippetInput): WorkerSnippets {
   const name = safeName(input.name)
-  const runtime = getRuntimeMeta(input.runtime)
-  const size = getSizeMeta(input.size)
+  const runtime = input.runtime ?? 'node'
 
   const cli = [
-    `supabase ${CLI_NAME} new ${name} --runtime ${runtime.cli}`,
+    `supabase ${CLI_NAME} new ${name} --runtime ${runtime}`,
     `supabase ${CLI_NAME} push ${name}`,
   ].join('\n')
 
@@ -43,8 +43,8 @@ export function buildWorkerSnippets(input: WorkerSnippetInput): WorkerSnippets {
     `# supabase/config.toml`,
     ``,
     `[${CLI_NAME}.${name}]`,
-    `runtime   = "${runtime.cli}"`,
-    `size      = "${input.size}"        # ${size.memory} / ${size.vcpu}`,
+    `runtime   = "${runtime}"`,
+    `size      = "${input.size}"    # ${formatSize(input.size)}`,
     `access    = "${input.access}"`,
     `instances = ${input.instances}`,
     `# region is locked to us-west-1 at alpha`,
@@ -90,7 +90,7 @@ export function buildWorkerSnippets(input: WorkerSnippetInput): WorkerSnippets {
 
   const aiPrompt = [
     `Deploy a Supabase ${PRODUCT_NAME} worker named "${name}".`,
-    `Use the ${runtime.label} runtime on a ${input.size} instance (${size.memory} / ${size.vcpu}),`,
+    `Use the ${formatRuntime(input.runtime)} runtime on a ${formatSize(input.size)} instance,`,
     `${input.access} access, ${input.instances} instance${input.instances === 1 ? '' : 's'}.`,
     `Write the config to supabase/config.toml and run \`supabase ${CLI_NAME} push ${name}\`.`,
   ].join(' ')

--- a/apps/studio/components/layouts/Navigation/NavigationBar/NavigationBar.utils.tsx
+++ b/apps/studio/components/layouts/Navigation/NavigationBar/NavigationBar.utils.tsx
@@ -148,6 +148,7 @@ export const generateProductRoutes = (
             disabled: !isProjectActive,
             icon: <Box size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,
             link: ref && (isProjectBuilding ? buildingUrl : `/project/${ref}/workers`),
+            isNew: true,
           },
         ]
       : []),

--- a/apps/studio/components/layouts/WorkersLayout/WorkersLayout.tsx
+++ b/apps/studio/components/layouts/WorkersLayout/WorkersLayout.tsx
@@ -85,7 +85,7 @@ const WorkersLayoutContent = ({ children, title }: PropsWithChildren<WorkersLayo
       {canReadWorkers ? (
         children
       ) : (
-        <NoPermission isFullPage resourceText={`view this project's ${PRODUCT_NAME} workers`} />
+        <NoPermission isFullPage resourceText="view this project's workers" />
       )}
     </ProjectLayout>
   )

--- a/apps/studio/components/ui/ui.types.ts
+++ b/apps/studio/components/ui/ui.types.ts
@@ -10,6 +10,7 @@ export interface Route {
   disabled?: boolean
   linkElement?: ReactNode
   items?: any | Route[]
+  isNew?: boolean
   /**
    * Binds a registered keyboard shortcut to this route when set. The sidebar
    * entry shows the keybind on hover and jumps to `link` when the shortcut

--- a/apps/studio/lib/constants/workers.ts
+++ b/apps/studio/lib/constants/workers.ts
@@ -1,5 +1,5 @@
-export const PRODUCT_NAME = 'Compute'
-export const CLI_NAME = 'compute'
+export const PRODUCT_NAME = 'Workers'
+export const CLI_NAME = 'workers'
 
 export const WORKERS_CLI_DEPLOY = `supabase ${CLI_NAME} push`
 

--- a/apps/studio/lib/constants/workers.ts
+++ b/apps/studio/lib/constants/workers.ts
@@ -14,7 +14,7 @@ Add a block to \`supabase/config.toml\`:
 \`\`\`toml
 [${CLI_NAME}.embed]
 runtime   = "python"   # node | deno | bun | python | dockerfile
-size      = "2x1"      # 2x1 (2GB/1vCPU) | 4x2 (4GB/2vCPU) — fixed at deploy
+size      = "2gb-1vcpu"   # 2gb-1vcpu | 4gb-2vcpu — fixed at deploy
 access    = "public"   # public | private
 instances = 1          # 1..10 per deploy; 100 cap per project
 secrets   = ["OPENAI_API_KEY"]   # names only — values live in the Secrets API
@@ -33,7 +33,7 @@ Config precedence: \`--flag\` > \`config.toml\` > interactive prompt > default.
 
 - Workers under \`supabase/${CLI_NAME}/<name>/\` are auto-discovered; the folder name is the slug.
 - \`entrypoint\` is inferred from the runtime (node index.js, deno run main.ts, python main.py, Dockerfile CMD).
-- \`region\` is locked to us-west-1 at alpha — do not set it.
+- \`region\` is locked to us-west-2 at alpha — do not set it.
 - Sizes are fixed at deploy time. To change size, delete the worker and redeploy.
 
 ## Manage

--- a/apps/studio/pages/project/[ref]/workers/index.tsx
+++ b/apps/studio/pages/project/[ref]/workers/index.tsx
@@ -31,7 +31,7 @@ import type { NextPageWithLayout } from '@/types'
 
 const WorkersPage: NextPageWithLayout = () => {
   const { ref } = useParams()
-  const [showDeployInstructions, setShowDeployInstructions] = useState(false)
+  const [isDeployInstructionsOpen, setIsDeployInstructionsOpen] = useState(false)
   const {
     data: workers,
     error,
@@ -76,20 +76,23 @@ const WorkersPage: NextPageWithLayout = () => {
             {isMissingPermission && <NoPermission resourceText="view this project's workers" />}
             {isUnexpectedError && <AlertError error={error} subject="Failed to retrieve workers" />}
             {isSuccess && workers.length === 0 && (
-              <WorkersEmptyState onDeploy={() => setShowDeployInstructions(true)} />
+              <WorkersEmptyState onDeploy={() => setIsDeployInstructionsOpen(true)} />
             )}
             {isSuccess && workers.length > 0 && ref && (
               <WorkersList
                 projectRef={ref}
                 workers={workers}
-                onDeploy={() => setShowDeployInstructions(true)}
+                onDeploy={() => setIsDeployInstructionsOpen(true)}
               />
             )}
           </PageSectionContent>
         </PageSection>
       </PageContainer>
 
-      <DeployWorkerDialog open={showDeployInstructions} onOpenChange={setShowDeployInstructions} />
+      <DeployWorkerDialog
+        open={isDeployInstructionsOpen}
+        onOpenChange={setIsDeployInstructionsOpen}
+      />
     </div>
   )
 }

--- a/apps/studio/pages/project/[ref]/workers/index.tsx
+++ b/apps/studio/pages/project/[ref]/workers/index.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { useParams } from 'common'
+import { useState } from 'react'
 import { Admonition } from 'ui-patterns/Admonition'
 import { PageContainer } from 'ui-patterns/PageContainer'
 import {
@@ -12,10 +13,12 @@ import {
 import { PageSection, PageSectionContent } from 'ui-patterns/PageSection'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 
+import { DeployWorkerDialog } from '@/components/interfaces/Workers/DeployWorkerDialog'
 import {
   isWorkersForbidden,
   isWorkersUnavailable,
 } from '@/components/interfaces/Workers/Workers.utils'
+import { WorkersEmptyState } from '@/components/interfaces/Workers/WorkersEmptyState'
 import { WorkersList } from '@/components/interfaces/Workers/WorkersList'
 import { DefaultLayout } from '@/components/layouts/DefaultLayout'
 import { WorkersLayout } from '@/components/layouts/WorkersLayout/WorkersLayout'
@@ -27,6 +30,7 @@ import type { NextPageWithLayout } from '@/types'
 
 const WorkersPage: NextPageWithLayout = () => {
   const { ref } = useParams()
+  const [showDeployInstructions, setShowDeployInstructions] = useState(false)
   const {
     data: workers,
     error,
@@ -66,16 +70,20 @@ const WorkersPage: NextPageWithLayout = () => {
             {isMissingPermission && <NoPermission resourceText="view this project's workers" />}
             {isUnexpectedError && <AlertError error={error} subject="Failed to retrieve workers" />}
             {isSuccess && workers.length === 0 && (
-              <p className="text-sm text-foreground-light">
-                No workers yet. Deploy your first worker with the Supabase CLI.
-              </p>
+              <WorkersEmptyState onDeploy={() => setShowDeployInstructions(true)} />
             )}
             {isSuccess && workers.length > 0 && ref && (
-              <WorkersList projectRef={ref} workers={workers} />
+              <WorkersList
+                projectRef={ref}
+                workers={workers}
+                onDeploy={() => setShowDeployInstructions(true)}
+              />
             )}
           </PageSectionContent>
         </PageSection>
       </PageContainer>
+
+      <DeployWorkerDialog open={showDeployInstructions} onOpenChange={setShowDeployInstructions} />
     </div>
   )
 }

--- a/apps/studio/pages/project/[ref]/workers/index.tsx
+++ b/apps/studio/pages/project/[ref]/workers/index.tsx
@@ -23,6 +23,7 @@ import { WorkersList } from '@/components/interfaces/Workers/WorkersList'
 import { DefaultLayout } from '@/components/layouts/DefaultLayout'
 import { WorkersLayout } from '@/components/layouts/WorkersLayout/WorkersLayout'
 import { AlertError } from '@/components/ui/AlertError'
+import { AlphaNotice } from '@/components/ui/AlphaNotice'
 import { NoPermission } from '@/components/ui/NoPermission'
 import { workersQueryOptions } from '@/data/workers/workers-query'
 import { PRODUCT_NAME } from '@/lib/constants/workers'
@@ -50,7 +51,7 @@ const WorkersPage: NextPageWithLayout = () => {
           <PageHeaderSummary>
             <PageHeaderTitle>{PRODUCT_NAME}</PageHeaderTitle>
             <PageHeaderDescription>
-              Run backend workers in microVMs next to your database
+              Run fully managed compute in isolation next to your database
             </PageHeaderDescription>
           </PageHeaderSummary>
         </PageHeaderMeta>
@@ -58,7 +59,12 @@ const WorkersPage: NextPageWithLayout = () => {
 
       <PageContainer size="large">
         <PageSection>
-          <PageSectionContent>
+          <PageSectionContent className="flex flex-col gap-y-8">
+            <AlphaNotice
+              entity="Workers"
+              feedbackUrl="https://github.com/orgs/supabase/discussions"
+            />
+
             {isPending && <GenericSkeletonLoader />}
             {isNotEnrolled && (
               <Admonition

--- a/apps/studio/pages/project/[ref]/workers/index.tsx
+++ b/apps/studio/pages/project/[ref]/workers/index.tsx
@@ -63,9 +63,7 @@ const WorkersPage: NextPageWithLayout = () => {
                 description={`${PRODUCT_NAME} is in private alpha. Contact support to have this project added to the alpha.`}
               />
             )}
-            {isMissingPermission && (
-              <NoPermission resourceText={`view this project's ${PRODUCT_NAME} workers`} />
-            )}
+            {isMissingPermission && <NoPermission resourceText="view this project's workers" />}
             {isUnexpectedError && <AlertError error={error} subject="Failed to retrieve workers" />}
             {isSuccess && workers.length === 0 && (
               <p className="text-sm text-foreground-light">

--- a/apps/studio/tests/pages/project/[ref]/workers/index.test.tsx
+++ b/apps/studio/tests/pages/project/[ref]/workers/index.test.tsx
@@ -86,7 +86,7 @@ describe('/project/[ref]/workers', () => {
 
     await renderWorkersPage()
 
-    expect(screen.getByText(/No workers yet/)).toBeVisible()
+    expect(screen.getByText('Deploy your first worker')).toBeVisible()
     expect(screen.queryByRole('table')).not.toBeInTheDocument()
   })
 

--- a/apps/studio/tests/pages/project/[ref]/workers/index.test.tsx
+++ b/apps/studio/tests/pages/project/[ref]/workers/index.test.tsx
@@ -105,9 +105,7 @@ describe('/project/[ref]/workers', () => {
     await renderWorkersPage()
 
     expect(
-      screen.getByText(
-        `You need additional permissions to view this project's ${PRODUCT_NAME} workers`
-      )
+      screen.getByText("You need additional permissions to view this project's workers")
     ).toBeVisible()
     expect(screen.queryByRole('table')).not.toBeInTheDocument()
   })


### PR DESCRIPTION
## What

The surface that shows you how to deploy a worker from the CLI, plus the product rename and the alpha framing.

- **Compute → Workers.** `PRODUCT_NAME` and `CLI_NAME` now say `Workers` / `workers`, so the sidebar, page title, command menu, and every generated snippet match the CLI. One name, not two.
- **`DeployWorkerDialog`** — scaffold / configure / push, with copyable `supabase workers` and `config.toml` snippets
- **`WorkersEmptyState`** — an `EmptyStatePresentational` with a permission-gated deploy action
- **`AlphaNotice`** on the list page, and a **New** badge on the sidebar entry (`Route.isNew`)
- **`WorkerSnippetTabs`** — CLI, `config.toml`, and curl/JS/Python calls built from one worker shape. Reused by #49195.

Snippet URLs resolve from the project's `app_config.endpoint` (`https://<project>/workers/v1/<name>`, the same shape as `/functions/v1/`), and fall back to `[YOUR WORKER URL]` before settings load rather than printing a wrong host.

## How to test

Only on the **Mockamaster** project in staging — it is the one project in the alpha allow-list.

1. Staging dashboard → Mockamaster → **Workers** (the sidebar entry carries a **New** badge)
2. **Deploy a worker** → step through the tabs; every snippet should name the real worker URL, not a placeholder
3. Copy the cURL snippet and run it: expect `401`. Reaching a deployed worker needs a second allow-list (`WORKERS_ALLOWED_PROJECTS` in api-gateway `customer-router/wrangler.toml`), separate from the flag that unlocks the dashboard.
4. Open a project with no workers to see the empty state

## Tests

`workerSnippets.test.ts` covers the generated output users copy: worker URL in all three call snippets, the `[YOUR WORKER URL]` fallback, anon vs service-role placeholder, empty-name fallback and trimming, runtime default, and every `config.toml` field.

## Unverified copy

The dialog steps and the `supabase workers <sub>` subcommands come from the original POC spec, not from the shipped CLI. Same for "Dockerfile, Node.js and Deno supported" in the empty state — only Deno is confirmed end to end. Worth a check by someone who knows the CLI surface.

Closes FE-4191
