### PR TITLE
fix(studio): use realtime entitlements for max settings

### DIFF
--- a/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
+++ b/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
@@ -23,6 +23,7 @@ import {
 import { Admonition } from 'ui-patterns/Admonition'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
+import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 import * as z from 'zod'
 
 import { AlertError } from '@/components/ui/AlertError'
@@ -64,7 +65,7 @@ export const RealtimeSettings = () => {
     projectRef: project?.ref,
     connectionString: project?.connectionString,
   })
-  const { data, error, isError } = useRealtimeConfigurationQuery({
+  const { data, error, isError, isPending } = useRealtimeConfigurationQuery({
     projectRef,
   })
 
@@ -93,6 +94,8 @@ export const RealtimeSettings = () => {
     isSuccessMaxEventsPerSecond &&
     isSuccessMaxPresenceEventsPerSecond &&
     isSuccessMaxPayloadSizeInKb
+
+  const isLoading = isPending || !isRealtimeEntitlementsLoaded
 
   const maxConcurrentUsersLimit = Math.min(
     getMaxConcurrentUsers() ?? Infinity,
@@ -220,16 +223,32 @@ export const RealtimeSettings = () => {
     }),
   ])
 
+  const configValues = data ?? REALTIME_DEFAULT_CONFIG
+  const sharedFormValues = {
+    connection_pool: configValues.connection_pool ?? REALTIME_DEFAULT_CONFIG.connection_pool,
+    max_concurrent_users:
+      configValues.max_concurrent_users ?? REALTIME_DEFAULT_CONFIG.max_concurrent_users,
+    max_events_per_second:
+      configValues.max_events_per_second ?? REALTIME_DEFAULT_CONFIG.max_events_per_second,
+    max_presence_events_per_second:
+      configValues.max_presence_events_per_second ??
+      REALTIME_DEFAULT_CONFIG.max_presence_events_per_second,
+    max_payload_size_in_kb:
+      configValues.max_payload_size_in_kb ?? REALTIME_DEFAULT_CONFIG.max_payload_size_in_kb,
+    allow_public: !(configValues.private_only ?? REALTIME_DEFAULT_CONFIG.private_only),
+  }
+  const formValues: z.infer<typeof FormSchema> = {
+    suspend: configValues.suspend ?? REALTIME_DEFAULT_CONFIG.suspend,
+    ...sharedFormValues,
+  }
+
   const form = useForm<z.infer<typeof FormSchema>>({
     resolver: zodResolver(FormSchema),
     defaultValues: {
       ...REALTIME_DEFAULT_CONFIG,
       allow_public: !REALTIME_DEFAULT_CONFIG.private_only,
     },
-    values: {
-      ...(data ?? REALTIME_DEFAULT_CONFIG),
-      allow_public: !(data?.private_only ?? REALTIME_DEFAULT_CONFIG.private_only),
-    } as any,
+    values: formValues,
   })
 
   const [allow_public, suspend] = useWatch({
@@ -283,6 +302,16 @@ export const RealtimeSettings = () => {
     })
   }
 
+  if (isLoading) {
+    return (
+      <Card>
+        <CardContent>
+          <GenericSkeletonLoader />
+        </CardContent>
+      </Card>
+    )
+  }
+
   return (
     <>
       <Form {...form}>
@@ -306,6 +335,7 @@ export const RealtimeSettings = () => {
                         <FormControl>
                           <Switch
                             id="suspend"
+                            aria-label="Toggle enabling of realtime service"
                             checked={!field.value}
                             onCheckedChange={(checked) => field.onChange(!checked)}
                             disabled={!canUpdateConfig}
@@ -320,30 +350,25 @@ export const RealtimeSettings = () => {
                   <Admonition
                     showIcon={false}
                     type={isDisablingRealtime || isEnablingRealtime ? 'warning' : 'default'}
-                  >
-                    <div className="flex items-center gap-x-2">
-                      <div>
-                        <h5 className="text-foreground mb-1">
-                          {isDisablingRealtime
-                            ? 'Realtime service will be disabled'
-                            : isEnablingRealtime
-                              ? 'Realtime service will be re-enabled'
-                              : isRealtimeDisabled
-                                ? 'Realtime service is disabled'
-                                : null}
-                        </h5>
-                        <p className="text-foreground-light">
-                          {isDisablingRealtime
-                            ? 'Clients will no longer be able to connect to your project’s realtime service once saved'
-                            : isEnablingRealtime
-                              ? "Clients will be able to connect to your project's realtime service again once saved"
-                              : isRealtimeDisabled
-                                ? 'You will need to enable it to continue using Realtime'
-                                : null}
-                        </p>
-                      </div>
-                    </div>
-                  </Admonition>
+                    title={
+                      isDisablingRealtime
+                        ? 'Realtime service will be disabled'
+                        : isEnablingRealtime
+                          ? 'Realtime service will be re-enabled'
+                          : isRealtimeDisabled
+                            ? 'Realtime service is disabled'
+                            : ''
+                    }
+                    description={
+                      isDisablingRealtime
+                        ? 'Clients will no longer be able to connect to your project’s realtime service once saved'
+                        : isEnablingRealtime
+                          ? "Clients will be able to connect to your project's realtime service again once saved"
+                          : isRealtimeDisabled
+                            ? 'You will need to enable it to continue using Realtime'
+                            : null
+                    }
+                  />
                 )}
               </CardContent>
 
@@ -364,6 +389,7 @@ export const RealtimeSettings = () => {
                             <FormControl>
                               <Switch
                                 id="allow_public"
+                                aria-label="Toggle allow public access"
                                 checked={field.value}
                                 onCheckedChange={field.onChange}
                                 disabled={!canUpdateConfig}
@@ -377,25 +403,23 @@ export const RealtimeSettings = () => {
                             !isRealtimeDisabled && (
                               <Admonition
                                 showIcon={false}
+                                className="mt-2"
                                 type="warning"
                                 title="No Realtime RLS policies found"
                                 description={
-                                  <>
-                                    <p className="prose max-w-full text-sm">
-                                      Private mode is {isSettingToPrivate ? 'being ' : ''}
-                                      enabled, but no RLS policies exists on the{' '}
-                                      <code className="text-code-inline">
-                                        realtime.messages
-                                      </code>{' '}
-                                      table. No messages will be received by users.
-                                    </p>
-
-                                    <Button asChild variant="default" className="mt-2">
-                                      <Link href={`/project/${projectRef}/realtime/policies`}>
-                                        Create policy
-                                      </Link>
-                                    </Button>
-                                  </>
+                                  <p className="prose max-w-full text-sm">
+                                    Private mode is {isSettingToPrivate ? 'being ' : ''}
+                                    enabled, but no RLS policies exists on the{' '}
+                                    <code className="text-code-inline">realtime.messages</code>{' '}
+                                    table. No messages will be received by users.
+                                  </p>
+                                }
+                                actions={
+                                  <Button asChild variant="default">
+                                    <Link href={`/project/${projectRef}/realtime/policies`}>
+                                      Create policy
+                                    </Link>
+                                  </Button>
                                 }
                               />
                             )}
@@ -654,7 +678,7 @@ export const RealtimeSettings = () => {
                 </div>
                 <div className="flex items-center gap-x-2">
                   {form.formState.isDirty && (
-                    <Button variant="default" onClick={() => form.reset(data as any)}>
+                    <Button variant="default" onClick={() => form.reset(formValues)}>
                       Cancel
                     </Button>
                   )}

--- a/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
+++ b/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
@@ -35,11 +35,19 @@ import {
   REALTIME_DEFAULT_CONFIG,
   useRealtimeConfigurationQuery,
 } from '@/data/realtime/realtime-config-query'
+import { useCheckEntitlements } from '@/hooks/misc/useCheckEntitlements'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 
 const formId = 'realtime-configuration-form'
+
+const REALTIME_SOFT_LIMITS = {
+  max_concurrent_users: 50_000,
+  max_events_per_second: 50_000,
+  max_presence_events_per_second: 5_000,
+  max_payload_size_in_kb: 3_000,
+}
 
 export const RealtimeSettings = () => {
   const { ref: projectRef } = useParams()
@@ -65,6 +73,43 @@ export const RealtimeSettings = () => {
     connectionString: project?.connectionString,
     schemas: ['realtime'],
   })
+
+  // Per-plan realtime ceilings come from the org's entitlements (plan + any overrides).
+  // The effective limit is the lower of the entitlement and the soft cap, so an unlimited
+  // plan is still bounded and self-hosted / loading falls back to the soft cap.
+  const { getEntitlementMax: getMaxConcurrentUsers, isSuccess: isSuccessMaxConcurrentUsers } =
+    useCheckEntitlements('realtime.max_concurrent_users')
+  const { getEntitlementMax: getMaxEventsPerSecond, isSuccess: isSuccessMaxEventsPerSecond } =
+    useCheckEntitlements('realtime.max_events_per_second')
+  const {
+    getEntitlementMax: getMaxPresenceEventsPerSecond,
+    isSuccess: isSuccessMaxPresenceEventsPerSecond,
+  } = useCheckEntitlements('realtime.max_presence_events_per_second')
+  const { getEntitlementMax: getMaxPayloadSizeInKb, isSuccess: isSuccessMaxPayloadSizeInKb } =
+    useCheckEntitlements('realtime.max_payload_size_in_kb')
+
+  const isRealtimeEntitlementsLoaded =
+    isSuccessMaxConcurrentUsers &&
+    isSuccessMaxEventsPerSecond &&
+    isSuccessMaxPresenceEventsPerSecond &&
+    isSuccessMaxPayloadSizeInKb
+
+  const maxConcurrentUsersLimit = Math.min(
+    getMaxConcurrentUsers() ?? Infinity,
+    REALTIME_SOFT_LIMITS.max_concurrent_users
+  )
+  const maxEventsPerSecondLimit = Math.min(
+    getMaxEventsPerSecond() ?? Infinity,
+    REALTIME_SOFT_LIMITS.max_events_per_second
+  )
+  const maxPresenceEventsPerSecondLimit = Math.min(
+    getMaxPresenceEventsPerSecond() ?? Infinity,
+    REALTIME_SOFT_LIMITS.max_presence_events_per_second
+  )
+  const maxPayloadSizeInKbLimit = Math.min(
+    getMaxPayloadSizeInKb() ?? Infinity,
+    REALTIME_SOFT_LIMITS.max_payload_size_in_kb
+  )
 
   const isFreePlan = organization?.plan.id === 'free'
   const isUsageBillingEnabled = organization?.usage_billing_enabled
@@ -93,10 +138,38 @@ export const RealtimeSettings = () => {
         .min(1)
         .max(maxConn?.maxConnections ?? 100)
         .optional(),
-      max_concurrent_users: z.coerce.number().min(1).max(50000).optional(),
-      max_events_per_second: z.coerce.number().min(1).max(50000).optional(),
-      max_presence_events_per_second: z.coerce.number().min(1).max(5000).optional(),
-      max_payload_size_in_kb: z.coerce.number().min(1).max(10000).optional(),
+      max_concurrent_users: z.coerce
+        .number()
+        .min(1)
+        .max(
+          maxConcurrentUsersLimit,
+          `Cannot exceed ${maxConcurrentUsersLimit.toLocaleString()} concurrent clients`
+        )
+        .optional(),
+      max_events_per_second: z.coerce
+        .number()
+        .min(1)
+        .max(
+          maxEventsPerSecondLimit,
+          `Cannot exceed ${maxEventsPerSecondLimit.toLocaleString()} events per second`
+        )
+        .optional(),
+      max_presence_events_per_second: z.coerce
+        .number()
+        .min(1)
+        .max(
+          maxPresenceEventsPerSecondLimit,
+          `Cannot exceed ${maxPresenceEventsPerSecondLimit.toLocaleString()} presence events per second`
+        )
+        .optional(),
+      max_payload_size_in_kb: z.coerce
+        .number()
+        .min(1)
+        .max(
+          maxPayloadSizeInKbLimit,
+          `Cannot exceed ${maxPayloadSizeInKbLimit.toLocaleString()} KB`
+        )
+        .optional(),
       // [Joshen] These fields are temporarily hidden from the UI
       // max_bytes_per_second: z.coerce.number().min(1).max(10000000).optional(),
       // max_channels_per_client: z.coerce.number().min(1).max(10000).optional(),
@@ -110,10 +183,34 @@ export const RealtimeSettings = () => {
         .number()
         .min(1)
         .max(maxConn?.maxConnections ?? 100),
-      max_concurrent_users: z.coerce.number().min(1).max(50000),
-      max_events_per_second: z.coerce.number().min(1).max(50000),
-      max_presence_events_per_second: z.coerce.number().min(1).max(5000),
-      max_payload_size_in_kb: z.coerce.number().min(1).max(10000),
+      max_concurrent_users: z.coerce
+        .number()
+        .min(1)
+        .max(
+          maxConcurrentUsersLimit,
+          `Cannot exceed ${maxConcurrentUsersLimit.toLocaleString()} concurrent clients`
+        ),
+      max_events_per_second: z.coerce
+        .number()
+        .min(1)
+        .max(
+          maxEventsPerSecondLimit,
+          `Cannot exceed ${maxEventsPerSecondLimit.toLocaleString()} events per second`
+        ),
+      max_presence_events_per_second: z.coerce
+        .number()
+        .min(1)
+        .max(
+          maxPresenceEventsPerSecondLimit,
+          `Cannot exceed ${maxPresenceEventsPerSecondLimit.toLocaleString()} presence events per second`
+        ),
+      max_payload_size_in_kb: z.coerce
+        .number()
+        .min(1)
+        .max(
+          maxPayloadSizeInKbLimit,
+          `Cannot exceed ${maxPayloadSizeInKbLimit.toLocaleString()} KB`
+        ),
       // [Joshen] These fields are temporarily hidden from the UI
       // max_bytes_per_second: z.coerce.number().min(1).max(10000000),
       // max_channels_per_client: z.coerce.number().min(1).max(10000),
@@ -145,11 +242,13 @@ export const RealtimeSettings = () => {
 
   const onSubmit: SubmitHandler<z.infer<typeof FormSchema>> = (_data) => {
     if (!projectRef) return console.error('Project ref is required')
+    if (!isRealtimeEntitlementsLoaded) return
     setIsConfirmNextModalOpen(true)
   }
 
   const onConfirmSave = () => {
     if (!projectRef) return console.error('Project ref is required')
+    if (!isRealtimeEntitlementsLoaded) return
     const values = form.getValues()
 
     // [Joshen] Casting to `Number` here as the values are being set as string when edited in the form
@@ -563,7 +662,12 @@ export const RealtimeSettings = () => {
                     variant="primary"
                     type="submit"
                     form={formId}
-                    disabled={!canUpdateConfig || isUpdatingConfig || !form.formState.isDirty}
+                    disabled={
+                      !canUpdateConfig ||
+                      isUpdatingConfig ||
+                      !form.formState.isDirty ||
+                      !isRealtimeEntitlementsLoaded
+                    }
                     loading={isUpdatingConfig}
                   >
                     Save changes

--- a/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
+++ b/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
@@ -409,7 +409,7 @@ export const RealtimeSettings = () => {
                                 description={
                                   <p className="prose max-w-full text-sm">
                                     Private mode is {isSettingToPrivate ? 'being ' : ''}
-                                    enabled, but no RLS policies exists on the{' '}
+                                    enabled, but no RLS policies exist on the{' '}
                                     <code className="text-code-inline">realtime.messages</code>{' '}
                                     table. No messages will be received by users.
                                   </p>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Use entitlements to decide the max value for settings instead of hardcoded numbers. 

Also use a soft limit for unlimited values and nicer error messages.

<img width="960" height="605" alt="Realtime_Settings___Realtime___Brand_new___Other_org___Supabase" src="https://github.com/user-attachments/assets/dbf41622-3546-45ad-9917-e4c672a85cee" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Realtime settings now respect plan-based limits while enforcing safe maximum caps.
  * Validation messages dynamically reflect the applicable limit.
  * Settings validate correctly whether realtime access is active or suspended.
  * Saving remains disabled until all applicable realtime limits are loaded.
  * A loading indicator appears while settings and limits are retrieved.
  * Improved form reset behavior, accessibility labels, and settings guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->