### PR TITLE
fix(studio): link auth db connections advisor hint to performance settings

### DIFF
--- a/apps/studio/components/interfaces/Linter/LintDetail.tsx
+++ b/apps/studio/components/interfaces/Linter/LintDetail.tsx
@@ -1,6 +1,7 @@
 import { ExternalLink } from 'lucide-react'
 import Link from 'next/link'
 import { Button } from 'ui'
+import { Admonition } from 'ui-patterns/Admonition'
 
 import { Markdown } from '../Markdown'
 import { asGraphqlExposureLint, GraphqlExposureCallout } from './GraphqlExposureLintCTA'
@@ -8,6 +9,7 @@ import { EntityTypeIcon, LintCTA, LintEntity } from './Linter.utils'
 import { createLintSummaryPrompt, lintInfoMap } from '@/components/interfaces/Linter/Linter.utils'
 import { SIDEBAR_KEYS } from '@/components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider'
 import { AiAssistantDropdown } from '@/components/ui/AiAssistantDropdown'
+import { InlineLink } from '@/components/ui/InlineLink'
 import { Lint } from '@/data/lint/lint-query'
 import { DOCS_URL } from '@/lib/constants'
 import { useTrack } from '@/lib/telemetry/track'
@@ -31,6 +33,9 @@ export const LintDetail = ({
   const snap = useAiAssistantStateSnapshot()
   const { openSidebar } = useSidebarManagerSnapshot()
   const isGraphqlExposureLint = !!asGraphqlExposureLint(lint.name)
+  const isAuthDbConnectionsAbsoluteLint = (
+    ['auth_db_connections_absolute'] as readonly string[]
+  ).includes(lint.name)
 
   const handleAskAssistant = () => {
     track('advisor_assistant_button_clicked', {
@@ -72,6 +77,24 @@ export const LintDetail = ({
       {isGraphqlExposureLint && (
         <div className="mb-4">
           <GraphqlExposureCallout projectRef={projectRef} />
+        </div>
+      )}
+
+      {isAuthDbConnectionsAbsoluteLint && (
+        <div className="mb-4">
+          <Admonition
+            type="default"
+            title="Where to fix this"
+            description={
+              <p>
+                Switch to a percentage-based connection allocation strategy from the{' '}
+                <InlineLink href={`/project/${projectRef}/auth/performance`}>
+                  Auth performance settings
+                </InlineLink>
+                .
+              </p>
+            }
+          />
         </div>
       )}
 


### PR DESCRIPTION
The `auth_db_connections_absolute` advisor hint explained the fix but only linked out via a separate "View settings" button below — the hint text itself had no direct link. Added an inline link to Auth performance settings right under the hint.

Fixes FE-4201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added targeted guidance for the authentication database connections lint.
  * Included a direct link to Auth performance settings with recommendations for percentage-based connection allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->