### PR TITLE
feat(studio): show role-aware connection strings for temporary access

### DIFF
--- a/apps/studio/components/interfaces/ConnectSheet/ConnectConfigSection.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/ConnectConfigSection.tsx
@@ -1,3 +1,4 @@
+import { Fragment, type ReactNode } from 'react'
 import {
   cn,
   RadioGroupStacked,
@@ -31,6 +32,13 @@ interface ConnectConfigSectionProps {
   state: Record<string, string | boolean | string[]>
   onFieldChange: (fieldId: string, value: string | boolean | string[]) => void
   getFieldOptions: (fieldId: string) => FieldOption[]
+  /** Rendered after this field when it is visible, otherwise at the top of the stack. */
+  insertAfter?: { fieldId: string; node: ReactNode }
+}
+
+function shouldShowConnectField(field: ResolvedField, options: FieldOption[]) {
+  if (field.type === 'switch' || field.type === 'multi-select') return true
+  return options.length > 1
 }
 
 export function ConnectConfigSection({
@@ -38,191 +46,202 @@ export function ConnectConfigSection({
   state,
   onFieldChange,
   getFieldOptions,
+  insertAfter,
 }: ConnectConfigSectionProps) {
   if (activeFields.length === 0) return null
 
+  const visibleFields = activeFields.filter((field) =>
+    shouldShowConnectField(field, getFieldOptions(field.id))
+  )
+  const insertAfterVisible = Boolean(
+    insertAfter?.node && visibleFields.some((field) => field.id === insertAfter.fieldId)
+  )
+
   return (
     <div className="flex flex-col gap-y-4">
-      {activeFields.map((field) => {
+      {!insertAfterVisible && insertAfter?.node}
+      {visibleFields.map((field) => {
         const options = getFieldOptions(field.id)
         const value = state[field.id]
 
-        // Skip fields with no options (or single option that's auto-selected)
-        // Exception: switch and multi-select fields don't require options
-        if (field.type !== 'switch' && field.type !== 'multi-select') {
-          if (options.length === 0) return null
-          if (options.length === 1) return null
-        }
-
-        switch (field.type) {
-          case 'radio-grid':
-            return (
-              <FormItemLayout
-                key={field.id}
-                isReactForm={false}
-                layout="horizontal"
-                label={field.label}
-              >
-                <RadioGroupStacked
-                  value={String(value ?? '')}
-                  onValueChange={(v) => onFieldChange(field.id, v)}
-                  className="flex-row gap-3 space-y-0"
+        const control = (() => {
+          switch (field.type) {
+            case 'radio-grid':
+              return (
+                <FormItemLayout
+                  key={field.id}
+                  isReactForm={false}
+                  layout="horizontal"
+                  label={field.label}
                 >
-                  {options.map((option) => (
-                    <RadioGroupStackedItem
-                      key={option.value}
-                      id={`connect-${field.id}-${option.value}`}
-                      value={option.value}
-                      label=""
-                      className="flex-1 rounded-lg text-left"
-                    >
-                      <div className="flex items-center gap-2">
-                        {option.icon && <ConnectionIcon supportsDarkMode icon={option.icon} />}
-                        <span className="text-sm">{option.label}</span>
-                      </div>
-                    </RadioGroupStackedItem>
-                  ))}
-                </RadioGroupStacked>
-              </FormItemLayout>
-            )
-
-          case 'radio-list':
-            return (
-              <FormItemLayout
-                key={field.id}
-                isReactForm={false}
-                layout="horizontal"
-                label={field.label}
-              >
-                <RadioGroupStacked
-                  value={String(value ?? '')}
-                  onValueChange={(v) => onFieldChange(field.id, v)}
-                  className="min-w-0 w-full"
-                >
-                  {options.map((option) => (
-                    <RadioGroupStackedItem
-                      key={option.value}
-                      id={`connect-${field.id}-${option.value}`}
-                      value={option.value}
-                      className="min-w-0 w-full text-left"
-                      label={
-                        <span className="flex min-w-0 items-center gap-2">
-                          {option.icon && <ConnectionIcon icon={option.icon} />}
-                          <span className="truncate">{option.label}</span>
-                        </span>
-                      }
-                      description={option.description}
-                    />
-                  ))}
-                </RadioGroupStacked>
-              </FormItemLayout>
-            )
-
-          case 'select':
-            return (
-              <FormItemLayout
-                key={field.id}
-                isReactForm={false}
-                layout="horizontal"
-                label={field.label}
-                description={field.description}
-              >
-                <Select
-                  value={String(value ?? '')}
-                  onValueChange={(v) => onFieldChange(field.id, v)}
-                >
-                  <SelectTrigger
-                    size="small"
-                    className="[&>span:first-child]:flex [&>span:first-child]:items-center [&>span:first-child]:gap-x-2"
+                  <RadioGroupStacked
+                    value={String(value ?? '')}
+                    onValueChange={(v) => onFieldChange(field.id, v)}
+                    className="flex-row gap-3 space-y-0"
                   >
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
                     {options.map((option) => (
-                      <SelectItem
+                      <RadioGroupStackedItem
                         key={option.value}
+                        id={`connect-${field.id}-${option.value}`}
                         value={option.value}
-                        className="[&>span:last-child]:flex [&>span:last-child]:items-center [&>span:last-child]:gap-x-2"
+                        label=""
+                        className="flex-1 rounded-lg text-left"
                       >
-                        {/*
+                        <div className="flex items-center gap-2">
+                          {option.icon && <ConnectionIcon supportsDarkMode icon={option.icon} />}
+                          <span className="text-sm">{option.label}</span>
+                        </div>
+                      </RadioGroupStackedItem>
+                    ))}
+                  </RadioGroupStacked>
+                </FormItemLayout>
+              )
+
+            case 'radio-list':
+              return (
+                <FormItemLayout
+                  key={field.id}
+                  isReactForm={false}
+                  layout="horizontal"
+                  label={field.label}
+                >
+                  <RadioGroupStacked
+                    value={String(value ?? '')}
+                    onValueChange={(v) => onFieldChange(field.id, v)}
+                    className="min-w-0 w-full"
+                  >
+                    {options.map((option) => (
+                      <RadioGroupStackedItem
+                        key={option.value}
+                        id={`connect-${field.id}-${option.value}`}
+                        value={option.value}
+                        className="min-w-0 w-full text-left"
+                        label={
+                          <span className="flex min-w-0 items-center gap-2">
+                            {option.icon && <ConnectionIcon icon={option.icon} />}
+                            <span className="truncate">{option.label}</span>
+                          </span>
+                        }
+                        description={option.description}
+                      />
+                    ))}
+                  </RadioGroupStacked>
+                </FormItemLayout>
+              )
+
+            case 'select':
+              return (
+                <FormItemLayout
+                  key={field.id}
+                  isReactForm={false}
+                  layout="horizontal"
+                  label={field.label}
+                  description={field.description}
+                >
+                  <Select
+                    value={String(value ?? '')}
+                    onValueChange={(v) => onFieldChange(field.id, v)}
+                  >
+                    <SelectTrigger
+                      size="small"
+                      className="[&>span:first-child]:flex [&>span:first-child]:items-center [&>span:first-child]:gap-x-2"
+                    >
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {options.map((option) => (
+                        <SelectItem
+                          key={option.value}
+                          value={option.value}
+                          className="[&>span:last-child]:flex [&>span:last-child]:items-center [&>span:last-child]:gap-x-2"
+                        >
+                          {/*
                           [Joshen] Omitting MCP icons for now as the images are not optimized (large)
                           and is causing noticeably latency issues on the browser (even with the existing Connect UI)
                          */}
-                        {field.id === 'framework' && option.icon && (
-                          <ConnectionIcon icon={option.icon} />
-                        )}
-                        {option.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </FormItemLayout>
-            )
-
-          case 'switch':
-            return (
-              <FormItemLayout
-                key={field.id}
-                isReactForm={false}
-                layout="horizontal"
-                label={field.label}
-                description={field.description}
-                className="[&>div>label>span]:break-keep! [&>div>label>span]:text-balance"
-              >
-                <Switch
-                  id={field.id}
-                  checked={Boolean(value)}
-                  onCheckedChange={(v) => onFieldChange(field.id, v)}
-                />
-              </FormItemLayout>
-            )
-
-          case 'multi-select':
-            return (
-              <FormItemLayout
-                key={field.id}
-                isReactForm={false}
-                layout="horizontal"
-                label={field.label}
-                description={field.description}
-              >
-                <MultiSelector
-                  values={Array.isArray(value) ? value : []}
-                  onValuesChange={(v) => onFieldChange(field.id, v)}
-                >
-                  <MultiSelectorTrigger
-                    className="w-full"
-                    label="Select features"
-                    badgeLimit="wrap"
-                    showIcon={true}
-                  />
-                  <MultiSelectorContent>
-                    <MultiSelectorList>
-                      {options.map((option) => (
-                        <MultiSelectorItem
-                          key={option.value}
-                          value={option.value}
-                          className="items-start"
-                        >
-                          <div className="flex flex-col ml-2 gap-y-0.5">
-                            <span className="font-medium">{option.label}</span>
-                            {option.description && (
-                              <span className="text-xs text-foreground-light">
-                                {option.description}
-                              </span>
-                            )}
-                          </div>
-                        </MultiSelectorItem>
+                          {field.id === 'framework' && option.icon && (
+                            <ConnectionIcon icon={option.icon} />
+                          )}
+                          {option.label}
+                        </SelectItem>
                       ))}
-                    </MultiSelectorList>
-                  </MultiSelectorContent>
-                </MultiSelector>
-              </FormItemLayout>
-            )
+                    </SelectContent>
+                  </Select>
+                </FormItemLayout>
+              )
 
-          default:
-            return null
-        }
+            case 'switch':
+              return (
+                <FormItemLayout
+                  key={field.id}
+                  isReactForm={false}
+                  layout="horizontal"
+                  label={field.label}
+                  description={field.description}
+                  className="[&>div>label>span]:break-keep! [&>div>label>span]:text-balance"
+                >
+                  <Switch
+                    id={field.id}
+                    checked={Boolean(value)}
+                    onCheckedChange={(v) => onFieldChange(field.id, v)}
+                  />
+                </FormItemLayout>
+              )
+
+            case 'multi-select':
+              return (
+                <FormItemLayout
+                  key={field.id}
+                  isReactForm={false}
+                  layout="horizontal"
+                  label={field.label}
+                  description={field.description}
+                >
+                  <MultiSelector
+                    values={Array.isArray(value) ? value : []}
+                    onValuesChange={(v) => onFieldChange(field.id, v)}
+                  >
+                    <MultiSelectorTrigger
+                      className="w-full"
+                      label="Select features"
+                      badgeLimit="wrap"
+                      showIcon={true}
+                    />
+                    <MultiSelectorContent>
+                      <MultiSelectorList>
+                        {options.map((option) => (
+                          <MultiSelectorItem
+                            key={option.value}
+                            value={option.value}
+                            className="items-start"
+                          >
+                            <div className="flex flex-col ml-2 gap-y-0.5">
+                              <span className="font-medium">{option.label}</span>
+                              {option.description && (
+                                <span className="text-xs text-foreground-light">
+                                  {option.description}
+                                </span>
+                              )}
+                            </div>
+                          </MultiSelectorItem>
+                        ))}
+                      </MultiSelectorList>
+                    </MultiSelectorContent>
+                  </MultiSelector>
+                </FormItemLayout>
+              )
+
+            default:
+              return null
+          }
+        })()
+
+        return (
+          <Fragment key={field.id}>
+            {control}
+            {insertAfterVisible && insertAfter?.fieldId === field.id ? insertAfter.node : null}
+          </Fragment>
+        )
       })}
     </div>
   )

--- a/apps/studio/components/interfaces/ConnectSheet/ConnectSheet.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/ConnectSheet.tsx
@@ -8,6 +8,8 @@ import type { ConnectMode, ProjectKeys } from './Connect.types'
 import { ConnectConfigSection, ModeSelector } from './ConnectConfigSection'
 import { resolveConnectSheetHydration } from './ConnectSheet.utils'
 import { ConnectStepsSection } from './ConnectStepsSection'
+import { TemporaryAccessConnectionProvider } from './TemporaryAccessConnectionProvider'
+import { TemporaryAccessRoleField } from './TemporaryAccessRoleField'
 import { useAvailableConnectModes } from './useAvailableConnectModes'
 import { useConnectSheetParams } from './useConnectSheetParams'
 import { useConnectSheetShortcut } from './useConnectSheetShortcut'
@@ -168,28 +170,35 @@ export const ConnectSheet = () => {
           <SheetDescription>Choose how you want to use Supabase</SheetDescription>
         </SheetHeader>
 
-        <div className="flex min-w-0 flex-1 flex-col overflow-y-auto overflow-x-hidden divide-y">
-          <div className="p-8">
-            <ModeSelector
-              modes={availableModes}
-              selected={state.mode}
-              onChange={handleModeChange}
-            />
-          </div>
-
-          {activeFields.length > 0 && (
+        <TemporaryAccessConnectionProvider enabled={showConnect}>
+          <div className="flex min-w-0 flex-1 flex-col overflow-y-auto overflow-x-hidden divide-y">
             <div className="p-8">
-              <ConnectConfigSection
-                state={state}
-                activeFields={activeFields}
-                onFieldChange={handleFieldChange}
-                getFieldOptions={getFieldOptions}
+              <ModeSelector
+                modes={availableModes}
+                selected={state.mode}
+                onChange={handleModeChange}
               />
             </div>
-          )}
 
-          <ConnectStepsSection steps={resolvedSteps} state={state} projectKeys={projectKeys} />
-        </div>
+            {activeFields.length > 0 && (
+              <div className="p-8">
+                <ConnectConfigSection
+                  state={state}
+                  activeFields={activeFields}
+                  onFieldChange={handleFieldChange}
+                  getFieldOptions={getFieldOptions}
+                  insertAfter={
+                    state.mode === 'direct'
+                      ? { fieldId: 'connectionSource', node: <TemporaryAccessRoleField /> }
+                      : undefined
+                  }
+                />
+              </div>
+            )}
+
+            <ConnectStepsSection steps={resolvedSteps} state={state} projectKeys={projectKeys} />
+          </div>
+        </TemporaryAccessConnectionProvider>
       </SheetContent>
     </Sheet>
   )

--- a/apps/studio/components/interfaces/ConnectSheet/ConnectStepsSection.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/ConnectStepsSection.tsx
@@ -14,6 +14,7 @@ import type {
   ResolvedStep,
   StepContentProps,
 } from './Connect.types'
+import { applyTemporaryAccessToPooler } from './ConnectionString.utils'
 import { ConnectSheetStep } from './ConnectSheetStep'
 import {
   resolveContentPath,
@@ -25,6 +26,7 @@ import {
 } from './ConnectStepsSection.utils'
 import { CopyPromptButton } from './CopyPromptAdmonition'
 import { buildConnectionStringPooler, getConnectionStrings } from './DatabaseSettings.utils'
+import { useTemporaryAccessConnection } from './TemporaryAccessConnectionProvider'
 import { getAddons } from '@/components/interfaces/Billing/Subscription/Subscription.utils'
 import { DocsButton } from '@/components/ui/DocsButton'
 import { InlineLink } from '@/components/ui/InlineLink'
@@ -211,6 +213,16 @@ export function ConnectStepsSection({ steps, state, projectKeys }: ConnectStepsS
   const stepsContainerRef = useRef<HTMLDivElement | null>(null)
   const deploymentMode = useDeploymentMode()
   const connectionStringPooler = useConnectionStringPooler(deploymentMode)
+  const {
+    meta: { grantRole },
+  } = useTemporaryAccessConnection()
+  const resolvedConnectionStringPooler = useMemo(
+    () =>
+      grantRole
+        ? applyTemporaryAccessToPooler(connectionStringPooler, grantRole)
+        : connectionStringPooler,
+    [connectionStringPooler, grantRole]
+  )
 
   const { data: ipv4Addon } = useProjectAddonsQuery(
     { projectRef: ref },
@@ -332,7 +344,7 @@ export function ConnectStepsSection({ steps, state, projectKeys }: ConnectStepsS
                 contentId={step.content}
                 state={state}
                 projectKeys={projectKeys}
-                connectionStringPooler={connectionStringPooler}
+                connectionStringPooler={resolvedConnectionStringPooler}
                 deploymentMode={deploymentMode}
               />
             </ConnectSheetStep>

--- a/apps/studio/components/interfaces/ConnectSheet/ConnectionString.utils.ts
+++ b/apps/studio/components/interfaces/ConnectSheet/ConnectionString.utils.ts
@@ -3,6 +3,8 @@ import type { ConnectionStringPooler } from './Connect.types'
 
 export const DEFAULT_PORT = '5432'
 export const PASSWORD_PLACEHOLDER = '[YOUR-PASSWORD]'
+export const TOKEN_PASSWORD_PLACEHOLDER = '[YOUR-ACCESS-TOKEN]'
+export const TEMPORARY_ACCESS_POOLER_OPTIONS = 'options=-c%20jit%3dtrue'
 
 /** Appends query params to a connection string, joining with `?` or `&` as needed */
 export const appendConnectionStringParams = (uri: string, params: string) =>
@@ -86,11 +88,12 @@ export const parseConnectionParams = (connectionString: string): ConnectionParam
 
 export const buildSafeConnectionString = (
   connectionString: string,
-  params: ConnectionParams
+  params: ConnectionParams,
+  passwordPlaceholder: string = PASSWORD_PLACEHOLDER
 ): string => {
   if (!connectionString) return ''
 
-  return `postgresql://${params.user}:${PASSWORD_PLACEHOLDER}@${params.host}:${params.port}/${params.database}${params.search}`
+  return `postgresql://${params.user}:${passwordPlaceholder}@${params.host}:${params.port}/${params.database}${params.search}`
 }
 
 export const buildPsqlCommand = (params: ConnectionParams) =>
@@ -100,12 +103,15 @@ export const buildPsqlCommand = (params: ConnectionParams) =>
       `psql "postgresql://${params.user}@${params.host}:${params.port}/${params.database}${params.search}"`
     : `psql -h ${params.host} -p ${params.port} -d ${params.database} -U ${params.user}`
 
-export const buildJdbcString = (params: ConnectionParams) => {
+export const buildJdbcString = (
+  params: ConnectionParams,
+  passwordPlaceholder: string = PASSWORD_PLACEHOLDER
+) => {
   // pgJDBC (42.7.4+) spells libpq's `sslnegotiation` as `sslNegotiation`
   const extraParams = params.search
     ? `&${params.search.slice(1).replace('sslnegotiation=', 'sslNegotiation=')}`
     : ''
-  return `jdbc:postgresql://${params.host}:${params.port}/${params.database}?user=${params.user}&password=${PASSWORD_PLACEHOLDER}${extraParams}`
+  return `jdbc:postgresql://${params.host}:${params.port}/${params.database}?user=${params.user}&password=${passwordPlaceholder}${extraParams}`
 }
 
 export const buildConnectionStringWithPassword = (
@@ -131,3 +137,85 @@ export const buildConnectionParameters = (params: ConnectionParams) => [
   { key: 'database', value: params.database },
   { key: 'user', value: params.user },
 ]
+
+/**
+ * Replaces the Postgres role in a connection username, keeping any pooler
+ * suffix (`postgres.projref` → `{role}.projref`).
+ */
+export const replaceConnectionUser = (user: string, role: string): string => {
+  if (!user || !role) return user
+  const suffixIndex = user.indexOf('.')
+  if (suffixIndex === -1) return role
+  return `${role}${user.slice(suffixIndex)}`
+}
+
+const replaceUserInConnectionString = (uri: string, role: string): string => {
+  const match = uri.match(/^(postgres(?:ql)?:\/\/)([^:/@]+)(:[^@]*)?@/)
+  if (!match) return uri
+
+  const [, protocol, rawUser, passwordPart = ''] = match
+  let user = rawUser
+  try {
+    user = decodeURIComponent(rawUser)
+  } catch {
+    // Keep the raw username when it is not valid percent-encoding.
+  }
+
+  return `${protocol}${replaceConnectionUser(user, role)}${passwordPart}@${uri.slice(match[0].length)}`
+}
+
+const hasTemporaryAccessPoolerOption = (uri: string) =>
+  uri.includes('jit%3dtrue') || uri.includes('jit=true')
+
+export const applyTemporaryAccessToConnectionString = (
+  uri: string,
+  {
+    role,
+    addPoolerJitOption = false,
+  }: {
+    role: string
+    addPoolerJitOption?: boolean
+  }
+): string => {
+  if (!uri || !role) return uri
+
+  const withRole = replaceUserInConnectionString(uri, role)
+  const withToken = withRole.split(PASSWORD_PLACEHOLDER).join(TOKEN_PASSWORD_PLACEHOLDER)
+
+  if (!addPoolerJitOption || hasTemporaryAccessPoolerOption(withToken)) {
+    return withToken
+  }
+
+  return appendConnectionStringParams(withToken, TEMPORARY_ACCESS_POOLER_OPTIONS)
+}
+
+export const applyTemporaryAccessToPooler = (
+  pooler: ConnectionStringPooler,
+  role: string
+): ConnectionStringPooler => {
+  const rewrite = (uri: string | undefined, addPoolerJitOption: boolean) =>
+    uri ? applyTemporaryAccessToConnectionString(uri, { role, addPoolerJitOption }) : uri
+
+  return {
+    ...pooler,
+    direct: rewrite(pooler.direct, false),
+    transactionShared: rewrite(pooler.transactionShared, true),
+    sessionShared: rewrite(pooler.sessionShared, true),
+    transactionDedicated: rewrite(pooler.transactionDedicated, false),
+    sessionDedicated: rewrite(pooler.sessionDedicated, false),
+  }
+}
+
+export const shouldAddTemporaryAccessPoolerOption = ({
+  connectionMethod,
+  useSharedPooler,
+  hasDedicatedPooler,
+}: {
+  connectionMethod: ConnectionStringMethod
+  useSharedPooler: boolean
+  hasDedicatedPooler: boolean
+}) => {
+  if (connectionMethod === 'direct') return false
+  if (connectionMethod === 'session') return true
+  return useSharedPooler || !hasDedicatedPooler
+}

--- a/apps/studio/components/interfaces/ConnectSheet/TemporaryAccessConnection.utils.ts
+++ b/apps/studio/components/interfaces/ConnectSheet/TemporaryAccessConnection.utils.ts
@@ -1,0 +1,34 @@
+export const DATABASE_PASSWORD_VALUE = '__database_password__'
+
+export function resolveSelectedTemporaryAccessRole({
+  selectedRole,
+  activeRoles,
+}: {
+  selectedRole: string | null
+  activeRoles: string[]
+}): string {
+  if (selectedRole === DATABASE_PASSWORD_VALUE) return DATABASE_PASSWORD_VALUE
+  if (selectedRole && activeRoles.includes(selectedRole)) return selectedRole
+  return activeRoles[0] ?? DATABASE_PASSWORD_VALUE
+}
+
+export type PopoverDirectConnectionBehavior =
+  | { type: 'copy'; role?: string }
+  | { type: 'open-connect' }
+  | { type: 'pending' }
+
+export function resolvePopoverDirectConnectionBehavior({
+  isJitEnabled,
+  isPending,
+  activeRoles,
+}: {
+  isJitEnabled: boolean
+  isPending: boolean
+  activeRoles: string[]
+}): PopoverDirectConnectionBehavior {
+  if (!isJitEnabled) return { type: 'copy' }
+  if (isPending) return { type: 'pending' }
+  if (activeRoles.length > 1) return { type: 'open-connect' }
+  if (activeRoles.length === 1) return { type: 'copy', role: activeRoles[0] }
+  return { type: 'copy' }
+}

--- a/apps/studio/components/interfaces/ConnectSheet/TemporaryAccessConnectionProvider.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/TemporaryAccessConnectionProvider.tsx
@@ -1,0 +1,80 @@
+import { useParams } from 'common'
+import { createContext, useContext, useMemo, useState, type ReactNode } from 'react'
+
+import { PASSWORD_PLACEHOLDER, TOKEN_PASSWORD_PLACEHOLDER } from './ConnectionString.utils'
+import {
+  DATABASE_PASSWORD_VALUE,
+  resolveSelectedTemporaryAccessRole,
+} from './TemporaryAccessConnection.utils'
+import { useActiveTemporaryAccessRoles } from '@/data/jit-db-access/use-active-temporary-access-roles'
+
+type TemporaryAccessConnectionContextValue = {
+  state: {
+    activeRoles: string[]
+    selectedRole: string
+  }
+  actions: {
+    setSelectedRole: (role: string) => void
+  }
+  meta: {
+    isGrantMode: boolean
+    grantRole: string | null
+    passwordPlaceholder: string
+  }
+}
+
+const NOOP_VALUE: TemporaryAccessConnectionContextValue = {
+  state: {
+    activeRoles: [],
+    selectedRole: DATABASE_PASSWORD_VALUE,
+  },
+  actions: {
+    setSelectedRole: () => {},
+  },
+  meta: {
+    isGrantMode: false,
+    grantRole: null,
+    passwordPlaceholder: PASSWORD_PLACEHOLDER,
+  },
+}
+
+const TemporaryAccessConnectionContext =
+  createContext<TemporaryAccessConnectionContextValue>(NOOP_VALUE)
+
+export function TemporaryAccessConnectionProvider({
+  children,
+  enabled = true,
+}: {
+  children: ReactNode
+  enabled?: boolean
+}) {
+  const { ref: projectRef } = useParams()
+  const { activeRoles } = useActiveTemporaryAccessRoles(projectRef, { enabled })
+  const [selectedRole, setSelectedRole] = useState<string | null>(null)
+
+  const value = useMemo(() => {
+    const resolvedRole = resolveSelectedTemporaryAccessRole({ selectedRole, activeRoles })
+    const isGrantMode = resolvedRole !== DATABASE_PASSWORD_VALUE
+
+    return {
+      state: {
+        activeRoles,
+        selectedRole: resolvedRole,
+      },
+      actions: { setSelectedRole },
+      meta: {
+        isGrantMode,
+        grantRole: isGrantMode ? resolvedRole : null,
+        passwordPlaceholder: isGrantMode ? TOKEN_PASSWORD_PLACEHOLDER : PASSWORD_PLACEHOLDER,
+      },
+    } satisfies TemporaryAccessConnectionContextValue
+  }, [activeRoles, selectedRole])
+
+  return (
+    <TemporaryAccessConnectionContext.Provider value={value}>
+      {children}
+    </TemporaryAccessConnectionContext.Provider>
+  )
+}
+
+export const useTemporaryAccessConnection = () => useContext(TemporaryAccessConnectionContext)

--- a/apps/studio/components/interfaces/ConnectSheet/TemporaryAccessRoleField.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/TemporaryAccessRoleField.tsx
@@ -1,0 +1,56 @@
+import { Select, SelectContent, SelectItem, SelectSeparator, SelectTrigger, SelectValue } from 'ui'
+import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
+
+import { DATABASE_PASSWORD_VALUE } from './TemporaryAccessConnection.utils'
+import { useTemporaryAccessConnection } from './TemporaryAccessConnectionProvider'
+import { InlineLink } from '@/components/ui/InlineLink'
+import { DOCS_URL } from '@/lib/constants'
+
+export function TemporaryAccessPasswordNote({ tokenHref }: { tokenHref?: string }) {
+  const {
+    meta: { isGrantMode },
+  } = useTemporaryAccessConnection()
+
+  if (!isGrantMode) return null
+
+  const tokenLabel = tokenHref ? (
+    <InlineLink href={tokenHref}>personal access token</InlineLink>
+  ) : (
+    'personal access token'
+  )
+
+  return (
+    <p className="text-sm text-foreground-lighter mb-1">
+      Use a {tokenLabel} as the password.{' '}
+      <InlineLink href={`${DOCS_URL}/guides/platform/temporary-access`}>Learn more</InlineLink>
+    </p>
+  )
+}
+
+export function TemporaryAccessRoleField() {
+  const {
+    state: { activeRoles, selectedRole },
+    actions: { setSelectedRole },
+  } = useTemporaryAccessConnection()
+
+  if (activeRoles.length === 0) return null
+
+  return (
+    <FormItemLayout isReactForm={false} layout="horizontal" label="Role">
+      <Select value={selectedRole} onValueChange={setSelectedRole}>
+        <SelectTrigger size="small">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {activeRoles.map((role) => (
+            <SelectItem key={role} value={role}>
+              {role}
+            </SelectItem>
+          ))}
+          <SelectSeparator />
+          <SelectItem value={DATABASE_PASSWORD_VALUE}>Database password</SelectItem>
+        </SelectContent>
+      </Select>
+    </FormItemLayout>
+  )
+}

--- a/apps/studio/components/interfaces/ConnectSheet/__tests__/ConnectionString.utils.test.ts
+++ b/apps/studio/components/interfaces/ConnectSheet/__tests__/ConnectionString.utils.test.ts
@@ -12,7 +12,6 @@ import {
   DEFAULT_PORT,
   parseConnectionParams,
   PASSWORD_PLACEHOLDER,
-  replaceConnectionUser,
   resolveConnectionString,
   shouldAddTemporaryAccessPoolerOption,
   TOKEN_PASSWORD_PLACEHOLDER,
@@ -260,76 +259,33 @@ describe('buildConnectionParameters', () => {
   })
 })
 
-describe('replaceConnectionUser', () => {
-  test('replaces a bare postgres user', () => {
-    expect(replaceConnectionUser('postgres', 'analytics')).toBe('analytics')
-  })
-
-  test('keeps the pooler project-ref suffix', () => {
-    expect(replaceConnectionUser('postgres.projref', 'analytics')).toBe('analytics.projref')
-  })
-
-  test('keeps the self-hosted pooler tenant placeholder', () => {
-    expect(replaceConnectionUser('postgres.[POOLER_TENANT_ID]', 'analytics')).toBe(
-      'analytics.[POOLER_TENANT_ID]'
-    )
-  })
-
-  test('returns the original user when role is empty', () => {
-    expect(replaceConnectionUser('postgres.projref', '')).toBe('postgres.projref')
-  })
-})
-
 describe('applyTemporaryAccessToConnectionString', () => {
-  test('returns the URI unchanged when input or role is empty', () => {
-    const uri = `postgresql://postgres:${PASSWORD_PLACEHOLDER}@db.proj.supabase.co:5432/postgres`
-
-    expect(applyTemporaryAccessToConnectionString('', { role: 'analytics' })).toBe('')
-    expect(applyTemporaryAccessToConnectionString(uri, { role: '' })).toBe(uri)
-  })
-
   test('rewrites a direct URI user and password placeholder', () => {
     const uri = `postgresql://postgres:${PASSWORD_PLACEHOLDER}@db.proj.supabase.co:5432/postgres?sslmode=require`
 
+    expect(applyTemporaryAccessToConnectionString('', { role: 'analytics' })).toBe('')
+    expect(applyTemporaryAccessToConnectionString(uri, { role: '' })).toBe(uri)
     expect(applyTemporaryAccessToConnectionString(uri, { role: 'analytics' })).toBe(
       `postgresql://analytics:${TOKEN_PASSWORD_PLACEHOLDER}@db.proj.supabase.co:5432/postgres?sslmode=require`
     )
   })
 
-  test('rewrites a shared pooler URI and appends the jit option', () => {
+  test('appends jit on shared pooler URIs once', () => {
     const uri = `postgresql://postgres.projref:${PASSWORD_PLACEHOLDER}@aws-0-eu-west-1.pooler.supabase.com:6543/postgres`
+    const withJit = applyTemporaryAccessToConnectionString(uri, {
+      role: 'analytics',
+      addPoolerJitOption: true,
+    })
 
-    expect(
-      applyTemporaryAccessToConnectionString(uri, { role: 'analytics', addPoolerJitOption: true })
-    ).toBe(
+    expect(withJit).toBe(
       `postgresql://analytics.projref:${TOKEN_PASSWORD_PLACEHOLDER}@aws-0-eu-west-1.pooler.supabase.com:6543/postgres?options=-c%20jit%3dtrue`
     )
-  })
-
-  test('does not double-append the jit option', () => {
-    const uri = `postgresql://postgres.projref:${PASSWORD_PLACEHOLDER}@host:6543/postgres?options=-c%20jit%3dtrue`
-
     expect(
-      applyTemporaryAccessToConnectionString(uri, { role: 'analytics', addPoolerJitOption: true })
-    ).toBe(
-      `postgresql://analytics.projref:${TOKEN_PASSWORD_PLACEHOLDER}@host:6543/postgres?options=-c%20jit%3dtrue`
-    )
-  })
-
-  test('does not add the jit option to a direct URI', () => {
-    const uri = `postgresql://postgres:${PASSWORD_PLACEHOLDER}@db.proj.supabase.co:5432/postgres`
-
-    expect(
-      applyTemporaryAccessToConnectionString(uri, { role: 'analytics', addPoolerJitOption: false })
-    ).not.toContain('jit')
-  })
-
-  test('decodes a percent-encoded pooler user before rewriting', () => {
-    const uri = `postgresql://postgres.%5BPOOLER_TENANT_ID%5D:${PASSWORD_PLACEHOLDER}@host:6543/postgres`
-
-    expect(applyTemporaryAccessToConnectionString(uri, { role: 'analytics' })).toBe(
-      `postgresql://analytics.[POOLER_TENANT_ID]:${TOKEN_PASSWORD_PLACEHOLDER}@host:6543/postgres`
-    )
+      applyTemporaryAccessToConnectionString(withJit, {
+        role: 'analytics',
+        addPoolerJitOption: true,
+      })
+    ).toBe(withJit)
   })
 })
 
@@ -350,18 +306,15 @@ describe('applyTemporaryAccessToPooler', () => {
     expect(rewritten.direct).toBe(
       `postgresql://analytics:${TOKEN_PASSWORD_PLACEHOLDER}@db.host:5432/postgres`
     )
-    expect(rewritten.transactionShared).toContain('analytics.proj')
     expect(rewritten.transactionShared).toContain('options=-c%20jit%3dtrue')
     expect(rewritten.sessionShared).toContain('options=-c%20jit%3dtrue')
-    expect(rewritten.transactionDedicated).toBe(
-      `postgresql://analytics.proj:${TOKEN_PASSWORD_PLACEHOLDER}@dedicated:6543/postgres`
-    )
+    expect(rewritten.transactionDedicated).not.toContain('jit')
     expect(rewritten.sessionDedicated).not.toContain('jit')
   })
 })
 
 describe('shouldAddTemporaryAccessPoolerOption', () => {
-  test('is false for direct connections', () => {
+  test('is true only for shared pooler connections', () => {
     expect(
       shouldAddTemporaryAccessPoolerOption({
         connectionMethod: 'direct',
@@ -369,9 +322,6 @@ describe('shouldAddTemporaryAccessPoolerOption', () => {
         hasDedicatedPooler: true,
       })
     ).toBe(false)
-  })
-
-  test('is true for session pooler (always shared)', () => {
     expect(
       shouldAddTemporaryAccessPoolerOption({
         connectionMethod: 'session',
@@ -379,9 +329,6 @@ describe('shouldAddTemporaryAccessPoolerOption', () => {
         hasDedicatedPooler: true,
       })
     ).toBe(true)
-  })
-
-  test('is true for shared transaction pooler and false for dedicated', () => {
     expect(
       shouldAddTemporaryAccessPoolerOption({
         connectionMethod: 'transaction',
@@ -403,31 +350,5 @@ describe('shouldAddTemporaryAccessPoolerOption', () => {
         hasDedicatedPooler: false,
       })
     ).toBe(true)
-  })
-})
-
-describe('buildSafeConnectionString and buildJdbcString password placeholders', () => {
-  test('buildSafeConnectionString can emit the token placeholder', () => {
-    const uri = `postgresql://analytics:${TOKEN_PASSWORD_PLACEHOLDER}@db.host:5432/postgres`
-    const params = parseConnectionParams(uri)
-
-    expect(buildSafeConnectionString(uri, params, TOKEN_PASSWORD_PLACEHOLDER)).toBe(uri)
-  })
-
-  test('buildJdbcString can emit the token placeholder', () => {
-    expect(
-      buildJdbcString(
-        {
-          host: 'db.host',
-          port: '5432',
-          user: 'analytics',
-          database: 'postgres',
-          search: '',
-        },
-        TOKEN_PASSWORD_PLACEHOLDER
-      )
-    ).toBe(
-      `jdbc:postgresql://db.host:5432/postgres?user=analytics&password=${TOKEN_PASSWORD_PLACEHOLDER}`
-    )
   })
 })

--- a/apps/studio/components/interfaces/ConnectSheet/__tests__/ConnectionString.utils.test.ts
+++ b/apps/studio/components/interfaces/ConnectSheet/__tests__/ConnectionString.utils.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from 'vitest'
 
 import {
   appendConnectionStringParams,
+  applyTemporaryAccessToConnectionString,
+  applyTemporaryAccessToPooler,
   buildConnectionParameters,
   buildConnectionStringWithPassword,
   buildJdbcString,
@@ -10,7 +12,10 @@ import {
   DEFAULT_PORT,
   parseConnectionParams,
   PASSWORD_PLACEHOLDER,
+  replaceConnectionUser,
   resolveConnectionString,
+  shouldAddTemporaryAccessPoolerOption,
+  TOKEN_PASSWORD_PLACEHOLDER,
 } from '../ConnectionString.utils'
 
 describe('parseConnectionParams', () => {
@@ -252,5 +257,177 @@ describe('buildConnectionParameters', () => {
       { key: 'database', value: 'd' },
       { key: 'user', value: 'u' },
     ])
+  })
+})
+
+describe('replaceConnectionUser', () => {
+  test('replaces a bare postgres user', () => {
+    expect(replaceConnectionUser('postgres', 'analytics')).toBe('analytics')
+  })
+
+  test('keeps the pooler project-ref suffix', () => {
+    expect(replaceConnectionUser('postgres.projref', 'analytics')).toBe('analytics.projref')
+  })
+
+  test('keeps the self-hosted pooler tenant placeholder', () => {
+    expect(replaceConnectionUser('postgres.[POOLER_TENANT_ID]', 'analytics')).toBe(
+      'analytics.[POOLER_TENANT_ID]'
+    )
+  })
+
+  test('returns the original user when role is empty', () => {
+    expect(replaceConnectionUser('postgres.projref', '')).toBe('postgres.projref')
+  })
+})
+
+describe('applyTemporaryAccessToConnectionString', () => {
+  test('returns the URI unchanged when input or role is empty', () => {
+    const uri = `postgresql://postgres:${PASSWORD_PLACEHOLDER}@db.proj.supabase.co:5432/postgres`
+
+    expect(applyTemporaryAccessToConnectionString('', { role: 'analytics' })).toBe('')
+    expect(applyTemporaryAccessToConnectionString(uri, { role: '' })).toBe(uri)
+  })
+
+  test('rewrites a direct URI user and password placeholder', () => {
+    const uri = `postgresql://postgres:${PASSWORD_PLACEHOLDER}@db.proj.supabase.co:5432/postgres?sslmode=require`
+
+    expect(applyTemporaryAccessToConnectionString(uri, { role: 'analytics' })).toBe(
+      `postgresql://analytics:${TOKEN_PASSWORD_PLACEHOLDER}@db.proj.supabase.co:5432/postgres?sslmode=require`
+    )
+  })
+
+  test('rewrites a shared pooler URI and appends the jit option', () => {
+    const uri = `postgresql://postgres.projref:${PASSWORD_PLACEHOLDER}@aws-0-eu-west-1.pooler.supabase.com:6543/postgres`
+
+    expect(
+      applyTemporaryAccessToConnectionString(uri, { role: 'analytics', addPoolerJitOption: true })
+    ).toBe(
+      `postgresql://analytics.projref:${TOKEN_PASSWORD_PLACEHOLDER}@aws-0-eu-west-1.pooler.supabase.com:6543/postgres?options=-c%20jit%3dtrue`
+    )
+  })
+
+  test('does not double-append the jit option', () => {
+    const uri = `postgresql://postgres.projref:${PASSWORD_PLACEHOLDER}@host:6543/postgres?options=-c%20jit%3dtrue`
+
+    expect(
+      applyTemporaryAccessToConnectionString(uri, { role: 'analytics', addPoolerJitOption: true })
+    ).toBe(
+      `postgresql://analytics.projref:${TOKEN_PASSWORD_PLACEHOLDER}@host:6543/postgres?options=-c%20jit%3dtrue`
+    )
+  })
+
+  test('does not add the jit option to a direct URI', () => {
+    const uri = `postgresql://postgres:${PASSWORD_PLACEHOLDER}@db.proj.supabase.co:5432/postgres`
+
+    expect(
+      applyTemporaryAccessToConnectionString(uri, { role: 'analytics', addPoolerJitOption: false })
+    ).not.toContain('jit')
+  })
+
+  test('decodes a percent-encoded pooler user before rewriting', () => {
+    const uri = `postgresql://postgres.%5BPOOLER_TENANT_ID%5D:${PASSWORD_PLACEHOLDER}@host:6543/postgres`
+
+    expect(applyTemporaryAccessToConnectionString(uri, { role: 'analytics' })).toBe(
+      `postgresql://analytics.[POOLER_TENANT_ID]:${TOKEN_PASSWORD_PLACEHOLDER}@host:6543/postgres`
+    )
+  })
+})
+
+describe('applyTemporaryAccessToPooler', () => {
+  test('rewrites every URI slot and only adds jit on shared pooler strings', () => {
+    const rewritten = applyTemporaryAccessToPooler(
+      {
+        transactionShared: `postgresql://postgres.proj:${PASSWORD_PLACEHOLDER}@pooler:6543/postgres`,
+        sessionShared: `postgresql://postgres.proj:${PASSWORD_PLACEHOLDER}@pooler:5432/postgres`,
+        transactionDedicated: `postgresql://postgres.proj:${PASSWORD_PLACEHOLDER}@dedicated:6543/postgres`,
+        sessionDedicated: `postgresql://postgres:${PASSWORD_PLACEHOLDER}@db.host:5432/postgres`,
+        ipv4SupportedForDedicatedPooler: true,
+        direct: `postgresql://postgres:${PASSWORD_PLACEHOLDER}@db.host:5432/postgres`,
+      },
+      'analytics'
+    )
+
+    expect(rewritten.direct).toBe(
+      `postgresql://analytics:${TOKEN_PASSWORD_PLACEHOLDER}@db.host:5432/postgres`
+    )
+    expect(rewritten.transactionShared).toContain('analytics.proj')
+    expect(rewritten.transactionShared).toContain('options=-c%20jit%3dtrue')
+    expect(rewritten.sessionShared).toContain('options=-c%20jit%3dtrue')
+    expect(rewritten.transactionDedicated).toBe(
+      `postgresql://analytics.proj:${TOKEN_PASSWORD_PLACEHOLDER}@dedicated:6543/postgres`
+    )
+    expect(rewritten.sessionDedicated).not.toContain('jit')
+  })
+})
+
+describe('shouldAddTemporaryAccessPoolerOption', () => {
+  test('is false for direct connections', () => {
+    expect(
+      shouldAddTemporaryAccessPoolerOption({
+        connectionMethod: 'direct',
+        useSharedPooler: false,
+        hasDedicatedPooler: true,
+      })
+    ).toBe(false)
+  })
+
+  test('is true for session pooler (always shared)', () => {
+    expect(
+      shouldAddTemporaryAccessPoolerOption({
+        connectionMethod: 'session',
+        useSharedPooler: false,
+        hasDedicatedPooler: true,
+      })
+    ).toBe(true)
+  })
+
+  test('is true for shared transaction pooler and false for dedicated', () => {
+    expect(
+      shouldAddTemporaryAccessPoolerOption({
+        connectionMethod: 'transaction',
+        useSharedPooler: true,
+        hasDedicatedPooler: true,
+      })
+    ).toBe(true)
+    expect(
+      shouldAddTemporaryAccessPoolerOption({
+        connectionMethod: 'transaction',
+        useSharedPooler: false,
+        hasDedicatedPooler: true,
+      })
+    ).toBe(false)
+    expect(
+      shouldAddTemporaryAccessPoolerOption({
+        connectionMethod: 'transaction',
+        useSharedPooler: false,
+        hasDedicatedPooler: false,
+      })
+    ).toBe(true)
+  })
+})
+
+describe('buildSafeConnectionString and buildJdbcString password placeholders', () => {
+  test('buildSafeConnectionString can emit the token placeholder', () => {
+    const uri = `postgresql://analytics:${TOKEN_PASSWORD_PLACEHOLDER}@db.host:5432/postgres`
+    const params = parseConnectionParams(uri)
+
+    expect(buildSafeConnectionString(uri, params, TOKEN_PASSWORD_PLACEHOLDER)).toBe(uri)
+  })
+
+  test('buildJdbcString can emit the token placeholder', () => {
+    expect(
+      buildJdbcString(
+        {
+          host: 'db.host',
+          port: '5432',
+          user: 'analytics',
+          database: 'postgres',
+          search: '',
+        },
+        TOKEN_PASSWORD_PLACEHOLDER
+      )
+    ).toBe(
+      `jdbc:postgresql://db.host:5432/postgres?user=analytics&password=${TOKEN_PASSWORD_PLACEHOLDER}`
+    )
   })
 })

--- a/apps/studio/components/interfaces/ConnectSheet/__tests__/TemporaryAccessConnection.utils.test.ts
+++ b/apps/studio/components/interfaces/ConnectSheet/__tests__/TemporaryAccessConnection.utils.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  DATABASE_PASSWORD_VALUE,
+  resolvePopoverDirectConnectionBehavior,
+  resolveSelectedTemporaryAccessRole,
+} from '../TemporaryAccessConnection.utils'
+
+describe('resolveSelectedTemporaryAccessRole', () => {
+  test('defaults to the first active grant', () => {
+    expect(
+      resolveSelectedTemporaryAccessRole({
+        selectedRole: null,
+        activeRoles: ['postgres', 'analytics'],
+      })
+    ).toBe('postgres')
+  })
+
+  test('keeps an explicit database-password opt-out', () => {
+    expect(
+      resolveSelectedTemporaryAccessRole({
+        selectedRole: DATABASE_PASSWORD_VALUE,
+        activeRoles: ['postgres'],
+      })
+    ).toBe(DATABASE_PASSWORD_VALUE)
+  })
+
+  test('falls back when the selected grant is no longer active', () => {
+    expect(
+      resolveSelectedTemporaryAccessRole({
+        selectedRole: 'analytics',
+        activeRoles: ['postgres'],
+      })
+    ).toBe('postgres')
+  })
+
+  test('falls back to the database password when there are no grants', () => {
+    expect(
+      resolveSelectedTemporaryAccessRole({
+        selectedRole: 'analytics',
+        activeRoles: [],
+      })
+    ).toBe(DATABASE_PASSWORD_VALUE)
+  })
+})
+
+describe('resolvePopoverDirectConnectionBehavior', () => {
+  test('copies the default string when temporary access is off', () => {
+    expect(
+      resolvePopoverDirectConnectionBehavior({
+        isJitEnabled: false,
+        isPending: true,
+        activeRoles: ['postgres'],
+      })
+    ).toEqual({ type: 'copy' })
+  })
+
+  test('waits until grants have loaded', () => {
+    expect(
+      resolvePopoverDirectConnectionBehavior({
+        isJitEnabled: true,
+        isPending: true,
+        activeRoles: [],
+      })
+    ).toEqual({ type: 'pending' })
+  })
+
+  test('copies a role-aware string for a single grant', () => {
+    expect(
+      resolvePopoverDirectConnectionBehavior({
+        isJitEnabled: true,
+        isPending: false,
+        activeRoles: ['analytics'],
+      })
+    ).toEqual({ type: 'copy', role: 'analytics' })
+  })
+
+  test('opens Connect when the user has multiple grants', () => {
+    expect(
+      resolvePopoverDirectConnectionBehavior({
+        isJitEnabled: true,
+        isPending: false,
+        activeRoles: ['postgres', 'analytics'],
+      })
+    ).toEqual({ type: 'open-connect' })
+  })
+
+  test('copies the default string when there are no grants', () => {
+    expect(
+      resolvePopoverDirectConnectionBehavior({
+        isJitEnabled: true,
+        isPending: false,
+        activeRoles: [],
+      })
+    ).toEqual({ type: 'copy' })
+  })
+})

--- a/apps/studio/components/interfaces/ConnectSheet/__tests__/TemporaryAccessConnection.utils.test.ts
+++ b/apps/studio/components/interfaces/ConnectSheet/__tests__/TemporaryAccessConnection.utils.test.ts
@@ -7,34 +7,25 @@ import {
 } from '../TemporaryAccessConnection.utils'
 
 describe('resolveSelectedTemporaryAccessRole', () => {
-  test('defaults to the first active grant', () => {
+  test('defaults to the first grant, keeps opt-out, and falls back when the grant is gone', () => {
     expect(
       resolveSelectedTemporaryAccessRole({
         selectedRole: null,
         activeRoles: ['postgres', 'analytics'],
       })
     ).toBe('postgres')
-  })
-
-  test('keeps an explicit database-password opt-out', () => {
     expect(
       resolveSelectedTemporaryAccessRole({
         selectedRole: DATABASE_PASSWORD_VALUE,
         activeRoles: ['postgres'],
       })
     ).toBe(DATABASE_PASSWORD_VALUE)
-  })
-
-  test('falls back when the selected grant is no longer active', () => {
     expect(
       resolveSelectedTemporaryAccessRole({
         selectedRole: 'analytics',
         activeRoles: ['postgres'],
       })
     ).toBe('postgres')
-  })
-
-  test('falls back to the database password when there are no grants', () => {
     expect(
       resolveSelectedTemporaryAccessRole({
         selectedRole: 'analytics',
@@ -45,7 +36,7 @@ describe('resolveSelectedTemporaryAccessRole', () => {
 })
 
 describe('resolvePopoverDirectConnectionBehavior', () => {
-  test('copies the default string when temporary access is off', () => {
+  test('copies by default, waits while pending, and opens Connect for multiple grants', () => {
     expect(
       resolvePopoverDirectConnectionBehavior({
         isJitEnabled: false,
@@ -53,9 +44,6 @@ describe('resolvePopoverDirectConnectionBehavior', () => {
         activeRoles: ['postgres'],
       })
     ).toEqual({ type: 'copy' })
-  })
-
-  test('waits until grants have loaded', () => {
     expect(
       resolvePopoverDirectConnectionBehavior({
         isJitEnabled: true,
@@ -63,9 +51,6 @@ describe('resolvePopoverDirectConnectionBehavior', () => {
         activeRoles: [],
       })
     ).toEqual({ type: 'pending' })
-  })
-
-  test('copies a role-aware string for a single grant', () => {
     expect(
       resolvePopoverDirectConnectionBehavior({
         isJitEnabled: true,
@@ -73,9 +58,6 @@ describe('resolvePopoverDirectConnectionBehavior', () => {
         activeRoles: ['analytics'],
       })
     ).toEqual({ type: 'copy', role: 'analytics' })
-  })
-
-  test('opens Connect when the user has multiple grants', () => {
     expect(
       resolvePopoverDirectConnectionBehavior({
         isJitEnabled: true,
@@ -83,9 +65,6 @@ describe('resolvePopoverDirectConnectionBehavior', () => {
         activeRoles: ['postgres', 'analytics'],
       })
     ).toEqual({ type: 'open-connect' })
-  })
-
-  test('copies the default string when there are no grants', () => {
     expect(
       resolvePopoverDirectConnectionBehavior({
         isJitEnabled: true,

--- a/apps/studio/components/interfaces/ConnectSheet/content/drizzle/content.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/content/drizzle/content.tsx
@@ -6,6 +6,7 @@ import type {
   StepContentProps,
 } from '@/components/interfaces/ConnectSheet/Connect.types'
 import { resolveOrmConnectionScenario } from '@/components/interfaces/ConnectSheet/OrmConnection.utils'
+import { TemporaryAccessPasswordNote } from '@/components/interfaces/ConnectSheet/TemporaryAccessRoleField'
 import { useIsHighAvailability } from '@/hooks/misc/useSelectedProject'
 
 function getEnvCode({
@@ -102,7 +103,12 @@ const allUsers = await db.select().from(users);
     },
   ]
 
-  return <MultipleCodeBlock files={files} />
+  return (
+    <div className="flex flex-col gap-3">
+      <MultipleCodeBlock files={files} />
+      <TemporaryAccessPasswordNote tokenHref="/account/tokens" />
+    </div>
+  )
 }
 
 export default ContentFile

--- a/apps/studio/components/interfaces/ConnectSheet/content/prisma/content.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/content/prisma/content.tsx
@@ -7,6 +7,7 @@ import type {
 } from '@/components/interfaces/ConnectSheet/Connect.types'
 import { appendConnectionStringParams } from '@/components/interfaces/ConnectSheet/ConnectionString.utils'
 import { resolveOrmConnectionScenario } from '@/components/interfaces/ConnectSheet/OrmConnection.utils'
+import { TemporaryAccessPasswordNote } from '@/components/interfaces/ConnectSheet/TemporaryAccessRoleField'
 import { useIsHighAvailability } from '@/hooks/misc/useSelectedProject'
 
 const withPgbouncerParam = (uri: string | undefined) =>
@@ -110,7 +111,12 @@ datasource db {
     },
   ]
 
-  return <MultipleCodeBlock files={files} />
+  return (
+    <div className="flex flex-col gap-3">
+      <MultipleCodeBlock files={files} />
+      <TemporaryAccessPasswordNote tokenHref="/account/tokens" />
+    </div>
+  )
 }
 
 export default ContentFile

--- a/apps/studio/components/interfaces/ConnectSheet/content/steps/direct-connection/content.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/content/steps/direct-connection/content.tsx
@@ -1,6 +1,8 @@
 import { useParams } from 'common'
 import { Check, KeyRound } from 'lucide-react'
+import Link from 'next/link'
 import { useMemo, useState } from 'react'
+import { Button } from 'ui'
 import { CodeBlock } from 'ui-patterns/CodeBlock'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 
@@ -18,16 +20,19 @@ import type {
 } from '@/components/interfaces/ConnectSheet/Connect.types'
 import { ConnectionParameters } from '@/components/interfaces/ConnectSheet/ConnectionParameters'
 import {
+  applyTemporaryAccessToConnectionString,
   buildConnectionParameters,
   buildConnectionStringWithPassword,
   buildJdbcString,
   buildPsqlCommand,
   buildSafeConnectionString,
   parseConnectionParams,
-  PASSWORD_PLACEHOLDER,
   resolveConnectionString,
+  shouldAddTemporaryAccessPoolerOption,
 } from '@/components/interfaces/ConnectSheet/ConnectionString.utils'
 import { PasswordEncodingNote } from '@/components/interfaces/ConnectSheet/PasswordEncodingNote'
+import { useTemporaryAccessConnection } from '@/components/interfaces/ConnectSheet/TemporaryAccessConnectionProvider'
+import { TemporaryAccessPasswordNote } from '@/components/interfaces/ConnectSheet/TemporaryAccessRoleField'
 import { ResetDbPasswordDialog } from '@/components/interfaces/Settings/Database/DatabaseSettings/ResetDbPasswordDialog'
 import { InlineLink } from '@/components/ui/InlineLink'
 import { usePgbouncerConfigQuery } from '@/data/database/pgbouncer-config-query'
@@ -154,6 +159,9 @@ function DirectConnectionContent({ state, deploymentMode }: StepContentProps) {
   const { hasAccess: hasDedicatedPooler } = useCheckEntitlements('dedicated_pooler')
   const isHighAvailability = useIsHighAvailability()
   const [temporaryDatabasePassword, setTemporaryDatabasePassword] = useState('')
+  const {
+    meta: { grantRole, isGrantMode, passwordPlaceholder },
+  } = useTemporaryAccessConnection()
 
   const connectionSource = state.connectionSource
   const connectionType = (state.connectionType as DatabaseConnectionType) ?? 'uri'
@@ -164,15 +172,23 @@ function DirectConnectionContent({ state, deploymentMode }: StepContentProps) {
   const connectionStringPooler: ConnectionStringPooler | undefined =
     connectionStrings[connectionSource as keyof typeof connectionStrings]
   // Determine which connection string to use
-  const resolvedConnectionString = useMemo(
-    () =>
-      resolveConnectionString({
+  const resolvedConnectionString = useMemo(() => {
+    const uri = resolveConnectionString({
+      connectionMethod,
+      useSharedPooler,
+      connectionStringPooler,
+    })
+    if (!grantRole) return uri
+
+    return applyTemporaryAccessToConnectionString(uri, {
+      role: grantRole,
+      addPoolerJitOption: shouldAddTemporaryAccessPoolerOption({
         connectionMethod,
         useSharedPooler,
-        connectionStringPooler,
+        hasDedicatedPooler: Boolean(connectionStringPooler?.transactionDedicated),
       }),
-    [connectionMethod, useSharedPooler, connectionStringPooler]
-  )
+    })
+  }, [connectionMethod, connectionStringPooler, grantRole, useSharedPooler])
 
   const connectionParams = useMemo(
     () => parseConnectionParams(resolvedConnectionString),
@@ -180,8 +196,9 @@ function DirectConnectionContent({ state, deploymentMode }: StepContentProps) {
   )
 
   const safeConnectionString = useMemo(
-    () => buildSafeConnectionString(resolvedConnectionString, connectionParams),
-    [resolvedConnectionString, connectionParams]
+    () =>
+      buildSafeConnectionString(resolvedConnectionString, connectionParams, passwordPlaceholder),
+    [resolvedConnectionString, connectionParams, passwordPlaceholder]
   )
 
   const redactedConnectionString = useMemo(() => {
@@ -189,24 +206,24 @@ function DirectConnectionContent({ state, deploymentMode }: StepContentProps) {
       case 'psql':
         return buildPsqlCommand(connectionParams)
       case 'jdbc':
-        return buildJdbcString(connectionParams)
+        return buildJdbcString(connectionParams, passwordPlaceholder)
       case 'php':
         return `DATABASE_URL=${safeConnectionString}`
       case 'uri':
       default:
         return safeConnectionString
     }
-  }, [connectionType, connectionParams, safeConnectionString])
+  }, [connectionType, connectionParams, passwordPlaceholder, safeConnectionString])
 
   const connectionString = useMemo(() => {
-    if (!temporaryDatabasePassword) return redactedConnectionString
+    if (isGrantMode || !temporaryDatabasePassword) return redactedConnectionString
 
     if (connectionType === 'psql') {
       return redactedConnectionString
     }
 
     return buildConnectionStringWithPassword(redactedConnectionString, temporaryDatabasePassword)
-  }, [connectionType, redactedConnectionString, temporaryDatabasePassword])
+  }, [connectionType, isGrantMode, redactedConnectionString, temporaryDatabasePassword])
 
   const trackCopy = () => {
     const typeConfig = DATABASE_CONNECTION_TYPES.find((t) => t.id === connectionType)
@@ -236,12 +253,16 @@ function DirectConnectionContent({ state, deploymentMode }: StepContentProps) {
         ? 'Shared pooler'
         : null
 
-  const showPasswordPlaceholder = connectionString.includes(PASSWORD_PLACEHOLDER)
+  const showPasswordPlaceholder = connectionString.includes(passwordPlaceholder)
   const showSelfHostedDirectNotice = deploymentMode.isSelfHosted && connectionMethod === 'direct'
   const showPoolerTitle = deploymentMode.isPlatform && !!poolerBadge && !isHighAvailability
   const showResetInTitle =
-    deploymentMode.isPlatform && showPasswordPlaceholder && !temporaryDatabasePassword
-  const showStringTitleRow = showPoolerTitle || showResetInTitle
+    deploymentMode.isPlatform &&
+    !isGrantMode &&
+    showPasswordPlaceholder &&
+    !temporaryDatabasePassword
+  const showCreateTokenInTitle = deploymentMode.isPlatform && isGrantMode
+  const showStringTitleRow = showPoolerTitle || showResetInTitle || showCreateTokenInTitle
 
   return (
     <div className="flex flex-col gap-3">
@@ -260,6 +281,11 @@ function DirectConnectionContent({ state, deploymentMode }: StepContentProps) {
                 onPasswordReset={setTemporaryDatabasePassword}
               />
             )}
+            {showCreateTokenInTitle && (
+              <Button asChild variant="default" icon={<KeyRound />}>
+                <Link href="/account/tokens">Create access token</Link>
+              </Button>
+            )}
           </div>
         )}
         <div data-connect-copy-value={redactedConnectionString}>
@@ -274,14 +300,15 @@ function DirectConnectionContent({ state, deploymentMode }: StepContentProps) {
             {connectionString}
           </CodeBlock>
         </div>
-        {deploymentMode.isPlatform && temporaryDatabasePassword && (
+        {deploymentMode.isPlatform && !isGrantMode && temporaryDatabasePassword && (
           <div className="flex items-center gap-2 border-t px-4 py-3 text-sm text-foreground-light">
             <Check size={16} className="text-brand shrink-0" />
             <span>New password shown until refresh.</span>
           </div>
         )}
       </div>
-      {showPasswordPlaceholder && <PasswordEncodingNote />}
+      {showPasswordPlaceholder && !isGrantMode && <PasswordEncodingNote />}
+      <TemporaryAccessPasswordNote />
       {showSelfHostedDirectNotice && (
         <p className="text-sm text-foreground-lighter">
           Manually{' '}

--- a/apps/studio/components/interfaces/ConnectSheet/content/steps/direct-files/content.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/content/steps/direct-files/content.tsx
@@ -12,10 +12,11 @@ import {
   buildConnectionParameters,
   buildSafeConnectionString,
   parseConnectionParams,
-  PASSWORD_PLACEHOLDER,
   resolveConnectionString,
 } from '@/components/interfaces/ConnectSheet/ConnectionString.utils'
 import { PasswordEncodingNote } from '@/components/interfaces/ConnectSheet/PasswordEncodingNote'
+import { useTemporaryAccessConnection } from '@/components/interfaces/ConnectSheet/TemporaryAccessConnectionProvider'
+import { TemporaryAccessPasswordNote } from '@/components/interfaces/ConnectSheet/TemporaryAccessRoleField'
 
 type DirectFilesConfig = {
   files: {
@@ -32,6 +33,9 @@ function DirectFilesContent({ state, connectionStringPooler }: StepContentProps)
   const connectionType = (state.connectionType as DatabaseConnectionType) ?? 'uri'
   const connectionMethod = (state.connectionMethod as ConnectionStringMethod) ?? 'direct'
   const useSharedPooler = Boolean(state.useSharedPooler)
+  const {
+    meta: { isGrantMode, passwordPlaceholder },
+  } = useTemporaryAccessConnection()
 
   const resolvedConnectionString = useMemo(
     () =>
@@ -49,8 +53,9 @@ function DirectFilesContent({ state, connectionStringPooler }: StepContentProps)
   )
 
   const safeConnectionString = useMemo(
-    () => buildSafeConnectionString(resolvedConnectionString, connectionParams),
-    [resolvedConnectionString, connectionParams]
+    () =>
+      buildSafeConnectionString(resolvedConnectionString, connectionParams, passwordPlaceholder),
+    [resolvedConnectionString, connectionParams, passwordPlaceholder]
   )
 
   const config: DirectFilesConfig | null = useMemo(() => {
@@ -125,7 +130,7 @@ func main() {
               language: 'json',
               code: `{
   "ConnectionStrings": {
-    "DefaultConnection": "Host=${connectionParams.host};Database=${connectionParams.database};Username=${connectionParams.user};Password=${PASSWORD_PLACEHOLDER};SSL Mode=Require;Trust Server Certificate=true"
+                "DefaultConnection": "Host=${connectionParams.host};Database=${connectionParams.database};Username=${connectionParams.user};Password=${passwordPlaceholder};SSL Mode=Require;Trust Server Certificate=true"
   }
 }`,
             },
@@ -200,7 +205,7 @@ except Exception as e:
               language: 'bash',
               code: [
                 `user=${connectionParams.user}`,
-                `password=${PASSWORD_PLACEHOLDER}`,
+                `password=${passwordPlaceholder}`,
                 `host=${connectionParams.host}`,
                 `port=${connectionParams.port}`,
                 `dbname=${connectionParams.database}`,
@@ -214,7 +219,7 @@ except Exception as e:
       default:
         return null
     }
-  }, [connectionType, safeConnectionString, connectionParams])
+  }, [connectionType, safeConnectionString, connectionParams, passwordPlaceholder])
 
   const defaultFile = config?.files[0]?.name ?? ''
   const [activeFile, setActiveFile] = useState(defaultFile)
@@ -238,7 +243,8 @@ except Exception as e:
   return (
     <div className="flex flex-col gap-3">
       <MultipleCodeBlock files={config.files} value={activeFile} onValueChange={setActiveFile} />
-      {config.passwordInUrl && <PasswordEncodingNote />}
+      {config.passwordInUrl && !isGrantMode && <PasswordEncodingNote />}
+      <TemporaryAccessPasswordNote tokenHref="/account/tokens" />
       <ConnectionParameters parameters={buildConnectionParameters(connectionParams)} />
     </div>
   )

--- a/apps/studio/components/interfaces/ProjectHome/ProjectConnectionPopover.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/ProjectConnectionPopover.tsx
@@ -1,6 +1,6 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { Check, ChevronDown, Copy, Database, KeyRound, Link2, Terminal } from 'lucide-react'
-import { parseAsBoolean, useQueryState } from 'nuqs'
+import { parseAsBoolean, parseAsString, useQueryState } from 'nuqs'
 import { useEffect, useMemo, useState } from 'react'
 import {
   Button,
@@ -15,9 +15,12 @@ import {
 import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 
 import { getConnectionStrings } from '@/components/interfaces/Connect/DatabaseSettings.utils'
+import { applyTemporaryAccessToConnectionString } from '@/components/interfaces/ConnectSheet/ConnectionString.utils'
 import { appendHighAvailabilitySslParams } from '@/components/interfaces/ConnectSheet/DatabaseSettings.utils'
+import { resolvePopoverDirectConnectionBehavior } from '@/components/interfaces/ConnectSheet/TemporaryAccessConnection.utils'
 import { useAPIKeys } from '@/data/api-keys/api-keys-query'
 import { useProjectApiUrl } from '@/data/config/project-endpoint-query'
+import { useActiveTemporaryAccessRoles } from '@/data/jit-db-access/use-active-temporary-access-roles'
 import { useReadReplicasQuery } from '@/data/read-replicas/replicas-query'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
 import { useIsHighAvailability } from '@/hooks/misc/useSelectedProject'
@@ -40,6 +43,7 @@ export const ProjectConnectionPopover = ({ projectRef }: ProjectConnectionPopove
   const [open, setOpen] = useState(false)
   const [copiedItem, setCopiedItem] = useState<string | null>(null)
   const [, setShowConnect] = useQueryState('showConnect', parseAsBoolean.withDefault(false))
+  const [, setConnectTab] = useQueryState('connectTab', parseAsString)
 
   const { isLoading: isLoadingPermissions, can: canReadAPIKeys } = useAsyncCheckPermissions(
     PermissionAction.READ,
@@ -60,6 +64,16 @@ export const ProjectConnectionPopover = ({ projectRef }: ProjectConnectionPopove
   )
   const primaryDatabase = databases?.find((db) => db.identifier === projectRef)
   const isHighAvailability = useIsHighAvailability()
+  const {
+    activeRoles,
+    isPending: isLoadingTemporaryAccess,
+    isJitEnabled,
+  } = useActiveTemporaryAccessRoles(projectRef, { enabled: open })
+  const directConnectionBehavior = resolvePopoverDirectConnectionBehavior({
+    isJitEnabled,
+    isPending: isLoadingTemporaryAccess,
+    activeRoles,
+  })
 
   const directConnectionString = useMemo(() => {
     if (
@@ -75,8 +89,13 @@ export const ProjectConnectionPopover = ({ projectRef }: ProjectConnectionPopove
       connectionInfo: { ...EMPTY_CONNECTION_INFO, ...connectionInfo },
       metadata: { projectRef },
     }).direct.uri
-    return isHighAvailability ? appendHighAvailabilitySslParams(uri) : uri
-  }, [primaryDatabase, projectRef, isHighAvailability])
+    const withSsl = isHighAvailability ? appendHighAvailabilitySslParams(uri) : uri
+    return directConnectionBehavior.type === 'copy' && directConnectionBehavior.role
+      ? applyTemporaryAccessToConnectionString(withSsl, {
+          role: directConnectionBehavior.role,
+        })
+      : withSsl
+  }, [primaryDatabase, projectRef, isHighAvailability, directConnectionBehavior])
 
   const cliCommands = useMemo(
     () =>
@@ -93,6 +112,47 @@ export const ProjectConnectionPopover = ({ projectRef }: ProjectConnectionPopove
   // the entry entirely on !IS_PLATFORM when the key isn't available. Platform
   // behavior is unchanged.
   const showPublishableKey = IS_PLATFORM || !!publishableKey?.api_key
+
+  const openConnectDirect = () => {
+    setOpen(false)
+    setConnectTab('direct')
+    setShowConnect(true)
+  }
+
+  const directConnectionItem = useMemo(() => {
+    if (directConnectionBehavior.type === 'pending') {
+      return {
+        label: 'Direct connection string',
+        value: '',
+        displayValue: 'Loading connection string...',
+        disabled: true,
+        icon: Database,
+        action: 'copy' as const,
+      }
+    }
+
+    if (directConnectionBehavior.type === 'open-connect') {
+      return {
+        label: 'Direct connection string',
+        value: '',
+        displayValue: 'Multiple roles. Open Connect to choose.',
+        disabled: false,
+        icon: Database,
+        action: 'open-connect' as const,
+      }
+    }
+
+    return {
+      label: 'Direct connection string',
+      value: directConnectionString,
+      displayValue: isLoadingDatabases
+        ? 'Loading connection string...'
+        : directConnectionString || 'Connection string unavailable',
+      disabled: isLoadingDatabases || !directConnectionString,
+      icon: Database,
+      action: 'copy' as const,
+    }
+  }, [directConnectionBehavior.type, directConnectionString, isLoadingDatabases])
 
   const menuItems = useMemo(
     () => [
@@ -127,15 +187,7 @@ export const ProjectConnectionPopover = ({ projectRef }: ProjectConnectionPopove
         : []),
       ...(IS_PLATFORM
         ? [
-            {
-              label: 'Direct connection string',
-              value: directConnectionString,
-              displayValue: isLoadingDatabases
-                ? 'Loading connection string...'
-                : directConnectionString || 'Connection string unavailable',
-              disabled: isLoadingDatabases || !directConnectionString,
-              icon: Database,
-            },
+            directConnectionItem,
             {
               label: 'CLI setup commands',
               value: cliCommands,
@@ -149,9 +201,8 @@ export const ProjectConnectionPopover = ({ projectRef }: ProjectConnectionPopove
     [
       canReadAPIKeys,
       cliCommands,
-      directConnectionString,
+      directConnectionItem,
       isLoadingApiUrl,
-      isLoadingDatabases,
       isLoadingKeys,
       isLoadingPermissions,
       projectRef,
@@ -196,6 +247,7 @@ export const ProjectConnectionPopover = ({ projectRef }: ProjectConnectionPopove
           <DropdownMenuContent side="bottom" align="center" className="w-80 p-1">
             {menuItems.map((item) => {
               const Icon = item.icon
+              const opensConnect = 'action' in item && item.action === 'open-connect'
 
               return (
                 <DropdownMenuItem
@@ -205,6 +257,10 @@ export const ProjectConnectionPopover = ({ projectRef }: ProjectConnectionPopove
                   onSelect={(event) => {
                     event.preventDefault()
                     if (item.disabled) return
+                    if (opensConnect) {
+                      openConnectDirect()
+                      return
+                    }
 
                     copyToClipboard(item.value)
                     setCopiedItem(item.label)
@@ -213,7 +269,9 @@ export const ProjectConnectionPopover = ({ projectRef }: ProjectConnectionPopove
                   <Icon size={14} className="mt-0.5 shrink-0 text-foreground-light" />
                   <div className="min-w-0 flex-1">
                     <div className="text-sm text-foreground">
-                      {copiedItem !== item.label ? <span className="sr-only">Copy</span> : null}
+                      {!opensConnect && copiedItem !== item.label ? (
+                        <span className="sr-only">Copy</span>
+                      ) : null}
                       {item.label}
                       {copiedItem === item.label ? (
                         <span className="sr-only">copied to your clipboard</span>
@@ -223,14 +281,16 @@ export const ProjectConnectionPopover = ({ projectRef }: ProjectConnectionPopove
                       {item.displayValue}
                     </div>
                   </div>
-                  <div
-                    className={cn(
-                      'absolute right-2 top-1/2 -translate-y-1/2 text-foreground-lighter opacity-0 transition-opacity group-hover:opacity-100',
-                      copiedItem === item.label && 'opacity-100 text-brand'
-                    )}
-                  >
-                    {copiedItem === item.label ? <Check size={14} /> : <Copy size={14} />}
-                  </div>
+                  {!opensConnect && (
+                    <div
+                      className={cn(
+                        'absolute right-2 top-1/2 -translate-y-1/2 text-foreground-lighter opacity-0 transition-opacity group-hover:opacity-100',
+                        copiedItem === item.label && 'opacity-100 text-brand'
+                      )}
+                    >
+                      {copiedItem === item.label ? <Check size={14} /> : <Copy size={14} />}
+                    </div>
+                  )}
                 </DropdownMenuItem>
               )
             })}
@@ -245,7 +305,7 @@ export const ProjectConnectionPopover = ({ projectRef }: ProjectConnectionPopove
                   setShowConnect(true)
                 }}
               >
-                Get Connected
+                Get connected
               </Button>
             </div>
           </DropdownMenuContent>

--- a/apps/studio/data/jit-db-access/jit-db-access-roles.utils.test.ts
+++ b/apps/studio/data/jit-db-access/jit-db-access-roles.utils.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  getActiveTemporaryAccessRoles,
+  isTemporaryAccessRoleExpired,
+} from './jit-db-access-roles.utils'
+
+describe('isTemporaryAccessRoleExpired', () => {
+  test('treats a missing expiry as active', () => {
+    expect(isTemporaryAccessRoleExpired(undefined, 1_000)).toBe(false)
+  })
+
+  test('compares unix seconds against now', () => {
+    expect(isTemporaryAccessRoleExpired(999, 1_000)).toBe(true)
+    expect(isTemporaryAccessRoleExpired(1_001, 1_000)).toBe(false)
+  })
+
+  test('normalises millisecond timestamps', () => {
+    const now = 1_700_000_000
+    expect(isTemporaryAccessRoleExpired(1_699_000_000_000, now)).toBe(true)
+    expect(isTemporaryAccessRoleExpired(1_701_000_000_000, now)).toBe(false)
+  })
+})
+
+describe('getActiveTemporaryAccessRoles', () => {
+  test('returns an empty list when grants are missing', () => {
+    expect(getActiveTemporaryAccessRoles(undefined, 1_000)).toEqual([])
+    expect(getActiveTemporaryAccessRoles({}, 1_000)).toEqual([])
+    expect(getActiveTemporaryAccessRoles({ user_roles: [] }, 1_000)).toEqual([])
+  })
+
+  test('keeps unexpired roles and drops expired ones', () => {
+    expect(
+      getActiveTemporaryAccessRoles(
+        {
+          user_roles: [
+            { role: 'postgres', expires_at: 2_000 },
+            { role: 'supabase_read_only_user', expires_at: 500 },
+            { role: 'analytics' },
+          ],
+        },
+        1_000
+      )
+    ).toEqual(['postgres', 'analytics'])
+  })
+
+  test('deduplicates role names', () => {
+    expect(
+      getActiveTemporaryAccessRoles(
+        {
+          user_roles: [{ role: 'postgres' }, { role: 'postgres' }],
+        },
+        1_000
+      )
+    ).toEqual(['postgres'])
+  })
+})

--- a/apps/studio/data/jit-db-access/jit-db-access-roles.utils.test.ts
+++ b/apps/studio/data/jit-db-access/jit-db-access-roles.utils.test.ts
@@ -6,52 +6,30 @@ import {
 } from './jit-db-access-roles.utils'
 
 describe('isTemporaryAccessRoleExpired', () => {
-  test('treats a missing expiry as active', () => {
+  test('treats missing expiry as active and normalises second vs millisecond timestamps', () => {
     expect(isTemporaryAccessRoleExpired(undefined, 1_000)).toBe(false)
-  })
-
-  test('compares unix seconds against now', () => {
     expect(isTemporaryAccessRoleExpired(999, 1_000)).toBe(true)
     expect(isTemporaryAccessRoleExpired(1_001, 1_000)).toBe(false)
-  })
-
-  test('normalises millisecond timestamps', () => {
-    const now = 1_700_000_000
-    expect(isTemporaryAccessRoleExpired(1_699_000_000_000, now)).toBe(true)
-    expect(isTemporaryAccessRoleExpired(1_701_000_000_000, now)).toBe(false)
+    expect(isTemporaryAccessRoleExpired(1_699_000_000_000, 1_700_000_000)).toBe(true)
+    expect(isTemporaryAccessRoleExpired(1_701_000_000_000, 1_700_000_000)).toBe(false)
   })
 })
 
 describe('getActiveTemporaryAccessRoles', () => {
-  test('returns an empty list when grants are missing', () => {
+  test('keeps unexpired unique roles', () => {
     expect(getActiveTemporaryAccessRoles(undefined, 1_000)).toEqual([])
-    expect(getActiveTemporaryAccessRoles({}, 1_000)).toEqual([])
-    expect(getActiveTemporaryAccessRoles({ user_roles: [] }, 1_000)).toEqual([])
-  })
-
-  test('keeps unexpired roles and drops expired ones', () => {
     expect(
       getActiveTemporaryAccessRoles(
         {
           user_roles: [
             { role: 'postgres', expires_at: 2_000 },
             { role: 'supabase_read_only_user', expires_at: 500 },
+            { role: 'postgres' },
             { role: 'analytics' },
           ],
         },
         1_000
       )
     ).toEqual(['postgres', 'analytics'])
-  })
-
-  test('deduplicates role names', () => {
-    expect(
-      getActiveTemporaryAccessRoles(
-        {
-          user_roles: [{ role: 'postgres' }, { role: 'postgres' }],
-        },
-        1_000
-      )
-    ).toEqual(['postgres'])
   })
 })

--- a/apps/studio/data/jit-db-access/jit-db-access-roles.utils.test.ts
+++ b/apps/studio/data/jit-db-access/jit-db-access-roles.utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest'
 
 import {
   getActiveTemporaryAccessRoles,
+  getNextTemporaryAccessExpirySeconds,
   isTemporaryAccessRoleExpired,
 } from './jit-db-access-roles.utils'
 
@@ -31,5 +32,30 @@ describe('getActiveTemporaryAccessRoles', () => {
         1_000
       )
     ).toEqual(['postgres', 'analytics'])
+  })
+})
+
+describe('getNextTemporaryAccessExpirySeconds', () => {
+  test('returns the soonest future expiry and ignores missing or past ones', () => {
+    expect(getNextTemporaryAccessExpirySeconds(undefined, 1_000)).toBeUndefined()
+    expect(
+      getNextTemporaryAccessExpirySeconds(
+        {
+          user_roles: [
+            { role: 'postgres', expires_at: 500 },
+            { role: 'analytics' },
+            { role: 'postgres', expires_at: 2_000 },
+            { role: 'supabase_read_only_user', expires_at: 1_500 },
+          ],
+        },
+        1_000
+      )
+    ).toBe(1_500)
+    expect(
+      getNextTemporaryAccessExpirySeconds(
+        { user_roles: [{ role: 'postgres', expires_at: 1_701_000_000_000 }] },
+        1_700_000_000
+      )
+    ).toBe(1_701_000_000)
   })
 })

--- a/apps/studio/data/jit-db-access/jit-db-access-roles.utils.ts
+++ b/apps/studio/data/jit-db-access/jit-db-access-roles.utils.ts
@@ -5,13 +5,32 @@ export type TemporaryAccessRoleGrant = {
 
 const MILLISECONDS_THRESHOLD = 1e12
 
+function toExpirySeconds(expiresAt: number) {
+  return expiresAt > MILLISECONDS_THRESHOLD ? expiresAt / 1000 : expiresAt
+}
+
 export function isTemporaryAccessRoleExpired(
   expiresAt: number | undefined,
   nowSeconds: number
 ): boolean {
   if (!expiresAt) return false
-  const expiresSeconds = expiresAt > MILLISECONDS_THRESHOLD ? expiresAt / 1000 : expiresAt
-  return expiresSeconds <= nowSeconds
+  return toExpirySeconds(expiresAt) <= nowSeconds
+}
+
+export function getNextTemporaryAccessExpirySeconds(
+  grants: { user_roles?: TemporaryAccessRoleGrant[] } | undefined,
+  nowSeconds: number
+): number | undefined {
+  if (!grants?.user_roles?.length) return
+
+  let next: number | undefined
+  for (const grant of grants.user_roles) {
+    if (!grant.role || grant.expires_at == null) continue
+    const expiresSeconds = toExpirySeconds(grant.expires_at)
+    if (expiresSeconds <= nowSeconds) continue
+    if (next == null || expiresSeconds < next) next = expiresSeconds
+  }
+  return next
 }
 
 export function getActiveTemporaryAccessRoles(

--- a/apps/studio/data/jit-db-access/jit-db-access-roles.utils.ts
+++ b/apps/studio/data/jit-db-access/jit-db-access-roles.utils.ts
@@ -1,0 +1,28 @@
+export type TemporaryAccessRoleGrant = {
+  role: string
+  expires_at?: number
+}
+
+const MILLISECONDS_THRESHOLD = 1e12
+
+export function isTemporaryAccessRoleExpired(
+  expiresAt: number | undefined,
+  nowSeconds: number
+): boolean {
+  if (!expiresAt) return false
+  const expiresSeconds = expiresAt > MILLISECONDS_THRESHOLD ? expiresAt / 1000 : expiresAt
+  return expiresSeconds <= nowSeconds
+}
+
+export function getActiveTemporaryAccessRoles(
+  grants: { user_roles?: TemporaryAccessRoleGrant[] } | undefined,
+  nowSeconds: number
+): string[] {
+  if (!grants?.user_roles?.length) return []
+
+  const roles = grants.user_roles
+    .filter((grant) => grant.role && !isTemporaryAccessRoleExpired(grant.expires_at, nowSeconds))
+    .map((grant) => grant.role)
+
+  return [...new Set(roles)]
+}

--- a/apps/studio/data/jit-db-access/jit-db-access-self-query.ts
+++ b/apps/studio/data/jit-db-access/jit-db-access-self-query.ts
@@ -1,0 +1,45 @@
+import { queryOptions, useQuery } from '@tanstack/react-query'
+
+import { jitDbAccessKeys } from './keys'
+import { get, handleError } from '@/data/fetchers'
+import { IS_PLATFORM } from '@/lib/constants'
+import type { ResponseError, UseCustomQueryOptions } from '@/types'
+
+export type JitDbAccessSelfVariables = { projectRef?: string }
+
+async function getJitDbAccessSelf({ projectRef }: JitDbAccessSelfVariables, signal?: AbortSignal) {
+  if (!projectRef) throw new Error('projectRef is required')
+
+  const { data, error } = await get(`/v1/projects/{ref}/database/jit`, {
+    params: { path: { ref: projectRef } },
+    signal,
+  })
+
+  if (error) handleError(error)
+  return data
+}
+
+export type JitDbAccessSelfData = Awaited<ReturnType<typeof getJitDbAccessSelf>>
+export type JitDbAccessSelfError = ResponseError
+
+export const jitDbAccessSelfQueryOptions = ({ projectRef }: JitDbAccessSelfVariables) =>
+  queryOptions({
+    queryKey: jitDbAccessKeys.self(projectRef),
+    queryFn: ({ signal }) => getJitDbAccessSelf({ projectRef }, signal),
+    enabled: IS_PLATFORM && typeof projectRef !== 'undefined',
+    retry: false,
+    refetchOnWindowFocus: false,
+  })
+
+export const useJitDbAccessSelfQuery = <TData = JitDbAccessSelfData>(
+  { projectRef }: JitDbAccessSelfVariables,
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<JitDbAccessSelfData, JitDbAccessSelfError, TData> = {}
+) =>
+  useQuery<JitDbAccessSelfData, JitDbAccessSelfError, TData>({
+    ...jitDbAccessSelfQueryOptions({ projectRef }),
+    enabled: enabled && IS_PLATFORM && typeof projectRef !== 'undefined',
+    ...options,
+  })

--- a/apps/studio/data/jit-db-access/keys.ts
+++ b/apps/studio/data/jit-db-access/keys.ts
@@ -4,4 +4,5 @@ export const jitDbAccessKeys = {
     ['projects', projectRef, 'jit-db-access-status'] as const,
   members: (projectRef: string | undefined) =>
     ['projects', projectRef, 'jit-db-access-members'] as const,
+  self: (projectRef: string | undefined) => ['projects', projectRef, 'jit-db-access-self'] as const,
 }

--- a/apps/studio/data/jit-db-access/use-active-temporary-access-roles.ts
+++ b/apps/studio/data/jit-db-access/use-active-temporary-access-roles.ts
@@ -1,8 +1,15 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 import { useIsJitDbAccessEnabled } from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
-import { getActiveTemporaryAccessRoles } from '@/data/jit-db-access/jit-db-access-roles.utils'
+import {
+  getActiveTemporaryAccessRoles,
+  getNextTemporaryAccessExpirySeconds,
+} from '@/data/jit-db-access/jit-db-access-roles.utils'
 import { useJitDbAccessSelfQuery } from '@/data/jit-db-access/jit-db-access-self-query'
+
+function readNowSeconds() {
+  return Math.floor(Date.now() / 1000)
+}
 
 export function useActiveTemporaryAccessRoles(
   projectRef: string | undefined,
@@ -13,11 +20,31 @@ export function useActiveTemporaryAccessRoles(
     { projectRef },
     { enabled: enabled && isJitEnabled }
   )
+  const [nowSeconds, setNowSeconds] = useState(readNowSeconds)
+
+  useEffect(() => {
+    if (!enabled || !isJitEnabled || isError) return
+
+    const now = readNowSeconds()
+    if (now !== nowSeconds) {
+      setNowSeconds(now)
+      return
+    }
+
+    const nextExpiry = getNextTemporaryAccessExpirySeconds(data, nowSeconds)
+    if (nextExpiry == null) return
+
+    const timeout = window.setTimeout(
+      () => setNowSeconds(readNowSeconds()),
+      Math.max(0, nextExpiry * 1000 - Date.now())
+    )
+    return () => window.clearTimeout(timeout)
+  }, [data, enabled, isError, isJitEnabled, nowSeconds])
 
   const activeRoles = useMemo(() => {
     if (!isJitEnabled || isError) return []
-    return getActiveTemporaryAccessRoles(data, Math.floor(Date.now() / 1000))
-  }, [data, isError, isJitEnabled])
+    return getActiveTemporaryAccessRoles(data, nowSeconds)
+  }, [data, isError, isJitEnabled, nowSeconds])
 
   return {
     activeRoles,

--- a/apps/studio/data/jit-db-access/use-active-temporary-access-roles.ts
+++ b/apps/studio/data/jit-db-access/use-active-temporary-access-roles.ts
@@ -1,0 +1,27 @@
+import { useMemo } from 'react'
+
+import { useIsJitDbAccessEnabled } from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
+import { getActiveTemporaryAccessRoles } from '@/data/jit-db-access/jit-db-access-roles.utils'
+import { useJitDbAccessSelfQuery } from '@/data/jit-db-access/jit-db-access-self-query'
+
+export function useActiveTemporaryAccessRoles(
+  projectRef: string | undefined,
+  { enabled = true }: { enabled?: boolean } = {}
+) {
+  const isJitEnabled = useIsJitDbAccessEnabled()
+  const { data, isPending, isError } = useJitDbAccessSelfQuery(
+    { projectRef },
+    { enabled: enabled && isJitEnabled }
+  )
+
+  const activeRoles = useMemo(() => {
+    if (!isJitEnabled || isError) return []
+    return getActiveTemporaryAccessRoles(data, Math.floor(Date.now() / 1000))
+  }, [data, isError, isJitEnabled])
+
+  return {
+    activeRoles,
+    isPending: Boolean(isJitEnabled && isPending),
+    isJitEnabled,
+  }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature. Studio discoverability for temporary database access (Resolves [DEPR-643](https://linear.app/supabase/issue/DEPR-643/add-role-aware-connection-strings-on-connect-direct), contributes to [SEC-888](https://linear.app/supabase/issue/SEC-888/fix-ui-ux-issues-on-temporary-access-feature)).

## What is the current behavior?

Connect Direct always assumes the `postgres` user and `[YOUR-PASSWORD]`. Project members who were granted a temporary-access role (Developers cannot reset the database password) have no way to copy a string that will actually log them in.

## What is the new behavior?

If the JIT preview is on and the current user has active grants:

- Direct shows a **Role** control under Source
- Copied URI / JDBC / psql / parameters use that Postgres role and `[YOUR-ACCESS-TOKEN]`
- Shared pooler strings also get `options=-c%20jit%3dtrue`
- Title row offers **Create access token** instead of reset password
- ORM and Direct files inherit the rewritten string
- Home Copy: one grant copies a role-aware Direct URI; multiple grants open Connect Direct

No grants: Connect is unchanged. Invitees without project membership are out of scope (DEPR-642 / DEPR-644).

| After |
| --- |
| <img width="1268" height="2282" alt="CleanShot 2026-08-19 at 14 14 09@2x" src="https://github.com/user-attachments/assets/64e3ce77-f8e6-403d-8643-9c43c2ff513e" /> |

## To test

Needs the `jitDbAccess` feature preview and at least one active grant on the current user (Developer is the realistic role: they can open Connect, they cannot reset the database password).

1. Open any project → **Connect** → **Direct**. Confirm **Role** sits under Source. Copy the URI: user is the granted role, password is `[YOUR-ACCESS-TOKEN]`. **Create access token** is in the string title row.
2. Switch Role to **Database password**. Confirm the string returns to `postgres` + `[YOUR-PASSWORD]` and Reset is back.
3. With Role on a grant, switch to **ORM**. Confirm `.env` uses the rewritten user and token placeholder.
4. Project home Copy menu: one grant copies the role-aware Direct URI. Two grants should open Connect on Direct instead of copying.