### PR TITLE
docs: point dashboard links at pages that still exist

### DIFF
--- a/apps/docs/content/guides/ai/examples/huggingface-image-captioning.mdx
+++ b/apps/docs/content/guides/ai/examples/huggingface-image-captioning.mdx
@@ -24,7 +24,7 @@ We can combine Hugging Face with [Supabase Storage](/storage) and [Database Webh
   - Create a `caption` column of type `text`.
 - Regenerate TypeScript types to include new `image_caption` table.
 - Deploy the function to Supabase: `supabase functions deploy huggingface-image-captioning`.
-- Create the Database Webhook in the [Supabase Dashboard](/dashboard/project/_/database/hooks) to trigger the `huggingface-image-captioning` function anytime a record is added to the `storage.objects` table.
+- Create the Database Webhook in the [Supabase Dashboard](/dashboard/project/_/integrations/webhooks/overview) to trigger the `huggingface-image-captioning` function anytime a record is added to the `storage.objects` table.
 
 ## Generate TypeScript types
 

--- a/apps/docs/content/guides/auth/general-configuration.mdx
+++ b/apps/docs/content/guides/auth/general-configuration.mdx
@@ -16,7 +16,7 @@ This section covers the [general configuration options](/dashboard/project/_/aut
 - [Multi-Factor](/dashboard/project/_/auth/mfa) to require users to provide additional verification factors to authenticate.
 - [URL Configuration](/dashboard/project/_/auth/url-configuration) to configure site URL and redirect URLs for authentication. Read more [in the redirect URLs documentation](/docs/guides/auth/redirect-urls).
 - [Attack Protection](/dashboard/project/_/auth/protection) to configure security settings to protect your project from attacks.
-- [Auth Hooks (BETA)](/dashboard/project/_/auth/auth-hooks) to use Postgres functions or HTTP endpoints to customize the behavior of Supabase Auth to meet your needs.
+- [Auth Hooks (BETA)](/dashboard/project/_/auth/hooks) to use Postgres functions or HTTP endpoints to customize the behavior of Supabase Auth to meet your needs.
 - [Audit Logs (BETA)](/dashboard/project/_/auth/audit-logs) to track and monitor auth events in your project.
 - [Performance](/dashboard/project/_/auth/performance) to configure and optimize authentication server settings.
 

--- a/apps/docs/content/guides/functions/examples/push-notifications.mdx
+++ b/apps/docs/content/guides/functions/examples/push-notifications.mdx
@@ -271,7 +271,7 @@ Push notifications are an important part of any mobile app. They allow you to se
 
     ## Create the database webhook
 
-    Navigate to the [Database Webhooks settings](/dashboard/project/_/database/hooks) in your Supabase Dashboard.
+    Navigate to the [Database Webhooks settings](/dashboard/project/_/integrations/webhooks/overview) in your Supabase Dashboard.
 
     1. Enable and create a new hook.
     1. Conditions to fire webhook: Select the `public.notifications` table and tick the `Insert` event.

--- a/apps/docs/content/guides/platform/migrating-within-supabase/backup-restore.mdx
+++ b/apps/docs/content/guides/platform/migrating-within-supabase/backup-restore.mdx
@@ -107,7 +107,7 @@ These steps cover a manual logical restore (`pg_dump` / `psql`) into a project y
       <StepHikeCompact.Details title="Configure newly created project" fullWidth>
         In the new project:
 
-        - If Webhooks were used in the old database, enable [Database Webhooks](/dashboard/project/_/database/hooks).
+        - If Webhooks were used in the old database, enable [Database Webhooks](/dashboard/project/_/integrations/webhooks/overview).
         - If any non-default extensions were used in the old database, enable the [Extensions](/dashboard/project/_/database/extensions).
       </StepHikeCompact.Details>
 

--- a/apps/docs/content/guides/platform/migrating-within-supabase/dashboard-restore.mdx
+++ b/apps/docs/content/guides/platform/migrating-within-supabase/dashboard-restore.mdx
@@ -39,7 +39,7 @@ Dashboard backups are only available for older projects that still use logical b
           <StepHikeCompact.Details title="Configure your new project" fullWidth>
                 In your new project:
 
-                - If you were using Webhooks, enable [Database Webhooks](/dashboard/project/_/database/hooks).
+                - If you were using Webhooks, enable [Database Webhooks](/dashboard/project/_/integrations/webhooks/overview).
                 - If you were using any extensions, enable the [Extensions](/dashboard/project/_/database/extensions).
                 - If you were using Replication for Realtime, enable [Publication](/dashboard/project/_/database/publications) where needed.
           </StepHikeCompact.Details>

--- a/apps/docs/content/troubleshooting/cloudflare-origin-error-1016-on-custom-domain-a57af4.mdx
+++ b/apps/docs/content/troubleshooting/cloudflare-origin-error-1016-on-custom-domain-a57af4.mdx
@@ -13,7 +13,7 @@ When encountering a 'Cloudflare Origin Error 1016' when accessing a custom domai
 
 ## How to resolve this issue
 
-1.  Navigate to your project's [custom domain settings](/dashboard/project/_/settings/custom-domain).
+1.  Navigate to your project's [custom domain settings](/dashboard/project/_/settings/general).
 2.  Initiate a DNS record re-verification. This action prompts an attempt to renew the SSL certificate.
 3.  If the error persists after re-verification, remove the custom domain configuration from your project.
 4.  Re-add the custom domain configuration. Ensure all DNS records are correctly established as instructed by the dashboard. This process forces a hard reset and triggers a new certificate request.

--- a/apps/docs/content/troubleshooting/webhook-debugging-guide-M8sk47.mdx
+++ b/apps/docs/content/troubleshooting/webhook-debugging-guide-M8sk47.mdx
@@ -43,7 +43,7 @@ Go to your [Table Editor](/dashboard/project/_/editor/) and navigate to the net 
 
 The `_http_response` table saves all the response messages from the past 6 hours. If every column contains NULL values, except for the `id`, `error_msg`, and `created` columns, then you are experiencing [a timeout bug](https://github.com/supabase/pg_net/issues/86).
 
-By default, webhooks will execute the next 200 available queued requests. If the requests are too intense, it may result in a mass timeout. In the [Webhook Dashboard](/dashboard/project/_/database/hooks), you should increase your webhook's timeout to minimize this issue.
+By default, webhooks will execute the next 200 available queued requests. If the requests are too intense, it may result in a mass timeout. In the [Webhook Dashboard](/dashboard/project/_/integrations/webhooks/overview), you should increase your webhook's timeout to minimize this issue.
 
 **4. Inspect endpoints**
 The below code makes a request to the Postman Echo API through PG_NET


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs fix. Seven "go do this in the dashboard" links point at dashboard routes that no longer exist, so readers following them land on a 404 inside their project.

## What is the current behavior?

| link in docs | files | route today |
| --- | --- | --- |
| `/dashboard/project/_/database/hooks` | 5 | no route, and no redirect |
| `/dashboard/project/_/auth/auth-hooks` | 1 | the page is `auth/hooks` |
| `/dashboard/project/_/settings/custom-domain` | 1 | no route, and no redirect |

These are the ones that fall through. The dashboard has a redirect table (`apps/studio/redirects.shared.ts`) that quietly rescues most old paths, including the neighbouring `database/webhooks`, `storage/buckets`, `logs-explorer` and `database/security-advisor`. These three have no entry, so nothing catches them.

## What is the new behavior?

- **Database Webhooks** links go to `/dashboard/project/_/integrations/webhooks/overview`. That is exactly where the existing `database/webhooks` redirect already sends people, so this matches the destination you already chose for the same feature, and it resolves through the `integrations/[id]/[pageId]` route.
- **Auth Hooks** goes to `/dashboard/project/_/auth/hooks`, which exists as `pages/project/[ref]/auth/hooks.tsx` and `routes/project/$ref/auth/hooks.tsx`.
- **Custom domain** goes to `/dashboard/project/_/settings/general`, which is where `CustomDomainConfig` is rendered (`settings/general.tsx` line 62, behind the `projectSettingsCustomDomains` flag).

## Additional context

`/dashboard` is behind auth so I could not check these with a status code. Instead I resolved every path against the studio route trees (`pages/project/[ref]` and `routes/project/$ref`, allowing for dynamic segments) and then against `redirects.shared.ts`, which is what turned up the three with no coverage either way.

For scale: docs reference 96 distinct `/dashboard/project/_/...` paths. 82 resolve directly, 11 more are covered by redirects, and these 3 are the remainder. I did not touch the 11 redirect-covered ones, since they work today and rewriting them would be churn.

Files touched: `guides/auth/general-configuration`, `guides/ai/examples/huggingface-image-captioning`, `guides/functions/examples/push-notifications`, `guides/platform/migrating-within-supabase/{backup-restore,dashboard-restore}`, `troubleshooting/webhook-debugging-guide-M8sk47`, `troubleshooting/cloudflare-origin-error-1016-on-custom-domain-a57af4`.

Gates: `test:prettier` passes repo wide and `typecheck --filter=docs --force` passes 8/8.

Freshman contributor, put this together with Claude Code's help and checked each target against the route trees and the redirect table myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Database Webhooks links to point to the current Integrations and Dashboard locations.
  - Updated Auth Hooks documentation links to the current route.
  - Updated custom domain troubleshooting instructions to reference the current settings page.
  - Updated webhook timeout guidance with the current Webhook Dashboard link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->