### PR TITLE
Properly hook up browser tab label for explorer

### DIFF
--- a/apps/studio/components/layouts/ExplorerLayout/ExplorerLayout.tsx
+++ b/apps/studio/components/layouts/ExplorerLayout/ExplorerLayout.tsx
@@ -37,9 +37,12 @@ export interface ExplorerLayoutProps extends ComponentProps<typeof ProjectLayout
 
 export const ExplorerLayout = ({ browserTitle, children, title }: ExplorerLayoutProps) => {
   const [section, setSection] = useState<ExplorerResourceType>()
+  const tabs = useTabsStateSnapshot()
 
-  // [Joshen] Temporary, to hook up with tabs store
-  const activeTabLabel = 'Active Tab Label'
+  const activeTab = tabs.activeTab ? tabs.tabsMap[tabs.activeTab] : undefined
+  const isActiveExplorerTab =
+    activeTab !== undefined && editorEntityTypes.explorer.includes(activeTab.type)
+  const activeTabLabel = isActiveExplorerTab ? activeTab.label || 'Untitled' : 'Explorer'
 
   const mergedBrowserTitle = {
     ...browserTitle,


### PR DESCRIPTION
## Context

Very tiny one - just hooks up the browser tab label for explorer properly

Browser tab should be the focused explorer tab, otherwise defaults to 'Explorer'
<img width="175" height="48" alt="image" src="https://github.com/user-attachments/assets/fa6eef96-3222-4bf6-b929-993441970728" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Browser titles now accurately reflect the active Explorer tab.
  - Untitled tabs display “Untitled,” while views without an active Explorer tab display “Explorer.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->