### PR TITLE
docs: add Sealos self-hosting option

### DIFF
--- a/apps/docs/data/content-listings/self-hosting.data.ts
+++ b/apps/docs/data/content-listings/self-hosting.data.ts
@@ -41,6 +41,11 @@ export const selfHostingCommunity: ContentListingGroup = {
       hasLightIcon: false,
       description: 'A self-hosted Supabase setup with Traefik as a reverse proxy.',
     },
+    {
+      title: 'Sealos',
+      href: 'https://sealos.io/products/app-store/supabase',
+      description: 'Deploy Supabase on Sealos with PostgreSQL and local or S3-compatible Storage.',
+    },
   ],
 }
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md)

YES

## What kind of change does this PR introduce?

Docs update.

## What is the current behavior?

The community self-hosting list includes Kubernetes and Traefik. It does not include the verified Sealos deployment path.

## What is the new behavior?

The self-hosting page lists Sealos with a direct App Store link and a short description of its PostgreSQL and local or S3-compatible Storage options.

## Additional context

The Sealos template is pinned to the component bundle validated in [labring-actions/templates#727](https://github.com/labring-actions/templates/pull/727). It uses the existing Kong compatibility path and remains independently versioned from the official Docker Compose defaults.

Validation:

- `pnpm test:local lib/content-listings.test.ts --run` from `apps/docs` (19 tests passed)
- `git diff --check`
- Sealos App Store link: https://sealos.io/products/app-store/supabase
- Prior live validation in [labring-actions/templates#727](https://github.com/labring-actions/templates/pull/727) covered Studio, Auth, REST, Storage, S3, persistence, and restarts on 2026-07-21.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Sealos as a self-hosting deployment option in the community listings.
  - Included a product link and deployment description for the new option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->