### PR TITLE
fix: clamp Popover/Select/DropdownMenu content to viewport height

### DIFF
--- a/packages/ui/src/components/shadcn/ui/dropdown-menu.tsx
+++ b/packages/ui/src/components/shadcn/ui/dropdown-menu.tsx
@@ -84,7 +84,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        'z-50 min-w-32 overflow-hidden rounded-md border border-overlay bg-overlay p-1 text-foreground-light shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 w-64',
+        'z-50 min-w-32 max-h-(--radix-dropdown-menu-content-available-height) overflow-y-auto rounded-md border border-overlay bg-overlay p-1 text-foreground-light shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 w-64',
         className
       )}
       {...props}

--- a/packages/ui/src/components/shadcn/ui/popover.tsx
+++ b/packages/ui/src/components/shadcn/ui/popover.tsx
@@ -46,7 +46,7 @@ const PopoverContent = React.forwardRef<
         sideOffset={sideOffset}
         className={cn(
           sameWidthAsTrigger ? styles['popover-trigger-width'] : '',
-          'z-50 w-72 rounded-md border border-overlay bg-overlay p-4 text-popover-foreground shadow-md outline-hidden animate-in data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+          'z-50 w-72 max-h-(--radix-popover-content-available-height) overflow-y-auto rounded-md border border-overlay bg-overlay p-4 text-popover-foreground shadow-md outline-hidden animate-in data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
           className
         )}
         {...props}

--- a/packages/ui/src/components/shadcn/ui/select.tsx
+++ b/packages/ui/src/components/shadcn/ui/select.tsx
@@ -107,9 +107,9 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        'relative z-50 max-h-(--radix-select-content-available-height) min-w-32 overflow-y-auto rounded-md border bg-overlay text-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        'relative z-50 max-h-96 min-w-32 overflow-y-auto rounded-md border bg-overlay text-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         position === 'popper' &&
-          'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+          'max-h-(--radix-select-content-available-height) data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
         className
       )}
       position={position}

--- a/packages/ui/src/components/shadcn/ui/select.tsx
+++ b/packages/ui/src/components/shadcn/ui/select.tsx
@@ -107,7 +107,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        'relative z-50 max-h-96 min-w-32 overflow-hidden rounded-md border bg-overlay text-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        'relative z-50 max-h-(--radix-select-content-available-height) min-w-32 overflow-y-auto rounded-md border bg-overlay text-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         position === 'popper' &&
           'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
         className


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

Fixes #49155. The three dropdowns in the issue (Edge Function Logs Severity filter, and the two dropdowns in the "Add foreign key relationship" modal) all get clipped by the viewport with no way to scroll to the rest of the content, in some cases making buttons unreachable.

All three share the same root cause: `PopoverContent`, `SelectContent`, and `DropdownMenuContent` in `packages/ui/src/components/shadcn/ui/` each cap their max height with either a hardcoded pixel value (`max-h-96`, `max-h-[300px]`) or nothing at all, instead of using the available-height CSS variable Radix's Popper already computes and exposes for exactly this purpose. When the real available space is smaller than the hardcoded cap, the content still renders at the larger size and overflows past the edge of the screen.

## What is the new behavior?

Swapped the fixed `max-h-*` values for the matching `--radix-*-content-available-height` variable on all three components, and changed `overflow-hidden` to `overflow-y-auto` so any content that still doesn't fully fit gets an internal scrollbar instead of clipping off-screen.

## Additional context

**On verification:** I wasn't able to get an actual visual click-through of this fix. Locally, `apps/design-system` (the component demo site) hits a known contentlayer2 issue on Windows that leaves every `/docs/*` page 404ing regardless of this change. The CI preview deployment for `design-system` did build successfully, but it's gated behind Vercel SSO (team-only), which I don't have access to as an external contributor.

What I did verify directly:
- `pnpm --filter=ui typecheck` passes clean.
- The three CSS variable names I'm referencing (`--radix-select-content-available-height`, `--radix-popover-content-available-height`, `--radix-dropdown-menu-content-available-height`) are real — confirmed by reading the installed `@radix-ui/react-select`, `@radix-ui/react-popover`, and `@radix-ui/react-dropdown-menu` source directly, where each one aliases its own variable to the underlying `--radix-popper-available-height` that Popper computes.
- Compiled the exact new classes through this repo's pinned Tailwind version (4.2.4) via `@tailwindcss/postcss` directly, and confirmed each one generates the expected rule, e.g. `.max-h-\(--radix-popover-content-available-height\) { max-height: var(--radix-popover-content-available-height); }` — so there's no syntax mistake in the arbitrary-value class.

Happy to have someone with repo access check the design-system preview, or I can revisit this once I have another way to view it.

There's also a fourth spot in the report — the Severity filter's option list (`packages/ui-patterns/src/FilterBar/DefaultCommandList.tsx`), which hardcodes its own `max-h-[300px]` on an inner div rather than the `PopoverContent` primitive directly. That div renders inside the now-fixed `PopoverContent`, so it may already be covered by this change since CSS custom properties inherit to descendants — but since I couldn't confirm that visually either, I've left it untouched for now rather than guess.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dropdown menus, popovers, and select menus now adapt to the available screen height.
  * Long content can scroll vertically instead of being cut off or hidden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->