### PR TITLE
fix(www): point 36 dead redirect destinations at the pages that exist

### DIFF
--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -2368,11 +2368,6 @@ module.exports = [
     destination: '/docs/guides/database/extensions/pg_repack',
   },
   {
-    permanent: false,
-    source: '/docs/guides/database/extensions/pg_partman',
-    destination: '/docs/guides/database/extensions',
-  },
-  {
     permanent: true,
     source: '/docs/guides/ai/structured-unstructured-embeddings',
     destination: '/docs/guides/ai/structured-unstructured',

--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -138,7 +138,7 @@ module.exports = [
   {
     permanent: true,
     source: '/docs/guides/reports/:match*',
-    destination: '/docs/guides/observability/:match*',
+    destination: '/docs/guides/monitoring-and-debugging/:match*',
   },
   {
     permanent: true,

--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -2067,32 +2067,32 @@ module.exports = [
   {
     permanent: true,
     source: '/docs/reference/javascript',
-    destination: '/docs/reference/javascript/start',
+    destination: '/docs/reference/javascript/introduction',
   },
   {
     permanent: true,
     source: '/docs/reference/dart',
-    destination: '/docs/reference/dart/start',
+    destination: '/docs/reference/dart/introduction',
   },
   {
     permanent: true,
     source: '/docs/reference/python',
-    destination: '/docs/reference/python/start',
+    destination: '/docs/reference/python/introduction',
   },
   {
     permanent: true,
     source: '/docs/reference/csharp',
-    destination: '/docs/reference/csharp/start',
+    destination: '/docs/reference/csharp/introduction',
   },
   {
     permanent: true,
     source: '/docs/reference/swift',
-    destination: '/docs/reference/swift/start',
+    destination: '/docs/reference/swift/introduction',
   },
   {
     permanent: true,
     source: '/docs/reference/kotlin',
-    destination: '/docs/reference/kotlin/start',
+    destination: '/docs/reference/kotlin/introduction',
   },
   {
     permanent: true,

--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -1306,52 +1306,52 @@ module.exports = [
   {
     permanent: true,
     source: '/docs/reference/cli/supabase-db-branch-list',
-    destination: '/docs/reference/supabase-branches-list',
+    destination: '/docs/reference/cli/supabase-branches-list',
   },
   {
     permanent: true,
     source: '/docs/reference/cli/supabase-db-branch-create',
-    destination: '/docs/reference/supabase-branches-create',
+    destination: '/docs/reference/cli/supabase-branches-create',
   },
   {
     permanent: true,
     source: '/docs/reference/cli/supabase-db-branch-delete',
-    destination: '/docs/reference/supabase-branches-delete',
+    destination: '/docs/reference/cli/supabase-branches-delete',
   },
   {
     permanent: true,
     source: '/docs/reference/cli/supabase-db-switch',
-    destination: '/docs/reference/supabase-branches-create',
+    destination: '/docs/reference/cli/supabase-branches-create',
   },
   {
     permanent: true,
     source: '/docs/reference/cli/supabase-db-changes',
-    destination: '/docs/reference/supabase-db-diff',
+    destination: '/docs/reference/cli/supabase-db-diff',
   },
   {
     permanent: true,
     source: '/docs/reference/cli/supabase-db-commit',
-    destination: '/docs/reference/supabase-db-pull',
+    destination: '/docs/reference/cli/supabase-db-pull',
   },
   {
     permanent: true,
     source: '/docs/reference/cli/supabase-db-remote-set',
-    destination: '/docs/reference/supabase-link',
+    destination: '/docs/reference/cli/supabase-link',
   },
   {
     permanent: true,
     source: '/docs/reference/cli/supabase-db-remote-changes',
-    destination: '/docs/reference/supabase-db-diff',
+    destination: '/docs/reference/cli/supabase-db-diff',
   },
   {
     permanent: true,
     source: '/docs/reference/cli/supabase-db-remote-commit',
-    destination: '/docs/reference/supabase-db-pull',
+    destination: '/docs/reference/cli/supabase-db-pull',
   },
   {
     permanent: true,
     source: '/docs/reference/cli/supabase-gen-types-typescript',
-    destination: '/docs/reference/supabase-gen-types',
+    destination: '/docs/reference/cli/supabase-gen-types',
   },
 
   {

--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -2907,17 +2907,17 @@ module.exports = [
   {
     permanent: true,
     source: '/docs/guides/functions/debugging',
-    destination: '/docs/functions/logging',
+    destination: '/docs/guides/functions/logging',
   },
   {
     permanent: true,
     source: '/docs/guides/functions/log-drains',
-    destination: '/docs/platform/log-drains',
+    destination: '/docs/guides/monitoring-and-debugging/log-drains',
   },
   {
     permanent: true,
     source: '/docs/guides/functions/functions-headers',
-    destination: '/docs/functions/logging',
+    destination: '/docs/guides/functions/logging',
   },
   {
     permanent: true,

--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -1596,12 +1596,25 @@ module.exports = [
   {
     permanent: true,
     source: '/docs/reference/dart/removesubscription',
-    destination: '/docs/reference/dart/v0/removesubscription',
+    destination: '/docs/reference/dart/removechannel',
   },
   {
     permanent: true,
     source: '/docs/reference/dart/getsubscriptions',
-    destination: '/docs/reference/dart/v0/getsubscriptions',
+    destination: '/docs/reference/dart/getchannels',
+  },
+  // The Dart reference kept no v0 archive, so anything already pointing into
+  // /v0/ needs bridging to the renamed page the way auth-signinwithprovider is
+  // above. Non-permanent so a cached 301 to the removed page can recover.
+  {
+    permanent: false,
+    source: '/docs/reference/dart/v0/removesubscription',
+    destination: '/docs/reference/dart/removechannel',
+  },
+  {
+    permanent: false,
+    source: '/docs/reference/dart/v0/getsubscriptions',
+    destination: '/docs/reference/dart/getchannels',
   },
   {
     permanent: true,

--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -1440,70 +1440,70 @@ module.exports = [
   {
     permanent: true,
     source: '/docs/reference/javascript/auth-api-getuser',
-    destination: '/docs/reference/javascript/v1/auth-api-getuser',
+    destination: '/docs/reference/javascript/auth-getuser',
   },
   // v1: /auth-api-resetpasswordforemail
   // v2: /auth-resetpasswordforemail
   {
     permanent: true,
     source: '/docs/reference/javascript/auth-api-resetpasswordforemail',
-    destination: '/docs/reference/javascript/v1/auth-api-resetpasswordforemail',
+    destination: '/docs/reference/javascript/auth-resetpasswordforemail',
   },
   // v1: /auth-api-verifyotp
   // v2: /auth-verifyotp
   {
     permanent: true,
     source: '/docs/reference/javascript/auth-api-verifyotp',
-    destination: '/docs/reference/javascript/v1/auth-api-verifyotp',
+    destination: '/docs/reference/javascript/auth-verifyotp',
   },
   // v1: /auth-api-listusers
   // v2: /auth-admin-listusers
   {
     permanent: true,
     source: '/docs/reference/javascript/auth-api-listusers',
-    destination: '/docs/reference/javascript/v1/auth-api-listusers',
+    destination: '/docs/reference/javascript/auth-admin-listusers',
   },
   // v1: /auth-api-createuser
   // v2: /auth-admin-createuser
   {
     permanent: true,
     source: '/docs/reference/javascript/auth-api-createuser',
-    destination: '/docs/reference/javascript/v1/auth-api-createuser',
+    destination: '/docs/reference/javascript/auth-admin-createuser',
   },
   // v1: /auth-api-deleteuser
   // v2: /auth-admin-deleteuser
   {
     permanent: true,
     source: '/docs/reference/javascript/auth-api-deleteuser',
-    destination: '/docs/reference/javascript/v1/auth-api-deleteuser',
+    destination: '/docs/reference/javascript/auth-admin-deleteuser',
   },
   // v1: /auth-api-generatelink
   // v2: /auth-admin-generatelink
   {
     permanent: true,
     source: '/docs/reference/javascript/auth-api-generatelink',
-    destination: '/docs/reference/javascript/v1/auth-api-generatelink',
+    destination: '/docs/reference/javascript/auth-admin-generatelink',
   },
   // v1: /auth-api-inviteuserbyemail
   // v2: /auth-admin-inviteuserbyemail
   {
     permanent: true,
     source: '/docs/reference/javascript/auth-api-inviteuserbyemail',
-    destination: '/docs/reference/javascript/v1/auth-api-inviteuserbyemail',
+    destination: '/docs/reference/javascript/auth-admin-inviteuserbyemail',
   },
   // v1: /auth-api-getuserbyid
   // v2: /auth-admin-getuserbyid
   {
     permanent: true,
     source: '/docs/reference/javascript/auth-api-getuserbyid',
-    destination: '/docs/reference/javascript/v1/auth-api-getuserbyid',
+    destination: '/docs/reference/javascript/auth-admin-getuserbyid',
   },
   // v1: /auth-api-updateuserbyid
   // v2: /auth-admin-updateuserbyid
   {
     permanent: true,
     source: '/docs/reference/javascript/auth-api-updateuserbyid',
-    destination: '/docs/reference/javascript/v1/auth-api-updateuserbyid',
+    destination: '/docs/reference/javascript/auth-admin-updateuserbyid',
   },
   // signIn method is now split into signInWithPassword ,signInWithOtp ,signInWithOAuth
   // send traffic to v1 docs instead
@@ -1524,7 +1524,7 @@ module.exports = [
   {
     permanent: true,
     source: '/docs/reference/javascript/auth-api-sendmobileotp',
-    destination: '/docs/reference/javascript/v1/auth-api-sendmobileotp',
+    destination: '/docs/reference/javascript/auth-signinwithotp',
   },
 
   // realtime methods been replaced with new names

--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -366,7 +366,7 @@ module.exports = [
   {
     permanent: false,
     source: '/docs/client/generating-types',
-    destination: '/docs/reference/javascript/generating-types',
+    destination: '/docs/guides/api/rest/generating-types',
   },
   {
     permanent: false,
@@ -2385,7 +2385,7 @@ module.exports = [
   {
     permanent: true,
     source: '/docs/guides/cli/using-environment-variables-in-config',
-    destination: '/docs/guides/cli/managing-config',
+    destination: '/docs/guides/local-development/managing-config',
   },
   {
     permanent: true,
@@ -2692,7 +2692,7 @@ module.exports = [
   {
     permanent: true,
     source: '/docs/reference/dart/sign-in-with-apple',
-    destination: '/docs/reference/dart/sign-in-with-id-token',
+    destination: '/docs/reference/dart/auth-signinwithidtoken',
   },
   {
     permanent: true,

--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -2972,6 +2972,29 @@ module.exports = [
     source: '/docs/guides/cli/managing-environments',
     destination: '/docs/guides/deployment/managing-environments',
   },
+  // These have to stay above the `/docs/guides/cli/:path*` catch-all below.
+  // Next matches redirects in order, so the catch-all would otherwise send
+  // them to `/docs/guides/local-development/cli/...`, which does not exist.
+  {
+    permanent: true,
+    source: '/docs/guides/cli/github-actions/:path*',
+    destination: '/docs/guides/deployment/ci/:path*',
+  },
+  {
+    permanent: true,
+    source: '/docs/guides/cli/github-action/:path*',
+    destination: '/docs/guides/deployment/ci/:path*',
+  },
+  {
+    permanent: true,
+    source: '/docs/guides/cli/cicd-workflow',
+    destination: '/docs/guides/deployment/managing-environments',
+  },
+  {
+    permanent: true,
+    source: '/docs/guides/cli/seeding-your-database',
+    destination: '/docs/guides/local-development/seeding-your-database',
+  },
   {
     permanent: true,
     source: '/docs/guides/cli/:path*',
@@ -3014,11 +3037,6 @@ module.exports = [
     permanent: true,
     source: '/docs/guides/platform/shared-responsibility-model',
     destination: '/docs/guides/deployment/shared-responsibility-model',
-  },
-  {
-    permanent: true,
-    source: '/docs/guides/cli/github-actions/:path*',
-    destination: '/docs/guides/deployment/ci/:path*',
   },
   {
     permanent: true,

--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -3008,6 +3008,29 @@ module.exports = [
     source: '/docs/guides/local-development/cli/managing-environments',
     destination: '/docs/guides/deployment/managing-environments',
   },
+  // Same reasoning as the entry above, for the paths the catch-all used to
+  // send people to. The old `/docs/guides/cli/:path*` rule was permanent, so
+  // browsers that already followed it have these dead targets cached.
+  {
+    permanent: false,
+    source: '/docs/guides/local-development/cli/github-actions/:path*',
+    destination: '/docs/guides/deployment/ci/:path*',
+  },
+  {
+    permanent: false,
+    source: '/docs/guides/local-development/cli/github-action/:path*',
+    destination: '/docs/guides/deployment/ci/:path*',
+  },
+  {
+    permanent: false,
+    source: '/docs/guides/local-development/cli/cicd-workflow',
+    destination: '/docs/guides/deployment/managing-environments',
+  },
+  {
+    permanent: false,
+    source: '/docs/guides/local-development/cli/seeding-your-database',
+    destination: '/docs/guides/local-development/seeding-your-database',
+  },
   {
     permanent: true,
     source: '/docs/guides/platform/branching',


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix, and a consolidation. 36 entries in `apps/www/lib/redirects.js` send visitors to a page that does not exist, so the redirect fires and lands on a 404. Those 36 are retargeted, one stale entry is deleted, and nine are added (bridges for URLs the old permanent rules already cached, and four that a catch-all was swallowing). This replaces eight separate PRs I opened against this one file (#48560, #48562, #49120, #49121, #49122, #49123, #49124, #49125), which was the wrong way to send them and is on me. Same commits, one review.

## What is the current behavior?

Six independent groups, all found by resolving every static destination in the file:

**1. CLI reference lost its `/cli/` segment** (10 entries). `/docs/reference/cli/supabase-db-branch-list` sends you to `/docs/reference/supabase-branches-list`, which 404s. The page is `/docs/reference/cli/supabase-branches-list`.

**2. JS `auth-api-*` point into a v1 archive that is gone** (11 entries). Each entry carries a comment naming its own answer, for example:

```js
// v1: /auth-api-getuser
// v2: /auth-getuser
{ source: '/docs/reference/javascript/auth-api-getuser',
  destination: '/docs/reference/javascript/v1/auth-api-getuser' },  // 404
```

The `v2` line in the comment is the page that exists. `sendmobileotp` has no v2 comment; it maps to `auth-signinwithotp`, which is where `signInWithMobileOtp` went.

**3. Dart realtime points into a removed v0 archive** (2 entries, plus 2 new). `removesubscription` and `getsubscriptions` go to `/docs/reference/dart/v0/...`, and the Dart reference kept no v0 archive at all. They become `removechannel` and `getchannels`. Because those two rules were `permanent: true`, browsers have the dead `/v0/` URLs cached, so I added two non-permanent rules bridging `/v0/removesubscription` and `/v0/getsubscriptions` as well. That is the same shape as the existing `auth-signinwithprovider` bridge a few lines above.

**4. Client library landing pages still say `/start`** (6 entries). `/docs/reference/javascript` sends you to `/docs/reference/javascript/start`, which 404s; the landing page is `introduction`. Same for dart, python, csharp, swift, kotlin.

**5. Edge Functions redirects missed the `/guides/` move** (3 entries). `/docs/functions/logging` and `/docs/platform/log-drains` are pre-move paths. Log drains additionally moved out of the functions namespace into `monitoring-and-debugging`.

**6. Three individually moved pages** (3 entries): `generating-types` now lives under `guides/api/rest`, `managing-config` moved from the `cli` namespace into `local-development`, and the Dart Apple sign in page is `auth-signinwithidtoken`.

**7. A wildcard destination pointing at a directory that never existed.** `/docs/guides/reports/:match*` redirects to `/docs/guides/observability/:match*`, and there is no `guides/observability`. #40470 added that rule while the section was still `guides/telemetry`, and #48243 later renamed the section to `monitoring-and-debugging`, so the whole `/docs/guides/reports/*` space has been landing on a 404. Verified for `reports`, `metrics`, `logs`, `log-drains` and `advanced-log-filtering`: all five 404 today, all five resolve under `monitoring-and-debugging`.

My original sweep only resolved the 510 **static** destinations, so wildcard destinations went unchecked. There are 13 of them and this is the only broken one. `/docs/guides/monitoring-troubleshooting/:path*` also targets a directory that does not exist, but the `guides/telemetry/:match*` rule higher in the file rescues it and it chains through to the right page, so I left it alone and confirmed that live rather than assuming.

Plus two ordering and lifecycle items in the same file:

**7. A catch-all swallowing four live URLs.** `/docs/guides/cli/:path*` is matched in order, so it captures `/docs/guides/cli/github-actions/...`, `cicd-workflow` and `seeding-your-database` and rewrites them to `/docs/guides/local-development/cli/...`, which does not exist. The `github-actions` rule that was supposed to handle this sits about 90 entries *below* the catch-all, so it never runs. Moving it above the catch-all and adding the other three fixes it. The catch-all was permanent, so I also added four non-permanent rules for the dead `local-development/cli/...` targets browsers already cached.

**8. A temp redirect that outlived its revert.** `/docs/guides/database/extensions/pg_partman` still redirects to the generic extensions index, so the sidebar entry for it cannot reach its own page. Sequence: #29206 added the docs, #30109 reverted them, #30149 added *temp* redirects for `pgmq` and `pg_partman` because the pages were gone, #40037 brought the pg_partman page back. #33170 already removed the `pgmq` half; only `pg_partman` was left behind, so this brings the pair back in line.

## What I deliberately left out

- `/docs/guides/database/connecting/direct-connections`. Its destination `/docs/guides/database/connection-pooling` 404s, but there is an earlier duplicate entry for the same source that wins under first-match-wins, so visitors get a 200 today and this is not a live break. Picking a successor is a docs call, not a path repair.
- The `/docs/reference/javascript/*` filter methods (`ilike`, `overlaps` and friends). They point at `using-filters`, which resolves, but I fetched the rendered page and it has no per-method anchors, so there is nothing better to point them at without writing docs.
- 36 other non-resolving destinations that need someone who knows where the content went.

## Verification

A 200 is not proof on its own here. `/docs/reference/cli/` and `/docs/reference/self-hosting-auth/` return 200 for literally any slug, so a status code is meaningless in those namespaces. For every group above I checked a deliberate nonsense URL in the same namespace first and confirmed it 404s, then checked the source URL as a visitor experiences it, then read the destination page to confirm it is about the thing the source promises.

Ordering is checked too, since Next matches in array order: no entry in the file is shadowed by an earlier pattern, and the four duplicate sources are unchanged from master.

Gates: `test:prettier` passes repo wide, `typecheck --filter=www --force` passes 8/8, and the www vitest suite passes (6 files, 75 tests) including the `next.config.test.ts` redirect coverage.

Freshman contributor. Put this together with Claude Code's help, and I verified every status code, every namespace canary and every target page myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated redirects across monitoring, JavaScript, Dart, CLI, API, reference, Functions, and local-development documentation.
  * Added recovery routes for cached Dart documentation URLs.
  * Improved handling for specific CLI documentation links and their non-permanent variants.
  * Removed outdated redirects and updated destinations to reflect reorganized documentation pages.
  * Redirects now point to renamed authentication, SDK, CLI, and local-development documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->