### PR TITLE
feat(studio): deploy a worker from the dashboard

### DIFF
--- a/apps/studio/components/interfaces/Workers/CreateWorkerDialog.tsx
+++ b/apps/studio/components/interfaces/Workers/CreateWorkerDialog.tsx
@@ -93,7 +93,7 @@ export const CreateWorkerDialog = ({ projectRef, open, onOpenChange }: CreateWor
                 control={form.control}
                 name="size"
                 render={({ field }) => (
-                  <FormItemLayout label="Size" description="Fixed at deploy time">
+                  <FormItemLayout label="Size">
                     <Select value={field.value} onValueChange={field.onChange}>
                       <FormControl>
                         <SelectTrigger>
@@ -116,10 +116,7 @@ export const CreateWorkerDialog = ({ projectRef, open, onOpenChange }: CreateWor
                 control={form.control}
                 name="access"
                 render={({ field }) => (
-                  <FormItemLayout
-                    label="Access"
-                    description="Public workers accept requests with an anon key"
-                  >
+                  <FormItemLayout label="Access">
                     <Select value={field.value} onValueChange={field.onChange}>
                       <FormControl>
                         <SelectTrigger>

--- a/apps/studio/components/interfaces/Workers/CreateWorkerDialog.tsx
+++ b/apps/studio/components/interfaces/Workers/CreateWorkerDialog.tsx
@@ -1,0 +1,203 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useForm } from 'react-hook-form'
+import { toast } from 'sonner'
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogSection,
+  DialogTitle,
+  Form,
+  FormControl,
+  FormField,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from 'ui'
+import { Admonition } from 'ui-patterns/Admonition'
+import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
+
+import {
+  RUNTIMES,
+  WORKER_MAX_INSTANCES,
+  WORKER_MIN_INSTANCES,
+  WORKER_SIZES,
+} from './Workers.constants'
+import { CreateWorkerSchema, type CreateWorkerForm } from './Workers.schema'
+import { formatSize } from './Workers.utils'
+import { useWorkerDeployMutation } from '@/data/workers/worker-deploy-mutation'
+
+const FORM_ID = 'create-worker-form'
+
+const RUNTIME_VALUES = Object.keys(RUNTIMES).filter((runtime) => runtime !== 'dockerfile')
+
+const defaultValues: CreateWorkerForm = {
+  name: '',
+  runtime: 'node',
+  size: WORKER_SIZES[0],
+  access: 'private',
+  instances: WORKER_MIN_INSTANCES,
+}
+
+interface CreateWorkerDialogProps {
+  projectRef: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export const CreateWorkerDialog = ({ projectRef, open, onOpenChange }: CreateWorkerDialogProps) => {
+  const form = useForm<CreateWorkerForm>({
+    resolver: zodResolver(CreateWorkerSchema),
+    defaultValues,
+  })
+
+  const { mutate: deployWorker, isPending } = useWorkerDeployMutation({
+    onSuccess: (worker) => {
+      toast.success(`Deploying ${worker.name}`)
+      form.reset(defaultValues)
+      onOpenChange(false)
+    },
+  })
+
+  const onSubmit = (values: CreateWorkerForm) => deployWorker({ projectRef, ...values })
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent size="medium">
+        <DialogHeader>
+          <DialogTitle>Deploy a worker</DialogTitle>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form id={FORM_ID} onSubmit={form.handleSubmit(onSubmit)}>
+            <DialogSection className="space-y-4">
+              <Admonition
+                type="default"
+                title="This deploys an empty worker"
+                description="A worker deployed from the dashboard runs the runtime's default entrypoint. Push your own code with the Supabase CLI."
+              />
+
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItemLayout
+                    label="Name"
+                    description="Lowercase letters, numbers, and hyphens only"
+                  >
+                    <FormControl>
+                      <Input {...field} placeholder="embed" autoComplete="off" />
+                    </FormControl>
+                  </FormItemLayout>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="runtime"
+                render={({ field }) => (
+                  <FormItemLayout label="Runtime">
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {RUNTIME_VALUES.map((runtime) => (
+                          <SelectItem key={runtime} value={runtime}>
+                            {RUNTIMES[runtime].label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </FormItemLayout>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="size"
+                render={({ field }) => (
+                  <FormItemLayout label="Size" description="Fixed at deploy time">
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {WORKER_SIZES.map((size) => (
+                          <SelectItem key={size} value={size}>
+                            {formatSize(size)}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </FormItemLayout>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="access"
+                render={({ field }) => (
+                  <FormItemLayout
+                    label="Access"
+                    description="Public workers accept requests with an anon key"
+                  >
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value="private">Private</SelectItem>
+                        <SelectItem value="public">Public</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </FormItemLayout>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="instances"
+                render={({ field }) => (
+                  <FormItemLayout
+                    label="Instances"
+                    description={`${WORKER_MIN_INSTANCES} to ${WORKER_MAX_INSTANCES}`}
+                  >
+                    <FormControl>
+                      <Input
+                        {...field}
+                        type="number"
+                        min={WORKER_MIN_INSTANCES}
+                        max={WORKER_MAX_INSTANCES}
+                      />
+                    </FormControl>
+                  </FormItemLayout>
+                )}
+              />
+            </DialogSection>
+          </form>
+        </Form>
+
+        <DialogFooter>
+          <Button variant="default" disabled={isPending} onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button variant="primary" type="submit" form={FORM_ID} loading={isPending}>
+            Deploy worker
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/studio/components/interfaces/Workers/CreateWorkerDialog.tsx
+++ b/apps/studio/components/interfaces/Workers/CreateWorkerDialog.tsx
@@ -22,23 +22,15 @@ import {
 import { Admonition } from 'ui-patterns/Admonition'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
-import {
-  RUNTIMES,
-  WORKER_MAX_INSTANCES,
-  WORKER_MIN_INSTANCES,
-  WORKER_SIZES,
-} from './Workers.constants'
+import { WORKER_MAX_INSTANCES, WORKER_MIN_INSTANCES, WORKER_SIZES } from './Workers.constants'
 import { CreateWorkerSchema, type CreateWorkerForm } from './Workers.schema'
 import { formatSize } from './Workers.utils'
 import { useWorkerDeployMutation } from '@/data/workers/worker-deploy-mutation'
 
 const FORM_ID = 'create-worker-form'
 
-const RUNTIME_VALUES = Object.keys(RUNTIMES).filter((runtime) => runtime !== 'dockerfile')
-
 const defaultValues: CreateWorkerForm = {
   name: '',
-  runtime: 'node',
   size: WORKER_SIZES[0],
   access: 'private',
   instances: WORKER_MIN_INSTANCES,
@@ -78,8 +70,8 @@ export const CreateWorkerDialog = ({ projectRef, open, onOpenChange }: CreateWor
             <DialogSection className="space-y-4">
               <Admonition
                 type="default"
-                title="This deploys an empty worker"
-                description="A worker deployed from the dashboard runs the runtime's default entrypoint. Push your own code with the Supabase CLI."
+                title="Deploys a Deno starter worker"
+                description="The dashboard deploys a hello-world worker you can then edit and redeploy with the Supabase CLI."
               />
 
               <FormField
@@ -93,29 +85,6 @@ export const CreateWorkerDialog = ({ projectRef, open, onOpenChange }: CreateWor
                     <FormControl>
                       <Input {...field} placeholder="embed" autoComplete="off" />
                     </FormControl>
-                  </FormItemLayout>
-                )}
-              />
-
-              <FormField
-                control={form.control}
-                name="runtime"
-                render={({ field }) => (
-                  <FormItemLayout label="Runtime">
-                    <Select value={field.value} onValueChange={field.onChange}>
-                      <FormControl>
-                        <SelectTrigger>
-                          <SelectValue />
-                        </SelectTrigger>
-                      </FormControl>
-                      <SelectContent>
-                        {RUNTIME_VALUES.map((runtime) => (
-                          <SelectItem key={runtime} value={runtime}>
-                            {RUNTIMES[runtime].label}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
                   </FormItemLayout>
                 )}
               />

--- a/apps/studio/components/interfaces/Workers/DeployWorkerDialog.tsx
+++ b/apps/studio/components/interfaces/Workers/DeployWorkerDialog.tsx
@@ -9,6 +9,7 @@ import {
 
 import { EXAMPLE_WORKER } from './workerSnippets'
 import { WorkerSnippetTabs } from './WorkerSnippetTabs'
+import { CLI_NAME } from '@/lib/constants/workers'
 
 interface DeployWorkerDialogProps {
   open: boolean
@@ -18,7 +19,7 @@ interface DeployWorkerDialogProps {
 const STEPS = [
   {
     title: 'Scaffold the worker',
-    description: 'Creates supabase/workers/<name>/ with an entrypoint for the runtime you pick.',
+    description: `Creates supabase/${CLI_NAME}/<name>/ with an entrypoint for the runtime you pick.`,
   },
   {
     title: 'Configure it',
@@ -34,13 +35,12 @@ export const DeployWorkerDialog = ({ open, onOpenChange }: DeployWorkerDialogPro
   <Dialog open={open} onOpenChange={onOpenChange}>
     <DialogContent size="large">
       <DialogHeader>
-        <DialogTitle>Deploy a worker</DialogTitle>
+        <DialogTitle>Deploy with the CLI</DialogTitle>
       </DialogHeader>
 
       <DialogSection className="space-y-4">
         <p className="text-sm text-foreground-light">
-          Workers are deployed with the Supabase CLI. This dashboard is read-only during the private
-          alpha.
+          The dashboard deploys a starter worker. Push your own code with the Supabase CLI.
         </p>
         <ol className="space-y-4">
           {STEPS.map((step, index) => (

--- a/apps/studio/components/interfaces/Workers/WorkerTestDeployButton.tsx
+++ b/apps/studio/components/interfaces/Workers/WorkerTestDeployButton.tsx
@@ -1,0 +1,42 @@
+import { FlaskConical } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from 'ui'
+
+import { WORKER_SIZES } from './Workers.constants'
+import { useWorkerDeployMutation } from '@/data/workers/worker-deploy-mutation'
+import { IS_STAGING_OR_LOCAL } from '@/lib/constants'
+
+interface WorkerTestDeployButtonProps {
+  projectRef: string
+}
+
+const testWorkerName = () => `test-worker-${Date.now().toString(36)}`
+
+// Staff-only affordance for exercising the deploy path (and the log pipeline behind it)
+// without the create dialog. Never rendered on production — see IS_STAGING_OR_LOCAL.
+export const WorkerTestDeployButton = ({ projectRef }: WorkerTestDeployButtonProps) => {
+  const { mutate: deployWorker, isPending } = useWorkerDeployMutation({
+    onSuccess: (worker) => toast.success(`Deploying ${worker.name}`),
+  })
+
+  if (!IS_STAGING_OR_LOCAL) return null
+
+  return (
+    <Button
+      variant="default"
+      icon={<FlaskConical />}
+      loading={isPending}
+      onClick={() =>
+        deployWorker({
+          projectRef,
+          name: testWorkerName(),
+          size: WORKER_SIZES[0],
+          access: 'public',
+          instances: 1,
+        })
+      }
+    >
+      Deploy test worker
+    </Button>
+  )
+}

--- a/apps/studio/components/interfaces/Workers/Workers.constants.ts
+++ b/apps/studio/components/interfaces/Workers/Workers.constants.ts
@@ -18,6 +18,11 @@ export const workerUrl = ({
 
 export const LISTENING_PORT = 8080
 
+export const WORKER_SIZES = ['2gb-1vcpu', '4gb-2vcpu'] as const
+
+export const WORKER_MIN_INSTANCES = 1
+export const WORKER_MAX_INSTANCES = 10
+
 export interface RuntimeMeta {
   label: string
   baseImage: string

--- a/apps/studio/components/interfaces/Workers/Workers.schema.test.ts
+++ b/apps/studio/components/interfaces/Workers/Workers.schema.test.ts
@@ -4,7 +4,6 @@ import { CreateWorkerSchema } from './Workers.schema'
 
 const valid = {
   name: 'embed',
-  runtime: 'node',
   size: '2gb-1vcpu',
   access: 'private' as const,
   instances: 1,

--- a/apps/studio/components/interfaces/Workers/Workers.schema.test.ts
+++ b/apps/studio/components/interfaces/Workers/Workers.schema.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+
+import { CreateWorkerSchema } from './Workers.schema'
+
+const valid = {
+  name: 'embed',
+  runtime: 'node',
+  size: '2gb-1vcpu',
+  access: 'private' as const,
+  instances: 1,
+}
+
+const errorFor = (input: Record<string, unknown>, field: string) => {
+  const result = CreateWorkerSchema.safeParse(input)
+  if (result.success) return undefined
+  return result.error.issues.find((issue) => issue.path[0] === field)?.message
+}
+
+describe('CreateWorkerSchema', () => {
+  it('accepts a valid spec', () => {
+    expect(CreateWorkerSchema.safeParse(valid).success).toBe(true)
+  })
+
+  it('accepts hyphenated lowercase names', () => {
+    expect(CreateWorkerSchema.safeParse({ ...valid, name: 'resize-images-v2' }).success).toBe(true)
+  })
+
+  it('rejects names the CLI slug rules disallow', () => {
+    for (const name of ['Embed', 'embed_batch', '-embed', 'embed-', 'em--bed', 'embed images']) {
+      expect(errorFor({ ...valid, name }, 'name')).toBe(
+        'Lowercase letters, numbers, and hyphens only'
+      )
+    }
+  })
+
+  it('requires a name', () => {
+    expect(errorFor({ ...valid, name: '   ' }, 'name')).toBe('Provide a name for your worker')
+  })
+
+  it('caps the name length', () => {
+    expect(errorFor({ ...valid, name: 'a'.repeat(49) }, 'name')).toBe('Use 48 characters or fewer')
+  })
+
+  it('holds instances within the alpha range', () => {
+    expect(errorFor({ ...valid, instances: 0 }, 'instances')).toBe('At least 1 instance')
+    expect(errorFor({ ...valid, instances: 11 }, 'instances')).toBe('At most 10 instances')
+    expect(errorFor({ ...valid, instances: 1.5 }, 'instances')).toBe('Whole numbers only')
+  })
+
+  it('coerces the instance count the number input reports as a string', () => {
+    const result = CreateWorkerSchema.safeParse({ ...valid, instances: '3' })
+    expect(result.success && result.data.instances).toBe(3)
+  })
+
+  it('rejects an access value the API does not accept', () => {
+    expect(CreateWorkerSchema.safeParse({ ...valid, access: 'internal' }).success).toBe(false)
+  })
+})

--- a/apps/studio/components/interfaces/Workers/Workers.schema.ts
+++ b/apps/studio/components/interfaces/Workers/Workers.schema.ts
@@ -12,7 +12,6 @@ export const CreateWorkerSchema = z.object({
     .min(1, 'Provide a name for your worker')
     .max(48, 'Use 48 characters or fewer')
     .regex(WORKER_NAME_PATTERN, 'Lowercase letters, numbers, and hyphens only'),
-  runtime: z.string().min(1, 'Pick a runtime'),
   size: z.string().min(1, 'Pick a size'),
   access: z.enum(['public', 'private']),
   instances: z.coerce

--- a/apps/studio/components/interfaces/Workers/Workers.schema.ts
+++ b/apps/studio/components/interfaces/Workers/Workers.schema.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod'
+
+import { WORKER_MAX_INSTANCES, WORKER_MIN_INSTANCES } from './Workers.constants'
+
+// Worker names become the URL slug and the CLI argument, so they follow the CLI's slug rules.
+const WORKER_NAME_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
+
+export const CreateWorkerSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1, 'Provide a name for your worker')
+    .max(48, 'Use 48 characters or fewer')
+    .regex(WORKER_NAME_PATTERN, 'Lowercase letters, numbers, and hyphens only'),
+  runtime: z.string().min(1, 'Pick a runtime'),
+  size: z.string().min(1, 'Pick a size'),
+  access: z.enum(['public', 'private']),
+  instances: z.coerce
+    .number()
+    .int('Whole numbers only')
+    .gte(WORKER_MIN_INSTANCES, `At least ${WORKER_MIN_INSTANCES} instance`)
+    .lte(WORKER_MAX_INSTANCES, `At most ${WORKER_MAX_INSTANCES} instances`),
+})
+
+export type CreateWorkerForm = z.infer<typeof CreateWorkerSchema>

--- a/apps/studio/components/interfaces/Workers/WorkersEmptyState.tsx
+++ b/apps/studio/components/interfaces/Workers/WorkersEmptyState.tsx
@@ -1,6 +1,7 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { BoxPlus } from 'icons'
-import { Plus } from 'lucide-react'
+import { Plus, Terminal } from 'lucide-react'
+import { Button } from 'ui'
 import { EmptyStatePresentational } from 'ui-patterns/EmptyStatePresentational'
 
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
@@ -8,9 +9,10 @@ import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
 
 interface WorkersEmptyStateProps {
   onDeploy: () => void
+  onCreate: () => void
 }
 
-export const WorkersEmptyState = ({ onDeploy }: WorkersEmptyStateProps) => {
+export const WorkersEmptyState = ({ onDeploy, onCreate }: WorkersEmptyStateProps) => {
   const { can: canDeployWorkers } = useAsyncCheckPermissions(PermissionAction.FUNCTIONS_WRITE, '*')
 
   return (
@@ -24,7 +26,7 @@ export const WorkersEmptyState = ({ onDeploy }: WorkersEmptyStateProps) => {
         size="tiny"
         icon={<Plus size={14} />}
         disabled={!canDeployWorkers}
-        onClick={onDeploy}
+        onClick={onCreate}
         tooltip={{
           content: {
             side: 'bottom',
@@ -34,8 +36,11 @@ export const WorkersEmptyState = ({ onDeploy }: WorkersEmptyStateProps) => {
           },
         }}
       >
-        Deploy a worker
+        New worker
       </ButtonTooltip>
+      <Button variant="default" size="tiny" icon={<Terminal size={14} />} onClick={onDeploy}>
+        Deploy with CLI
+      </Button>
     </EmptyStatePresentational>
   )
 }

--- a/apps/studio/components/interfaces/Workers/WorkersList.test.tsx
+++ b/apps/studio/components/interfaces/Workers/WorkersList.test.tsx
@@ -19,7 +19,9 @@ const worker = (name: string, overrides: Partial<Worker> = {}): Worker => ({
 })
 
 const renderList = (workers: Worker[]) =>
-  customRender(<WorkersList projectRef="default" workers={workers} onDeploy={vi.fn()} />)
+  customRender(
+    <WorkersList projectRef="default" workers={workers} onDeploy={vi.fn()} onCreate={vi.fn()} />
+  )
 
 const rowNames = () =>
   screen

--- a/apps/studio/components/interfaces/Workers/WorkersList.tsx
+++ b/apps/studio/components/interfaces/Workers/WorkersList.tsx
@@ -1,4 +1,4 @@
-import { ChevronLeft, ChevronRight, Terminal } from 'lucide-react'
+import { ChevronLeft, ChevronRight, Plus, Terminal } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useState } from 'react'
@@ -32,6 +32,7 @@ interface WorkersListProps {
   projectRef: string
   workers: Worker[]
   onDeploy: () => void
+  onCreate: () => void
 }
 
 const STATE_FILTERS: { value: WorkerBuildState | 'all'; label: string }[] = [
@@ -55,7 +56,7 @@ const parseStateFilter = (value: string): WorkerBuildState | 'all' =>
 const parseAccessFilter = (value: string): WorkerAccess | 'all' =>
   ACCESS_FILTERS.find((option) => option.value === value)?.value ?? 'all'
 
-export const WorkersList = ({ projectRef, workers, onDeploy }: WorkersListProps) => {
+export const WorkersList = ({ projectRef, workers, onDeploy, onCreate }: WorkersListProps) => {
   const router = useRouter()
   const [search, setSearch] = useState('')
   const [stateFilter, setStateFilter] = useState<WorkerBuildState | 'all'>('all')
@@ -127,8 +128,11 @@ export const WorkersList = ({ projectRef, workers, onDeploy }: WorkersListProps)
           <span className="text-sm text-foreground-lighter">
             {filtered.length} worker{filtered.length === 1 ? '' : 's'}
           </span>
-          <Button variant="primary" icon={<Terminal />} onClick={onDeploy}>
-            Deploy a worker
+          <Button variant="default" icon={<Terminal />} onClick={onDeploy}>
+            Deploy with CLI
+          </Button>
+          <Button variant="primary" icon={<Plus />} onClick={onCreate}>
+            New worker
           </Button>
         </div>
       </div>

--- a/apps/studio/components/interfaces/Workers/WorkersList.tsx
+++ b/apps/studio/components/interfaces/Workers/WorkersList.tsx
@@ -1,3 +1,4 @@
+import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { ChevronLeft, ChevronRight, Plus, Terminal } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
@@ -27,6 +28,7 @@ import type { Worker, WorkerAccess, WorkerBuildState } from './Workers.types'
 import { filterWorkers, formatResources, getPage } from './Workers.utils'
 import { WorkerStatePill } from './WorkerStatePill'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
+import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
 
 interface WorkersListProps {
   projectRef: string
@@ -58,6 +60,7 @@ const parseAccessFilter = (value: string): WorkerAccess | 'all' =>
 
 export const WorkersList = ({ projectRef, workers, onDeploy, onCreate }: WorkersListProps) => {
   const router = useRouter()
+  const { can: canDeployWorkers } = useAsyncCheckPermissions(PermissionAction.FUNCTIONS_WRITE, '*')
   const [search, setSearch] = useState('')
   const [stateFilter, setStateFilter] = useState<WorkerBuildState | 'all'>('all')
   const [accessFilter, setAccessFilter] = useState<WorkerAccess | 'all'>('all')
@@ -131,9 +134,22 @@ export const WorkersList = ({ projectRef, workers, onDeploy, onCreate }: Workers
           <Button variant="default" icon={<Terminal />} onClick={onDeploy}>
             Deploy with CLI
           </Button>
-          <Button variant="primary" icon={<Plus />} onClick={onCreate}>
+          <ButtonTooltip
+            variant="primary"
+            icon={<Plus />}
+            disabled={!canDeployWorkers}
+            onClick={onCreate}
+            tooltip={{
+              content: {
+                side: 'bottom',
+                text: canDeployWorkers
+                  ? undefined
+                  : 'You need additional permissions to deploy workers',
+              },
+            }}
+          >
             New worker
-          </Button>
+          </ButtonTooltip>
         </div>
       </div>
 

--- a/apps/studio/data/workers/createTarGz.test.ts
+++ b/apps/studio/data/workers/createTarGz.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+import { createTar } from './createTarGz'
+
+const BLOCK = 512
+const decoder = new TextDecoder()
+const field = (tar: Uint8Array, start: number, end: number) =>
+  decoder.decode(tar.slice(start, end)).replace(/\0.*$/, '')
+
+describe('createTar', () => {
+  const tar = createTar([{ name: 'index.ts', content: 'hello' }])
+
+  it('pads the archive to whole 512-byte blocks', () => {
+    expect(tar.length % BLOCK).toBe(0)
+  })
+
+  it('ends with two zero blocks', () => {
+    expect(tar.slice(-BLOCK * 2).every((byte) => byte === 0)).toBe(true)
+  })
+
+  it('writes a ustar header for the file', () => {
+    expect(field(tar, 0, 100)).toBe('index.ts')
+    expect(field(tar, 257, 263)).toBe('ustar')
+    expect(decoder.decode(tar.slice(156, 157))).toBe('0')
+  })
+
+  it('records the content length in octal', () => {
+    expect(field(tar, 124, 136)).toBe('00000000005')
+  })
+
+  it('writes a checksum matching the header bytes', () => {
+    const header = Uint8Array.from(tar.slice(0, BLOCK))
+    header.fill(32, 148, 156)
+    const expected = header.reduce((total, byte) => total + byte, 0)
+    expect(parseInt(field(tar, 148, 156), 8)).toBe(expected)
+  })
+
+  it('stores the content immediately after the header', () => {
+    expect(field(tar, BLOCK, BLOCK + 5)).toBe('hello')
+  })
+
+  it('lays out each file in its own header plus content blocks', () => {
+    const two = createTar([
+      { name: 'a.ts', content: 'x' },
+      { name: 'b.ts', content: 'y' },
+    ])
+    expect(two.length).toBe(BLOCK * 6)
+    expect(field(two, 0, 100)).toBe('a.ts')
+    expect(field(two, BLOCK * 2, BLOCK * 2 + 100)).toBe('b.ts')
+  })
+
+  it('pads content longer than one block', () => {
+    const big = createTar([{ name: 'big.ts', content: 'z'.repeat(600) }])
+    expect(big.length).toBe(BLOCK * 5)
+  })
+})

--- a/apps/studio/data/workers/createTarGz.ts
+++ b/apps/studio/data/workers/createTarGz.ts
@@ -35,7 +35,7 @@ const buildHeader = (name: string, size: number): Uint8Array => {
 
 const padToBlock = (length: number) => (BLOCK_SIZE - (length % BLOCK_SIZE)) % BLOCK_SIZE
 
-export const createTar = (files: TarFile[]): Uint8Array => {
+export const createTar = (files: TarFile[]): Uint8Array<ArrayBuffer> => {
   const encoder = new TextEncoder()
   const parts: Uint8Array[] = []
 
@@ -50,7 +50,7 @@ export const createTar = (files: TarFile[]): Uint8Array => {
   parts.push(new Uint8Array(BLOCK_SIZE * 2))
 
   const total = parts.reduce((size, part) => size + part.length, 0)
-  const tar = new Uint8Array(total)
+  const tar = new Uint8Array(new ArrayBuffer(total))
   let offset = 0
   for (const part of parts) {
     tar.set(part, offset)

--- a/apps/studio/data/workers/createTarGz.ts
+++ b/apps/studio/data/workers/createTarGz.ts
@@ -1,0 +1,67 @@
+const BLOCK_SIZE = 512
+
+export interface TarFile {
+  name: string
+  content: string
+}
+
+const writeAscii = (block: Uint8Array, offset: number, value: string) => {
+  for (let i = 0; i < value.length; i++) block[offset + i] = value.charCodeAt(i)
+}
+
+// Octal, NUL-terminated, right-aligned and zero-padded, as the ustar header expects.
+const writeOctal = (block: Uint8Array, offset: number, value: number, length: number) =>
+  writeAscii(block, offset, value.toString(8).padStart(length - 1, '0') + '\0')
+
+const buildHeader = (name: string, size: number): Uint8Array => {
+  const header = new Uint8Array(BLOCK_SIZE)
+  writeAscii(header, 0, name)
+  writeOctal(header, 100, 0o644, 8)
+  writeOctal(header, 108, 0, 8)
+  writeOctal(header, 116, 0, 8)
+  writeOctal(header, 124, size, 12)
+  writeOctal(header, 136, 0, 12)
+  header[156] = '0'.charCodeAt(0)
+  writeAscii(header, 257, 'ustar\0')
+  writeAscii(header, 263, '00')
+
+  // The checksum is the sum of every header byte with the checksum field itself read as spaces.
+  header.fill(32, 148, 156)
+  const checksum = header.reduce((total, byte) => total + byte, 0)
+  writeAscii(header, 148, checksum.toString(8).padStart(6, '0') + '\0 ')
+
+  return header
+}
+
+const padToBlock = (length: number) => (BLOCK_SIZE - (length % BLOCK_SIZE)) % BLOCK_SIZE
+
+export const createTar = (files: TarFile[]): Uint8Array => {
+  const encoder = new TextEncoder()
+  const parts: Uint8Array[] = []
+
+  for (const file of files) {
+    const content = encoder.encode(file.content)
+    parts.push(buildHeader(file.name, content.length), content)
+    const padding = padToBlock(content.length)
+    if (padding > 0) parts.push(new Uint8Array(padding))
+  }
+
+  // Two zero blocks mark the end of the archive.
+  parts.push(new Uint8Array(BLOCK_SIZE * 2))
+
+  const total = parts.reduce((size, part) => size + part.length, 0)
+  const tar = new Uint8Array(total)
+  let offset = 0
+  for (const part of parts) {
+    tar.set(part, offset)
+    offset += part.length
+  }
+  return tar
+}
+
+export const createTarGz = async (files: TarFile[]): Promise<Blob> => {
+  const tar = createTar(files)
+  const gzip = new CompressionStream('gzip')
+  const stream = new Blob([tar]).stream().pipeThrough(gzip)
+  return new Response(stream).blob()
+}

--- a/apps/studio/data/workers/worker-deploy-mutation.ts
+++ b/apps/studio/data/workers/worker-deploy-mutation.ts
@@ -1,0 +1,70 @@
+import { useMutation, useQueryClient, type UseMutationOptions } from '@tanstack/react-query'
+import { toast } from 'sonner'
+
+import { workersKeys } from './keys'
+import { parseWorker } from './workers.utils'
+import { handleError, post } from '@/data/fetchers'
+import type { ResponseError } from '@/types'
+
+export type WorkerDeployVariables = {
+  projectRef: string
+  name: string
+  runtime: string
+  size: string
+  access: 'public' | 'private'
+  instances: number
+}
+
+// The deploy endpoint accepts a spec without a build context as long as `runtime` is set,
+// which is how the dashboard deploys without uploading a tarball the way the CLI does.
+async function deployWorker({
+  projectRef,
+  name,
+  runtime,
+  size,
+  access,
+  instances,
+}: WorkerDeployVariables) {
+  const { data, error } = await post('/v2/projects/{ref}/workers/{name}/deploy', {
+    params: { path: { ref: projectRef, name } },
+    body: {
+      data: {
+        type: 'project_worker',
+        attributes: {
+          spec: { runtime, size, exposure: access, instances },
+        },
+      },
+    },
+  })
+
+  if (error) return handleError(error)
+  return parseWorker(data.data)
+}
+
+type WorkerDeployData = Awaited<ReturnType<typeof deployWorker>>
+
+export const useWorkerDeployMutation = ({
+  onSuccess,
+  onError,
+  ...options
+}: UseMutationOptions<WorkerDeployData, ResponseError, WorkerDeployVariables> = {}) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: deployWorker,
+    async onSuccess(data, variables, context) {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: workersKeys.list(variables.projectRef) }),
+        queryClient.invalidateQueries({
+          queryKey: workersKeys.detail(variables.projectRef, variables.name),
+        }),
+      ])
+      await onSuccess?.(data, variables, context)
+    },
+    async onError(error, variables, context) {
+      if (onError === undefined) toast.error(`Failed to deploy worker: ${error.message}`)
+      else onError(error, variables, context)
+    },
+    ...options,
+  })
+}

--- a/apps/studio/data/workers/worker-deploy-mutation.ts
+++ b/apps/studio/data/workers/worker-deploy-mutation.ts
@@ -1,7 +1,9 @@
 import { useMutation, useQueryClient, type UseMutationOptions } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
+import { createTarGz } from './createTarGz'
 import { workersKeys } from './keys'
+import { STARTER_RUNTIME, starterFiles } from './workers.templates'
 import { parseWorker } from './workers.utils'
 import { handleError, post } from '@/data/fetchers'
 import type { ResponseError } from '@/types'
@@ -9,35 +11,42 @@ import type { ResponseError } from '@/types'
 export type WorkerDeployVariables = {
   projectRef: string
   name: string
-  runtime: string
   size: string
   access: 'public' | 'private'
   instances: number
 }
 
-// The deploy endpoint accepts a spec without a build context as long as `runtime` is set,
-// which is how the dashboard deploys without uploading a tarball the way the CLI does.
-async function deployWorker({
-  projectRef,
-  name,
-  runtime,
-  size,
-  access,
-  instances,
-}: WorkerDeployVariables) {
+async function deployWorker({ projectRef, name, size, access, instances }: WorkerDeployVariables) {
+  const { data: slot, error: slotError } = await post('/v2/projects/{ref}/workers/{name}/uploads', {
+    params: { path: { ref: projectRef, name } },
+  })
+  if (slotError) return handleError(slotError)
+
+  // The presigned URL carries its own authorization, so this one call bypasses the API client
+  // on purpose — sending our bearer token to storage would be rejected.
+  const upload = await fetch(slot.data.attributes.url, {
+    method: 'PUT',
+    body: await createTarGz(starterFiles()),
+    headers: { 'content-type': 'application/gzip' },
+  })
+  if (!upload.ok) {
+    throw new Error(`Failed to upload the build context (${upload.status})`)
+  }
+
   const { data, error } = await post('/v2/projects/{ref}/workers/{name}/deploy', {
     params: { path: { ref: projectRef, name } },
     body: {
       data: {
         type: 'project_worker',
         attributes: {
-          spec: { runtime, size, exposure: access, instances },
+          context_upload_id: slot.data.id,
+          spec: { runtime: STARTER_RUNTIME, size, exposure: access, instances },
         },
       },
     },
   })
-
   if (error) return handleError(error)
+
   return parseWorker(data.data)
 }
 

--- a/apps/studio/data/workers/worker-query.ts
+++ b/apps/studio/data/workers/worker-query.ts
@@ -29,4 +29,6 @@ export const workerQueryOptions = ({ projectRef, name }: WorkerVariables) =>
     queryKey: workersKeys.detail(projectRef, name),
     queryFn: ({ signal }) => getWorker({ projectRef, name }, signal),
     enabled: IS_PLATFORM && typeof projectRef !== 'undefined' && typeof name !== 'undefined',
+    // Builds finish asynchronously, so keep polling until the build state settles.
+    refetchInterval: (query) => (query.state.data?.buildState === 'building' ? 5_000 : false),
   })

--- a/apps/studio/data/workers/workers-query.ts
+++ b/apps/studio/data/workers/workers-query.ts
@@ -28,4 +28,7 @@ export const workersQueryOptions = ({ projectRef }: WorkersVariables) =>
     queryKey: workersKeys.list(projectRef),
     queryFn: ({ signal }) => getWorkers({ projectRef }, signal),
     enabled: IS_PLATFORM && typeof projectRef !== 'undefined',
+    // Builds finish asynchronously, so keep polling until nothing is mid-build.
+    refetchInterval: (query) =>
+      query.state.data?.some((worker) => worker.buildState === 'building') ? 5_000 : false,
   })

--- a/apps/studio/data/workers/workers.templates.ts
+++ b/apps/studio/data/workers/workers.templates.ts
@@ -1,0 +1,13 @@
+import type { TarFile } from './createTarGz'
+
+// The runtime invokes the module's default export; a top-level Deno.serve() is ignored.
+const DENO_STARTER = `export default {
+  fetch(_req: Request) {
+    return new Response("hello from workers\\n")
+  },
+}
+`
+
+export const STARTER_RUNTIME = 'deno'
+
+export const starterFiles = (): TarFile[] => [{ name: 'index.ts', content: DENO_STARTER }]

--- a/apps/studio/pages/project/[ref]/workers/index.tsx
+++ b/apps/studio/pages/project/[ref]/workers/index.tsx
@@ -13,6 +13,7 @@ import {
 import { PageSection, PageSectionContent } from 'ui-patterns/PageSection'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 
+import { CreateWorkerDialog } from '@/components/interfaces/Workers/CreateWorkerDialog'
 import { DeployWorkerDialog } from '@/components/interfaces/Workers/DeployWorkerDialog'
 import {
   isWorkersForbidden,
@@ -32,6 +33,7 @@ import type { NextPageWithLayout } from '@/types'
 const WorkersPage: NextPageWithLayout = () => {
   const { ref } = useParams()
   const [isDeployInstructionsOpen, setIsDeployInstructionsOpen] = useState(false)
+  const [isCreateOpen, setIsCreateOpen] = useState(false)
   const {
     data: workers,
     error,
@@ -76,13 +78,17 @@ const WorkersPage: NextPageWithLayout = () => {
             {isMissingPermission && <NoPermission resourceText="view this project's workers" />}
             {isUnexpectedError && <AlertError error={error} subject="Failed to retrieve workers" />}
             {isSuccess && workers.length === 0 && (
-              <WorkersEmptyState onDeploy={() => setIsDeployInstructionsOpen(true)} />
+              <WorkersEmptyState
+                onDeploy={() => setIsDeployInstructionsOpen(true)}
+                onCreate={() => setIsCreateOpen(true)}
+              />
             )}
             {isSuccess && workers.length > 0 && ref && (
               <WorkersList
                 projectRef={ref}
                 workers={workers}
                 onDeploy={() => setIsDeployInstructionsOpen(true)}
+                onCreate={() => setIsCreateOpen(true)}
               />
             )}
           </PageSectionContent>
@@ -93,6 +99,9 @@ const WorkersPage: NextPageWithLayout = () => {
         open={isDeployInstructionsOpen}
         onOpenChange={setIsDeployInstructionsOpen}
       />
+      {ref && (
+        <CreateWorkerDialog projectRef={ref} open={isCreateOpen} onOpenChange={setIsCreateOpen} />
+      )}
     </div>
   )
 }

--- a/apps/studio/pages/project/[ref]/workers/index.tsx
+++ b/apps/studio/pages/project/[ref]/workers/index.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/components/interfaces/Workers/Workers.utils'
 import { WorkersEmptyState } from '@/components/interfaces/Workers/WorkersEmptyState'
 import { WorkersList } from '@/components/interfaces/Workers/WorkersList'
+import { WorkerTestDeployButton } from '@/components/interfaces/Workers/WorkerTestDeployButton'
 import { DefaultLayout } from '@/components/layouts/DefaultLayout'
 import { WorkersLayout } from '@/components/layouts/WorkersLayout/WorkersLayout'
 import { AlertError } from '@/components/ui/AlertError'
@@ -67,6 +68,7 @@ const WorkersPage: NextPageWithLayout = () => {
               feedbackUrl="https://github.com/orgs/supabase/discussions"
             />
 
+            {ref && <WorkerTestDeployButton projectRef={ref} />}
             {isPending && <GenericSkeletonLoader />}
             {isNotEnrolled && (
               <Admonition


### PR DESCRIPTION
## What

Deploy a worker from the dashboard, no CLI. Base: #49195.

**New worker** — in the list header and the empty state, both permission-gated — opens a form (name, size, access, instances) and runs the three-step flow the API team documented:

1. `POST /workers/{name}/uploads` → presigned URL + upload id
2. `PUT` a gzipped tar of the starter source to that URL, no auth header (the URL signature authorizes it, so this one call bypasses the API client on purpose)
3. `POST /workers/{name}/deploy` with `context_upload_id`, then poll until `build_state` leaves `building`

`data/workers/createTarGz.ts` writes a minimal ustar archive and gzips it with `CompressionStream` — no tar dependency exists in the repo. 9 unit tests cover the header layout, octal size field, checksum, padding, and end-of-archive blocks.

The starter is Deno only: one entrypoint contract is verified, and runtimes that build and then fail are worse than no option. Adding one later is an entry in `workers.templates.ts`. Both **New worker** buttons are gated on `PermissionAction.FUNCTIONS_WRITE`.

## How to test

Only on the **Mockamaster** project in staging — it is the one project in the alpha allow-list, and this is why this PR exists: standing a worker up any other way is involved right now.

1. Staging dashboard → Mockamaster → **Workers** → **New worker**
2. Name it something new, leave the defaults, deploy
3. The row appears as `Building` and flips to `Active` within a minute or so, no refresh needed
4. Open it → Overview shows 1 declared / 1 live / 1 ready
5. Calling the worker over HTTP still returns `401` — that needs the separate api-gateway allow-list (`WORKERS_ALLOWED_PROJECTS`), not this PR

Verified end to end on Mockamaster with the tarball this PR produces: `build_state: active`, 1/1/1/0 instances, `image_version: 1.0`, at `2gb-1vcpu` / `deno` / `public` / 1 instance.

## Form constraints need a second opinion

`V2DeployWorkerRequest` documents no enums and no bounds — `size`, `instances`, `exposure`, and `runtime` are free-form with one `@example` each. So the form's limits are inherited from the original POC spec, not from the API:

| Constraint | Status |
|---|---|
| `2gb-1vcpu` | confirmed by the deploy above |
| `4gb-2vcpu` | **unconfirmed** — offered in the picker on POC authority alone |
| instances 1–10 | **unconfirmed** as a platform cap; enforced client-side only |
| name ≤ 48 chars | **unconfirmed**; the slug regex is a safe bet since the name is a URL segment |

An invalid size fails loudly (the deploy POST errors and toasts), so this is not silent — but if infra confirms only one size exists at alpha, the picker should go.

## Staff-only test deploy

`WorkerTestDeployButton` — a one-click "Deploy test worker" that deploys the starter under a generated `test-worker-<id>` name, so the deploy path (and the log pipeline behind it) can be exercised without the dialog. Gated on `IS_STAGING_OR_LOCAL`, so it renders on staging/local and never on production, matching the existing OTEL-toggle precedent.

## Notes

- No ticket covers dashboard create — FE-4191 scoped creation to the CLI. Deliberate change of direction.
- Delete (FE-4190) is still out. If create lands, delete should probably follow.


