### PR TITLE
feat(storage): add version history to the file preview panel (FE-4163)

### DIFF
--- a/apps/studio/components/interfaces/Storage/StorageExplorer/ConfirmDeleteModal.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/ConfirmDeleteModal.tsx
@@ -2,27 +2,57 @@ import { useEffect, useState } from 'react'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 
 import { STORAGE_ROW_TYPES } from '../Storage.constants'
+import { getBucketVersioningState } from '../StorageVersioning.constants'
+import { useIsStorageVersioningEnabled } from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
 import { useStorageExplorerStateSnapshot } from '@/state/storage-explorer'
 
 export const ConfirmDeleteModal = () => {
   const [deleting, setDeleting] = useState(false)
-  const { selectedItemsToDelete, deleteFolder, deleteFiles, setSelectedItemsToDelete } =
-    useStorageExplorerStateSnapshot()
+  const {
+    selectedBucket,
+    selectedItemsToDelete,
+    deleteFolder,
+    deleteFiles,
+    setSelectedItemsToDelete,
+  } = useStorageExplorerStateSnapshot()
+
+  const isStorageVersioningEnabled = useIsStorageVersioningEnabled()
+  // On a versioned bucket a delete is a soft delete: the object is hidden but
+  // every version stays recoverable, so the usual "cannot be undone" warning
+  // would be wrong.
+  const isVersionedBucket =
+    isStorageVersioningEnabled && getBucketVersioningState(selectedBucket) !== 'disabled'
 
   const visible = selectedItemsToDelete.length > 0
   const multipleFiles = selectedItemsToDelete.length > 1
+  const [firstItem] = selectedItemsToDelete
 
-  const title = multipleFiles
-    ? `Confirm deletion of ${selectedItemsToDelete.length} items`
-    : selectedItemsToDelete.length === 1
-      ? `Confirm deletion of ${selectedItemsToDelete[0].name}`
-      : ``
+  const getTitle = () => {
+    if (multipleFiles) {
+      const verb = isVersionedBucket ? 'Archive' : 'Delete'
+      return `${verb} ${selectedItemsToDelete.length} items?`
+    }
+    if (firstItem === undefined) return ''
+    return isVersionedBucket ? `Archive ${firstItem.name}?` : `Delete ${firstItem.name}?`
+  }
 
-  const description = multipleFiles
-    ? `Are you sure you want to delete the selected ${selectedItemsToDelete.length} items?`
-    : selectedItemsToDelete.length === 1
-      ? `Are you sure you want to delete the selected ${selectedItemsToDelete[0].type.toLowerCase()}?`
-      : ``
+  const getSubject = () => {
+    if (multipleFiles) return `the selected ${selectedItemsToDelete.length} items`
+    if (firstItem === undefined) return 'the selected item'
+    return `the selected ${firstItem.type.toLowerCase()}`
+  }
+
+  const alert = isVersionedBucket
+    ? {
+        base: { variant: 'warning' as const },
+        title: 'Versions are kept',
+        description: `Archiving ${getSubject()} hides it from the bucket. Its noncurrent versions stay retained until you delete them individually or a lifecycle policy expires them.`,
+      }
+    : {
+        base: { variant: 'destructive' as const },
+        title: 'This action cannot be undone',
+        description: `Are you sure you want to delete ${getSubject()}?`,
+      }
 
   const onDeleteSelectedFiles = async () => {
     try {
@@ -49,16 +79,13 @@ export const ConfirmDeleteModal = () => {
     <ConfirmationModal
       size="medium"
       visible={visible}
-      title={<span className="wrap-break-word">{title}</span>}
+      title={<span className="wrap-break-word">{getTitle()}</span>}
+      confirmLabel={isVersionedBucket ? 'Archive' : 'Delete'}
       loading={deleting}
       onCancel={() => setSelectedItemsToDelete([])}
       onConfirm={onDeleteSelectedFiles}
-      variant="destructive"
-      alert={{
-        base: { variant: 'destructive' },
-        title: 'This action cannot be undone',
-        description,
-      }}
+      variant={isVersionedBucket ? 'warning' : 'destructive'}
+      alert={alert}
     />
   )
 }

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/ConfirmDeleteModal.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/ConfirmDeleteModal.tsx
@@ -17,9 +17,6 @@ export const ConfirmDeleteModal = () => {
   } = useStorageExplorerStateSnapshot()
 
   const isStorageVersioningEnabled = useIsStorageVersioningEnabled()
-  // On a versioned bucket a delete is a soft delete: the object is hidden but
-  // every version stays recoverable, so the usual "cannot be undone" warning
-  // would be wrong.
   const isVersionedBucket =
     isStorageVersioningEnabled && getBucketVersioningState(selectedBucket) !== 'disabled'
 

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/ConfirmDeleteModal.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/ConfirmDeleteModal.tsx
@@ -45,7 +45,7 @@ export const ConfirmDeleteModal = () => {
   const alert = isVersionedBucket
     ? {
         base: { variant: 'warning' as const },
-        title: 'Versions are kept',
+        title: 'Versions are retained',
         description: `Archiving ${getSubject()} hides it from the bucket. Its noncurrent versions stay retained until you delete them individually or a lifecycle policy expires them.`,
       }
     : {

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/PreviewPane.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/PreviewPane.tsx
@@ -1,26 +1,61 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { AlertCircle, ChevronDown, Copy, Download, LoaderCircle, Trash2, X } from 'lucide-react'
-import SVG from 'react-inlinesvg'
+import { useQuery } from '@tanstack/react-query'
 import {
+  AlertCircle,
+  Archive,
+  ChevronDown,
+  Copy,
+  Download,
+  LoaderCircle,
+  Trash2,
+  X,
+} from 'lucide-react'
+import { parseAsBoolean, useQueryState } from 'nuqs'
+import { useRef, useState } from 'react'
+import SVG from 'react-inlinesvg'
+import { toast } from 'sonner'
+import {
+  Badge,
   Button,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from 'ui'
+import { ConfirmationModal } from 'ui-patterns/Dialogs/ConfirmationModal'
 
 import { URL_EXPIRY_DURATION } from '../Storage.constants'
 import { StorageItem } from '../Storage.types'
+import { getBucketVersioningState } from '../StorageVersioning.constants'
+import { PreviewSection } from './PreviewSection'
 import { getPathAlongOpenedFolders } from './StorageExplorer.utils'
 import { useCopyUrl } from './useCopyUrl'
 import { useFetchFileUrlQuery } from './useFetchFileUrlQuery'
+import { VersionCompareWidget } from './VersionCompareWidget'
+import { VersionHistory } from './VersionHistory'
+import { useIsStorageVersioningEnabled } from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
+import { useObjectPurgeMutation } from '@/data/storage/versioning/object-purge-mutation'
+import { useObjectVersionRestoreMutation } from '@/data/storage/versioning/object-version-restore-mutation'
+import {
+  objectVersionsQueryOptions,
+  type LifecyclePolicy,
+  type ObjectVersion,
+} from '@/data/storage/versioning/object-versions-query'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
 import { BASE_PATH } from '@/lib/constants'
 import { formatBytes } from '@/lib/helpers'
 import { useStorageExplorerStateSnapshot } from '@/state/storage-explorer'
 
 const PREVIEW_SIZE_LIMIT = 10 * 1024 * 1024 // 10MB
+
+const PANEL_WIDTH = 450
+
+/**
+ * TODO(storage-versioning): read the bucket's stored policy once the Storage API
+ * returns it. No condition is set until then, so no row shows an expiry.
+ */
+const EMPTY_LIFECYCLE_POLICY: LifecyclePolicy = { expiryDays: null, maxVersions: null }
 
 const PreviewFile = ({ item }: { item: StorageItem }) => {
   const { projectRef, selectedBucket, openedFolders } = useStorageExplorerStateSnapshot()
@@ -114,8 +149,198 @@ const PreviewFile = ({ item }: { item: StorageItem }) => {
   )
 }
 
+interface FileDetailsProps {
+  createdAt: string
+  updatedAt: string
+}
+
+const FileDetails = ({ createdAt, updatedAt }: FileDetailsProps) => (
+  <div className="space-y-2">
+    <div>
+      <label className="mb-1 text-xs text-foreground-lighter">Added on</label>
+      <p className="text-sm text-foreground-light">{createdAt}</p>
+    </div>
+    <div>
+      <label className="mb-1 text-xs text-foreground-lighter">Last modified</label>
+      <p className="text-sm text-foreground-light">{updatedAt}</p>
+    </div>
+  </div>
+)
+
+interface CurrentFilePreviewProps {
+  file: StorageItem
+  mimeType?: string
+  size: string | null
+  isPublicBucket: boolean
+  isVersionedBucket: boolean
+  hasCurrentVersion: boolean
+  canUpdateFiles: boolean
+  onCopyUrl: (path: string, expiry?: number) => void
+  onDownload: () => void
+  onCustomExpiry: () => void
+  onDelete: () => void
+  onPurge: () => void
+}
+
+/** The default top slot: the current file's thumbnail, metadata and actions. */
+const CurrentFilePreview = ({
+  file,
+  mimeType,
+  size,
+  isPublicBucket,
+  isVersionedBucket,
+  hasCurrentVersion,
+  canUpdateFiles,
+  onCopyUrl,
+  onDownload,
+  onCustomExpiry,
+  onDelete,
+  onPurge,
+}: CurrentFilePreviewProps) => (
+  <div className="border-b border-overlay p-3">
+    <div
+      /*
+       * ~144px of chrome sits above, so the preview takes 40% of what's left of
+       * the viewport. The floor keeps the sections below scrollable; the cap
+       * stops the preview dominating tall viewports.
+       */
+      className="flex items-center justify-center overflow-hidden rounded-md border border-overlay"
+      style={{ height: 'clamp(120px, calc((100vh - 144px) * 0.4), 180px)' }}
+    >
+      <PreviewFile item={file} />
+    </div>
+
+    <div className="mt-2 flex flex-col">
+      <div className="shrink">
+        <p className="truncate text-sm font-medium text-foreground" title={file.name}>
+          {file.name}
+        </p>
+        <p className="mt-0.5 flex flex-wrap items-center gap-x-1.5 truncate text-xs text-foreground-light">
+          {mimeType}
+          {size && <>, {size}</>}
+          {isVersionedBucket && hasCurrentVersion && (
+            <Badge variant="success" className="-my-1">
+              Current
+            </Badge>
+          )}
+        </p>
+        {file.isCorrupted && (
+          <div className="mt-1 flex items-center gap-x-1.5">
+            <AlertCircle size={12} className="shrink-0 text-foreground-light" />
+            <p className="text-xs text-foreground-light">File is corrupted</p>
+          </div>
+        )}
+      </div>
+
+      <div className="mt-3 flex shrink-0 items-center gap-x-1">
+        <ButtonTooltip
+          variant="outline"
+          className="px-2"
+          icon={<Download size={14} />}
+          disabled={file.isCorrupted}
+          onClick={onDownload}
+          tooltip={{ content: { side: 'top', text: 'Download current' } }}
+        />
+
+        {isPublicBucket ? (
+          <Button
+            variant="outline"
+            size="tiny"
+            icon={<Copy size={14} />}
+            disabled={file.isCorrupted}
+            onClick={() => onCopyUrl(file.path!)}
+          >
+            Copy URL
+          </Button>
+        ) : (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="outline"
+                size="tiny"
+                icon={<Copy size={14} />}
+                iconRight={<ChevronDown size={14} />}
+                disabled={file.isCorrupted}
+                aria-label={`Copy URL for ${file.name}`}
+              >
+                Copy URL
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={() => onCopyUrl(file.path!, URL_EXPIRY_DURATION.WEEK)}>
+                Expire in 1 week
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => onCopyUrl(file.path!, URL_EXPIRY_DURATION.MONTH)}>
+                Expire in 1 month
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => onCopyUrl(file.path!, URL_EXPIRY_DURATION.YEAR)}>
+                Expire in 1 year
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={onCustomExpiry}>Custom expiry</DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+
+        {/* A delete here is a soft delete, so the button says so and the real
+            destructive action moves behind the split menu. */}
+        {canUpdateFiles && isVersionedBucket && (
+          <div className="flex">
+            <Button
+              variant="outline"
+              size="tiny"
+              className="rounded-r-none"
+              icon={<Archive size={14} />}
+              onClick={onDelete}
+            >
+              Archive
+            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="tiny"
+                  className="-ml-px shrink-0 rounded-l-none border-l-transparent px-1.5"
+                  icon={<ChevronDown size={14} />}
+                  aria-label="More delete options"
+                />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem
+                  className="flex w-full flex-col items-start gap-1.5"
+                  onClick={onPurge}
+                >
+                  <div className="flex items-center space-x-1 text-foreground">
+                    <Trash2 size={14} className="shrink-0 text-destructive" />
+                    <p>Delete permanently</p>
+                  </div>
+                  <p className="block text-foreground-light">
+                    Also deletes every version of this file. This cannot be undone.
+                  </p>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        )}
+
+        {canUpdateFiles && !isVersionedBucket && (
+          <ButtonTooltip
+            variant="outline"
+            size="tiny"
+            icon={<Trash2 size={14} />}
+            onClick={onDelete}
+            tooltip={{ content: { side: 'top', text: 'Delete file' } }}
+          >
+            Delete file
+          </ButtonTooltip>
+        )}
+      </div>
+    </div>
+  </div>
+)
+
 export const PreviewPane = () => {
   const {
+    projectRef,
     selectedBucket,
     selectedFilePreview: file,
     setSelectedItemsToDelete,
@@ -126,142 +351,161 @@ export const PreviewPane = () => {
   const { onCopyUrl } = useCopyUrl()
 
   const { can: canUpdateFiles } = useAsyncCheckPermissions(PermissionAction.STORAGE_WRITE, '*')
+  const isStorageVersioningEnabled = useIsStorageVersioningEnabled()
+
+  // The bucket page owns `?edit=true` and mounts the modal on it, so routing
+  // through the URL avoids threading a callback down the explorer tree.
+  const [, setShowEditBucketModal] = useQueryState(
+    'edit',
+    parseAsBoolean.withDefault(false).withOptions({ history: 'push', clearOnDefault: true })
+  )
+
+  const scrollContainerRef = useRef<HTMLDivElement>(null)
+  const [previewedVersion, setPreviewedVersion] = useState<ObjectVersion>()
+  const [isPurgeConfirmVisible, setIsPurgeConfirmVisible] = useState(false)
+
+  const versioningState = getBucketVersioningState(selectedBucket)
+
+  const { data: versions } = useQuery({
+    ...objectVersionsQueryOptions({
+      projectRef,
+      bucketId: selectedBucket?.id,
+      objectName: file?.name,
+      lifecyclePolicy: EMPTY_LIFECYCLE_POLICY,
+    }),
+    enabled: isStorageVersioningEnabled && !!projectRef && !!selectedBucket?.id && !!file?.name,
+  })
+
+  const { mutate: restoreVersion, isPending: isRestoring } = useObjectVersionRestoreMutation({
+    onSuccess: () => {
+      toast.success('Version restored as the current version')
+      setPreviewedVersion(undefined)
+    },
+  })
+
+  const { mutate: purgeObject, isPending: isPurging } = useObjectPurgeMutation({
+    onSuccess: () => {
+      setIsPurgeConfirmVisible(false)
+      setSelectedFilePreview(undefined)
+    },
+  })
 
   if (!file) return null
 
-  const width = 450
   const size = file.metadata ? formatBytes(file.metadata.size) : null
   const mimeType = file.metadata ? file.metadata.mimetype : undefined
   const createdAt = file.created_at ? new Date(file.created_at).toLocaleString() : 'Unknown'
   const updatedAt = file.updated_at ? new Date(file.updated_at).toLocaleString() : 'Unknown'
 
+  const currentVersion = versions?.find((version) => version.isCurrent)
+  const isVersionedBucket = isStorageVersioningEnabled && versioningState !== 'disabled'
+  const isComparing = previewedVersion !== undefined && !previewedVersion.isCurrent
+
+  const handleRestore = () => {
+    if (!projectRef || !selectedBucket?.id || !previewedVersion) return
+    restoreVersion({
+      projectRef,
+      bucketId: selectedBucket.id,
+      objectName: file.name,
+      versionId: previewedVersion.versionId,
+    })
+  }
+
+  const handlePurge = () => {
+    if (!projectRef || !selectedBucket?.id) return
+    purgeObject({ projectRef, bucketId: selectedBucket.id, objectName: file.name })
+  }
+
+  // The compare widget replaces the top of the panel, so scroll up to show it.
+  const handlePreviewVersion = (version: ObjectVersion) => {
+    setPreviewedVersion(version)
+    scrollContainerRef.current?.scrollTo({ top: 0, behavior: 'smooth' })
+  }
+
   return (
     <div
-      className="h-full border-l border-overlay bg-surface-100 p-4 overflow-y-auto"
-      style={{ width }}
+      key={file.id ?? file.name}
+      className="flex h-full min-w-[390px] max-w-[600px] flex-col border-l border-overlay bg-surface-100"
+      style={{ width: PANEL_WIDTH }}
     >
-      {/* Preview Header */}
-      <div className="flex w-full justify-end text-foreground-lighter transition-colors hover:text-foreground">
-        <X className="cursor-pointer" size={14} onClick={() => setSelectedFilePreview(undefined)} />
-      </div>
-
-      {/* Preview Thumbnail*/}
-      <div className="my-4 border border-overlay">
-        <div className="flex h-56 w-full items-center 2xl:h-72">
-          <PreviewFile item={file} />
-        </div>
-      </div>
-
-      <div className="w-full space-y-6">
-        {/* Preview Information */}
-        <div className="space-y-1">
-          <h5 className="wrap-break-word text-base text-foreground">{file.name}</h5>
-          {file.isCorrupted && (
-            <div className="flex items-center space-x-2">
-              <AlertCircle size={14} className="text-foreground-light" />
-              <p className="text-sm text-foreground-light">
-                File is corrupted, please delete and reupload this file again
-              </p>
-            </div>
-          )}
-          {mimeType && (
-            <p className="text-sm text-foreground-light">
-              {mimeType}
-              {size && <span> - {size}</span>}
-            </p>
-          )}
-        </div>
-
-        {/* Preview Metadata */}
-        <div className="space-y-2">
-          <div>
-            <label className="mb-1 text-xs text-foreground-lighter">Added on</label>
-            <p className="text-sm text-foreground-light">{createdAt}</p>
-          </div>
-          <div>
-            <label className="mb-1 text-xs text-foreground-lighter">Last modified</label>
-            <p className="text-sm text-foreground-light">{updatedAt}</p>
-          </div>
-        </div>
-
-        {/* Actions */}
-        <div className="flex space-x-2 border-b border-overlay pb-4">
-          <Button
-            variant="default"
-            icon={<Download />}
-            disabled={file.isCorrupted}
-            onClick={() => downloadFile(file)}
-          >
-            Download
-          </Button>
-          {selectedBucket.public ? (
-            <Button
-              variant="outline"
-              icon={<Copy />}
-              onClick={() => onCopyUrl(file.path!)}
-              disabled={file.isCorrupted}
-            >
-              Get URL
-            </Button>
-          ) : (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="outline"
-                  icon={<Copy />}
-                  iconRight={<ChevronDown />}
-                  disabled={file.isCorrupted}
-                >
-                  Get URL
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent side="bottom" align="center">
-                <DropdownMenuItem
-                  key="expires-one-week"
-                  onClick={() => onCopyUrl(file.path!, URL_EXPIRY_DURATION.WEEK)}
-                >
-                  Expire in 1 week
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  key="expires-one-month"
-                  onClick={() => onCopyUrl(file.path!, URL_EXPIRY_DURATION.MONTH)}
-                >
-                  Expire in 1 month
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  key="expires-one-year"
-                  onClick={() => onCopyUrl(file.path!, URL_EXPIRY_DURATION.YEAR)}
-                >
-                  Expire in 1 year
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  key="custom-expiry"
-                  onClick={() => setSelectedFileCustomExpiry(file)}
-                >
-                  Custom expiry
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          )}
-        </div>
-        <ButtonTooltip
-          variant="outline"
-          disabled={!canUpdateFiles}
-          size="tiny"
-          icon={<Trash2 />}
-          onClick={() => setSelectedItemsToDelete([file])}
-          tooltip={{
-            content: {
-              side: 'bottom',
-              text: !canUpdateFiles
-                ? 'You need additional permissions to delete this file'
-                : undefined,
-            },
-          }}
+      <div className="flex items-center gap-x-2 border-b border-overlay px-4 py-2.5">
+        <p className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">File Preview</p>
+        <Button
+          variant="text"
+          className="h-7 w-7 shrink-0 p-0"
+          onClick={() => setSelectedFilePreview(undefined)}
+          aria-label="Close preview"
         >
-          Delete file
-        </ButtonTooltip>
+          <X size={14} />
+        </Button>
       </div>
+
+      <div ref={scrollContainerRef} className="min-h-0 flex-1 overflow-y-auto">
+        {isComparing ? (
+          <VersionCompareWidget
+            mimeType={mimeType}
+            selectedVersion={previewedVersion}
+            currentVersion={currentVersion}
+            isRestoring={isRestoring}
+            onRestore={handleRestore}
+            onDismiss={() => setPreviewedVersion(undefined)}
+          />
+        ) : (
+          <CurrentFilePreview
+            file={file}
+            mimeType={mimeType}
+            size={size}
+            isPublicBucket={!!selectedBucket?.public}
+            isVersionedBucket={isVersionedBucket}
+            hasCurrentVersion={currentVersion !== undefined}
+            canUpdateFiles={canUpdateFiles}
+            onCopyUrl={onCopyUrl}
+            onDownload={() => downloadFile(file)}
+            onCustomExpiry={() => setSelectedFileCustomExpiry(file)}
+            onDelete={() => setSelectedItemsToDelete([file])}
+            onPurge={() => setIsPurgeConfirmVisible(true)}
+          />
+        )}
+
+        <div className="space-y-3 px-4 pt-3">
+          <FileDetails createdAt={createdAt} updatedAt={updatedAt} />
+
+          {isStorageVersioningEnabled && (
+            <PreviewSection title="Versions" count={versions?.length} defaultOpen>
+              <VersionHistory
+                projectRef={projectRef}
+                bucketId={selectedBucket?.id}
+                objectName={file.name}
+                versioningState={versioningState}
+                lifecyclePolicy={EMPTY_LIFECYCLE_POLICY}
+                expirationMode="and"
+                mimeType={mimeType}
+                previewedVersionId={previewedVersion?.versionId}
+                onPreview={handlePreviewVersion}
+                clearPreview={() => setPreviewedVersion(undefined)}
+                onEditBucket={() => setShowEditBucketModal(true)}
+              />
+            </PreviewSection>
+          )}
+        </div>
+      </div>
+
+      <ConfirmationModal
+        variant="destructive"
+        visible={isPurgeConfirmVisible}
+        title={<span className="wrap-break-word">Permanently delete {file.name}?</span>}
+        confirmLabel="Delete permanently"
+        confirmLabelLoading="Deleting..."
+        loading={isPurging}
+        onCancel={() => setIsPurgeConfirmVisible(false)}
+        onConfirm={handlePurge}
+        alert={{
+          base: { variant: 'destructive' },
+          title: 'This cannot be undone',
+          description:
+            'This deletes the file and every noncurrent version of it. None of them can be restored afterwards.',
+        }}
+      />
     </div>
   )
 }

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/PreviewPane.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/PreviewPane.tsx
@@ -199,11 +199,6 @@ const CurrentFilePreview = ({
 }: CurrentFilePreviewProps) => (
   <div className="border-b border-overlay p-3">
     <div
-      /*
-       * ~144px of chrome sits above, so the preview takes 40% of what's left of
-       * the viewport. The floor keeps the sections below scrollable; the cap
-       * stops the preview dominating tall viewports.
-       */
       className="flex items-center justify-center overflow-hidden rounded-md border border-overlay"
       style={{ height: 'clamp(120px, calc((100vh - 144px) * 0.4), 180px)' }}
     >
@@ -281,8 +276,7 @@ const CurrentFilePreview = ({
           </DropdownMenu>
         )}
 
-        {/* A delete here is a soft delete, so the button says so and the real
-            destructive action moves behind the split menu. */}
+        {/* A delete in a versioned bucket is a soft delete/archive, unless specified explicitly */}
         {canUpdateFiles && isVersionedBucket && (
           <div className="flex">
             <Button
@@ -353,8 +347,6 @@ export const PreviewPane = () => {
   const { can: canUpdateFiles } = useAsyncCheckPermissions(PermissionAction.STORAGE_WRITE, '*')
   const isStorageVersioningEnabled = useIsStorageVersioningEnabled()
 
-  // The bucket page owns `?edit=true` and mounts the modal on it, so routing
-  // through the URL avoids threading a callback down the explorer tree.
   const [, setShowEditBucketModal] = useQueryState(
     'edit',
     parseAsBoolean.withDefault(false).withOptions({ history: 'push', clearOnDefault: true })

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/PreviewSection.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/PreviewSection.tsx
@@ -9,7 +9,6 @@ interface PreviewSectionProps {
   children: ReactNode
 }
 
-/** A collapsible section in the file preview panel. */
 export const PreviewSection = ({
   title,
   count,

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/PreviewSection.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/PreviewSection.tsx
@@ -1,0 +1,43 @@
+import { ChevronRight } from 'lucide-react'
+import { useState, type ReactNode } from 'react'
+import { cn, Collapsible, CollapsibleContent, CollapsibleTrigger } from 'ui'
+
+interface PreviewSectionProps {
+  title: string
+  count?: number
+  defaultOpen?: boolean
+  children: ReactNode
+}
+
+/** A collapsible section in the file preview panel. */
+export const PreviewSection = ({
+  title,
+  count,
+  defaultOpen = false,
+  children,
+}: PreviewSectionProps) => {
+  const [isOpen, setIsOpen] = useState(defaultOpen)
+
+  return (
+    <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+      <CollapsibleTrigger asChild>
+        <button
+          type="button"
+          className="flex w-full items-center justify-between py-3 text-left text-sm font-medium text-foreground transition-colors hover:text-foreground-light"
+        >
+          <span className="flex items-center gap-x-2">
+            {title}
+            {count !== undefined && (
+              <span className="text-xs font-normal text-foreground-lighter">{count}</span>
+            )}
+          </span>
+          <ChevronRight
+            size={14}
+            className={cn('text-foreground-lighter transition-transform', isOpen && 'rotate-90')}
+          />
+        </button>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="pb-4">{children}</CollapsibleContent>
+    </Collapsible>
+  )
+}

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/PreviewSection.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/PreviewSection.tsx
@@ -23,6 +23,7 @@ export const PreviewSection = ({
       <CollapsibleTrigger asChild>
         <button
           type="button"
+          tabIndex={0}
           className="flex w-full items-center justify-between py-3 text-left text-sm font-medium text-foreground transition-colors hover:text-foreground-light"
         >
           <span className="flex items-center gap-x-2">

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/VersionCompareWidget.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/VersionCompareWidget.tsx
@@ -1,0 +1,81 @@
+import dayjs from 'dayjs'
+import { ArrowRight, RotateCcw, X } from 'lucide-react'
+import { Button } from 'ui'
+
+import { VersionThumbnail } from './VersionThumbnail'
+import type { ObjectVersion } from '@/data/storage/versioning/object-versions-query'
+import { formatBytes } from '@/lib/helpers'
+
+interface VersionCompareWidgetProps {
+  mimeType?: string
+  selectedVersion: ObjectVersion
+  currentVersion?: ObjectVersion
+  isRestoring: boolean
+  onRestore: () => void
+  onDismiss: () => void
+}
+
+/**
+ * Takes over the top of the preview panel when a noncurrent version is selected:
+ * comparison and restore confirmation in one, so there is no modal.
+ */
+export const VersionCompareWidget = ({
+  mimeType,
+  selectedVersion,
+  currentVersion,
+  isRestoring,
+  onRestore,
+  onDismiss,
+}: VersionCompareWidgetProps) => (
+  <div className="space-y-3 border-b border-overlay bg-brand-200/30 p-3">
+    <div className="flex items-center gap-x-1.5">
+      <RotateCcw size={13} className="shrink-0 text-brand" />
+      <p className="truncate text-sm font-medium text-foreground">
+        Restore v.{selectedVersion.versionId}?
+      </p>
+      <button
+        type="button"
+        className="ml-auto shrink-0 text-foreground-lighter transition-colors hover:text-foreground"
+        onClick={onDismiss}
+        aria-label="Cancel comparison"
+      >
+        <X size={13} />
+      </button>
+    </div>
+
+    <div className="flex items-center gap-x-2">
+      <div className="flex-1 space-y-1.5">
+        <div className="flex h-24 items-center justify-center rounded-md border border-brand-400 bg-surface-200">
+          <VersionThumbnail mimeType={mimeType} isCurrent={false} size={20} />
+        </div>
+        <p className="truncate text-center font-mono text-[11px] text-brand">
+          {dayjs(selectedVersion.createdAt).format('MMM D')} · {formatBytes(selectedVersion.size)}
+        </p>
+      </div>
+      <ArrowRight size={14} className="shrink-0 text-foreground-lighter" />
+      <div className="flex-1 space-y-1.5">
+        <div className="flex h-24 items-center justify-center rounded-md border border-overlay bg-surface-200">
+          <VersionThumbnail mimeType={mimeType} isCurrent size={20} />
+        </div>
+        <p className="truncate text-center font-mono text-[11px] text-foreground-lighter">
+          Current{currentVersion && <> · {formatBytes(currentVersion.size)}</>}
+        </p>
+      </div>
+    </div>
+
+    <Button
+      variant="primary"
+      block
+      icon={<RotateCcw size={14} />}
+      loading={isRestoring}
+      onClick={onRestore}
+    >
+      Restore version as current
+    </Button>
+
+    <p className="text-xs leading-relaxed text-foreground-lighter">
+      {currentVersion && <strong>{currentVersion.versionId} </strong>}becomes a noncurrent version —
+      nothing is deleted.
+    </p>
+  </div>
+)

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/VersionCompareWidget.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/VersionCompareWidget.tsx
@@ -15,10 +15,6 @@ interface VersionCompareWidgetProps {
   onDismiss: () => void
 }
 
-/**
- * Takes over the top of the preview panel when a noncurrent version is selected:
- * comparison and restore confirmation in one, so there is no modal.
- */
 export const VersionCompareWidget = ({
   mimeType,
   selectedVersion,

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/VersionCompareWidget.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/VersionCompareWidget.tsx
@@ -35,6 +35,7 @@ export const VersionCompareWidget = ({
       </p>
       <button
         type="button"
+        tabIndex={0}
         className="ml-auto shrink-0 text-foreground-lighter transition-colors hover:text-foreground"
         onClick={onDismiss}
         aria-label="Cancel comparison"

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/VersionHistory.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/VersionHistory.tsx
@@ -34,10 +34,6 @@ import { formatBytes } from '@/lib/helpers'
 /** Version IDs are long opaque strings; show enough to tell two rows apart. */
 export const shortVersion = (versionId: string) => `${versionId.slice(0, 6)}…${versionId.slice(-2)}`
 
-/**
- * A row's removal outlook. `retained` renders nothing — saying "Retained" on
- * every unflagged row repeats what the absence of a warning already says.
- */
 const VersionFateLabel = ({ fate }: { fate: VersionFate }) => {
   switch (fate.type) {
     case 'retained':
@@ -132,17 +128,13 @@ interface VersionHistoryProps {
   projectRef?: string
   bucketId?: string
   objectName: string
-  /** The bucket's versioning state, for the suspended notice. */
   versioningState: BucketVersioningState
-  /** The bucket's lifecycle policy, which drives the per-row expiry outlook. */
   lifecyclePolicy: LifecyclePolicy
   expirationMode: ExpirationMode
-  /** Drives the row thumbnail glyph — falls back to a generic file icon. */
   mimeType?: string
   previewedVersionId?: string
   onPreview?: (version: ObjectVersion) => void
   clearPreview: () => void
-  /** Opens the bucket settings, where the lifecycle policy is configured. */
   onEditBucket: () => void
 }
 
@@ -275,12 +267,7 @@ export const VersionHistory = ({
                   !isComparing && !isDeleteMarker && 'hover:bg-surface-200'
                 )}
               >
-                {/*
-                 * A marker has no content to preview, so it renders as plain
-                 * content rather than a control that does nothing when pressed.
-                 * A real button elsewhere, so Enter/Space and screen readers
-                 * work for free.
-                 */}
+                {/* A marker has no content to preview */}
                 {isDeleteMarker ? (
                   <span className="flex min-w-0 flex-1 items-center gap-x-2.5">{rowContent}</span>
                 ) : (

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/VersionHistory.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/VersionHistory.tsx
@@ -1,0 +1,358 @@
+import { useQuery } from '@tanstack/react-query'
+import dayjs from 'dayjs'
+import { MoreVertical, RotateCcw, Trash2 } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { toast } from 'sonner'
+import {
+  Badge,
+  Button,
+  cn,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from 'ui'
+import { Admonition } from 'ui-patterns/Admonition'
+import { ConfirmationModal } from 'ui-patterns/Dialogs/ConfirmationModal'
+import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
+
+import type { BucketVersioningState, ExpirationMode } from '../StorageVersioning.constants'
+import { computeVersionFate, type VersionFate } from './VersionHistory.utils'
+import { VersionHistoryPolicyRow } from './VersionHistoryPolicyRow'
+import { VersionThumbnail } from './VersionThumbnail'
+import { AlertError } from '@/components/ui/AlertError'
+import { useObjectVersionDeleteMutation } from '@/data/storage/versioning/object-version-delete-mutation'
+import { useObjectVersionRestoreMutation } from '@/data/storage/versioning/object-version-restore-mutation'
+import {
+  objectVersionsQueryOptions,
+  type LifecyclePolicy,
+  type ObjectVersion,
+} from '@/data/storage/versioning/object-versions-query'
+import { formatBytes } from '@/lib/helpers'
+
+/** Version IDs are long opaque strings; show enough to tell two rows apart. */
+export const shortVersion = (versionId: string) => `${versionId.slice(0, 6)}…${versionId.slice(-2)}`
+
+/**
+ * A row's removal outlook. `kept` renders nothing — saying "Kept" on every
+ * unflagged row repeats what the absence of a warning already says.
+ */
+const VersionFateLabel = ({ fate }: { fate: VersionFate }) => {
+  switch (fate.type) {
+    case 'kept':
+      return null
+    case 'expires-in':
+      return (
+        <span className="shrink-0 text-xs text-foreground-lighter">
+          Expires in <span className="text-foreground-light">{fate.days}d</span>
+        </span>
+      )
+    case 'expires-on-next-upload':
+      return (
+        <div className="flex flex-col items-end">
+          <span className="shrink-0 text-xs text-warning-600">Expires on next upload</span>
+          {fate.daysRemaining !== undefined && (
+            <span className="shrink-0 text-xs text-warning-600">or in {fate.daysRemaining}d</span>
+          )}
+        </div>
+      )
+    case 'expiring-now':
+      return <span className="shrink-0 text-xs text-destructive">Expiring now</span>
+  }
+}
+
+const VersionRowBadge = ({
+  isCurrent,
+  isComparing,
+  fate,
+}: {
+  isCurrent: boolean
+  isComparing: boolean
+  fate?: VersionFate
+}) => {
+  if (isCurrent) return <Badge variant="success">Current</Badge>
+  if (isComparing) return <Badge variant="success">Comparing</Badge>
+  if (fate) return <VersionFateLabel fate={fate} />
+  return null
+}
+
+interface VersionActionsMenuProps {
+  version: ObjectVersion
+  isRestoring: boolean
+  onRestore: () => void
+  onDelete: () => void
+}
+
+const VersionActionsMenu = ({
+  version,
+  isRestoring,
+  onRestore,
+  onDelete,
+}: VersionActionsMenuProps) => {
+  const label = shortVersion(version.versionId)
+  const isDeleteMarker = version.action === 'delete marker'
+
+  // Restoring and deleting only make sense for the versions behind the current one.
+  if (version.isCurrent) return null
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="text"
+          size="tiny"
+          className="px-1.5"
+          icon={<MoreVertical size={14} />}
+          aria-label={isDeleteMarker ? 'Actions for delete marker' : `Actions for version ${label}`}
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        {/* A marker holds no content, so there is nothing to restore to. */}
+        {!isDeleteMarker && (
+          <>
+            <DropdownMenuItem className="gap-x-2" disabled={isRestoring} onClick={onRestore}>
+              <RotateCcw size={14} />
+              Restore as current
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+          </>
+        )}
+        <DropdownMenuItem
+          onClick={onDelete}
+          className="gap-x-2 text-destructive focus:text-destructive"
+        >
+          <Trash2 size={14} />
+          {isDeleteMarker ? 'Delete marker permanently' : 'Delete permanently'}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+interface VersionHistoryProps {
+  projectRef?: string
+  bucketId?: string
+  objectName: string
+  /** The bucket's versioning state, for the suspended notice. */
+  versioningState: BucketVersioningState
+  /** The bucket's lifecycle policy, which drives the per-row expiry outlook. */
+  lifecyclePolicy: LifecyclePolicy
+  expirationMode: ExpirationMode
+  /** Drives the row thumbnail glyph — falls back to a generic file icon. */
+  mimeType?: string
+  previewedVersionId?: string
+  onPreview?: (version: ObjectVersion) => void
+  clearPreview: () => void
+  /** Opens the bucket settings, where the lifecycle policy is configured. */
+  onEditBucket: () => void
+}
+
+export const VersionHistory = ({
+  projectRef,
+  bucketId,
+  objectName,
+  versioningState,
+  lifecyclePolicy,
+  expirationMode,
+  mimeType,
+  previewedVersionId,
+  onPreview,
+  clearPreview,
+  onEditBucket,
+}: VersionHistoryProps) => {
+  const {
+    data: versions,
+    isPending,
+    isError,
+    error,
+    isSuccess,
+  } = useQuery(objectVersionsQueryOptions({ projectRef, bucketId, objectName, lifecyclePolicy }))
+
+  const [versionToDelete, setVersionToDelete] = useState<ObjectVersion>()
+
+  const { mutate: restoreVersion, isPending: isRestoring } = useObjectVersionRestoreMutation({
+    onSuccess: () => toast.success('Version restored as the current version'),
+  })
+
+  const { mutate: deleteVersion, isPending: isDeleting } = useObjectVersionDeleteMutation({
+    onSuccess: () => {
+      toast.success('Version permanently deleted')
+      setVersionToDelete(undefined)
+    },
+  })
+
+  const { expiryDays, maxVersions: cap } = lifecyclePolicy
+  const hasPolicy = (cap !== null && cap > 0) || (expiryDays !== null && expiryDays > 0)
+
+  // `versions` arrives newest-first, so the oldest sits at `chronoIndex` 0.
+  const fateByVersionId = useMemo(() => {
+    const noncurrentVersions = (versions ?? []).filter((version) => !version.isCurrent)
+    const noncurrentCount = noncurrentVersions.length
+
+    return new Map(
+      noncurrentVersions.map((version, index) => [
+        version.versionId,
+        computeVersionFate({
+          daysOld: dayjs().diff(dayjs(version.createdAt), 'day'),
+          chronoIndex: noncurrentCount - 1 - index,
+          noncurrentCount,
+          expiryDays,
+          cap,
+          mode: expirationMode,
+        }),
+      ])
+    )
+  }, [versions, expiryDays, cap, expirationMode])
+
+  const handleRestore = (version: ObjectVersion) => {
+    if (!projectRef || !bucketId) return
+    restoreVersion({ projectRef, bucketId, objectName, versionId: version.versionId })
+  }
+
+  if (isPending) return <GenericSkeletonLoader />
+  if (isError) return <AlertError error={error} subject="Failed to retrieve versions" />
+
+  return (
+    <div className="space-y-4">
+      {hasPolicy && (
+        <VersionHistoryPolicyRow
+          cap={cap}
+          expiryDays={expiryDays}
+          mode={expirationMode}
+          onEditBucket={onEditBucket}
+        />
+      )}
+
+      {versioningState === 'suspended' && (
+        <Admonition
+          type="default"
+          title="Versioning is suspended on this bucket"
+          description="New noncurrent versions are no longer created. Everything already retained here stays as it is until you delete it or a lifecycle policy expires it."
+        />
+      )}
+
+      {isSuccess && versions.length === 0 && (
+        <p className="text-sm text-foreground-light">
+          No previous versions yet. Overwriting this file will keep a recoverable copy here.
+        </p>
+      )}
+
+      {isSuccess && versions.length > 0 && (
+        <ol className="flex flex-col gap-y-0.5">
+          {versions.map((version) => {
+            const isComparing = previewedVersionId === version.versionId
+            const isDeleteMarker = version.action === 'delete marker'
+
+            const rowContent = (
+              <>
+                <VersionThumbnail
+                  mimeType={mimeType}
+                  isCurrent={version.isCurrent}
+                  isDeleteMarker={isDeleteMarker}
+                />
+                <span className="min-w-0 flex-1">
+                  <span
+                    className={cn(
+                      'block truncate text-sm text-foreground',
+                      !isDeleteMarker && onPreview && 'group-hover:underline'
+                    )}
+                  >
+                    {dayjs(version.createdAt).format('MMM D, HH:mm')}
+                  </span>
+                  <span className="block truncate font-mono text-xs text-foreground-lighter">
+                    {isDeleteMarker ? 'Delete marker' : formatBytes(version.size)}
+                  </span>
+                </span>
+              </>
+            )
+
+            return (
+              <li
+                key={version.versionId}
+                className={cn(
+                  'group -mx-2 flex items-center gap-x-2.5 rounded-md border border-transparent px-2 py-1.5',
+                  isComparing && 'border-brand-500 bg-brand-200',
+                  !isComparing && isDeleteMarker && 'opacity-70',
+                  !isComparing && !isDeleteMarker && 'hover:bg-surface-200'
+                )}
+              >
+                {/*
+                 * A marker has no content to preview, so it renders as plain
+                 * content rather than a control that does nothing when pressed.
+                 * A real button elsewhere, so Enter/Space and screen readers
+                 * work for free.
+                 */}
+                {isDeleteMarker ? (
+                  <span className="flex min-w-0 flex-1 items-center gap-x-2.5">{rowContent}</span>
+                ) : (
+                  <button
+                    type="button"
+                    className="flex min-w-0 flex-1 items-center gap-x-2.5 text-left"
+                    onClick={() => (version.isCurrent ? clearPreview() : onPreview?.(version))}
+                  >
+                    {rowContent}
+                  </button>
+                )}
+
+                <VersionRowBadge
+                  isCurrent={version.isCurrent}
+                  isComparing={isComparing}
+                  fate={fateByVersionId.get(version.versionId)}
+                />
+
+                <VersionActionsMenu
+                  version={version}
+                  isRestoring={isRestoring}
+                  onRestore={() => handleRestore(version)}
+                  onDelete={() => setVersionToDelete(version)}
+                />
+              </li>
+            )
+          })}
+        </ol>
+      )}
+
+      <ConfirmationModal
+        variant="destructive"
+        visible={versionToDelete !== undefined}
+        title={
+          versionToDelete?.action === 'delete marker'
+            ? 'Permanently delete this delete marker?'
+            : 'Permanently delete this version?'
+        }
+        confirmLabel={
+          versionToDelete?.action === 'delete marker' ? 'Delete marker' : 'Delete version'
+        }
+        confirmLabelLoading="Deleting..."
+        loading={isDeleting}
+        onCancel={() => setVersionToDelete(undefined)}
+        onConfirm={() => {
+          if (!projectRef || !bucketId || !versionToDelete) return
+          deleteVersion({
+            projectRef,
+            bucketId,
+            objectName,
+            versionId: versionToDelete.versionId,
+          })
+        }}
+      >
+        {versionToDelete?.action === 'delete marker' ? (
+          <p className="text-sm text-foreground-light">
+            The delete marker in {objectName}&apos;s history will be removed permanently. Other
+            versions of this file are not affected. This cannot be undone.
+          </p>
+        ) : (
+          <p className="text-sm text-foreground-light">
+            Version{' '}
+            <span className="font-mono text-foreground">
+              {versionToDelete ? shortVersion(versionToDelete.versionId) : ''}
+            </span>{' '}
+            of {objectName} will be deleted permanently. The current version is not affected. This
+            cannot be undone.
+          </p>
+        )}
+      </ConfirmationModal>
+    </div>
+  )
+}

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/VersionHistory.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/VersionHistory.tsx
@@ -222,9 +222,16 @@ export const VersionHistory = ({
         />
       )}
 
-      {isSuccess && versions.length === 0 && (
+      {isSuccess && versions.length === 0 && versioningState === 'disabled' && (
         <p className="text-sm text-foreground-light">
-          No previous versions yet. Overwriting this file will keep a recoverable copy here.
+          Versioning is off for this bucket, so previous versions aren&apos;t retained. Turn it on
+          in the bucket settings to start keeping them.
+        </p>
+      )}
+
+      {isSuccess && versions.length === 0 && versioningState !== 'disabled' && (
+        <p className="text-sm text-foreground-light">
+          No previous versions yet. Overwriting this file will retain a recoverable copy here.
         </p>
       )}
 

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/VersionHistory.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/VersionHistory.tsx
@@ -35,12 +35,12 @@ import { formatBytes } from '@/lib/helpers'
 export const shortVersion = (versionId: string) => `${versionId.slice(0, 6)}…${versionId.slice(-2)}`
 
 /**
- * A row's removal outlook. `kept` renders nothing — saying "Kept" on every
- * unflagged row repeats what the absence of a warning already says.
+ * A row's removal outlook. `retained` renders nothing — saying "Retained" on
+ * every unflagged row repeats what the absence of a warning already says.
  */
 const VersionFateLabel = ({ fate }: { fate: VersionFate }) => {
   switch (fate.type) {
-    case 'kept':
+    case 'retained':
       return null
     case 'expires-in':
       return (

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/VersionHistory.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/VersionHistory.tsx
@@ -52,9 +52,7 @@ const VersionFateLabel = ({ fate }: { fate: VersionFate }) => {
       return (
         <div className="flex flex-col items-end">
           <span className="shrink-0 text-xs text-warning-600">Expires on next upload</span>
-          {fate.daysRemaining !== undefined && (
-            <span className="shrink-0 text-xs text-warning-600">or in {fate.daysRemaining}d</span>
-          )}
+          <span className="shrink-0 text-xs text-warning-600">or in {fate.daysRemaining}d</span>
         </div>
       )
     case 'expiring-now':
@@ -288,6 +286,7 @@ export const VersionHistory = ({
                 ) : (
                   <button
                     type="button"
+                    tabIndex={0}
                     className="flex min-w-0 flex-1 items-center gap-x-2.5 text-left"
                     onClick={() => (version.isCurrent ? clearPreview() : onPreview?.(version))}
                   >

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/VersionHistoryPolicyRow.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/VersionHistoryPolicyRow.tsx
@@ -60,7 +60,8 @@ const PolicyFullRule = ({ cap, expiryDays, mode }: PolicyRuleProps) => {
 
   return (
     <>
-      Only the {cap} newest noncurrent versions are kept. Older ones are deleted on the next upload.
+      Only the {cap} newest noncurrent versions are retained. Older ones are deleted on the next
+      upload.
     </>
   )
 }

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/VersionHistoryPolicyRow.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/VersionHistoryPolicyRow.tsx
@@ -34,34 +34,27 @@ interface PolicyRuleProps {
 
 /** The policy spelled out in plain language, for the hover card. */
 const PolicyFullRule = ({ cap, expiryDays, mode }: PolicyRuleProps) => {
+  // A cap always arrives with an age, so there are only three shapes to describe:
+  // age alone, or age combined with the cap under either operator.
   const hasCap = cap !== null && cap > 0
-  const hasExpiryDays = expiryDays !== null && expiryDays > 0
 
-  if (hasCap && hasExpiryDays) {
-    if (mode === 'and') {
-      return (
-        <>
-          A noncurrent version is permanently deleted only once it is <em>both</em> older than{' '}
-          {expiryDays} days and beyond the {cap} newest noncurrent versions.
-        </>
-      )
-    }
+  if (!hasCap) {
+    return <>A noncurrent version is permanently deleted once it is older than {expiryDays} days.</>
+  }
+
+  if (mode === 'and') {
     return (
       <>
-        A noncurrent version is permanently deleted as soon as it is <em>either</em> older than{' '}
-        {expiryDays} days <em>or</em> beyond the {cap} newest noncurrent versions.
+        A noncurrent version is permanently deleted only once it is <em>both</em> older than{' '}
+        {expiryDays} days and beyond the {cap} newest noncurrent versions.
       </>
     )
   }
 
-  if (hasExpiryDays) {
-    return <>A noncurrent version is permanently deleted once it is older than {expiryDays} days.</>
-  }
-
   return (
     <>
-      Only the {cap} newest noncurrent versions are retained. Older ones are deleted on the next
-      upload.
+      A noncurrent version is permanently deleted as soon as it is <em>either</em> older than{' '}
+      {expiryDays} days <em>or</em> beyond the {cap} newest noncurrent versions.
     </>
   )
 }
@@ -91,6 +84,7 @@ export const VersionHistoryPolicyRow = ({
       <HoverCardTrigger asChild>
         <button
           type="button"
+          tabIndex={0}
           onClick={onEditBucket}
           className="flex items-center gap-x-2 text-left"
           aria-label="Lifecycle policy details"
@@ -105,9 +99,6 @@ export const VersionHistoryPolicyRow = ({
             <span className="font-mono text-[11px] text-foreground-lighter">
               — no retention cap
             </span>
-          )}
-          {hasCap && !hasExpiryDays && (
-            <span className="font-mono text-[11px] text-foreground-lighter">— no age limit</span>
           )}
           <Info size={13} className="text-foreground-lighter" />
         </button>

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/VersionHistoryPolicyRow.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/VersionHistoryPolicyRow.tsx
@@ -5,7 +5,6 @@ import { Button, cn, HoverCard, HoverCardContent, HoverCardTrigger } from 'ui'
 import { BroomSparklesIcon } from '../BroomSparklesIcon'
 import type { ExpirationMode } from '../StorageVersioning.constants'
 
-/** Shared chip styling so the tokens and the operator badge read as one family. */
 const POLICY_CHIP_CLASSNAME = 'rounded-sm border px-1.5 py-0.5 font-mono text-[10.5px]'
 
 const PolicyChip = ({ children }: { children: ReactNode }) => (
@@ -32,10 +31,7 @@ interface PolicyRuleProps {
   mode: ExpirationMode
 }
 
-/** The policy spelled out in plain language, for the hover card. */
 const PolicyFullRule = ({ cap, expiryDays, mode }: PolicyRuleProps) => {
-  // A cap always arrives with an age, so there are only three shapes to describe:
-  // age alone, or age combined with the cap under either operator.
   const hasCap = cap !== null && cap > 0
 
   if (!hasCap) {
@@ -60,15 +56,9 @@ const PolicyFullRule = ({ cap, expiryDays, mode }: PolicyRuleProps) => {
 }
 
 interface VersionHistoryPolicyRowProps extends PolicyRuleProps {
-  /** Opens the bucket settings, where the policy is configured. */
   onEditBucket: () => void
 }
 
-/**
- * The bucket's lifecycle policy as one inline row. A hover card rather than a
- * tooltip because the content holds a button — tooltip content is not reachable
- * by pointer or keyboard.
- */
 export const VersionHistoryPolicyRow = ({
   cap,
   expiryDays,

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/VersionHistoryPolicyRow.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/VersionHistoryPolicyRow.tsx
@@ -1,0 +1,128 @@
+import { Info } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { Button, cn, HoverCard, HoverCardContent, HoverCardTrigger } from 'ui'
+
+import { BroomSparklesIcon } from '../BroomSparklesIcon'
+import type { ExpirationMode } from '../StorageVersioning.constants'
+
+/** Shared chip styling so the tokens and the operator badge read as one family. */
+const POLICY_CHIP_CLASSNAME = 'rounded-sm border px-1.5 py-0.5 font-mono text-[10.5px]'
+
+const PolicyChip = ({ children }: { children: ReactNode }) => (
+  <span className={cn(POLICY_CHIP_CLASSNAME, 'border-strong bg-surface-300 text-foreground-light')}>
+    {children}
+  </span>
+)
+
+const PolicyOperatorChip = ({ mode }: { mode: ExpirationMode }) => (
+  <span
+    className={cn(
+      POLICY_CHIP_CLASSNAME,
+      'border-strong border-dashed uppercase tracking-wide text-foreground-lighter',
+      mode === 'and' && 'bg-surface-300'
+    )}
+  >
+    {mode === 'and' ? 'Both' : 'Either'}
+  </span>
+)
+
+interface PolicyRuleProps {
+  cap: number | null
+  expiryDays: number | null
+  mode: ExpirationMode
+}
+
+/** The policy spelled out in plain language, for the hover card. */
+const PolicyFullRule = ({ cap, expiryDays, mode }: PolicyRuleProps) => {
+  const hasCap = cap !== null && cap > 0
+  const hasExpiryDays = expiryDays !== null && expiryDays > 0
+
+  if (hasCap && hasExpiryDays) {
+    if (mode === 'and') {
+      return (
+        <>
+          A noncurrent version is permanently deleted only once it is <em>both</em> older than{' '}
+          {expiryDays} days and beyond the {cap} newest noncurrent versions.
+        </>
+      )
+    }
+    return (
+      <>
+        A noncurrent version is permanently deleted as soon as it is <em>either</em> older than{' '}
+        {expiryDays} days <em>or</em> beyond the {cap} newest noncurrent versions.
+      </>
+    )
+  }
+
+  if (hasExpiryDays) {
+    return <>A noncurrent version is permanently deleted once it is older than {expiryDays} days.</>
+  }
+
+  return (
+    <>
+      Only the {cap} newest noncurrent versions are kept. Older ones are deleted on the next upload.
+    </>
+  )
+}
+
+interface VersionHistoryPolicyRowProps extends PolicyRuleProps {
+  /** Opens the bucket settings, where the policy is configured. */
+  onEditBucket: () => void
+}
+
+/**
+ * The bucket's lifecycle policy as one inline row. A hover card rather than a
+ * tooltip because the content holds a button — tooltip content is not reachable
+ * by pointer or keyboard.
+ */
+export const VersionHistoryPolicyRow = ({
+  cap,
+  expiryDays,
+  mode,
+  onEditBucket,
+}: VersionHistoryPolicyRowProps) => {
+  const hasCap = cap !== null && cap > 0
+  const hasExpiryDays = expiryDays !== null && expiryDays > 0
+  const hasBoth = hasCap && hasExpiryDays
+
+  return (
+    <HoverCard openDelay={100}>
+      <HoverCardTrigger asChild>
+        <button
+          type="button"
+          onClick={onEditBucket}
+          className="flex items-center gap-x-2 text-left"
+          aria-label="Lifecycle policy details"
+        >
+          <BroomSparklesIcon size={16} className="mr-1 shrink-0 text-foreground-lighter" />
+          <span className="flex items-center gap-x-1">
+            {hasExpiryDays && <PolicyChip>{expiryDays}d</PolicyChip>}
+            {hasBoth && <PolicyOperatorChip mode={mode} />}
+            {hasCap && <PolicyChip>{cap} noncurrent v. retained</PolicyChip>}
+          </span>
+          {hasExpiryDays && !hasCap && (
+            <span className="font-mono text-[11px] text-foreground-lighter">
+              — no retention cap
+            </span>
+          )}
+          {hasCap && !hasExpiryDays && (
+            <span className="font-mono text-[11px] text-foreground-lighter">— no age limit</span>
+          )}
+          <Info size={13} className="text-foreground-lighter" />
+        </button>
+      </HoverCardTrigger>
+      <HoverCardContent side="top" className="w-72 space-y-1.5 text-xs">
+        <div className="flex items-center gap-x-1">
+          <BroomSparklesIcon size={16} className="mr-1 shrink-0" />
+          <p className="font-medium text-foreground">Lifecycle policy</p>
+        </div>
+        <p className="text-foreground-light">
+          <PolicyFullRule cap={cap} expiryDays={expiryDays} mode={mode} />
+        </p>
+        <Button variant="default" onClick={onEditBucket}>
+          View bucket settings
+        </Button>
+      </HoverCardContent>
+    </HoverCard>
+  )
+}

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/VersionThumbnail.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/VersionThumbnail.tsx
@@ -17,16 +17,10 @@ const MimeTypeIcon = ({ mimeType, size }: { mimeType?: string; size: number }) =
 interface VersionThumbnailProps {
   mimeType?: string
   isCurrent: boolean
-  /** An empty placeholder standing in for a soft delete in the object's history. */
   isDeleteMarker?: boolean
   size?: number
 }
 
-/**
- * Type glyph for a version row. Noncurrent versions have no thumbnail of their
- * own so they share one; the current version gets a restore glyph, and a delete
- * marker a dashed outline so it reads as "nothing here".
- */
 export const VersionThumbnail = ({
   mimeType,
   isCurrent,

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/VersionThumbnail.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/VersionThumbnail.tsx
@@ -1,0 +1,48 @@
+import { Archive, File, Film, Image as ImageIcon, Music, RotateCcw } from 'lucide-react'
+import { cn } from 'ui'
+
+const MimeTypeIcon = ({ mimeType, size }: { mimeType?: string; size: number }) => {
+  if (mimeType?.includes('image')) {
+    return <ImageIcon size={size} className="text-foreground-lighter" />
+  }
+  if (mimeType?.includes('audio')) {
+    return <Music size={size} className="text-foreground-lighter" />
+  }
+  if (mimeType?.includes('video')) {
+    return <Film size={size} className="text-foreground-lighter" />
+  }
+  return <File size={size} className="text-foreground-lighter" />
+}
+
+interface VersionThumbnailProps {
+  mimeType?: string
+  isCurrent: boolean
+  /** An empty placeholder standing in for a soft delete in the object's history. */
+  isDeleteMarker?: boolean
+  size?: number
+}
+
+/**
+ * Type glyph for a version row. Noncurrent versions have no thumbnail of their
+ * own so they share one; the current version gets a restore glyph, and a delete
+ * marker a dashed outline so it reads as "nothing here".
+ */
+export const VersionThumbnail = ({
+  mimeType,
+  isCurrent,
+  isDeleteMarker = false,
+  size = 14,
+}: VersionThumbnailProps) => (
+  <span
+    className={cn(
+      'flex h-7 w-7 shrink-0 items-center justify-center rounded-md border',
+      isCurrent && 'border-brand-400 bg-surface-200',
+      !isCurrent && isDeleteMarker && 'border-strong border-dashed bg-surface-100',
+      !isCurrent && !isDeleteMarker && 'border-overlay bg-surface-100'
+    )}
+  >
+    {isCurrent && <RotateCcw size={size} className="text-brand" />}
+    {!isCurrent && isDeleteMarker && <Archive size={size} className="text-foreground-muted" />}
+    {!isCurrent && !isDeleteMarker && <MimeTypeIcon mimeType={mimeType} size={size} />}
+  </span>
+)

--- a/apps/studio/state/storage-explorer.tsx
+++ b/apps/studio/state/storage-explorer.tsx
@@ -1899,13 +1899,8 @@ export const StorageExplorerStateContextProvider = ({ children }: PropsWithChild
     bucket,
   ])
 
-  // The effect above only seeds `selectedBucket` once, when the explorer state is
-  // (re)created for a project — after that it never re-syncs. Editing the bucket
-  // afterwards (toggling public/private in bucket settings, say) then leaves every
-  // consumer of `selectedBucket` reading stale metadata, which is how the preview
-  // panel's Copy URL action ends up signing a URL for the wrong visibility.
-  // Re-sync whenever the query refetches, as long as it still describes the bucket
-  // the store already has selected.
+  // Re-sync selectedBucket also when the bucket changes,
+  // to ensure the state is always up-to-date with the latest bucket data
   useEffect(() => {
     if (bucket && state.selectedBucket?.id === bucket.id && state.selectedBucket !== bucket) {
       state.selectedBucket = bucket

--- a/apps/studio/state/storage-explorer.tsx
+++ b/apps/studio/state/storage-explorer.tsx
@@ -1899,6 +1899,19 @@ export const StorageExplorerStateContextProvider = ({ children }: PropsWithChild
     bucket,
   ])
 
+  // The effect above only seeds `selectedBucket` once, when the explorer state is
+  // (re)created for a project — after that it never re-syncs. Editing the bucket
+  // afterwards (toggling public/private in bucket settings, say) then leaves every
+  // consumer of `selectedBucket` reading stale metadata, which is how the preview
+  // panel's Copy URL action ends up signing a URL for the wrong visibility.
+  // Re-sync whenever the query refetches, as long as it still describes the bucket
+  // the store already has selected.
+  useEffect(() => {
+    if (bucket && state.selectedBucket?.id === bucket.id && state.selectedBucket !== bucket) {
+      state.selectedBucket = bucket
+    }
+  }, [bucket, state])
+
   return (
     <StorageExplorerStateContext.Provider value={state}>
       {children}


### PR DESCRIPTION

## [5/6] Storage object versioning: version history in the file preview panel

**Base:** `feat/storage-versioning/004-object-versions-data` (PR 4)

### This PR

The whole versioning experience in the file preview panel. This is the largest PR in the stack: the version list and the panel that hosts it are one conceptual unit, and splitting them would give you a PR of unreachable UI followed by a PR of pure wiring.

- `VersionHistory` + `VersionHistoryPolicyRow` + `VersionThumbnail` — the version list, the inline lifecycle policy summary, and the row glyph
- `VersionCompareWidget` — takes over the top of the panel when a noncurrent version is selected, so restoring is a visible before/after rather than a modal
- `PreviewSection` — the collapsible section wrapper
- `PreviewPane` — new panel chrome, viewport-clamped thumbnail, and an **Archive / Delete permanently** split button on versioned buckets
- `ConfirmDeleteModal` — on a versioned bucket a delete is a soft delete, so the copy no longer claims it cannot be undone

### Also in here

`state/storage-explorer.tsx` re-syncs `selectedBucket` when the bucket query refetches. It was only ever seeded once when the explorer state was created, so editing a bucket afterwards left consumers reading stale metadata — which is how Copy URL could sign a URL for the wrong visibility after a public/private toggle. Orthogonal to versioning; happy to split it out if you'd rather.
