### PR TITLE
docs(mcp): revise authentication note to match style guide

### DIFF
--- a/apps/docs/features/ui/McpConfigPanel.tsx
+++ b/apps/docs/features/ui/McpConfigPanel.tsx
@@ -338,15 +338,11 @@ export function McpConfigPanel() {
       {isPlatform && (
         <Admonition type="note" title="Authentication" className="mt-3">
           <p>
-            {
-              "Some MCP clients will automatically prompt you to login during setup, while others may require manual authentication steps. Either authentication method will open a browser window where you can login to your Supabase account and grant organization access to the MCP client. In the future, we'll offer more fine grain control over these permissions."
-            }
+            Some MCP clients automatically prompt you to log in during setup. Others require manual
+            authentication steps. Either method opens a browser window where you log in to your
+            Supabase account and grant the MCP client access to your organization.
           </p>
-          <p>
-            {
-              'Previously Supabase MCP required you to generate a personal access token (PAT), but this is no longer required.'
-            }
-          </p>
+          <p>You don't need a personal access token (PAT).</p>
         </Admonition>
       )}
     </>

--- a/apps/docs/features/ui/McpConfigPanel.tsx
+++ b/apps/docs/features/ui/McpConfigPanel.tsx
@@ -26,6 +26,7 @@ import {
 import { Admonition } from 'ui-patterns/Admonition'
 import {
   createMcpCopyHandler,
+  MCP_HOSTED_AUTH_NOTE,
   McpConfigPanel as McpConfigPanelBase,
   type McpClient,
 } from 'ui-patterns/McpUrlBuilder'
@@ -336,13 +337,8 @@ export function McpConfigPanel() {
         />
       </div>
       {isPlatform && (
-        <Admonition type="note" title="Authentication" className="mt-3">
-          <p>
-            Some MCP clients automatically prompt you to log in during setup. Others require manual
-            authentication steps. Either method opens a browser window where you log in to your
-            Supabase account and grant the MCP client access to your organization.
-          </p>
-          <p>You don't need a personal access token (PAT).</p>
+        <Admonition type="note" title={MCP_HOSTED_AUTH_NOTE.title} className="mt-3">
+          <p>{MCP_HOSTED_AUTH_NOTE.body}</p>
         </Admonition>
       )}
     </>

--- a/packages/ui-patterns/src/McpUrlBuilder/McpConfigPanel.md.tsx
+++ b/packages/ui-patterns/src/McpUrlBuilder/McpConfigPanel.md.tsx
@@ -9,6 +9,7 @@ import {
   DEFAULT_MCP_URL_NON_PLATFORM as LOCAL_URL,
   MCP_CLIENT_DATA,
   MCP_CLIENT_GROUPS,
+  MCP_HOSTED_AUTH_NOTE,
 } from './clients.data'
 import type { McpClientData } from './clients.data'
 import {
@@ -144,14 +145,9 @@ export function McpConfigPanel() {
       ))}
 
       <paragraph>
-        <strong>Authentication</strong>
+        <strong>{MCP_HOSTED_AUTH_NOTE.title}</strong>
       </paragraph>
-      <paragraph>
-        Some MCP clients automatically prompt you to log in during setup. Others require manual
-        authentication steps. Either method opens a browser window where you log in to your Supabase
-        account and grant the MCP client access to your organization.
-      </paragraph>
-      <paragraph>You don't need a personal access token (PAT).</paragraph>
+      <paragraph>{MCP_HOSTED_AUTH_NOTE.body}</paragraph>
     </>
   )
 }

--- a/packages/ui-patterns/src/McpUrlBuilder/McpConfigPanel.md.tsx
+++ b/packages/ui-patterns/src/McpUrlBuilder/McpConfigPanel.md.tsx
@@ -147,13 +147,11 @@ export function McpConfigPanel() {
         <strong>Authentication</strong>
       </paragraph>
       <paragraph>
-        Some MCP clients automatically prompt you to log in during setup, while others require
-        manual authentication steps. Either way, a browser window opens where you log in to your
-        Supabase account and grant the MCP client access to your organization.
+        Some MCP clients automatically prompt you to log in during setup. Others require manual
+        authentication steps. Either method opens a browser window where you log in to your Supabase
+        account and grant the MCP client access to your organization.
       </paragraph>
-      <paragraph>
-        A personal access token (PAT) was previously required, but is no longer needed.
-      </paragraph>
+      <paragraph>You don't need a personal access token (PAT).</paragraph>
     </>
   )
 }

--- a/packages/ui-patterns/src/McpUrlBuilder/clients.data.ts
+++ b/packages/ui-patterns/src/McpUrlBuilder/clients.data.ts
@@ -418,3 +418,12 @@ export const DEFAULT_MCP_URL_NON_PLATFORM = 'http://localhost:54321/mcp'
  * docs document (and what to fall back to in production).
  */
 export const HOSTED_MCP_URL = 'https://mcp.supabase.com/mcp'
+
+/**
+ * Hosted MCP authentication note. Shared by the docs HTML callout and the
+ * markdown export so the two pipelines cannot drift.
+ */
+export const MCP_HOSTED_AUTH_NOTE = {
+  title: 'Authentication',
+  body: "Some MCP clients automatically prompt you to log in during setup. Others require manual authentication steps. Either method opens a browser window where you log in to your Supabase account and grant the MCP client access to your organization. You don't need a personal access token (PAT).",
+} as const

--- a/packages/ui-patterns/src/McpUrlBuilder/index.ts
+++ b/packages/ui-patterns/src/McpUrlBuilder/index.ts
@@ -9,6 +9,7 @@ export {
   FEATURE_GROUPS_NON_PLATFORM,
   MCP_CLIENT_GROUPS,
   MCP_CLIENT_DATA,
+  MCP_HOSTED_AUTH_NOTE,
 } from './clients.data'
 export type { McpClientData } from './clients.data'
 export { MCP_CLIENTS } from './mcpClients'


### PR DESCRIPTION

<img width="769" height="212" alt="Screenshot 2026-08-18 at 12 17 18 PM" src="https://github.com/user-attachments/assets/38ce6606-84ae-4833-a7d9-7a1931fdd773" />


## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update. Copy and dedupe.

## What is the current behavior?

Gave this a style edit. Basically, saw this note breaking a lot of style rules at once (`login` instead of `log in`, future tense, and also breaking timelessness) and couldn't help myself for submitting a revision. 😅

## What is the new behavior?

Preview: https://docs-git-cursor-revise-mcp-auth-note-bbe8-supabase.vercel.app/docs/guides/ai-tools/mcp