### PR TITLE
feat(storage): add bucket object versioning form fields (FE-4161)

### DIFF
--- a/apps/studio/components/interfaces/Storage/BucketVersioningFields.schema.test.ts
+++ b/apps/studio/components/interfaces/Storage/BucketVersioningFields.schema.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+
+import {
+  bucketVersioningFormFields,
+  S3_MAX_NONCURRENT_VERSIONS,
+  superRefineBucketVersioning,
+  type BucketVersioningFormValues,
+} from './BucketVersioningFields.schema'
+
+const values = (
+  overrides: Partial<BucketVersioningFormValues> = {}
+): BucketVersioningFormValues => ({
+  enable_versioning: true,
+  version_expiry_days: 30,
+  max_noncurrent_versions: 10,
+  expiration_mode: 'and',
+  ...overrides,
+})
+
+/** Runs the refine in isolation and returns the issues it produced. */
+const refine = (formValues: BucketVersioningFormValues) => {
+  const result = z
+    .custom<BucketVersioningFormValues>()
+    .superRefine(superRefineBucketVersioning)
+    .safeParse(formValues)
+
+  if (result.success) return []
+  return result.error.issues.map((issue) => ({
+    path: issue.path.join('.'),
+    message: issue.message,
+  }))
+}
+
+describe('superRefineBucketVersioning', () => {
+  it('accepts a valid policy', () => {
+    expect(refine(values())).toEqual([])
+  })
+
+  it('skips validation entirely when versioning is off', () => {
+    // Out-of-range values are irrelevant while the fields are hidden, so stale
+    // numbers must not block an unrelated bucket-settings save.
+    expect(refine(values({ enable_versioning: false, version_expiry_days: -5 }))).toEqual([])
+  })
+
+  it('treats empty values as "no condition set" rather than zero', () => {
+    expect(refine(values({ version_expiry_days: '', max_noncurrent_versions: '' }))).toEqual([])
+  })
+
+  it('rejects a retention window below one day', () => {
+    expect(refine(values({ version_expiry_days: 0 })).map((i) => i.path)).toEqual([
+      'version_expiry_days',
+    ])
+  })
+
+  it('rejects a version cap with no expiration age, which S3 will not accept', () => {
+    const issues = refine(values({ version_expiry_days: '', max_noncurrent_versions: 10 }))
+    expect(issues).toHaveLength(1)
+    expect(issues[0].path).toBe('max_noncurrent_versions')
+    expect(issues[0].message).toMatch(/expiration age/i)
+  })
+
+  it('rejects a version cap below one', () => {
+    expect(refine(values({ max_noncurrent_versions: 0 })).map((i) => i.path)).toEqual([
+      'max_noncurrent_versions',
+    ])
+  })
+
+  it('rejects exceeding the S3 ceiling of 100 versions', () => {
+    const issues = refine(values({ max_noncurrent_versions: S3_MAX_NONCURRENT_VERSIONS + 1 }))
+    expect(issues).toHaveLength(1)
+    expect(issues[0].message).toContain(String(S3_MAX_NONCURRENT_VERSIONS))
+  })
+
+  it('accepts exactly the S3 ceiling', () => {
+    expect(refine(values({ max_noncurrent_versions: S3_MAX_NONCURRENT_VERSIONS }))).toEqual([])
+  })
+
+  it('reports both fields independently', () => {
+    const issues = refine(values({ version_expiry_days: 0, max_noncurrent_versions: 0 }))
+    expect(issues.map((i) => i.path).sort()).toEqual([
+      'max_noncurrent_versions',
+      'version_expiry_days',
+    ])
+  })
+})
+
+describe('bucketVersioningFormFields', () => {
+  const schema = z.object(bucketVersioningFormFields)
+
+  it('defaults to versioning off with no conditions set', () => {
+    expect(schema.parse({})).toEqual({
+      enable_versioning: false,
+      version_expiry_days: '',
+      max_noncurrent_versions: '',
+      expiration_mode: 'and',
+    })
+  })
+
+  it('coerces numeric strings from the input element', () => {
+    const parsed = schema.parse({ version_expiry_days: '45', max_noncurrent_versions: '5' })
+    expect(parsed.version_expiry_days).toBe(45)
+    expect(parsed.max_noncurrent_versions).toBe(5)
+  })
+
+  it('preserves the empty sentinel instead of coercing it to zero', () => {
+    // `Number('')` is 0, so a bare coercion would turn "no condition" into
+    // "expire immediately". The union literal has to win.
+    expect(schema.parse({ version_expiry_days: '' }).version_expiry_days).toBe('')
+  })
+
+  it('rejects a fractional retention window', () => {
+    expect(schema.safeParse({ version_expiry_days: 1.5 }).success).toBe(false)
+  })
+
+  it('rejects an unknown expiration mode', () => {
+    expect(schema.safeParse({ expiration_mode: 'xor' }).success).toBe(false)
+  })
+})

--- a/apps/studio/components/interfaces/Storage/BucketVersioningFields.schema.ts
+++ b/apps/studio/components/interfaces/Storage/BucketVersioningFields.schema.ts
@@ -3,16 +3,12 @@ import { z } from 'zod'
 import type { ExpirationMode } from './StorageVersioning.constants'
 
 /**
- * `''` is the in-form empty sentinel for both number fields, so they stay
- * controlled and deletable. Empty means the condition isn't part of the policy,
- * which is distinct from zero.
+ * Empty means the condition isn't part of the policy, which is distinct from zero.
  */
 const versioningNumberField = z.union([z.literal(''), z.coerce.number().int()])
 
-/** S3 lifecycle policies support at most 100 noncurrent versions per rule. */
 export const S3_MAX_NONCURRENT_VERSIONS = 100
 
-/** Spread into the create/edit bucket form schemas so both share one definition. */
 export const bucketVersioningFormFields = {
   enable_versioning: z.boolean().default(false),
   version_expiry_days: versioningNumberField.default(''),
@@ -28,9 +24,7 @@ export interface BucketVersioningFormValues {
 }
 
 /**
- * Call from the parent modal's `.superRefine` so errors surface through the
- * usual `FormItemLayout`/`FormMessage` rendering. Both number fields are
- * optional — an empty value drops that condition from the policy.
+ * Both number fields are optional — an empty value drops that condition from the policy.
  */
 export const superRefineBucketVersioning = (
   data: BucketVersioningFormValues,
@@ -50,8 +44,7 @@ export const superRefineBucketVersioning = (
 
   if (versions === '') return
 
-  // S3 only accepts a noncurrent-count condition alongside a noncurrent-days
-  // one. The form disables the cap while no age is set, so this is a backstop.
+  // S3 only accepts a noncurrent-count condition alongside a noncurrent-days one
   if (days === '') {
     ctx.addIssue({
       path: ['max_noncurrent_versions'],

--- a/apps/studio/components/interfaces/Storage/BucketVersioningFields.schema.ts
+++ b/apps/studio/components/interfaces/Storage/BucketVersioningFields.schema.ts
@@ -1,0 +1,77 @@
+import { z } from 'zod'
+
+import type { ExpirationMode } from './StorageVersioning.constants'
+
+/**
+ * `''` is the in-form empty sentinel for both number fields, so they stay
+ * controlled and deletable. Empty means the condition isn't part of the policy,
+ * which is distinct from zero.
+ */
+const versioningNumberField = z.union([z.literal(''), z.coerce.number().int()])
+
+/** S3 lifecycle policies support at most 100 noncurrent versions per rule. */
+export const S3_MAX_NONCURRENT_VERSIONS = 100
+
+/** Spread into the create/edit bucket form schemas so both share one definition. */
+export const bucketVersioningFormFields = {
+  enable_versioning: z.boolean().default(false),
+  version_expiry_days: versioningNumberField.default(''),
+  max_noncurrent_versions: versioningNumberField.default(''),
+  expiration_mode: z.enum(['and', 'or']).default('and'),
+}
+
+export interface BucketVersioningFormValues {
+  enable_versioning: boolean
+  version_expiry_days: '' | number
+  max_noncurrent_versions: '' | number
+  expiration_mode: ExpirationMode
+}
+
+/**
+ * Call from the parent modal's `.superRefine` so errors surface through the
+ * usual `FormItemLayout`/`FormMessage` rendering. Both number fields are
+ * optional — an empty value drops that condition from the policy.
+ */
+export const superRefineBucketVersioning = (
+  data: BucketVersioningFormValues,
+  ctx: z.RefinementCtx
+) => {
+  if (!data.enable_versioning) return
+
+  const { version_expiry_days: days, max_noncurrent_versions: versions } = data
+
+  if (days !== '' && days < 1) {
+    ctx.addIssue({
+      path: ['version_expiry_days'],
+      code: z.ZodIssueCode.custom,
+      message: 'Must be at least 1 day',
+    })
+  }
+
+  if (versions === '') return
+
+  // S3 only accepts a noncurrent-count condition alongside a noncurrent-days
+  // one. The form disables the cap while no age is set, so this is a backstop.
+  if (days === '') {
+    ctx.addIssue({
+      path: ['max_noncurrent_versions'],
+      code: z.ZodIssueCode.custom,
+      message: 'Requires an expiration age to be set',
+    })
+    return
+  }
+
+  if (versions < 1) {
+    ctx.addIssue({
+      path: ['max_noncurrent_versions'],
+      code: z.ZodIssueCode.custom,
+      message: 'Must be at least 1 version',
+    })
+  } else if (versions > S3_MAX_NONCURRENT_VERSIONS) {
+    ctx.addIssue({
+      path: ['max_noncurrent_versions'],
+      code: z.ZodIssueCode.custom,
+      message: `Cannot exceed ${S3_MAX_NONCURRENT_VERSIONS} versions`,
+    })
+  }
+}

--- a/apps/studio/components/interfaces/Storage/BucketVersioningFields.test.tsx
+++ b/apps/studio/components/interfaces/Storage/BucketVersioningFields.test.tsx
@@ -1,0 +1,197 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { screen, waitForElementToBeRemoved, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useForm } from 'react-hook-form'
+import { Form } from 'ui'
+import { describe, expect, test } from 'vitest'
+import { z } from 'zod'
+
+import { BucketVersioningFields } from './BucketVersioningFields'
+import {
+  bucketVersioningFormFields,
+  superRefineBucketVersioning,
+  type BucketVersioningFormValues,
+} from './BucketVersioningFields.schema'
+import type { BucketVersioningState } from './StorageVersioning.constants'
+import { customRender } from '@/tests/lib/custom-render'
+
+/** Mirrors how the bucket modals compose these fields into their own schema. */
+const FormSchema = z.object(bucketVersioningFormFields).superRefine(superRefineBucketVersioning)
+
+const DEFAULT_VALUES: BucketVersioningFormValues = {
+  enable_versioning: false,
+  version_expiry_days: 30,
+  max_noncurrent_versions: 10,
+  expiration_mode: 'and',
+}
+
+/** The fields expect their parent modal's form provider, so supply a minimal one. */
+const Harness = ({
+  defaultValues,
+  ...props
+}: {
+  defaultValues?: Partial<BucketVersioningFormValues>
+  initialVersioningState?: BucketVersioningState
+  initialRetentionDays?: number | null
+  initialMaxVersions?: number | null
+  isPublicBucket?: boolean
+}) => {
+  const form = useForm<BucketVersioningFormValues>({
+    resolver: zodResolver(FormSchema),
+    defaultValues: { ...DEFAULT_VALUES, ...defaultValues },
+    mode: 'onChange',
+  })
+
+  return (
+    <Form {...form}>
+      <form>
+        <BucketVersioningFields {...props} />
+      </form>
+    </Form>
+  )
+}
+
+const renderFields = (props: Parameters<typeof Harness>[0] = {}) =>
+  customRender(<Harness {...props} />)
+
+const getVersioningSwitch = () => screen.getByRole('switch')
+const getDaysInput = () =>
+  screen.getByRole('spinbutton', { name: /noncurrent version expiration/i })
+const getVersionsInput = () =>
+  screen.getByRole('spinbutton', { name: /retained noncurrent versions/i })
+
+describe('BucketVersioningFields', () => {
+  test('hides the lifecycle policy until versioning is turned on', async () => {
+    renderFields()
+
+    expect(screen.getByText('Object versioning')).toBeInTheDocument()
+    expect(screen.queryByText('Lifecycle policy')).not.toBeInTheDocument()
+
+    await userEvent.click(getVersioningSwitch())
+
+    expect(await screen.findByText('Lifecycle policy')).toBeInTheDocument()
+    expect(screen.getByText('Noncurrent version expiration')).toBeInTheDocument()
+    expect(screen.getByText('Retained noncurrent versions')).toBeInTheDocument()
+  })
+
+  test('rejects a version cap above the S3 ceiling', async () => {
+    renderFields({ defaultValues: { enable_versioning: true } })
+
+    const versionsInput = getVersionsInput()
+    await userEvent.clear(versionsInput)
+    await userEvent.type(versionsInput, '150')
+
+    expect(await screen.findByText(/Cannot exceed 100 versions/)).toBeInTheDocument()
+  })
+
+  test('disables the version cap until an expiration age is set', async () => {
+    renderFields({
+      defaultValues: { enable_versioning: true, version_expiry_days: '' },
+    })
+
+    expect(getVersionsInput()).toBeDisabled()
+    expect(screen.getByText('Requires an expiration age to be set.')).toBeInTheDocument()
+
+    await userEvent.type(getDaysInput(), '30')
+
+    expect(getVersionsInput()).toBeEnabled()
+  })
+
+  test('clears an orphaned version cap when the expiration age is removed', async () => {
+    // S3 rejects a noncurrent-count rule with no noncurrent-days condition, so
+    // the cap can't be left behind once the age is cleared.
+    renderFields({
+      defaultValues: {
+        enable_versioning: true,
+        version_expiry_days: 30,
+        max_noncurrent_versions: 10,
+      },
+    })
+
+    expect(getVersionsInput()).toHaveValue(10)
+
+    await userEvent.clear(getDaysInput())
+
+    expect(getVersionsInput()).toHaveValue(null)
+    expect(getVersionsInput()).toBeDisabled()
+  })
+
+  test('offers the and/or mode only while both conditions are set', async () => {
+    renderFields({ defaultValues: { enable_versioning: true } })
+
+    expect(screen.getByText('Expire a noncurrent version when')).toBeInTheDocument()
+
+    // One condition left means there is nothing to combine. The section animates
+    // out, so it lingers in the DOM until the exit transition finishes.
+    await userEvent.clear(getVersionsInput())
+
+    await waitForElementToBeRemoved(() => screen.queryByText('Expire a noncurrent version when'))
+  })
+
+  test('warns when neither lifecycle condition is set', async () => {
+    renderFields({
+      defaultValues: {
+        enable_versioning: true,
+        version_expiry_days: '',
+        max_noncurrent_versions: '',
+      },
+    })
+
+    expect(screen.getByText('No lifecycle policy')).toBeInTheDocument()
+  })
+
+  test('warns that a public bucket serves every version', () => {
+    renderFields({ defaultValues: { enable_versioning: true }, isPublicBucket: true })
+
+    expect(screen.getByText('A public bucket serves every version')).toBeInTheDocument()
+  })
+
+  test('does not warn about public exposure for a private bucket', () => {
+    renderFields({ defaultValues: { enable_versioning: true }, isPublicBucket: false })
+
+    expect(screen.getByText('Lifecycle policy')).toBeInTheDocument()
+    expect(screen.queryByText('A public bucket serves every version')).not.toBeInTheDocument()
+  })
+
+  test('explains that turning the switch off suspends rather than disables', async () => {
+    renderFields({
+      defaultValues: { enable_versioning: true },
+      initialVersioningState: 'enabled',
+    })
+
+    await userEvent.click(getVersioningSwitch())
+
+    expect(await screen.findByText('Saving will suspend versioning')).toBeInTheDocument()
+    await waitForElementToBeRemoved(() => screen.queryByText('Lifecycle policy'))
+  })
+
+  test('warns before tightening the retention window on an already-versioned bucket', async () => {
+    renderFields({
+      defaultValues: { enable_versioning: true, version_expiry_days: 30 },
+      initialVersioningState: 'enabled',
+      initialRetentionDays: 30,
+      initialMaxVersions: 10,
+    })
+
+    const daysInput = getDaysInput()
+    await userEvent.clear(daysInput)
+    await userEvent.type(daysInput, '7')
+
+    const warning = await screen.findByText('Tightening retention expires some versions')
+    expect(
+      within(warning.parentElement!).getByText(/past the shorter retention window/)
+    ).toBeInTheDocument()
+  })
+
+  test('does not warn about tightening when enabling versioning for the first time', async () => {
+    renderFields({ initialVersioningState: 'disabled', initialRetentionDays: null })
+
+    await userEvent.click(getVersioningSwitch())
+
+    const daysInput = getDaysInput()
+    await userEvent.clear(daysInput)
+    await userEvent.type(daysInput, '7')
+
+    expect(screen.queryByText('Tightening retention expires some versions')).not.toBeInTheDocument()
+  })
+})

--- a/apps/studio/components/interfaces/Storage/BucketVersioningFields.tsx
+++ b/apps/studio/components/interfaces/Storage/BucketVersioningFields.tsx
@@ -15,21 +15,12 @@ import type { BucketVersioningState, ExpirationMode } from './StorageVersioning.
 import { FormSectionCollapse } from '@/components/ui/FormSectionCollapse'
 
 interface BucketVersioningFieldsProps {
-  /** The bucket's versioning state when the modal opened. Always `disabled` when creating. */
   initialVersioningState?: BucketVersioningState
-  /** The bucket's retention window when the modal opened, for tightening detection. */
   initialRetentionDays?: number | null
-  /** The bucket's version cap when the modal opened, for tightening detection. */
   initialMaxVersions?: number | null
-  /** Public buckets serve every version by default, which is worth calling out. */
   isPublicBucket?: boolean
 }
 
-/**
- * Object versioning and lifecycle policy controls for the create/edit bucket
- * modals. Expects to render inside the parent modal's `<Form>` provider, whose
- * schema spreads `bucketVersioningFormFields`.
- */
 export const BucketVersioningFields = ({
   initialVersioningState = 'disabled',
   initialRetentionDays,
@@ -43,8 +34,8 @@ export const BucketVersioningFields = ({
   const maxVersions = useWatch({ control, name: 'max_noncurrent_versions' })
   const expirationMode = useWatch({ control, name: 'expiration_mode' })
 
-  // Turning the switch off suspends rather than disables, so this is a heads-up
-  // rather than a destructive confirmation.
+  // Turning the switch off suspends rather than disables,
+  // so this is a heads-up rather than a destructive confirmation.
   const isSuspending = !isVersioningEnabled && initialVersioningState !== 'disabled'
 
   const tightening = getRetentionTightening({

--- a/apps/studio/components/interfaces/Storage/BucketVersioningFields.tsx
+++ b/apps/studio/components/interfaces/Storage/BucketVersioningFields.tsx
@@ -67,7 +67,7 @@ export const BucketVersioningFields = ({
               hideMessage
               name="enable_versioning"
               label="Object versioning"
-              description="Keeps previous versions of an object when it is overwritten or deleted"
+              description="Retains previous versions of an object when it is overwritten or deleted"
               layout="flex"
             >
               <FormControl>

--- a/apps/studio/components/interfaces/Storage/BucketVersioningFields.tsx
+++ b/apps/studio/components/interfaces/Storage/BucketVersioningFields.tsx
@@ -1,0 +1,150 @@
+import { AnimatePresence } from 'framer-motion'
+import { useFormContext, useWatch } from 'react-hook-form'
+import { DialogSection, DialogSectionSeparator, FormControl, FormField, Switch } from 'ui'
+import { Admonition } from 'ui-patterns/Admonition'
+import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
+
+import { type BucketVersioningFormValues } from './BucketVersioningFields.schema'
+import {
+  getRetentionTightening,
+  RETENTION_TIGHTENING_DESCRIPTION,
+  toNullableNumber,
+} from './BucketVersioningFields.utils'
+import { LifecyclePolicySection } from './LifecyclePolicySection'
+import type { BucketVersioningState, ExpirationMode } from './StorageVersioning.constants'
+import { FormSectionCollapse } from '@/components/ui/FormSectionCollapse'
+
+interface BucketVersioningFieldsProps {
+  /** The bucket's versioning state when the modal opened. Always `disabled` when creating. */
+  initialVersioningState?: BucketVersioningState
+  /** The bucket's retention window when the modal opened, for tightening detection. */
+  initialRetentionDays?: number | null
+  /** The bucket's version cap when the modal opened, for tightening detection. */
+  initialMaxVersions?: number | null
+  /** Public buckets serve every version by default, which is worth calling out. */
+  isPublicBucket?: boolean
+}
+
+/**
+ * Object versioning and lifecycle policy controls for the create/edit bucket
+ * modals. Expects to render inside the parent modal's `<Form>` provider, whose
+ * schema spreads `bucketVersioningFormFields`.
+ */
+export const BucketVersioningFields = ({
+  initialVersioningState = 'disabled',
+  initialRetentionDays,
+  initialMaxVersions,
+  isPublicBucket = false,
+}: BucketVersioningFieldsProps) => {
+  const { control, setValue } = useFormContext<BucketVersioningFormValues>()
+
+  const isVersioningEnabled = useWatch({ control, name: 'enable_versioning' })
+  const retentionDays = useWatch({ control, name: 'version_expiry_days' })
+  const maxVersions = useWatch({ control, name: 'max_noncurrent_versions' })
+  const expirationMode = useWatch({ control, name: 'expiration_mode' })
+
+  // Turning the switch off suspends rather than disables, so this is a heads-up
+  // rather than a destructive confirmation.
+  const isSuspending = !isVersioningEnabled && initialVersioningState !== 'disabled'
+
+  const tightening = getRetentionTightening({
+    initialVersioningState,
+    isVersioningEnabled,
+    initialRetentionDays,
+    initialMaxVersions,
+    nextRetentionDays: toNullableNumber(retentionDays),
+    nextMaxVersions: toNullableNumber(maxVersions),
+  })
+
+  const hasDays = typeof retentionDays === 'number' && retentionDays > 0
+  const hasVersions = typeof maxVersions === 'number' && maxVersions > 0
+
+  const handleModeChange = (mode: ExpirationMode) => {
+    setValue('expiration_mode', mode, { shouldDirty: true })
+  }
+
+  return (
+    <>
+      <DialogSectionSeparator />
+
+      <DialogSection className="space-y-3">
+        <FormField
+          name="enable_versioning"
+          control={control}
+          render={({ field }) => (
+            <FormItemLayout
+              hideMessage
+              name="enable_versioning"
+              label="Object versioning"
+              description="Keeps previous versions of an object when it is overwritten or deleted"
+              layout="flex"
+            >
+              <FormControl>
+                <Switch
+                  id="enable-versioning"
+                  size="large"
+                  checked={field.value}
+                  onCheckedChange={field.onChange}
+                />
+              </FormControl>
+            </FormItemLayout>
+          )}
+        />
+
+        <AnimatePresence initial={false}>
+          {isSuspending && (
+            <FormSectionCollapse key="suspension-notice">
+              <Admonition
+                type="default"
+                title={
+                  initialVersioningState === 'enabled'
+                    ? 'Saving will suspend versioning'
+                    : 'Versioning is suspended on this bucket'
+                }
+                description="Existing versions stay put. Re-enable versioning at any time."
+              />
+            </FormSectionCollapse>
+          )}
+
+          {isVersioningEnabled && isPublicBucket && (
+            <FormSectionCollapse key="public-bucket-warning">
+              <Admonition
+                type="warning"
+                title="A public bucket serves every version"
+                description={
+                  <>
+                    Anyone with a version ID can fetch a noncurrent version of a public object. To
+                    hide noncurrent versions, add an RLS policy on <code>storage.objects</code> that
+                    filters on <code>metadata-&gt;&gt;'isCurrent' = 'true'</code>.
+                  </>
+                }
+              />
+            </FormSectionCollapse>
+          )}
+
+          {isVersioningEnabled && tightening !== 'none' && (
+            <FormSectionCollapse key="tightening-warning">
+              <Admonition
+                type="warning"
+                title="Tightening retention expires some versions"
+                description={RETENTION_TIGHTENING_DESCRIPTION[tightening]}
+              />
+            </FormSectionCollapse>
+          )}
+
+          {isVersioningEnabled && (
+            <FormSectionCollapse key="lifecycle-policy">
+              <LifecyclePolicySection
+                control={control}
+                hasDays={hasDays}
+                hasVersions={hasVersions}
+                mode={expirationMode}
+                onModeChange={handleModeChange}
+              />
+            </FormSectionCollapse>
+          )}
+        </AnimatePresence>
+      </DialogSection>
+    </>
+  )
+}

--- a/apps/studio/components/interfaces/Storage/BucketVersioningFields.utils.test.ts
+++ b/apps/studio/components/interfaces/Storage/BucketVersioningFields.utils.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  getRetentionTightening,
+  RETENTION_TIGHTENING_DESCRIPTION,
+  toNullableNumber,
+} from './BucketVersioningFields.utils'
+
+const params = (overrides: Partial<Parameters<typeof getRetentionTightening>[0]> = {}) => ({
+  initialVersioningState: 'enabled' as const,
+  isVersioningEnabled: true,
+  initialRetentionDays: 30,
+  initialMaxVersions: 10,
+  nextRetentionDays: 30,
+  nextMaxVersions: 10,
+  ...overrides,
+})
+
+describe('getRetentionTightening', () => {
+  it('reports no tightening when nothing changed', () => {
+    expect(getRetentionTightening(params())).toBe('none')
+  })
+
+  it('detects a shorter retention window', () => {
+    expect(getRetentionTightening(params({ nextRetentionDays: 7 }))).toBe('days')
+  })
+
+  it('detects a lower version cap', () => {
+    expect(getRetentionTightening(params({ nextMaxVersions: 3 }))).toBe('versions')
+  })
+
+  it('detects both bounds tightening at once', () => {
+    expect(getRetentionTightening(params({ nextRetentionDays: 7, nextMaxVersions: 3 }))).toBe(
+      'both'
+    )
+  })
+
+  it('does not warn when a bound is raised', () => {
+    expect(getRetentionTightening(params({ nextRetentionDays: 90, nextMaxVersions: 20 }))).toBe(
+      'none'
+    )
+  })
+
+  it('does not warn when a bound is cleared, which retains more rather than less', () => {
+    expect(getRetentionTightening(params({ nextRetentionDays: null, nextMaxVersions: null }))).toBe(
+      'none'
+    )
+  })
+
+  it('does not warn when a bound is newly added where none existed', () => {
+    // Going from "no age condition" to 7 days does tighten the policy, but the
+    // helper only compares against a previous bound; a brand new condition is
+    // covered by the generic lifecycle-policy copy instead.
+    expect(
+      getRetentionTightening(params({ initialRetentionDays: null, nextRetentionDays: 7 }))
+    ).toBe('none')
+  })
+
+  it('does not warn while the initial bounds are still loading', () => {
+    expect(
+      getRetentionTightening(
+        params({ initialRetentionDays: undefined, initialMaxVersions: undefined })
+      )
+    ).toBe('none')
+  })
+
+  it('does not warn when versioning is being turned off', () => {
+    // Suspending stops new versions from being created but never expires the
+    // ones already retained, so there is nothing to lose.
+    expect(
+      getRetentionTightening(params({ isVersioningEnabled: false, nextRetentionDays: 7 }))
+    ).toBe('none')
+  })
+
+  it('does not warn when versioning is being enabled for the first time', () => {
+    expect(
+      getRetentionTightening(
+        params({
+          initialVersioningState: 'disabled',
+          initialRetentionDays: null,
+          initialMaxVersions: null,
+          nextRetentionDays: 7,
+        })
+      )
+    ).toBe('none')
+  })
+
+  it('does not warn when re-enabling a suspended bucket', () => {
+    // A suspended bucket can be retaining versions, but its stored bounds are
+    // cleared while suspended, so there is no previous value to tighten from.
+    expect(
+      getRetentionTightening(params({ initialVersioningState: 'suspended', nextRetentionDays: 7 }))
+    ).toBe('none')
+  })
+
+  it('has a description for every tightening kind it can report', () => {
+    for (const kind of ['days', 'versions', 'both'] as const) {
+      expect(RETENTION_TIGHTENING_DESCRIPTION[kind], kind).toBeTruthy()
+    }
+  })
+})
+
+describe('toNullableNumber', () => {
+  it('maps the empty sentinel to null', () => {
+    expect(toNullableNumber('')).toBeNull()
+  })
+
+  it('preserves zero rather than treating it as empty', () => {
+    expect(toNullableNumber(0)).toBe(0)
+  })
+
+  it('passes numbers through', () => {
+    expect(toNullableNumber(30)).toBe(30)
+  })
+})

--- a/apps/studio/components/interfaces/Storage/BucketVersioningFields.utils.test.ts
+++ b/apps/studio/components/interfaces/Storage/BucketVersioningFields.utils.test.ts
@@ -48,9 +48,6 @@ describe('getRetentionTightening', () => {
   })
 
   it('does not warn when a bound is newly added where none existed', () => {
-    // Going from "no age condition" to 7 days does tighten the policy, but the
-    // helper only compares against a previous bound; a brand new condition is
-    // covered by the generic lifecycle-policy copy instead.
     expect(
       getRetentionTightening(params({ initialRetentionDays: null, nextRetentionDays: 7 }))
     ).toBe('none')

--- a/apps/studio/components/interfaces/Storage/BucketVersioningFields.utils.ts
+++ b/apps/studio/components/interfaces/Storage/BucketVersioningFields.utils.ts
@@ -8,9 +8,7 @@ interface GetRetentionTighteningParams {
   isVersioningEnabled: boolean
   initialRetentionDays: number | null | undefined
   initialMaxVersions: number | null | undefined
-  /** `null` for the empty sentinel. */
   nextRetentionDays: number | null
-  /** `null` for the empty sentinel. */
   nextMaxVersions: number | null
 }
 
@@ -59,6 +57,6 @@ export const RETENTION_TIGHTENING_DESCRIPTION: Record<
   versions: 'Saving permanently deletes noncurrent versions beyond the lower per-object cap.',
 }
 
-/** Converts the form's `'' | number` sentinel into a plain nullable number. */
+/** Converts the form's `'' | number` into a plain nullable number. */
 export const toNullableNumber = (value: '' | number): number | null =>
   typeof value === 'number' ? value : null

--- a/apps/studio/components/interfaces/Storage/BucketVersioningFields.utils.ts
+++ b/apps/studio/components/interfaces/Storage/BucketVersioningFields.utils.ts
@@ -1,0 +1,64 @@
+import type { BucketVersioningState } from './StorageVersioning.constants'
+
+/** Which lifecycle conditions the user has just made stricter. */
+export type RetentionTightening = 'none' | 'days' | 'versions' | 'both'
+
+interface GetRetentionTighteningParams {
+  initialVersioningState: BucketVersioningState
+  isVersioningEnabled: boolean
+  initialRetentionDays: number | null | undefined
+  initialMaxVersions: number | null | undefined
+  /** `null` for the empty sentinel. */
+  nextRetentionDays: number | null
+  /** `null` for the empty sentinel. */
+  nextMaxVersions: number | null
+}
+
+/**
+ * Only a bucket that was already actively versioning can lose data to a
+ * tightened policy: enabling for the first time has nothing retained to expire,
+ * and suspending stops new versions without touching old ones.
+ *
+ * Raising or clearing a bound is never a tightening — clearing removes the
+ * condition, which can only retain more.
+ */
+export const getRetentionTightening = ({
+  initialVersioningState,
+  isVersioningEnabled,
+  initialRetentionDays,
+  initialMaxVersions,
+  nextRetentionDays,
+  nextMaxVersions,
+}: GetRetentionTighteningParams): RetentionTightening => {
+  if (initialVersioningState !== 'enabled' || !isVersioningEnabled) return 'none'
+
+  const isTighteningDays =
+    initialRetentionDays !== null &&
+    initialRetentionDays !== undefined &&
+    nextRetentionDays !== null &&
+    nextRetentionDays < initialRetentionDays
+
+  const isTighteningVersions =
+    initialMaxVersions !== null &&
+    initialMaxVersions !== undefined &&
+    nextMaxVersions !== null &&
+    nextMaxVersions < initialMaxVersions
+
+  if (isTighteningDays && isTighteningVersions) return 'both'
+  if (isTighteningDays) return 'days'
+  if (isTighteningVersions) return 'versions'
+  return 'none'
+}
+
+export const RETENTION_TIGHTENING_DESCRIPTION: Record<
+  Exclude<RetentionTightening, 'none'>,
+  string
+> = {
+  both: 'Saving permanently deletes noncurrent versions past the shorter retention window, and any beyond the lower per-object cap.',
+  days: 'Saving permanently deletes noncurrent versions past the shorter retention window.',
+  versions: 'Saving permanently deletes noncurrent versions beyond the lower per-object cap.',
+}
+
+/** Converts the form's `'' | number` sentinel into a plain nullable number. */
+export const toNullableNumber = (value: '' | number): number | null =>
+  typeof value === 'number' ? value : null

--- a/apps/studio/components/interfaces/Storage/ExpirationModeToggle.tsx
+++ b/apps/studio/components/interfaces/Storage/ExpirationModeToggle.tsx
@@ -1,0 +1,40 @@
+import { RadioGroupStacked, RadioGroupStackedItem } from 'ui'
+
+import type { ExpirationMode } from './StorageVersioning.constants'
+
+interface ExpirationModeToggleProps {
+  mode: ExpirationMode
+  onModeChange: (mode: ExpirationMode) => void
+}
+
+/**
+ * How the two lifecycle conditions combine. Laid out vertically so the two-line
+ * option descriptions get the full section width.
+ */
+export const ExpirationModeToggle = ({ mode, onModeChange }: ExpirationModeToggleProps) => (
+  <div className="mt-2 flex w-full flex-col gap-y-2">
+    <label htmlFor="expiration_mode" className="text-sm text-foreground">
+      Expire a noncurrent version when
+    </label>
+    <RadioGroupStacked
+      id="expiration_mode"
+      className="w-full"
+      value={mode}
+      onValueChange={(value: ExpirationMode) => {
+        // Radix emits '' when the active item is re-selected; never allow no mode.
+        if (value) onModeChange(value)
+      }}
+    >
+      <RadioGroupStackedItem
+        value="and"
+        label="Both conditions are met"
+        description="It exceeds both the age limit and the retained-versions cap."
+      />
+      <RadioGroupStackedItem
+        value="or"
+        label="Either condition is met"
+        description="It exceeds either the age limit or the retained-versions cap."
+      />
+    </RadioGroupStacked>
+  </div>
+)

--- a/apps/studio/components/interfaces/Storage/ExpirationModeToggle.tsx
+++ b/apps/studio/components/interfaces/Storage/ExpirationModeToggle.tsx
@@ -7,10 +7,6 @@ interface ExpirationModeToggleProps {
   onModeChange: (mode: ExpirationMode) => void
 }
 
-/**
- * How the two lifecycle conditions combine. Laid out vertically so the two-line
- * option descriptions get the full section width.
- */
 export const ExpirationModeToggle = ({ mode, onModeChange }: ExpirationModeToggleProps) => (
   <div className="mt-2 flex w-full flex-col gap-y-2">
     <label htmlFor="expiration_mode" className="text-sm text-foreground">
@@ -21,7 +17,6 @@ export const ExpirationModeToggle = ({ mode, onModeChange }: ExpirationModeToggl
       className="w-full"
       value={mode}
       onValueChange={(value: ExpirationMode) => {
-        // Radix emits '' when the active item is re-selected; never allow no mode.
         if (value) onModeChange(value)
       }}
     >

--- a/apps/studio/components/interfaces/Storage/LifecyclePolicySection.tsx
+++ b/apps/studio/components/interfaces/Storage/LifecyclePolicySection.tsx
@@ -17,7 +17,6 @@ import { ExpirationModeToggle } from './ExpirationModeToggle'
 import type { ExpirationMode } from './StorageVersioning.constants'
 import { FormSectionCollapse } from '@/components/ui/FormSectionCollapse'
 
-/** Digits only, so a partially typed value never lands in form state as `NaN`. */
 const toFieldValue = (rawInput: string): '' | number => {
   const digits = rawInput.replace(/[^0-9]/g, '')
   return digits === '' ? '' : Number(digits)
@@ -25,9 +24,7 @@ const toFieldValue = (rawInput: string): '' | number => {
 
 interface LifecyclePolicySectionProps {
   control: Control<BucketVersioningFormValues>
-  /** The age condition is part of the policy. */
   hasDays: boolean
-  /** The count condition is part of the policy. */
   hasVersions: boolean
   mode: ExpirationMode
   onModeChange: (mode: ExpirationMode) => void
@@ -103,8 +100,6 @@ export const LifecyclePolicySection = ({
             label="Retained noncurrent versions"
             description={hasDays ? undefined : 'Requires an expiration age to be set.'}
             layout="flex-row-reverse"
-            // Dim label and description too, so the dependency reads at a glance
-            // rather than a disabled input sitting under a full-strength label.
             className={hasDays ? undefined : 'opacity-60'}
           >
             <FormControl>

--- a/apps/studio/components/interfaces/Storage/LifecyclePolicySection.tsx
+++ b/apps/studio/components/interfaces/Storage/LifecyclePolicySection.tsx
@@ -1,0 +1,153 @@
+import { AnimatePresence } from 'framer-motion'
+import { useEffect, useRef } from 'react'
+import { useFormContext, type Control } from 'react-hook-form'
+import {
+  FormControl,
+  FormField,
+  FormInputGroupInput,
+  InputGroup,
+  InputGroupAddon,
+  InputGroupText,
+} from 'ui'
+import { Admonition } from 'ui-patterns/Admonition'
+import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
+
+import type { BucketVersioningFormValues } from './BucketVersioningFields.schema'
+import { ExpirationModeToggle } from './ExpirationModeToggle'
+import type { ExpirationMode } from './StorageVersioning.constants'
+import { FormSectionCollapse } from '@/components/ui/FormSectionCollapse'
+
+/** Digits only, so a partially typed value never lands in form state as `NaN`. */
+const toFieldValue = (rawInput: string): '' | number => {
+  const digits = rawInput.replace(/[^0-9]/g, '')
+  return digits === '' ? '' : Number(digits)
+}
+
+interface LifecyclePolicySectionProps {
+  control: Control<BucketVersioningFormValues>
+  /** The age condition is part of the policy. */
+  hasDays: boolean
+  /** The count condition is part of the policy. */
+  hasVersions: boolean
+  mode: ExpirationMode
+  onModeChange: (mode: ExpirationMode) => void
+}
+
+export const LifecyclePolicySection = ({
+  control,
+  hasDays,
+  hasVersions,
+  mode,
+  onModeChange,
+}: LifecyclePolicySectionProps) => {
+  const { setValue } = useFormContext<BucketVersioningFormValues>()
+  const hasNoPolicy = !hasDays && !hasVersions
+  const hasBothConditions = hasDays && hasVersions
+
+  // S3 requires the noncurrent-days condition on any noncurrent-count rule, so
+  // clear an orphaned cap the moment the age field flips from set to unset. Only
+  // on the actual flip, not on mount — a bucket opened with a stale
+  // `{ days: null, versions: N }` shouldn't silently lose N, and the input stays
+  // disabled meanwhile so the value is visible.
+  const prevHasDaysRef = useRef(hasDays)
+  useEffect(() => {
+    const wasSet = prevHasDaysRef.current
+    prevHasDaysRef.current = hasDays
+    if (wasSet && !hasDays) setValue('max_noncurrent_versions', '', { shouldDirty: true })
+  }, [hasDays, setValue])
+
+  return (
+    <div className="flex flex-col gap-y-2">
+      <div className="flex flex-col gap-y-0.5">
+        <p className="text-sm font-medium text-foreground">Lifecycle policy</p>
+        <p className="text-sm text-foreground-lighter">Automatically expire noncurrent versions</p>
+      </div>
+
+      <FormField
+        name="version_expiry_days"
+        control={control}
+        render={({ field }) => (
+          <FormItemLayout
+            name="version_expiry_days"
+            label="Noncurrent version expiration"
+            layout="flex-row-reverse"
+          >
+            <FormControl>
+              <InputGroup>
+                <FormInputGroupInput
+                  id={field.name}
+                  name={field.name}
+                  ref={field.ref}
+                  onBlur={field.onBlur}
+                  type="number"
+                  inputMode="numeric"
+                  placeholder="—"
+                  value={field.value}
+                  onChange={(e) => field.onChange(toFieldValue(e.target.value))}
+                />
+                <InputGroupAddon align="inline-end">
+                  <InputGroupText>days</InputGroupText>
+                </InputGroupAddon>
+              </InputGroup>
+            </FormControl>
+          </FormItemLayout>
+        )}
+      />
+
+      <FormField
+        name="max_noncurrent_versions"
+        control={control}
+        render={({ field }) => (
+          <FormItemLayout
+            name="max_noncurrent_versions"
+            label="Retained noncurrent versions"
+            description={hasDays ? undefined : 'Requires an expiration age to be set.'}
+            layout="flex-row-reverse"
+            // Dim label and description too, so the dependency reads at a glance
+            // rather than a disabled input sitting under a full-strength label.
+            className={hasDays ? undefined : 'opacity-60'}
+          >
+            <FormControl>
+              <InputGroup>
+                <FormInputGroupInput
+                  id={field.name}
+                  name={field.name}
+                  ref={field.ref}
+                  onBlur={field.onBlur}
+                  type="number"
+                  inputMode="numeric"
+                  placeholder="—"
+                  disabled={!hasDays}
+                  value={field.value}
+                  onChange={(e) => field.onChange(toFieldValue(e.target.value))}
+                />
+                <InputGroupAddon align="inline-end">
+                  <InputGroupText>versions</InputGroupText>
+                </InputGroupAddon>
+              </InputGroup>
+            </FormControl>
+          </FormItemLayout>
+        )}
+      />
+
+      <AnimatePresence initial={false}>
+        {hasBothConditions && (
+          <FormSectionCollapse key="mode">
+            <ExpirationModeToggle mode={mode} onModeChange={onModeChange} />
+          </FormSectionCollapse>
+        )}
+
+        {hasNoPolicy && (
+          <FormSectionCollapse key="no-policy">
+            <Admonition
+              type="warning"
+              className="mt-2"
+              title="No lifecycle policy"
+              description="Lifecycle policies are recommended to manage and reduce storage costs for noncurrent versions."
+            />
+          </FormSectionCollapse>
+        )}
+      </AnimatePresence>
+    </div>
+  )
+}

--- a/apps/studio/components/interfaces/Storage/StorageVersioning.constants.ts
+++ b/apps/studio/components/interfaces/Storage/StorageVersioning.constants.ts
@@ -1,0 +1,37 @@
+import type { Bucket } from '@/data/storage/buckets-query'
+
+/**
+ * Mirrors the three S3 bucket versioning states. A bucket can never return to
+ * `disabled` once enabled — turning versioning off suspends it, which stops new
+ * noncurrent versions without touching the ones already retained.
+ */
+export type BucketVersioningState = 'enabled' | 'suspended' | 'disabled'
+
+/**
+ * How the two lifecycle conditions combine: `and` expires a version only once
+ * both are true, `or` as soon as either is.
+ */
+export type ExpirationMode = 'and' | 'or'
+
+/** Prefilled when a user first enables versioning on a bucket. */
+export const PROJECT_VERSIONING_DEFAULTS = {
+  versionExpiryDays: 30,
+  maxNoncurrentVersions: 10,
+} as const
+
+/**
+ * TODO(storage-versioning): return `bucket.versioning` once the Storage API
+ * exposes it. Every bucket reports `disabled` until then.
+ */
+export const getBucketVersioningState = (_bucket?: Bucket): BucketVersioningState => 'disabled'
+
+/** True only while a bucket is actively creating noncurrent versions. */
+export const isBucketVersioned = (bucket?: Bucket) => getBucketVersioningState(bucket) === 'enabled'
+
+/**
+ * True once a bucket has ever been versioned, covering `suspended` too — a
+ * suspended bucket can still be retaining versions. Surfaces that warn about
+ * already-retained data should use this rather than {@link isBucketVersioned}.
+ */
+export const hasVersioningHistory = (bucket?: Bucket) =>
+  getBucketVersioningState(bucket) !== 'disabled'

--- a/apps/studio/components/interfaces/Storage/StorageVersioning.constants.ts
+++ b/apps/studio/components/interfaces/Storage/StorageVersioning.constants.ts
@@ -1,37 +1,22 @@
 import type { Bucket } from '@/data/storage/buckets-query'
 
-/**
- * Mirrors the three S3 bucket versioning states. A bucket can never return to
- * `disabled` once enabled — turning versioning off suspends it, which stops new
- * noncurrent versions without touching the ones already retained.
- */
 export type BucketVersioningState = 'enabled' | 'suspended' | 'disabled'
-
-/**
- * How the two lifecycle conditions combine: `and` expires a version only once
- * both are true, `or` as soon as either is.
- */
 export type ExpirationMode = 'and' | 'or'
 
-/** Prefilled when a user first enables versioning on a bucket. */
 export const PROJECT_VERSIONING_DEFAULTS = {
   versionExpiryDays: 30,
   maxNoncurrentVersions: 10,
 } as const
 
 /**
- * TODO(storage-versioning): return `bucket.versioning` once the Storage API
- * exposes it. Every bucket reports `disabled` until then.
+ * TODO(storage-versioning): return `bucket.versioning` once the API exposes it.
+ * Every bucket reports `disabled` until then.
  */
 export const getBucketVersioningState = (_bucket?: Bucket): BucketVersioningState => 'disabled'
 
-/** True only while a bucket is actively creating noncurrent versions. */
+// True only while a bucket is actively creating noncurrent versions.
 export const isBucketVersioned = (bucket?: Bucket) => getBucketVersioningState(bucket) === 'enabled'
 
-/**
- * True once a bucket has ever been versioned, covering `suspended` too — a
- * suspended bucket can still be retaining versions. Surfaces that warn about
- * already-retained data should use this rather than {@link isBucketVersioned}.
- */
+// True if a bucket has ever been versioned — a suspended bucket can still be retaining versions.
 export const hasVersioningHistory = (bucket?: Bucket) =>
   getBucketVersioningState(bucket) !== 'disabled'

--- a/apps/studio/components/ui/FormSectionCollapse.tsx
+++ b/apps/studio/components/ui/FormSectionCollapse.tsx
@@ -1,0 +1,32 @@
+import { motion } from 'framer-motion'
+import type { ReactNode } from 'react'
+
+/**
+ * Enter/exit for a form section that appears in response to a toggle further up
+ * the form. Animates height and opacity so pushed siblings slide rather than
+ * snap. Wrap the parent in `<AnimatePresence initial={false}>` so a section
+ * already open on mount doesn't animate in on first paint, and give each child
+ * a stable `key`.
+ *
+ * `overflow` is hidden only while the height is animating — otherwise focus
+ * rings on nested inputs get clipped by the wrapper.
+ */
+export const FormSectionCollapse = ({ children }: { children: ReactNode }) => (
+  <motion.div
+    initial="collapsed"
+    animate="open"
+    exit="collapsed"
+    variants={{
+      collapsed: { opacity: 0, height: 0, overflow: 'hidden' },
+      open: {
+        opacity: 1,
+        height: 'auto',
+        overflow: 'hidden',
+        transitionEnd: { overflow: 'visible' },
+      },
+    }}
+    transition={{ duration: 0.18, ease: [0.4, 0, 0.2, 1] }}
+  >
+    {children}
+  </motion.div>
+)

--- a/apps/studio/components/ui/FormSectionCollapse.tsx
+++ b/apps/studio/components/ui/FormSectionCollapse.tsx
@@ -2,14 +2,8 @@ import { motion } from 'framer-motion'
 import type { ReactNode } from 'react'
 
 /**
- * Enter/exit for a form section that appears in response to a toggle further up
- * the form. Animates height and opacity so pushed siblings slide rather than
- * snap. Wrap the parent in `<AnimatePresence initial={false}>` so a section
- * already open on mount doesn't animate in on first paint, and give each child
- * a stable `key`.
- *
- * `overflow` is hidden only while the height is animating — otherwise focus
- * rings on nested inputs get clipped by the wrapper.
+ * Provides enter/exit animation for a form section that appears in response to a toggle in the form.
+ * Wrap the parent in `<AnimatePresence initial={false}>` to avoid animation on first paint.
  */
 export const FormSectionCollapse = ({ children }: { children: ReactNode }) => (
   <motion.div


### PR DESCRIPTION
| # | Branch | Base |
| - | ------ | ---- |
| 1 | `feat/storage-versioning-private-alpha` | `master` |
| 2 | `feat/storage-versioning/002-bucket-form-fields` ◀ | 1 |
| 3 | `feat/storage-versioning/003-bucket-modals` | 2 |
| 4 | `feat/storage-versioning/004-object-versions-data` | 3 |
| 5 | `feat/storage-versioning/005-file-preview-versions` | 4 |
| 6 | `feat/storage-versioning/006-billing-storage-retention` | 5 |

## [2/6] Storage object versioning: bucket form fields

**Base:** `feat/storage-versioning-private-alpha` (PR 1)

### This PR

The object versioning + lifecycle policy form section for the create and edit bucket modals. **Not mounted anywhere yet** — PR 3 wires it up — so this can be reviewed as a self-contained unit.

- `BucketVersioningFields` — the versioning switch and the suspension / public-bucket / retention-tightening warnings
- `LifecyclePolicySection` — the retention window and version cap inputs
- `ExpirationModeToggle` — how the two conditions combine (and / or)
- `BucketVersioningFields.schema.ts` — zod fields the parent modals spread into their own schema, plus `superRefineBucketVersioning`
- `BucketVersioningFields.utils.ts` — retention-tightening detection
- `StorageVersioning.constants.ts` — versioning state and expiration mode types, the prefill defaults, and `getBucketVersioningState`