### PR TITLE
fix(studio): escape json values correctly in Copy/Export rows as SQL

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/TableEntity.utils.test.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/TableEntity.utils.test.ts
@@ -89,6 +89,51 @@ describe('TableEntity.utils: formatTableRowsToSQL', () => {
     expect(result).toBe(expected)
   })
 
+  it('should escape json string values with embedded quotes and backslashes without corrupting them', () => {
+    const table: SupaTable = {
+      id: 1,
+      type: ENTITY_TYPE.TABLE,
+      columns: [
+        { name: 'id', dataType: 'bigint', format: 'int8', position: 0 },
+        { name: 'metadata', dataType: 'jsonb', format: 'jsonb', position: 1 },
+      ],
+      name: 'demo',
+      schema: 'public',
+      comment: undefined,
+      estimateRowCount: 1,
+    }
+    // Values as they arrive from Postgres (jsonb cast to text on export).
+    const rows = [
+      { idx: 1, id: 1, metadata: '{"note": "say \\"hi\\""}' },
+      { idx: 2, id: 2, metadata: '{"path": "C:\\\\Users\\\\me"}' },
+    ]
+    const result = formatTableRowsToSQL(table, rows)
+    const expected = `INSERT INTO "public"."demo" ("id", "metadata") VALUES (1, '{"note": "say \\"hi\\""}'), (2, '{"path": "C:\\\\Users\\\\me"}');`
+    expect(result).toBe(expected)
+  })
+
+  it('should stringify json object values instead of coercing them to [object Object]', () => {
+    const table: SupaTable = {
+      id: 1,
+      type: ENTITY_TYPE.TABLE,
+      columns: [
+        { name: 'id', dataType: 'bigint', format: 'int8', position: 0 },
+        { name: 'metadata', dataType: 'jsonb', format: 'jsonb', position: 1 },
+      ],
+      name: 'demo',
+      schema: 'public',
+      comment: undefined,
+      estimateRowCount: 1,
+    }
+    const rows = [
+      { idx: 1, id: 1, metadata: { version: 1 } },
+      { idx: 2, id: 2, metadata: { note: 'say "hi"' } },
+    ]
+    const result = formatTableRowsToSQL(table, rows)
+    const expected = `INSERT INTO "public"."demo" ("id", "metadata") VALUES (1, '{"version":1}'), (2, '{"note":"say \\"hi\\""}');`
+    expect(result).toBe(expected)
+  })
+
   it('should emit valid Postgres literals for booleans, numbers and text arrays', () => {
     const table: SupaTable = {
       id: 1,

--- a/apps/studio/components/interfaces/TableGridEditor/TableEntity.utils.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/TableEntity.utils.ts
@@ -58,7 +58,8 @@ export const formatTableRowsToSQL = (table: SupaTable, rows: any[]) => {
           const array = Array.isArray(val) ? val : JSON.parse(val as string)
           return `${formatArrayForSql(array as unknown[])}`
         } else if (format?.includes('json')) {
-          return `${JSON.stringify(val).replace(/\\"/g, '"').replace(/'/g, "''").replace('"', "'").replace(/.$/, "'")}`
+          const json = typeof val === 'string' ? val : JSON.stringify(val)
+          return `'${json.replaceAll("'", "''")}'`
         } else if (
           typeof format === 'string' &&
           typeof val === 'string' &&


### PR DESCRIPTION
Closes #49196

The json branch of `formatTableRowsToSQL` tried to turn `JSON.stringify(val)` back into a single-quoted literal with a chain of `.replace()` calls. It doubled every backslash and only swapped the first and last quote, so any json value with an embedded `"` produced invalid SQL (the export fails to reimport) and any value with a backslash (paths, `\n`, unicode escapes) came out corrupted.

json/jsonb values already arrive as JSON text (the export query casts to `::text`), so they just need the same single-quote escaping the text branch uses. I also stringify object values first so the grid's "Copy as SQL" doesn't emit `[object Object]`.

Added tests for embedded quotes, backslashes, and object values. Checked the output round-trips back to identical jsonb in Postgres.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved JSON-to-SQL export formatting.
  - Preserved embedded quotes and backslashes in JSON strings.
  - Correctly serialized JSON objects instead of converting them to `[object Object]`.

- **Tests**
  - Added coverage for JSON string and object export scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->