### PR TITLE
fix(studio): point the branch diff Schema Changes link at database/schemas

### DIFF
--- a/apps/studio/components/interfaces/BranchManagement/DatabaseDiffPanel.tsx
+++ b/apps/studio/components/interfaces/BranchManagement/DatabaseDiffPanel.tsx
@@ -68,7 +68,7 @@ export const DatabaseDiffPanel = ({
       <CardHeader className="flex shrink-0 flex-row items-center justify-between space-y-0 py-3">
         <CardTitle>
           <Link
-            href={`/project/${currentBranchRef}/database/schema`}
+            href={`/project/${currentBranchRef}/database/schemas`}
             className="flex items-center gap-2"
           >
             <Database strokeWidth={1.5} size={16} className="text-foreground-muted" />


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix. The "Schema Changes" link in the branch diff panel goes to a route that does not exist.

## What is the current behavior?

`DatabaseDiffPanel.tsx` links its card title at the singular `schema`:

```tsx
<Link href={`/project/${currentBranchRef}/database/schema`}>
```

There is no such route. The page is `database/schemas`, plural, and it exists in both trees:

- `apps/studio/pages/project/[ref]/database/schemas.tsx`
- `apps/studio/routes/project/$ref/database/schemas.tsx`

There is no `database/schema.tsx` in either, and `redirects.shared.ts` has no entry for the singular form, so clicking "Schema Changes" in the branch diff panel lands on a 404 rather than the schema view.

## What is the new behavior?

The link points at `database/schemas`.

## Additional context

I checked that this is the only place with the singular form. Every other in-app reference to that page already uses `schemas`.

How I found it: I extracted every in-app `/project/<ref>/...` route string referenced anywhere in `apps/studio` (121 distinct) and checked each against the `pages/` and `routes/` trees, allowing for dynamic segments, then against `redirects.shared.ts`. This was the only unambiguous miss.

Worth recording that most of what that sweep flagged was not a bug, since the same false positives will come up if anyone repeats it. `reports/*` looked broken but is covered by a `'/project/:ref/reports/:path*'` wildcard redirect. `database/backups` looked broken but the two bare occurrences are `router.pathname.includes(...)` prefix checks in `ProjectLayout`, not hrefs. Six others resolve through exact redirects.

No test added. There is no existing test file for this component, and asserting a literal href would pin the implementation rather than the behavior, so it seemed like the wrong place to start one. Happy to add coverage if you would rather have it.

Gates: `test:prettier` passes repo wide, `typecheck --filter=studio --force` passes 9/9, and `--filter studio run lint:ratchet` passes.

Freshman contributor, found this with Claude Code's help and verified the route trees and the redirect table myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the schema navigation link to direct users to the correct database schemas page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->