### PR TITLE
chore(a11y): have CodeRabbit flag live regions, keyboard, motion, and alt text

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -69,7 +69,7 @@ reviews:
           for both runtimes until the final cleanup pass (tracked in FE-3106).
         Keep this a reminder to verify, not a hard blocker: if no mirror is required,
         say so briefly rather than forcing a change.
-    - path: '{apps,packages}/**/*.{tsx,jsx,css}'
+    - path: '{apps,packages}/**/*.{tsx,jsx,css,mdx}'
       instructions: |
         When reviewing UI changes, flag these accessibility gaps. Comments are
         advisory. One comment per gap. Skip test files (*.test.*, *.spec.*) and
@@ -88,6 +88,10 @@ reviews:
           motion-safe:, or matchMedia('(prefers-reduced-motion: reduce)').
           packages/config/css/utilities.css only zeroes out .shimmer under
           reduced motion, not all animation.
+        - Alt text: flag generic values such as Image, Icon, Photo, Picture, or
+          the filename. If adjacent visible text already names the image (blog
+          thumbnail next to its title, icon next to its label), flag it as
+          redundant and recommend alt="" plus aria-hidden on the image.
 
 # Applies our internal engineering skills (.claude/skills/) as CodeRabbit review
 # guidelines. The skills are the single source of truth — they are consumed

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -73,16 +73,16 @@ reviews:
       instructions: |
         When reviewing UI changes, flag these accessibility gaps. Comments are
         advisory. One comment per gap. Skip test files (*.test.*, *.spec.*) and
-        generated files.
+        generated files. Skip Radix/shadcn primitives imported from ui for all
+        checks below.
         - State changes: if sighted users can see a status change (toast,
           loading/empty swap, copy confirmation, async result) and nothing
           announces it, suggest aria-live, role="status", or role="alert". Skip
           if a live region, Radix Toast, or Sonner is already there, or if the
           change is decoration only.
-        - Mouse interaction: flag onClick or onMouseEnter on a non-interactive
-          element (div, span) with no keyboard equivalent. Do not flag
-          Radix/shadcn primitives imported from ui. Those already handle
-          keyboard.
+        - Mouse interaction: flag pointer-only handlers (onClick, onMouseEnter,
+          onDoubleClick, onContextMenu) on a non-interactive element (div, span,
+          or similar) with no keyboard equivalent.
         - Animation: flag animate-*, keyframes, or JS motion with no
           reduced-motion treatment. Prefer Tailwind motion-reduce: /
           motion-safe:, or matchMedia('(prefers-reduced-motion: reduce)').

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -74,24 +74,46 @@ reviews:
         When reviewing UI changes, flag these accessibility gaps. Comments are
         advisory. One comment per gap. Skip test files (*.test.*, *.spec.*) and
         generated files. Skip Radix/shadcn primitives imported from ui for all
-        checks below.
+        checks below. Do not flag issues axe-core already catches mechanically,
+        such as a missing alt attribute, an empty button or link name, or
+        invalid ARIA.
         - State changes: if sighted users can see a status change (toast,
           loading/empty swap, copy confirmation, async result) and nothing
           announces it, suggest aria-live, role="status", or role="alert". Skip
           if a live region, Radix Toast, or Sonner is already there, or if the
-          change is decoration only.
+          change is decoration only. If a live region is created in the same
+          conditional as its message, flag that: the region must already exist
+          in the DOM, then receive the update, or screen readers often announce
+          nothing.
         - Mouse interaction: flag pointer-only handlers (onClick, onMouseEnter,
           onDoubleClick, onContextMenu) on a non-interactive element (div, span,
-          or similar) with no keyboard equivalent.
+          or similar) with no keyboard equivalent. Also flag hover-only UI
+          (content revealed with onMouseEnter or CSS :hover) that has no focus
+          or keyboard path.
         - Animation: flag animate-*, keyframes, or JS motion with no
           reduced-motion treatment. Prefer Tailwind motion-reduce: /
           motion-safe:, or matchMedia('(prefers-reduced-motion: reduce)').
           packages/config/css/utilities.css only zeroes out .shimmer under
           reduced motion, not all animation.
         - Alt text: flag generic values such as Image, Icon, Photo, Picture, or
-          the filename. If adjacent visible text already names the image (blog
-          thumbnail next to its title, icon next to its label), flag it as
-          redundant and recommend alt="" plus aria-hidden on the image.
+          the filename. Flag alt that starts with "image of" or "picture of".
+          If adjacent visible text already names the image (blog thumbnail next
+          to its title, icon next to its label), flag it as redundant and
+          recommend alt="" plus aria-hidden on the image. For a decorative SVG
+          next to visible text, recommend aria-hidden on the SVG. If alt is
+          longer than about two sentences, suggest moving the extra into a
+          caption, adjacent text, or aria-describedby. Do not treat a character
+          count as a hard fail.
+        - Focus visibility: flag outline-none or outline-hidden that is not
+          paired with a focus-visible ring or outline, or with the focus-ring
+          or focus-inset utility.
+        - Color-only state: flag status, validation, or selection that is
+          conveyed only by color. Suggest a text label, icon, or sr-only text
+          in addition.
+        - Link purpose: flag an accessible name that is only "click here",
+          "read more", or "learn more" when it does not describe the
+          destination. Skip if aria-label or wrapping context already names
+          where the link goes.
 
 # Applies our internal engineering skills (.claude/skills/) as CodeRabbit review
 # guidelines. The skills are the single source of truth — they are consumed

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -79,15 +79,17 @@ reviews:
         invalid ARIA.
         - State changes: if sighted users can see a status change (toast,
           loading/empty swap, copy confirmation, async result) and nothing
-          announces it, suggest aria-live, role="status", or role="alert". Skip
-          if a live region, Radix Toast, or Sonner is already there, or if the
-          change is decoration only. If a live region is created in the same
-          conditional as its message, flag that: the region must already exist
-          in the DOM, then receive the update, or screen readers often announce
-          nothing.
-        - Mouse interaction: flag pointer-only handlers (onClick, onMouseEnter,
-          onDoubleClick, onContextMenu) on a non-interactive element (div, span,
-          or similar) with no keyboard equivalent. Also flag hover-only UI
+          announces it, suggest aria-live="polite" or role="status". Reserve
+          role="alert" for urgent errors or warnings. Skip if a live region,
+          Radix Toast, or Sonner is already there, or if the change is
+          decoration only. If a live region is created in the same conditional
+          as its message, flag that: the region must already exist in the DOM,
+          then receive the update, or screen readers often announce nothing.
+        - Mouse interaction: flag pointer-only handlers on a non-interactive
+          element (div, span, or similar) with no keyboard equivalent. The
+          listed handlers are illustrative: onClick, onMouseEnter,
+          onDoubleClick, onContextMenu, onPointerDown, onPointerUp,
+          onTouchStart, onTouchEnd, and equivalents. Also flag hover-only UI
           (content revealed with onMouseEnter or CSS :hover) that has no focus
           or keyboard path.
         - Animation: flag animate-*, keyframes, or JS motion with no
@@ -104,9 +106,10 @@ reviews:
           longer than about two sentences, suggest moving the extra into a
           caption, adjacent text, or aria-describedby. Do not treat a character
           count as a hard fail.
-        - Focus visibility: flag outline-none or outline-hidden that is not
-          paired with a focus-visible ring or outline, or with the focus-ring
-          or focus-inset utility.
+        - Focus visibility: flag outline-none, outline-hidden, outline: none,
+          outline: 0, or equivalent :focus resets that are not paired with a
+          focus-visible ring or outline, or with the focus-ring or focus-inset
+          utility.
         - Color-only state: flag status, validation, or selection that is
           conveyed only by color. Suggest a text label, icon, or sr-only text
           in addition.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -69,6 +69,25 @@ reviews:
           for both runtimes until the final cleanup pass (tracked in FE-3106).
         Keep this a reminder to verify, not a hard blocker: if no mirror is required,
         say so briefly rather than forcing a change.
+    - path: '{apps,packages}/**/*.{tsx,jsx,css}'
+      instructions: |
+        When reviewing UI changes, flag these accessibility gaps. Comments are
+        advisory. One comment per gap. Skip test files (*.test.*, *.spec.*) and
+        generated files.
+        - State changes: if sighted users can see a status change (toast,
+          loading/empty swap, copy confirmation, async result) and nothing
+          announces it, suggest aria-live, role="status", or role="alert". Skip
+          if a live region, Radix Toast, or Sonner is already there, or if the
+          change is decoration only.
+        - Mouse interaction: flag onClick or onMouseEnter on a non-interactive
+          element (div, span) with no keyboard equivalent. Do not flag
+          Radix/shadcn primitives imported from ui. Those already handle
+          keyboard.
+        - Animation: flag animate-*, keyframes, or JS motion with no
+          reduced-motion treatment. Prefer Tailwind motion-reduce: /
+          motion-safe:, or matchMedia('(prefers-reduced-motion: reduce)').
+          packages/config/css/utilities.css only zeroes out .shimmer under
+          reduced motion, not all animation.
 
 # Applies our internal engineering skills (.claude/skills/) as CodeRabbit review
 # guidelines. The skills are the single source of truth — they are consumed


### PR DESCRIPTION
Closes FE-3811

## Problem

CodeRabbit reviews UI PRs without prompting on accessibility gaps axe-core cannot judge: live regions, keyboard and hover, reduced motion, alt quality, focus visibility, color-only state, and vague link names.

## Solution

- Add a path_instruction on `{apps,packages}/**/*.{tsx,jsx,css,mdx}`.
- Keep comments advisory. Skip tests, generated files, Radix/shadcn from `ui`, and mechanical axe findings.
- Cover live-region lifecycle, pointer-only and hover-only UI, reduced motion, alt quality including a two-sentence length heuristic, focus rings, color-only state, and generic link names.

## Manual testing

1. After merge, open a PR that touches a UI or MDX file under `apps/` or `packages/`.
2. Confirm CodeRabbit comments on at least one of: an unannounced status change, a live region created with its message, a pointer-only or hover-only control, animation without reduced motion, generic or redundant or long alt, `outline-none` without a focus-visible replacement, color-only status, or a "learn more" link that does not name its destination.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Expanded accessibility review coverage for interface content and styling.
  * Reviews now identify missing focus indicators, color-only status or selection cues, and unclear link labels.
  * Continued checks cover state announcements, pointer-only interactions, reduced-motion support, and alternative text quality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->