### PR TITLE
feat(storage): add object versions data layer

### DIFF
--- a/apps/studio/components/interfaces/Storage/BroomSparklesIcon.tsx
+++ b/apps/studio/components/interfaces/Storage/BroomSparklesIcon.tsx
@@ -1,0 +1,44 @@
+import { forwardRef, type SVGAttributes } from 'react'
+import { cn } from 'ui'
+
+interface BroomSparklesIconProps extends Omit<SVGAttributes<SVGSVGElement>, 'children'> {
+  size?: number | string
+}
+
+/**
+ * Inline copy of Lucide's `broom-sparkles` icon. The version of `lucide-react`
+ * pinned in Studio (`^0.436.0`) predates this icon, so we ship the SVG paths
+ * directly rather than pull in a mixed-version import. Sized and colored the
+ * same as a `lucide-react` icon (`size` prop, `currentColor` stroke) so it
+ * drops in wherever an icon component would.
+ */
+export const BroomSparklesIcon = forwardRef<SVGSVGElement, BroomSparklesIconProps>(
+  ({ size = 16, className, ...props }, ref) => (
+    <svg
+      ref={ref}
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={cn('lucide lucide-broom-sparkles', className)}
+      {...props}
+    >
+      <path d="M11 2v2" />
+      <path d="M12 3h-2" />
+      <path d="M13.5 10.5 22 2" />
+      <path d="M14.734 13.841a2 2 0 00-.314-2.42L12.58 9.58a2 2 0 00-2.421-.314l-7.657 4.461A1 1 0 002.3 15.3l6.403 6.403a1 1 0 001.571-.204z" />
+      <path d="M20 15v4" />
+      <path d="M22 17h-4" />
+      <path d="M4 4v4" />
+      <path d="m5 18 2-2" />
+      <path d="M6 6H2" />
+      <path d="m7.699 10.7 5.602 5.601" />
+    </svg>
+  )
+)
+BroomSparklesIcon.displayName = 'BroomSparklesIcon'

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/VersionHistory.utils.test.ts
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/VersionHistory.utils.test.ts
@@ -51,10 +51,8 @@ describe('computeVersionFate', () => {
   })
 
   it('ignores a cap that has no expiration age alongside it', () => {
-    // Not a reachable policy: S3 requires NoncurrentDays on any
-    // NoncurrentVersionExpiration rule, so the bucket form disables the cap until
-    // an age is set. Pinned here so a cap arriving alone can never be read as an
-    // active rule and start labelling versions for removal.
+    // Not a reachable policy: S3 requires NoncurrentDays
+    // on any NoncurrentVersionExpiration rule
     const base = { expiryDays: null, cap: 3, mode: 'and' as const }
 
     expect(computeVersionFate({ ...base, daysOld: 3, chronoIndex: 2, noncurrentCount: 3 })).toEqual(
@@ -62,7 +60,7 @@ describe('computeVersionFate', () => {
         type: 'retained',
       }
     )
-    // Would have been the cap boundary — still nothing to promise.
+
     expect(
       computeVersionFate({ ...base, daysOld: 216, chronoIndex: 0, noncurrentCount: 3 })
     ).toEqual({ type: 'retained' })

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/VersionHistory.utils.test.ts
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/VersionHistory.utils.test.ts
@@ -2,10 +2,6 @@ import { describe, expect, it } from 'vitest'
 
 import { computeVersionFate } from './VersionHistory.utils'
 
-// Each case below mirrors a worked example from the design handoff's
-// operator-notation reference matrix (one noncurrent version list per policy
-// shape), oldest version at chronoIndex 0.
-
 describe('computeVersionFate', () => {
   it('returns kept when no policy is configured', () => {
     expect(

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/VersionHistory.utils.test.ts
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/VersionHistory.utils.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest'
+
+import { computeVersionFate } from './VersionHistory.utils'
+
+// Each case below mirrors a worked example from the design handoff's
+// operator-notation reference matrix (one noncurrent version list per policy
+// shape), oldest version at chronoIndex 0.
+
+describe('computeVersionFate', () => {
+  it('returns kept when no policy is configured', () => {
+    expect(
+      computeVersionFate({
+        daysOld: 90,
+        chronoIndex: 0,
+        noncurrentCount: 1,
+        expiryDays: null,
+        cap: null,
+        mode: 'and',
+      })
+    ).toEqual({ type: 'kept' })
+  })
+
+  it('treats a zero bound as "condition not set" rather than "expire immediately"', () => {
+    // A 0 can only arrive from a partially-typed or cleared form field; reading
+    // it as an active bound would label every version as expiring.
+    expect(
+      computeVersionFate({
+        daysOld: 90,
+        chronoIndex: 0,
+        noncurrentCount: 3,
+        expiryDays: 0,
+        cap: 0,
+        mode: 'or',
+      })
+    ).toEqual({ type: 'kept' })
+  })
+
+  describe('age only', () => {
+    const base = {
+      chronoIndex: 0,
+      noncurrentCount: 3,
+      expiryDays: 30,
+      cap: null,
+      mode: 'and' as const,
+    }
+
+    it('gives every version a determined countdown', () => {
+      expect(computeVersionFate({ ...base, daysOld: 3 })).toEqual({ type: 'expires-in', days: 27 })
+      expect(computeVersionFate({ ...base, daysOld: 28 })).toEqual({ type: 'expires-in', days: 2 })
+    })
+
+    it('flips to expiring-now once the window has passed', () => {
+      expect(computeVersionFate({ ...base, daysOld: 31 })).toEqual({ type: 'expiring-now' })
+    })
+  })
+
+  describe('cap only', () => {
+    const base = { expiryDays: null, cap: 3, mode: 'and' as const }
+
+    it('keeps everything except the one at the cap boundary', () => {
+      expect(
+        computeVersionFate({ ...base, daysOld: 3, chronoIndex: 2, noncurrentCount: 3 })
+      ).toEqual({ type: 'kept' })
+      expect(
+        computeVersionFate({ ...base, daysOld: 163, chronoIndex: 1, noncurrentCount: 3 })
+      ).toEqual({ type: 'kept' })
+      expect(
+        computeVersionFate({ ...base, daysOld: 216, chronoIndex: 0, noncurrentCount: 3 })
+      ).toEqual({ type: 'expires-on-next-upload' })
+    })
+  })
+
+  describe('both — AND', () => {
+    const base = { expiryDays: 30, cap: 3, mode: 'and' as const }
+
+    it('keeps every version under the cap regardless of age', () => {
+      expect(
+        computeVersionFate({ ...base, daysOld: 45, chronoIndex: 1, noncurrentCount: 2 })
+      ).toEqual({ type: 'kept' })
+      expect(
+        computeVersionFate({ ...base, daysOld: 70, chronoIndex: 0, noncurrentCount: 2 })
+      ).toEqual({ type: 'kept' })
+    })
+
+    it('gives a countdown only once the cap is exceeded, since age is then the sole gate', () => {
+      expect(
+        computeVersionFate({ ...base, daysOld: 12, chronoIndex: 0, noncurrentCount: 4 })
+      ).toEqual({ type: 'expires-in', days: 18 })
+    })
+
+    it('is expiring-now once both conditions are met', () => {
+      expect(
+        computeVersionFate({ ...base, daysOld: 34, chronoIndex: 0, noncurrentCount: 4 })
+      ).toEqual({ type: 'expiring-now' })
+      // Still within the cap: kept even though very old — AND needs both.
+      expect(
+        computeVersionFate({ ...base, daysOld: 28, chronoIndex: 1, noncurrentCount: 4 })
+      ).toEqual({ type: 'kept' })
+    })
+  })
+
+  describe('either — OR', () => {
+    const base = { expiryDays: 30, cap: 3, mode: 'or' as const }
+
+    it('lets age alone trigger removal, even well under the cap', () => {
+      expect(
+        computeVersionFate({ ...base, daysOld: 12, chronoIndex: 1, noncurrentCount: 2 })
+      ).toEqual({ type: 'expires-in', days: 18 })
+      expect(
+        computeVersionFate({ ...base, daysOld: 34, chronoIndex: 0, noncurrentCount: 2 })
+      ).toEqual({ type: 'expiring-now' })
+    })
+
+    it('lets the cap alone trigger removal, even for a young version', () => {
+      expect(
+        computeVersionFate({ ...base, daysOld: 1, chronoIndex: 3, noncurrentCount: 4 })
+      ).toEqual({ type: 'expires-in', days: 29 })
+      expect(
+        computeVersionFate({ ...base, daysOld: 3, chronoIndex: 2, noncurrentCount: 4 })
+      ).toEqual({ type: 'expires-in', days: 27 })
+      expect(
+        computeVersionFate({ ...base, daysOld: 6, chronoIndex: 1, noncurrentCount: 4 })
+      ).toEqual({ type: 'expires-on-next-upload', daysRemaining: 24 })
+      expect(
+        computeVersionFate({ ...base, daysOld: 9, chronoIndex: 0, noncurrentCount: 4 })
+      ).toEqual({ type: 'expiring-now' })
+    })
+  })
+})

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/VersionHistory.utils.test.ts
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/VersionHistory.utils.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { computeVersionFate } from './VersionHistory.utils'
 
 describe('computeVersionFate', () => {
-  it('returns kept when no policy is configured', () => {
+  it('returns retained when no policy is configured', () => {
     expect(
       computeVersionFate({
         daysOld: 90,
@@ -13,7 +13,7 @@ describe('computeVersionFate', () => {
         cap: null,
         mode: 'and',
       })
-    ).toEqual({ type: 'kept' })
+    ).toEqual({ type: 'retained' })
   })
 
   it('treats a zero bound as "condition not set" rather than "expire immediately"', () => {
@@ -28,7 +28,7 @@ describe('computeVersionFate', () => {
         cap: 0,
         mode: 'or',
       })
-    ).toEqual({ type: 'kept' })
+    ).toEqual({ type: 'retained' })
   })
 
   describe('age only', () => {
@@ -53,13 +53,13 @@ describe('computeVersionFate', () => {
   describe('cap only', () => {
     const base = { expiryDays: null, cap: 3, mode: 'and' as const }
 
-    it('keeps everything except the one at the cap boundary', () => {
+    it('retains everything except the one at the cap boundary', () => {
       expect(
         computeVersionFate({ ...base, daysOld: 3, chronoIndex: 2, noncurrentCount: 3 })
-      ).toEqual({ type: 'kept' })
+      ).toEqual({ type: 'retained' })
       expect(
         computeVersionFate({ ...base, daysOld: 163, chronoIndex: 1, noncurrentCount: 3 })
-      ).toEqual({ type: 'kept' })
+      ).toEqual({ type: 'retained' })
       expect(
         computeVersionFate({ ...base, daysOld: 216, chronoIndex: 0, noncurrentCount: 3 })
       ).toEqual({ type: 'expires-on-next-upload' })
@@ -69,13 +69,13 @@ describe('computeVersionFate', () => {
   describe('both — AND', () => {
     const base = { expiryDays: 30, cap: 3, mode: 'and' as const }
 
-    it('keeps every version under the cap regardless of age', () => {
+    it('retains every version under the cap regardless of age', () => {
       expect(
         computeVersionFate({ ...base, daysOld: 45, chronoIndex: 1, noncurrentCount: 2 })
-      ).toEqual({ type: 'kept' })
+      ).toEqual({ type: 'retained' })
       expect(
         computeVersionFate({ ...base, daysOld: 70, chronoIndex: 0, noncurrentCount: 2 })
-      ).toEqual({ type: 'kept' })
+      ).toEqual({ type: 'retained' })
     })
 
     it('gives a countdown only once the cap is exceeded, since age is then the sole gate', () => {
@@ -88,10 +88,10 @@ describe('computeVersionFate', () => {
       expect(
         computeVersionFate({ ...base, daysOld: 34, chronoIndex: 0, noncurrentCount: 4 })
       ).toEqual({ type: 'expiring-now' })
-      // Still within the cap: kept even though very old — AND needs both.
+      // Still within the cap: retained even though very old — AND needs both.
       expect(
         computeVersionFate({ ...base, daysOld: 28, chronoIndex: 1, noncurrentCount: 4 })
-      ).toEqual({ type: 'kept' })
+      ).toEqual({ type: 'retained' })
     })
   })
 

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/VersionHistory.utils.test.ts
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/VersionHistory.utils.test.ts
@@ -50,20 +50,22 @@ describe('computeVersionFate', () => {
     })
   })
 
-  describe('cap only', () => {
+  it('ignores a cap that has no expiration age alongside it', () => {
+    // Not a reachable policy: S3 requires NoncurrentDays on any
+    // NoncurrentVersionExpiration rule, so the bucket form disables the cap until
+    // an age is set. Pinned here so a cap arriving alone can never be read as an
+    // active rule and start labelling versions for removal.
     const base = { expiryDays: null, cap: 3, mode: 'and' as const }
 
-    it('retains everything except the one at the cap boundary', () => {
-      expect(
-        computeVersionFate({ ...base, daysOld: 3, chronoIndex: 2, noncurrentCount: 3 })
-      ).toEqual({ type: 'retained' })
-      expect(
-        computeVersionFate({ ...base, daysOld: 163, chronoIndex: 1, noncurrentCount: 3 })
-      ).toEqual({ type: 'retained' })
-      expect(
-        computeVersionFate({ ...base, daysOld: 216, chronoIndex: 0, noncurrentCount: 3 })
-      ).toEqual({ type: 'expires-on-next-upload' })
-    })
+    expect(computeVersionFate({ ...base, daysOld: 3, chronoIndex: 2, noncurrentCount: 3 })).toEqual(
+      {
+        type: 'retained',
+      }
+    )
+    // Would have been the cap boundary — still nothing to promise.
+    expect(
+      computeVersionFate({ ...base, daysOld: 216, chronoIndex: 0, noncurrentCount: 3 })
+    ).toEqual({ type: 'retained' })
   })
 
   describe('both — AND', () => {

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/VersionHistory.utils.ts
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/VersionHistory.utils.ts
@@ -3,20 +3,12 @@ import type { ExpirationMode } from '../StorageVersioning.constants'
 export type VersionFate =
   | { type: 'retained' }
   | { type: 'expires-in'; days: number }
-  /**
-   * The cap forces this one out before its age would, so the exact date depends
-   * on when the next upload happens. `daysRemaining` is the date it would have
-   * hit anyway had the cap not got there first.
-   */
   | { type: 'expires-on-next-upload'; daysRemaining: number }
   | { type: 'expiring-now' }
 
 export interface ComputeVersionFateOptions {
-  /** Days since this version became noncurrent. */
   daysOld: number
-  /** 0-based position among noncurrent versions, oldest first. */
   chronoIndex: number
-  /** Total number of noncurrent versions the object currently has. */
   noncurrentCount: number
   expiryDays: number | null
   cap: number | null
@@ -27,12 +19,9 @@ export interface ComputeVersionFateOptions {
 const toActiveBound = (value: number | null) => (value !== null && value > 0 ? value : null)
 
 /**
- * The removal-outlook label a version row shows. Governing rule: never show a
- * countdown unless removal is actually guaranteed under the current policy — a
- * row only gets a day count once every other condition is already satisfied. So
+ * Never show a countdown unless removal is actually guaranteed under the current policy —
+ * a row only gets a day count once every other condition is already satisfied. So
  * an `and` policy shows one only once the cap is already exceeded.
- *
- * Each branch has a worked reference case in `VersionHistory.utils.test.ts`.
  */
 export const computeVersionFate = ({
   daysOld,
@@ -45,9 +34,7 @@ export const computeVersionFate = ({
   const activeExpiryDays = toActiveBound(expiryDays)
   const activeCap = toActiveBound(cap)
 
-  // A cap with no age isn't expressible in S3 — NoncurrentDays is required on any
-  // NoncurrentVersionExpiration rule, which is why the bucket form disables the
-  // cap until an age is set. So no age means no policy, whatever the cap says.
+  // A cap with no age isn't expressible in S3 — NoncurrentDays is required
   if (activeExpiryDays === null) return { type: 'retained' }
 
   const isAgeExceeded = daysOld >= activeExpiryDays
@@ -57,7 +44,6 @@ export const computeVersionFate = ({
     return isAgeExceeded ? { type: 'expiring-now' } : { type: 'expires-in', days: daysRemaining }
   }
 
-  // Already beyond the cap: among the oldest `noncurrentCount - cap` versions.
   const isCapExceeded = chronoIndex < noncurrentCount - activeCap
   const isAtCapBoundary = chronoIndex === noncurrentCount - activeCap
 

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/VersionHistory.utils.ts
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/VersionHistory.utils.ts
@@ -1,7 +1,7 @@
 import type { ExpirationMode } from '../StorageVersioning.constants'
 
 export type VersionFate =
-  | { type: 'kept' }
+  | { type: 'retained' }
   | { type: 'expires-in'; days: number }
   /**
    * The cap forces this one out, so the date depends on the next upload.
@@ -46,11 +46,11 @@ export const computeVersionFate = ({
   const activeCap = toActiveBound(cap)
 
   if (activeExpiryDays === null) {
-    if (activeCap === null) return { type: 'kept' }
+    if (activeCap === null) return { type: 'retained' }
 
     // Cap only: the oldest version still inside the cap is next to be evicted.
     const isAtCapBoundary = chronoIndex === noncurrentCount - activeCap
-    return isAtCapBoundary ? { type: 'expires-on-next-upload' } : { type: 'kept' }
+    return isAtCapBoundary ? { type: 'expires-on-next-upload' } : { type: 'retained' }
   }
 
   const isAgeExceeded = daysOld >= activeExpiryDays
@@ -65,7 +65,7 @@ export const computeVersionFate = ({
   const isAtCapBoundary = chronoIndex === noncurrentCount - activeCap
 
   if (mode === 'and') {
-    if (!isCapExceeded) return { type: 'kept' }
+    if (!isCapExceeded) return { type: 'retained' }
     return isAgeExceeded ? { type: 'expiring-now' } : { type: 'expires-in', days: daysRemaining }
   }
 

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/VersionHistory.utils.ts
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/VersionHistory.utils.ts
@@ -1,0 +1,75 @@
+import type { ExpirationMode } from '../StorageVersioning.constants'
+
+export type VersionFate =
+  | { type: 'kept' }
+  | { type: 'expires-in'; days: number }
+  /**
+   * The cap forces this one out, so the date depends on the next upload.
+   * `daysRemaining` is set when an age rule is also configured.
+   */
+  | { type: 'expires-on-next-upload'; daysRemaining?: number }
+  | { type: 'expiring-now' }
+
+export interface ComputeVersionFateOptions {
+  /** Days since this version became noncurrent. */
+  daysOld: number
+  /** 0-based position among noncurrent versions, oldest first. */
+  chronoIndex: number
+  /** Total number of noncurrent versions the object currently has. */
+  noncurrentCount: number
+  expiryDays: number | null
+  cap: number | null
+  mode: ExpirationMode
+}
+
+/** Treats a missing or non-positive bound as "condition not set". */
+const toActiveBound = (value: number | null) => (value !== null && value > 0 ? value : null)
+
+/**
+ * The removal-outlook label a version row shows. Governing rule: never show a
+ * countdown unless removal is actually guaranteed under the current policy — a
+ * row only gets a day count once every other condition is already satisfied.
+ * So a cap-only policy shows no dates except at the boundary, and an `and`
+ * policy shows one only once the cap is already exceeded.
+ *
+ * Each branch has a worked reference case in `VersionHistory.utils.test.ts`.
+ */
+export const computeVersionFate = ({
+  daysOld,
+  chronoIndex,
+  noncurrentCount,
+  expiryDays,
+  cap,
+  mode,
+}: ComputeVersionFateOptions): VersionFate => {
+  const activeExpiryDays = toActiveBound(expiryDays)
+  const activeCap = toActiveBound(cap)
+
+  if (activeExpiryDays === null) {
+    if (activeCap === null) return { type: 'kept' }
+
+    // Cap only: the oldest version still inside the cap is next to be evicted.
+    const isAtCapBoundary = chronoIndex === noncurrentCount - activeCap
+    return isAtCapBoundary ? { type: 'expires-on-next-upload' } : { type: 'kept' }
+  }
+
+  const isAgeExceeded = daysOld >= activeExpiryDays
+  const daysRemaining = activeExpiryDays - daysOld
+
+  if (activeCap === null) {
+    return isAgeExceeded ? { type: 'expiring-now' } : { type: 'expires-in', days: daysRemaining }
+  }
+
+  // Already beyond the cap: among the oldest `noncurrentCount - cap` versions.
+  const isCapExceeded = chronoIndex < noncurrentCount - activeCap
+  const isAtCapBoundary = chronoIndex === noncurrentCount - activeCap
+
+  if (mode === 'and') {
+    if (!isCapExceeded) return { type: 'kept' }
+    return isAgeExceeded ? { type: 'expiring-now' } : { type: 'expires-in', days: daysRemaining }
+  }
+
+  if (isAgeExceeded || isCapExceeded) return { type: 'expiring-now' }
+  if (isAtCapBoundary) return { type: 'expires-on-next-upload', daysRemaining }
+  return { type: 'expires-in', days: daysRemaining }
+}

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/VersionHistory.utils.ts
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/VersionHistory.utils.ts
@@ -4,10 +4,11 @@ export type VersionFate =
   | { type: 'retained' }
   | { type: 'expires-in'; days: number }
   /**
-   * The cap forces this one out, so the date depends on the next upload.
-   * `daysRemaining` is set when an age rule is also configured.
+   * The cap forces this one out before its age would, so the exact date depends
+   * on when the next upload happens. `daysRemaining` is the date it would have
+   * hit anyway had the cap not got there first.
    */
-  | { type: 'expires-on-next-upload'; daysRemaining?: number }
+  | { type: 'expires-on-next-upload'; daysRemaining: number }
   | { type: 'expiring-now' }
 
 export interface ComputeVersionFateOptions {
@@ -28,9 +29,8 @@ const toActiveBound = (value: number | null) => (value !== null && value > 0 ? v
 /**
  * The removal-outlook label a version row shows. Governing rule: never show a
  * countdown unless removal is actually guaranteed under the current policy — a
- * row only gets a day count once every other condition is already satisfied.
- * So a cap-only policy shows no dates except at the boundary, and an `and`
- * policy shows one only once the cap is already exceeded.
+ * row only gets a day count once every other condition is already satisfied. So
+ * an `and` policy shows one only once the cap is already exceeded.
  *
  * Each branch has a worked reference case in `VersionHistory.utils.test.ts`.
  */
@@ -45,13 +45,10 @@ export const computeVersionFate = ({
   const activeExpiryDays = toActiveBound(expiryDays)
   const activeCap = toActiveBound(cap)
 
-  if (activeExpiryDays === null) {
-    if (activeCap === null) return { type: 'retained' }
-
-    // Cap only: the oldest version still inside the cap is next to be evicted.
-    const isAtCapBoundary = chronoIndex === noncurrentCount - activeCap
-    return isAtCapBoundary ? { type: 'expires-on-next-upload' } : { type: 'retained' }
-  }
+  // A cap with no age isn't expressible in S3 — NoncurrentDays is required on any
+  // NoncurrentVersionExpiration rule, which is why the bucket form disables the
+  // cap until an age is set. So no age means no policy, whatever the cap says.
+  if (activeExpiryDays === null) return { type: 'retained' }
 
   const isAgeExceeded = daysOld >= activeExpiryDays
   const daysRemaining = activeExpiryDays - daysOld

--- a/apps/studio/data/storage/keys.ts
+++ b/apps/studio/data/storage/keys.ts
@@ -54,6 +54,26 @@ export const storageKeys = {
       ...(path ? [path] : []),
       ...(params ? [params] : []),
     ] as const,
+  /**
+   * The lifecycle policy is part of the key because the API applies it when
+   * deriving each version's expiry, so editing the policy must invalidate the
+   * cached version list rather than leave a stale one behind.
+   */
+  objectVersions: (
+    projectRef: string | undefined,
+    bucketId: string | undefined,
+    objectName: string | undefined,
+    lifecyclePolicy?: { expiryDays: number | null; maxVersions: number | null }
+  ) =>
+    [
+      'projects',
+      projectRef,
+      'buckets',
+      bucketId,
+      'object-versions',
+      objectName,
+      ...(lifecyclePolicy ? [lifecyclePolicy] : []),
+    ] as const,
   icebergNamespaces: ({ projectRef, warehouse }: { projectRef?: string; warehouse?: string }) =>
     [projectRef, 'warehouse', warehouse, 'namespaces'] as const,
   icebergNamespace: ({

--- a/apps/studio/data/storage/versioning/object-purge-mutation.ts
+++ b/apps/studio/data/storage/versioning/object-purge-mutation.ts
@@ -1,0 +1,53 @@
+import { useMutation, useQueryClient, type UseMutationOptions } from '@tanstack/react-query'
+import { toast } from 'sonner'
+
+import { storageKeys } from '../keys'
+import type { ResponseError } from '@/types'
+
+export type ObjectPurgeVariables = {
+  projectRef: string
+  bucketId: string
+  objectName: string
+}
+
+/**
+ * Permanently removes an object and every version of it. On a versioned bucket an
+ * ordinary delete only hides the object; this bypasses versioning entirely.
+ */
+async function purgeObject({ projectRef, bucketId, objectName }: ObjectPurgeVariables) {
+  if (!projectRef) throw new Error('projectRef is required')
+  if (!bucketId) throw new Error('bucketId is required')
+  if (!objectName) throw new Error('objectName is required')
+
+  // TODO(storage-versioning): call the real endpoint once Storage exposes it.
+  throw new Error('Permanently deleting an object is not available yet')
+}
+
+export const useObjectPurgeMutation = ({
+  onSuccess,
+  onError,
+  ...options
+}: Omit<UseMutationOptions<void, ResponseError, ObjectPurgeVariables>, 'mutationFn'> = {}) => {
+  const queryClient = useQueryClient()
+
+  return useMutation<void, ResponseError, ObjectPurgeVariables>({
+    mutationFn: purgeObject,
+    async onSuccess(data, variables, context) {
+      // The object list lives in the explorer's own state, not React Query, so
+      // callers refresh it through their existing delete flow.
+      await queryClient.invalidateQueries({
+        queryKey: storageKeys.objectVersions(
+          variables.projectRef,
+          variables.bucketId,
+          variables.objectName
+        ),
+      })
+      await onSuccess?.(data, variables, context)
+    },
+    async onError(error, variables, context) {
+      if (onError === undefined) toast.error(`Failed to delete object: ${error.message}`)
+      else onError(error, variables, context)
+    },
+    ...options,
+  })
+}

--- a/apps/studio/data/storage/versioning/object-version-delete-mutation.ts
+++ b/apps/studio/data/storage/versioning/object-version-delete-mutation.ts
@@ -1,0 +1,59 @@
+import { useMutation, useQueryClient, type UseMutationOptions } from '@tanstack/react-query'
+import { toast } from 'sonner'
+
+import { storageKeys } from '../keys'
+import type { ResponseError } from '@/types'
+
+export type ObjectVersionDeleteVariables = {
+  projectRef: string
+  bucketId: string
+  objectName: string
+  /** The single version to remove. Other versions of the object are untouched. */
+  versionId: string
+}
+
+async function deleteObjectVersion({
+  projectRef,
+  bucketId,
+  objectName,
+  versionId,
+}: ObjectVersionDeleteVariables) {
+  if (!projectRef) throw new Error('projectRef is required')
+  if (!bucketId) throw new Error('bucketId is required')
+  if (!objectName) throw new Error('objectName is required')
+  if (!versionId) throw new Error('versionId is required')
+
+  // TODO(storage-versioning): call the real endpoint once Storage exposes it.
+  // Deleting a specific version is permanent even on a versioned bucket.
+  throw new Error('Deleting a version is not available yet')
+}
+
+export const useObjectVersionDeleteMutation = ({
+  onSuccess,
+  onError,
+  ...options
+}: Omit<
+  UseMutationOptions<void, ResponseError, ObjectVersionDeleteVariables>,
+  'mutationFn'
+> = {}) => {
+  const queryClient = useQueryClient()
+
+  return useMutation<void, ResponseError, ObjectVersionDeleteVariables>({
+    mutationFn: deleteObjectVersion,
+    async onSuccess(data, variables, context) {
+      await queryClient.invalidateQueries({
+        queryKey: storageKeys.objectVersions(
+          variables.projectRef,
+          variables.bucketId,
+          variables.objectName
+        ),
+      })
+      await onSuccess?.(data, variables, context)
+    },
+    async onError(error, variables, context) {
+      if (onError === undefined) toast.error(`Failed to delete version: ${error.message}`)
+      else onError(error, variables, context)
+    },
+    ...options,
+  })
+}

--- a/apps/studio/data/storage/versioning/object-version-restore-mutation.ts
+++ b/apps/studio/data/storage/versioning/object-version-restore-mutation.ts
@@ -1,0 +1,60 @@
+import { useMutation, useQueryClient, type UseMutationOptions } from '@tanstack/react-query'
+import { toast } from 'sonner'
+
+import { storageKeys } from '../keys'
+import type { ResponseError } from '@/types'
+
+export type ObjectVersionRestoreVariables = {
+  projectRef: string
+  bucketId: string
+  objectName: string
+  /** The noncurrent version to promote back to current. */
+  versionId: string
+}
+
+async function restoreObjectVersion({
+  projectRef,
+  bucketId,
+  objectName,
+  versionId,
+}: ObjectVersionRestoreVariables) {
+  if (!projectRef) throw new Error('projectRef is required')
+  if (!bucketId) throw new Error('bucketId is required')
+  if (!objectName) throw new Error('objectName is required')
+  if (!versionId) throw new Error('versionId is required')
+
+  // TODO(storage-versioning): call the real endpoint once Storage exposes it.
+  // Restoring copies the version back over the object, which itself produces a
+  // new noncurrent version of whatever was current.
+  throw new Error('Restoring a version is not available yet')
+}
+
+export const useObjectVersionRestoreMutation = ({
+  onSuccess,
+  onError,
+  ...options
+}: Omit<
+  UseMutationOptions<void, ResponseError, ObjectVersionRestoreVariables>,
+  'mutationFn'
+> = {}) => {
+  const queryClient = useQueryClient()
+
+  return useMutation<void, ResponseError, ObjectVersionRestoreVariables>({
+    mutationFn: restoreObjectVersion,
+    async onSuccess(data, variables, context) {
+      await queryClient.invalidateQueries({
+        queryKey: storageKeys.objectVersions(
+          variables.projectRef,
+          variables.bucketId,
+          variables.objectName
+        ),
+      })
+      await onSuccess?.(data, variables, context)
+    },
+    async onError(error, variables, context) {
+      if (onError === undefined) toast.error(`Failed to restore version: ${error.message}`)
+      else onError(error, variables, context)
+    },
+    ...options,
+  })
+}

--- a/apps/studio/data/storage/versioning/object-versions-query.ts
+++ b/apps/studio/data/storage/versioning/object-versions-query.ts
@@ -1,0 +1,71 @@
+import { queryOptions } from '@tanstack/react-query'
+
+import { storageKeys } from '../keys'
+import { IS_PLATFORM } from '@/lib/constants'
+import type { ResponseError } from '@/types'
+
+/**
+ * What produced a version. A `delete marker` is the empty placeholder S3 writes
+ * to the top of the version stack on a soft delete; it can outlive the delete
+ * (delete → upload → delete → restore leaves one mid-history), so a live file's
+ * history can contain them.
+ */
+export type ObjectVersionAction = 'initial upload' | 'overwrite' | 'restore' | 'delete marker'
+
+export interface ObjectVersion {
+  versionId: string
+  size: number
+  createdAt: string
+  /** The version served when the object is fetched without a version ID. */
+  isCurrent: boolean
+  action: ObjectVersionAction
+}
+
+/** The bucket's lifecycle policy, which determines when each version expires. */
+export interface LifecyclePolicy {
+  /** `null` when no age condition is set. */
+  expiryDays: number | null
+  /** `null` when no version cap is set. */
+  maxVersions: number | null
+}
+
+export type ObjectVersionsVariables = {
+  projectRef?: string
+  bucketId?: string
+  objectName?: string
+  lifecyclePolicy?: LifecyclePolicy
+}
+
+export type ObjectVersionsError = ResponseError
+
+async function getObjectVersions(
+  { projectRef, bucketId, objectName }: ObjectVersionsVariables,
+  _signal?: AbortSignal
+): Promise<ObjectVersion[]> {
+  if (!projectRef) throw new Error('projectRef is required')
+  if (!bucketId) throw new Error('bucketId is required')
+  if (!objectName) throw new Error('objectName is required')
+
+  // TODO(storage-versioning): replace with the real endpoint once Storage exposes
+  // it, following the standard `get()` + `handleError()` shape. Every object
+  // reports no versions until then.
+  return []
+}
+
+export type ObjectVersionsData = Awaited<ReturnType<typeof getObjectVersions>>
+
+export const objectVersionsQueryOptions = ({
+  projectRef,
+  bucketId,
+  objectName,
+  lifecyclePolicy,
+}: ObjectVersionsVariables) =>
+  queryOptions({
+    queryKey: storageKeys.objectVersions(projectRef, bucketId, objectName, lifecyclePolicy),
+    queryFn: ({ signal }) => getObjectVersions({ projectRef, bucketId, objectName }, signal),
+    enabled:
+      IS_PLATFORM &&
+      typeof projectRef !== 'undefined' &&
+      typeof bucketId !== 'undefined' &&
+      typeof objectName !== 'undefined',
+  })


### PR DESCRIPTION
| # | Branch | Base |
| - | ------ | ---- |
| 1 | `feat/storage-versioning-private-alpha` | `master` |
| 2 | `feat/storage-versioning/002-bucket-form-fields` | 1 |
| 3 | `feat/storage-versioning/003-bucket-modals` | 2 |
| 4 | `feat/storage-versioning/004-object-versions-data` ◀ | 3 |
| 5 | `feat/storage-versioning/005-file-preview-versions` | 4 |
| 6 | `feat/storage-versioning/006-billing-storage-retention` | 5 |

## [4/6] Storage object versioning: object versions data layer

**Base:** `feat/storage-versioning/003-bucket-modals` (PR 3)

### This PR

The query and mutation hooks the version history UI needs, written to the studio `queryOptions` conventions with the endpoint calls stubbed.

- `object-versions-query.ts` — the version list, plus `ObjectVersion` and `LifecyclePolicy`
- `object-version-restore-mutation.ts` — promote a noncurrent version to current
- `object-version-delete-mutation.ts` — remove one specific version
- `object-purge-mutation.ts` — delete an object and every version, bypassing versioning
- `VersionHistory.utils.ts` — `computeVersionFate`, the pure rule deciding what removal outlook each version row shows
- `BroomSparklesIcon.tsx` — inline SVG for a glyph absent from lucide-react 0.436