### PR TITLE
fix: sync AI assistant project context for org-view support tickets

### DIFF
--- a/apps/studio/components/interfaces/Support/SupportAssistantSuccessCard.test.tsx
+++ b/apps/studio/components/interfaces/Support/SupportAssistantSuccessCard.test.tsx
@@ -1,11 +1,17 @@
 import { SupportCategories } from '@supabase/shared-types/out/constants'
-import { act, render, screen, waitFor } from '@testing-library/react'
+import { act, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { HttpResponse } from 'msw'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { SubmittedSupportRequest } from './SupportForm.state'
 import { NO_PROJECT_MARKER } from './SupportForm.utils'
 import { SupportAssistantSuccessCardContent as SupportAssistantSuccessCard } from '@/components/ui/AIAssistantPanel/SupportAssistantSuccessCardContent'
+import type { components } from '@/data/api'
+import { customRender } from '@/tests/lib/custom-render'
+import { addAPIMock, type APIErrorBody } from '@/tests/lib/msw'
+
+type ProjectDetailResponse = components['schemas']['ProjectDetailResponse']
 
 const {
   chatInstances,
@@ -13,6 +19,7 @@ const {
   mockNewChat,
   mockOpenSidebar,
   mockSelectChat,
+  mockSetContext,
   mockSyncSupportChatToFront,
   mockTrack,
 } = vi.hoisted(() => ({
@@ -21,6 +28,7 @@ const {
   mockNewChat: vi.fn(),
   mockOpenSidebar: vi.fn(),
   mockSelectChat: vi.fn(),
+  mockSetContext: vi.fn(),
   mockSyncSupportChatToFront: vi.fn(),
   mockTrack: vi.fn(),
 }))
@@ -51,6 +59,7 @@ vi.mock('@/state/ai-assistant-state', () => ({
   useAiAssistantState: () => ({
     chats,
     selectChat: mockSelectChat,
+    setContext: mockSetContext,
   }),
 }))
 
@@ -83,6 +92,45 @@ const supportRequest: SubmittedSupportRequest = {
   frontConversationId: 'front-conversation-1',
 }
 
+// A minimal but contract-accurate ProjectDetailResponse, so a mock drifting
+// from the OpenAPI shape (missing fields, stale enum values) fails to compile.
+const readyProjectDetail: ProjectDetailResponse = {
+  id: 1,
+  ref: 'project-1',
+  name: 'Project 1',
+  organization_id: 1,
+  cloud_provider: 'AWS',
+  connectionString: 'postgresql://postgres:postgres@db.project-1.example.com:5432/postgres',
+  db_host: 'db.project-1.example.com',
+  high_availability: false,
+  inserted_at: new Date(0).toISOString(),
+  integration_source: null,
+  is_branch_enabled: false,
+  is_physical_backups_enabled: false,
+  region: 'us-east-1',
+  restUrl: 'https://project-1.example.com/rest',
+  status: 'ACTIVE_HEALTHY',
+  subscription_id: 'subscription-1',
+  updated_at: new Date(0).toISOString(),
+}
+
+function mockProjectDetail(response: ProjectDetailResponse) {
+  addAPIMock({
+    method: 'get',
+    path: '/platform/projects/:ref',
+    response: () => HttpResponse.json<ProjectDetailResponse>(response),
+  })
+}
+
+function mockProjectDetailError() {
+  addAPIMock({
+    method: 'get',
+    path: '/platform/projects/:ref',
+    response: () =>
+      HttpResponse.json<APIErrorBody>({ message: 'Failed to load project' }, { status: 500 }),
+  })
+}
+
 describe('SupportAssistantSuccessCard', () => {
   let nextChatMessages: MockChat['messages']
   let emitChatMessagesChange: (() => void) | undefined
@@ -103,6 +151,7 @@ describe('SupportAssistantSuccessCard', () => {
     mockNewChat.mockReset()
     mockOpenSidebar.mockReset()
     mockSelectChat.mockReset()
+    mockSetContext.mockReset()
     mockSyncSupportChatToFront.mockReset()
     mockTrack.mockReset()
     nextChatMessages = []
@@ -113,15 +162,22 @@ describe('SupportAssistantSuccessCard', () => {
       chats['chat-1'] = { messages: nextChatMessages }
       return 'chat-1'
     })
+
+    mockProjectDetail(readyProjectDetail)
   })
 
   it('creates an assistant chat with the submitted support request', async () => {
-    render(<SupportAssistantSuccessCard request={supportRequest} />)
+    customRender(<SupportAssistantSuccessCard request={supportRequest} />)
 
     await waitFor(() => {
       expect(mockNewChat).toHaveBeenCalledTimes(1)
     })
 
+    expect(mockSetContext).toHaveBeenCalledWith({
+      projectRef: 'project-1',
+      orgSlug: 'org-1',
+      connectionString: readyProjectDetail.connectionString,
+    })
     expect(mockNewChat).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'Support request',
@@ -133,11 +189,44 @@ describe('SupportAssistantSuccessCard', () => {
     )
   })
 
+  it('does not create a chat while the project is still coming up', async () => {
+    mockProjectDetail({ ...readyProjectDetail, status: 'COMING_UP', connectionString: null })
+
+    customRender(<SupportAssistantSuccessCard request={supportRequest} />)
+
+    await screen.findByRole('heading', { name: 'While you wait' })
+    expect(mockNewChat).not.toHaveBeenCalled()
+    // Not interactive yet either - no chat has been created for the card to open
+    expect(
+      screen.queryByRole('button', { name: /open assistant response/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows a retry state when the project details request fails, and recovers on retry', async () => {
+    mockProjectDetailError()
+
+    const user = userEvent.setup()
+    customRender(<SupportAssistantSuccessCard request={supportRequest} />)
+
+    const retryButton = await screen.findByRole('button', { name: 'Try again' })
+    expect(mockNewChat).not.toHaveBeenCalled()
+    // The card itself has no chat yet, so it must not be interactive
+    expect(
+      screen.queryByRole('button', { name: /open assistant response/i })
+    ).not.toBeInTheDocument()
+
+    mockProjectDetail(readyProjectDetail)
+    await user.click(retryButton)
+
+    await waitFor(() => {
+      expect(mockNewChat).toHaveBeenCalledTimes(1)
+    })
+  })
+
   it('shows a loading preview before the assistant responds', async () => {
-    const { container } = render(<SupportAssistantSuccessCard request={supportRequest} />)
+    const { container } = customRender(<SupportAssistantSuccessCard request={supportRequest} />)
 
     expect(await screen.findByRole('heading', { name: 'While you wait' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /open assistant response/i })).toBeInTheDocument()
     expect(container.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0)
   })
 
@@ -151,7 +240,7 @@ describe('SupportAssistantSuccessCard', () => {
       },
     ]
 
-    render(<SupportAssistantSuccessCard request={supportRequest} />)
+    customRender(<SupportAssistantSuccessCard request={supportRequest} />)
 
     const preview = await screen.findByTestId('assistant-preview-message')
     expect(preview).toHaveTextContent(longResponse)
@@ -159,7 +248,7 @@ describe('SupportAssistantSuccessCard', () => {
   })
 
   it('updates the preview when the shared chat receives an assistant message', async () => {
-    render(<SupportAssistantSuccessCard request={supportRequest} />)
+    customRender(<SupportAssistantSuccessCard request={supportRequest} />)
 
     await waitFor(() => {
       expect(chatInstances['chat-1']?.['~registerMessagesCallback']).toHaveBeenCalled()
@@ -183,7 +272,7 @@ describe('SupportAssistantSuccessCard', () => {
 
   it('opens the generated assistant chat when the action is clicked', async () => {
     const user = userEvent.setup()
-    render(<SupportAssistantSuccessCard request={supportRequest} />)
+    customRender(<SupportAssistantSuccessCard request={supportRequest} />)
 
     const button = await screen.findByRole('button', { name: /open assistant response/i })
     await user.click(button)
@@ -202,7 +291,7 @@ describe('SupportAssistantSuccessCard', () => {
 
   it('tags the chat as a support chat and syncs it to Front on first open', async () => {
     const user = userEvent.setup()
-    render(<SupportAssistantSuccessCard request={supportRequest} />)
+    customRender(<SupportAssistantSuccessCard request={supportRequest} />)
 
     const button = await screen.findByRole('button', { name: /open assistant response/i })
     await user.click(button)
@@ -222,6 +311,8 @@ describe('SupportAssistantSuccessCard', () => {
       isSyncing: false,
       isLifecycleSyncing: false,
     })
+    // A database credential must never be persisted onto the chat's stored metadata
+    expect(chats['chat-1'].supportMetadata).not.toHaveProperty('connectionString')
 
     // The initial flush is behind a dynamic import, so it lands asynchronously
     await waitFor(() => {
@@ -244,7 +335,7 @@ describe('SupportAssistantSuccessCard', () => {
 
   it('opens the generated assistant chat with keyboard activation', async () => {
     const user = userEvent.setup()
-    render(<SupportAssistantSuccessCard request={supportRequest} />)
+    customRender(<SupportAssistantSuccessCard request={supportRequest} />)
 
     const button = await screen.findByRole('button', { name: /open assistant response/i })
     button.focus()
@@ -255,7 +346,7 @@ describe('SupportAssistantSuccessCard', () => {
   })
 
   it('does not render or create a chat when no project is selected', () => {
-    render(
+    customRender(
       <SupportAssistantSuccessCard
         request={{ ...supportRequest, projectRef: NO_PROJECT_MARKER, organizationSlug: 'org-1' }}
       />

--- a/apps/studio/components/interfaces/Support/SupportAssistantSuccessCard.test.tsx
+++ b/apps/studio/components/interfaces/Support/SupportAssistantSuccessCard.test.tsx
@@ -92,8 +92,6 @@ const supportRequest: SubmittedSupportRequest = {
   frontConversationId: 'front-conversation-1',
 }
 
-// A minimal but contract-accurate ProjectDetailResponse, so a mock drifting
-// from the OpenAPI shape (missing fields, stale enum values) fails to compile.
 const readyProjectDetail: ProjectDetailResponse = {
   id: 1,
   ref: 'project-1',

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.utils.ts
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.utils.ts
@@ -13,11 +13,24 @@ import { databasePoliciesKeys } from '@/data/database-policies/keys'
 import { databaseTriggerKeys } from '@/data/database-triggers/keys'
 import { databaseKeys } from '@/data/database/keys'
 import { enumeratedTypesKeys } from '@/data/enumerated-types/keys'
-import { handleError } from '@/data/fetchers'
+import { handleError, isValidConnString } from '@/data/fetchers'
+import type { ProjectDetail } from '@/data/projects/project-detail-query'
 import { tableKeys } from '@/data/tables/keys'
 import { tryParseJson } from '@/lib/helpers'
 import type { SqlSnippet } from '@/state/ai-assistant-state'
 import { ResponseError } from '@/types'
+
+// [Monica] Whether a project has finished provisioning and has a usable connection string
+export function isProjectReadyForAssistant(
+  projectDetail: Pick<ProjectDetail, 'status' | 'connectionString'> | undefined
+): boolean {
+  return (
+    !!projectDetail &&
+    projectDetail.status !== 'COMING_UP' &&
+    projectDetail.status !== 'UNKNOWN' &&
+    isValidConnString(projectDetail.connectionString)
+  )
+}
 
 export type MutationCategory = 'functions' | 'rls-policies'
 

--- a/apps/studio/components/ui/AIAssistantPanel/AssistantChat.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AssistantChat.tsx
@@ -101,6 +101,7 @@ export const AssistantChat = ({
   const snap = useAiAssistantStateSnapshot()
   const state = useAiAssistantState()
   const currentChat = snap.chats[chatId]
+  const supportMetadata = currentChat?.supportMetadata
 
   useShortcut(SHORTCUT_IDS.AI_ASSISTANT_CANCEL_EDIT, () => cancelEdit(), {
     enabled: shortcutsEnabled,
@@ -168,19 +169,26 @@ export const AssistantChat = ({
   const currentTable = tables?.find((t) => t.id.toString() === entityId)
   const currentSchema = searchParams?.get('schema') ?? 'public'
 
-  // Update context in state. Skip when there's no project in the URL (e.g. org-level
-  // pages) and the open chat is a support chat that already set its own project
-  // context (see SupportAssistantSuccessCardContent) — otherwise this would clobber
-  // that context back to undefined as soon as the panel mounts.
+  // Update context in state. On org-level pages there's no project in the URL, so
+  // fall back to the open chat's own support metadata (see
+  // SupportAssistantSuccessCardContent) rather than clobbering it back to undefined —
+  // this also restores the right context after switching between support chats.
   useEffect(() => {
-    if (!project?.ref && currentChat?.supportMetadata?.projectRef) return
+    if (!project?.ref && supportMetadata?.projectRef) {
+      state.setContext({
+        projectRef: supportMetadata.projectRef,
+        orgSlug: supportMetadata.organizationSlug,
+        connectionString: supportMetadata.connectionString ?? '',
+      })
+      return
+    }
 
     state.setContext({
       projectRef: project?.ref,
       orgSlug: selectedOrganization?.slug,
       connectionString: project?.connectionString ?? '',
     })
-  }, [project?.ref, project?.connectionString, selectedOrganization?.slug, state, currentChat])
+  }, [project?.ref, project?.connectionString, selectedOrganization?.slug, state, supportMetadata])
 
   const track = useTrack()
 
@@ -208,7 +216,6 @@ export const AssistantChat = ({
 
   const isChatLoading = chatStatus === 'submitted' || chatStatus === 'streaming'
   const hasPendingApproval = hasPendingToolApproval(chatMessages)
-  const supportMetadata = currentChat?.supportMetadata
   const isSupportChat = !!supportMetadata?.isSupportChat
   const isSupportChatClosed = isSupportChat && supportMetadata.lifecycleStatus !== 'bot_active'
   const supportConversationId = supportMetadata?.frontConversationId

--- a/apps/studio/components/ui/AIAssistantPanel/AssistantChat.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AssistantChat.tsx
@@ -168,14 +168,19 @@ export const AssistantChat = ({
   const currentTable = tables?.find((t) => t.id.toString() === entityId)
   const currentSchema = searchParams?.get('schema') ?? 'public'
 
-  // Update context in state
+  // Update context in state. Skip when there's no project in the URL (e.g. org-level
+  // pages) and the open chat is a support chat that already set its own project
+  // context (see SupportAssistantSuccessCardContent) — otherwise this would clobber
+  // that context back to undefined as soon as the panel mounts.
   useEffect(() => {
+    if (!project?.ref && currentChat?.supportMetadata?.projectRef) return
+
     state.setContext({
       projectRef: project?.ref,
       orgSlug: selectedOrganization?.slug,
       connectionString: project?.connectionString ?? '',
     })
-  }, [project?.ref, project?.connectionString, selectedOrganization?.slug, state])
+  }, [project?.ref, project?.connectionString, selectedOrganization?.slug, state, currentChat])
 
   const track = useTrack()
 

--- a/apps/studio/components/ui/AIAssistantPanel/AssistantChat.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AssistantChat.tsx
@@ -17,6 +17,7 @@ import { ASSISTANT_ERRORS } from './AiAssistant.constants'
 import {
   containsLogsSnippets,
   hasPendingToolApproval,
+  isProjectReadyForAssistant,
   onErrorChat,
   resolvePendingToolApprovalsAsDenied,
 } from './AIAssistant.utils'
@@ -31,7 +32,6 @@ import { Message } from './Message'
 import { Markdown } from '@/components/interfaces/Markdown'
 import { useCheckOpenAIKeyQuery } from '@/data/ai/check-api-key-query'
 import { useRateMessageMutation } from '@/data/ai/rate-message-mutation'
-import { isValidConnString } from '@/data/fetchers'
 import { useProjectDetailQuery } from '@/data/projects/project-detail-query'
 import { useTablesQuery } from '@/data/tables/tables-query'
 import { useCheckEntitlements } from '@/hooks/misc/useCheckEntitlements'
@@ -179,13 +179,7 @@ export const AssistantChat = ({
     isError: isSupportChatProjectError,
     refetch: refetchSupportChatProjectDetail,
   } = useProjectDetailQuery({ ref: supportMetadata?.projectRef }, { enabled: isOrgViewSupportChat })
-  // Mirrors the readiness check in SupportAssistantSuccessCardContent — a project still
-  // coming up, or with a connection string that isn't valid yet, isn't ready to send to.
-  const isSupportChatProjectReady =
-    !!supportChatProjectDetail &&
-    supportChatProjectDetail.status !== 'COMING_UP' &&
-    supportChatProjectDetail.status !== 'UNKNOWN' &&
-    isValidConnString(supportChatProjectDetail.connectionString)
+  const isSupportChatProjectReady = isProjectReadyForAssistant(supportChatProjectDetail)
   const isResolvingSupportChatConnectionString = isOrgViewSupportChat && !isSupportChatProjectReady
 
   // Update context in state. On org-level pages there's no project in the URL, so

--- a/apps/studio/components/ui/AIAssistantPanel/AssistantChat.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AssistantChat.tsx
@@ -174,10 +174,11 @@ export const AssistantChat = ({
   // on org-level pages, where there's no project in the URL,
   // resolve it fresh from the chat's own projectRef instead.
   const isOrgViewSupportChat = !project?.ref && !!supportMetadata?.projectRef
-  const { data: supportChatProjectDetail } = useProjectDetailQuery(
-    { ref: supportMetadata?.projectRef },
-    { enabled: isOrgViewSupportChat }
-  )
+  const {
+    data: supportChatProjectDetail,
+    isError: isSupportChatProjectError,
+    refetch: refetchSupportChatProjectDetail,
+  } = useProjectDetailQuery({ ref: supportMetadata?.projectRef }, { enabled: isOrgViewSupportChat })
   // Mirrors the readiness check in SupportAssistantSuccessCardContent — a project still
   // coming up, or with a connection string that isn't valid yet, isn't ready to send to.
   const isSupportChatProjectReady =
@@ -684,6 +685,24 @@ export const AssistantChat = ({
               type="default"
               title="Assistant has been temporarily disabled"
               description="We're currently looking into getting it back online"
+            />
+          )}
+
+          {isOrgViewSupportChat && isSupportChatProjectError && (
+            <Admonition
+              type="warning"
+              layout="horizontal"
+              title="Couldn't load this project's details"
+              description="The assistant needs this to respond to your support request."
+              actions={
+                <Button
+                  variant="default"
+                  size="tiny"
+                  onClick={() => refetchSupportChatProjectDetail()}
+                >
+                  Try again
+                </Button>
+              }
             />
           )}
 

--- a/apps/studio/components/ui/AIAssistantPanel/AssistantChat.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AssistantChat.tsx
@@ -159,18 +159,6 @@ export const AssistantChat = ({
 
   const { mutateAsync: rateMessage } = useRateMessageMutation()
 
-  const { data: tables } = useTablesQuery(
-    {
-      projectRef: project?.ref,
-      connectionString: project?.connectionString,
-      schema: 'public',
-    },
-    { enabled: isApiKeySet }
-  )
-
-  const currentTable = tables?.find((t) => t.id.toString() === entityId)
-  const currentSchema = searchParams?.get('schema') ?? 'public'
-
   // on org-level pages, where there's no project in the URL,
   // resolve it fresh from the chat's own projectRef instead.
   const isOrgViewSupportChat = !project?.ref && !!supportMetadata?.projectRef
@@ -181,6 +169,25 @@ export const AssistantChat = ({
   } = useProjectDetailQuery({ ref: supportMetadata?.projectRef }, { enabled: isOrgViewSupportChat })
   const isSupportChatProjectReady = isProjectReadyForAssistant(supportChatProjectDetail)
   const isResolvingSupportChatConnectionString = isOrgViewSupportChat && !isSupportChatProjectReady
+
+  // Table browsing needs the same org-view support chat fallback as the send context below,
+  // otherwise the assistant has no schema awareness for a support chat opened from an org page.
+  const tablesProjectRef = isOrgViewSupportChat ? supportMetadata?.projectRef : project?.ref
+  const tablesConnectionString = isOrgViewSupportChat
+    ? supportChatProjectDetail?.connectionString
+    : project?.connectionString
+
+  const { data: tables } = useTablesQuery(
+    {
+      projectRef: tablesProjectRef,
+      connectionString: tablesConnectionString,
+      schema: 'public',
+    },
+    { enabled: isApiKeySet && (!isOrgViewSupportChat || isSupportChatProjectReady) }
+  )
+
+  const currentTable = tables?.find((t) => t.id.toString() === entityId)
+  const currentSchema = searchParams?.get('schema') ?? 'public'
 
   // Update context in state. On org-level pages there's no project in the URL, so
   // fall back to the open chat's own support metadata (see

--- a/apps/studio/components/ui/AIAssistantPanel/AssistantChat.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AssistantChat.tsx
@@ -194,7 +194,7 @@ export const AssistantChat = ({
       state.setContext({
         projectRef: supportMetadata.projectRef,
         orgSlug: supportMetadata.organizationSlug,
-        connectionString: supportChatProjectDetail.connectionString ?? undefined,
+        connectionString: supportChatProjectDetail?.connectionString ?? undefined,
       })
       return
     }

--- a/apps/studio/components/ui/AIAssistantPanel/AssistantChat.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AssistantChat.tsx
@@ -31,6 +31,7 @@ import { Message } from './Message'
 import { Markdown } from '@/components/interfaces/Markdown'
 import { useCheckOpenAIKeyQuery } from '@/data/ai/check-api-key-query'
 import { useRateMessageMutation } from '@/data/ai/rate-message-mutation'
+import { useProjectDetailQuery } from '@/data/projects/project-detail-query'
 import { useTablesQuery } from '@/data/tables/tables-query'
 import { useCheckEntitlements } from '@/hooks/misc/useCheckEntitlements'
 import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
@@ -169,16 +170,29 @@ export const AssistantChat = ({
   const currentTable = tables?.find((t) => t.id.toString() === entityId)
   const currentSchema = searchParams?.get('schema') ?? 'public'
 
+  // on org-level pages, where there's no project in the URL,
+  // resolve it fresh from the chat's own projectRef instead.
+  const isOrgViewSupportChat = !project?.ref && !!supportMetadata?.projectRef
+  const { data: supportChatProjectDetail } = useProjectDetailQuery(
+    { ref: supportMetadata?.projectRef },
+    { enabled: isOrgViewSupportChat }
+  )
+  const isResolvingSupportChatConnectionString =
+    isOrgViewSupportChat && !supportChatProjectDetail?.connectionString
+
   // Update context in state. On org-level pages there's no project in the URL, so
   // fall back to the open chat's own support metadata (see
   // SupportAssistantSuccessCardContent) rather than clobbering it back to undefined —
   // this also restores the right context after switching between support chats.
   useEffect(() => {
-    if (!project?.ref && supportMetadata?.projectRef) {
+    if (isOrgViewSupportChat && supportMetadata) {
+      // Wait for the connection string fetch rather than setting an empty one
+      if (!supportChatProjectDetail?.connectionString) return
+
       state.setContext({
         projectRef: supportMetadata.projectRef,
         orgSlug: supportMetadata.organizationSlug,
-        connectionString: supportMetadata.connectionString ?? '',
+        connectionString: supportChatProjectDetail.connectionString,
       })
       return
     }
@@ -188,7 +202,15 @@ export const AssistantChat = ({
       orgSlug: selectedOrganization?.slug,
       connectionString: project?.connectionString ?? '',
     })
-  }, [project?.ref, project?.connectionString, selectedOrganization?.slug, state, supportMetadata])
+  }, [
+    project?.ref,
+    project?.connectionString,
+    selectedOrganization?.slug,
+    state,
+    isOrgViewSupportChat,
+    supportMetadata,
+    supportChatProjectDetail?.connectionString,
+  ])
 
   const track = useTrack()
 
@@ -220,7 +242,11 @@ export const AssistantChat = ({
   const isSupportChatClosed = isSupportChat && supportMetadata.lifecycleStatus !== 'bot_active'
   const supportConversationId = supportMetadata?.frontConversationId
   const isChatInputDisabled =
-    !isApiKeySet || disablePrompts || isLoadingOrganization || isSupportChatClosed
+    !isApiKeySet ||
+    disablePrompts ||
+    isLoadingOrganization ||
+    isSupportChatClosed ||
+    isResolvingSupportChatConnectionString
 
   const branchedFrom = currentChat?.branchedFrom
   const branchedConversation = branchedFrom ? snap.chats[branchedFrom.chatId] : undefined

--- a/apps/studio/components/ui/AIAssistantPanel/AssistantChat.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AssistantChat.tsx
@@ -170,12 +170,13 @@ export const AssistantChat = ({
   const isSupportChatProjectReady = isProjectReadyForAssistant(supportChatProjectDetail)
   const isResolvingSupportChatConnectionString = isOrgViewSupportChat && !isSupportChatProjectReady
 
-  // The project this chat is actually scoped to — falls back to the support chat's own
-  // resolved project on org-level pages, where `project` from the URL is undefined.
   const resolvedProjectRef = isOrgViewSupportChat ? supportMetadata?.projectRef : project?.ref
   const resolvedConnectionString = isOrgViewSupportChat
     ? supportChatProjectDetail?.connectionString
     : project?.connectionString
+  const resolvedOrgSlug = isOrgViewSupportChat
+    ? supportMetadata?.organizationSlug
+    : selectedOrganization?.slug
 
   const { data: tables } = useTablesQuery(
     {
@@ -315,7 +316,7 @@ export const AssistantChat = ({
 
   const handleRateMessage = useCallback(
     async (messageId: string, rating: 'positive' | 'negative', reason?: string) => {
-      if (!resolvedProjectRef || !selectedOrganization?.slug) return
+      if (!resolvedProjectRef || !resolvedOrgSlug) return
 
       // Optimistically update UI
       setMessageRatings((prev) => ({ ...prev, [messageId]: rating }))
@@ -326,7 +327,7 @@ export const AssistantChat = ({
           messages: chatMessages,
           messageId,
           projectRef: resolvedProjectRef,
-          orgSlug: selectedOrganization.slug,
+          orgSlug: resolvedOrgSlug,
           reason,
           spanId: state.messageSpanIds[messageId],
         })
@@ -346,15 +347,7 @@ export const AssistantChat = ({
         })
       }
     },
-    [
-      chatMessages,
-      resolvedProjectRef,
-      selectedOrganization?.slug,
-      rateMessage,
-      track,
-      state,
-      chatId,
-    ]
+    [chatMessages, resolvedProjectRef, resolvedOrgSlug, rateMessage, track, state, chatId]
   )
 
   const isContextExceededError =
@@ -522,7 +515,7 @@ export const AssistantChat = ({
         component: 'AIAssistant',
         feature: 'AI Assistant Panel',
         projectRef: resolvedProjectRef,
-        organizationSlug: selectedOrganization?.slug,
+        organizationSlug: resolvedOrgSlug,
       }}
       actions={[
         {

--- a/apps/studio/components/ui/AIAssistantPanel/AssistantChat.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AssistantChat.tsx
@@ -170,17 +170,17 @@ export const AssistantChat = ({
   const isSupportChatProjectReady = isProjectReadyForAssistant(supportChatProjectDetail)
   const isResolvingSupportChatConnectionString = isOrgViewSupportChat && !isSupportChatProjectReady
 
-  // Table browsing needs the same org-view support chat fallback as the send context below,
-  // otherwise the assistant has no schema awareness for a support chat opened from an org page.
-  const tablesProjectRef = isOrgViewSupportChat ? supportMetadata?.projectRef : project?.ref
-  const tablesConnectionString = isOrgViewSupportChat
+  // The project this chat is actually scoped to — falls back to the support chat's own
+  // resolved project on org-level pages, where `project` from the URL is undefined.
+  const resolvedProjectRef = isOrgViewSupportChat ? supportMetadata?.projectRef : project?.ref
+  const resolvedConnectionString = isOrgViewSupportChat
     ? supportChatProjectDetail?.connectionString
     : project?.connectionString
 
   const { data: tables } = useTablesQuery(
     {
-      projectRef: tablesProjectRef,
-      connectionString: tablesConnectionString,
+      projectRef: resolvedProjectRef,
+      connectionString: resolvedConnectionString,
       schema: 'public',
     },
     { enabled: isApiKeySet && (!isOrgViewSupportChat || isSupportChatProjectReady) }
@@ -315,7 +315,7 @@ export const AssistantChat = ({
 
   const handleRateMessage = useCallback(
     async (messageId: string, rating: 'positive' | 'negative', reason?: string) => {
-      if (!project?.ref || !selectedOrganization?.slug) return
+      if (!resolvedProjectRef || !selectedOrganization?.slug) return
 
       // Optimistically update UI
       setMessageRatings((prev) => ({ ...prev, [messageId]: rating }))
@@ -325,7 +325,7 @@ export const AssistantChat = ({
           rating,
           messages: chatMessages,
           messageId,
-          projectRef: project.ref,
+          projectRef: resolvedProjectRef,
           orgSlug: selectedOrganization.slug,
           reason,
           spanId: state.messageSpanIds[messageId],
@@ -346,7 +346,15 @@ export const AssistantChat = ({
         })
       }
     },
-    [chatMessages, project?.ref, selectedOrganization?.slug, rateMessage, track, state, chatId]
+    [
+      chatMessages,
+      resolvedProjectRef,
+      selectedOrganization?.slug,
+      rateMessage,
+      track,
+      state,
+      chatId,
+    ]
   )
 
   const isContextExceededError =
@@ -513,7 +521,7 @@ export const AssistantChat = ({
       sentryContext={{
         component: 'AIAssistant',
         feature: 'AI Assistant Panel',
-        projectRef: project?.ref,
+        projectRef: resolvedProjectRef,
         organizationSlug: selectedOrganization?.slug,
       }}
       actions={[

--- a/apps/studio/components/ui/AIAssistantPanel/AssistantChat.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AssistantChat.tsx
@@ -31,6 +31,7 @@ import { Message } from './Message'
 import { Markdown } from '@/components/interfaces/Markdown'
 import { useCheckOpenAIKeyQuery } from '@/data/ai/check-api-key-query'
 import { useRateMessageMutation } from '@/data/ai/rate-message-mutation'
+import { isValidConnString } from '@/data/fetchers'
 import { useProjectDetailQuery } from '@/data/projects/project-detail-query'
 import { useTablesQuery } from '@/data/tables/tables-query'
 import { useCheckEntitlements } from '@/hooks/misc/useCheckEntitlements'
@@ -177,8 +178,14 @@ export const AssistantChat = ({
     { ref: supportMetadata?.projectRef },
     { enabled: isOrgViewSupportChat }
   )
-  const isResolvingSupportChatConnectionString =
-    isOrgViewSupportChat && !supportChatProjectDetail?.connectionString
+  // Mirrors the readiness check in SupportAssistantSuccessCardContent — a project still
+  // coming up, or with a connection string that isn't valid yet, isn't ready to send to.
+  const isSupportChatProjectReady =
+    !!supportChatProjectDetail &&
+    supportChatProjectDetail.status !== 'COMING_UP' &&
+    supportChatProjectDetail.status !== 'UNKNOWN' &&
+    isValidConnString(supportChatProjectDetail.connectionString)
+  const isResolvingSupportChatConnectionString = isOrgViewSupportChat && !isSupportChatProjectReady
 
   // Update context in state. On org-level pages there's no project in the URL, so
   // fall back to the open chat's own support metadata (see
@@ -186,13 +193,13 @@ export const AssistantChat = ({
   // this also restores the right context after switching between support chats.
   useEffect(() => {
     if (isOrgViewSupportChat && supportMetadata) {
-      // Wait for the connection string fetch rather than setting an empty one
-      if (!supportChatProjectDetail?.connectionString) return
+      // Wait for a ready project rather than setting an empty/unready connection string
+      if (!isSupportChatProjectReady) return
 
       state.setContext({
         projectRef: supportMetadata.projectRef,
         orgSlug: supportMetadata.organizationSlug,
-        connectionString: supportChatProjectDetail.connectionString,
+        connectionString: supportChatProjectDetail.connectionString ?? undefined,
       })
       return
     }
@@ -208,6 +215,7 @@ export const AssistantChat = ({
     selectedOrganization?.slug,
     state,
     isOrgViewSupportChat,
+    isSupportChatProjectReady,
     supportMetadata,
     supportChatProjectDetail?.connectionString,
   ])

--- a/apps/studio/components/ui/AIAssistantPanel/SupportAssistantSuccessCardContent.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/SupportAssistantSuccessCardContent.tsx
@@ -197,21 +197,34 @@ export function SupportAssistantSuccessCardContent({
           aria-hidden
         />
       </CardHeader>
-      {chat ? (
-        <SupportAssistantResponsePreview chat={chat as SupportAssistantPreviewChat} />
-      ) : isProjectDetailError ? (
-        <SupportAssistantResponseErrorState
-          onRetry={(event) => {
-            event.stopPropagation()
-            refetchProjectDetail()
-          }}
-        />
-      ) : (
-        <CardContent>
-          <SupportAssistantResponseLoadingSkeleton />
-        </CardContent>
-      )}
+      <SupportAssistantCardBody
+        chat={chat as SupportAssistantPreviewChat | undefined}
+        isError={isProjectDetailError}
+        onRetry={(event) => {
+          event.stopPropagation()
+          refetchProjectDetail()
+        }}
+      />
     </Card>
+  )
+}
+
+function SupportAssistantCardBody({
+  chat,
+  isError,
+  onRetry,
+}: {
+  chat: SupportAssistantPreviewChat | undefined
+  isError: boolean
+  onRetry: (event: MouseEvent<HTMLButtonElement>) => void
+}) {
+  if (chat) return <SupportAssistantResponsePreview chat={chat} />
+  if (isError) return <SupportAssistantResponseErrorState onRetry={onRetry} />
+
+  return (
+    <CardContent>
+      <SupportAssistantResponseLoadingSkeleton />
+    </CardContent>
   )
 }
 

--- a/apps/studio/components/ui/AIAssistantPanel/SupportAssistantSuccessCardContent.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/SupportAssistantSuccessCardContent.tsx
@@ -1,7 +1,15 @@
 import type { UIMessage as MessageType } from '@ai-sdk/react'
 import { ArrowUpRight } from 'lucide-react'
 import dynamic from 'next/dynamic'
-import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useEffectEvent,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react'
 import type { JSX, MouseEvent } from 'react'
 import type { StreamdownProps } from 'streamdown'
 import {
@@ -16,11 +24,11 @@ import {
   Skeleton,
 } from 'ui'
 
+import { isProjectReadyForAssistant } from './AIAssistant.utils'
 import { buildSupportAssistantPrompt } from '@/components/interfaces/Support/SupportAssistant.utils'
 import type { SubmittedSupportRequest } from '@/components/interfaces/Support/SupportForm.state'
 import { NO_PROJECT_MARKER } from '@/components/interfaces/Support/SupportForm.utils'
 import { SIDEBAR_KEYS } from '@/components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider'
-import { isValidConnString } from '@/data/fetchers'
 import { useProjectDetailQuery } from '@/data/projects/project-detail-query'
 import { useTrack } from '@/lib/telemetry/track'
 import {
@@ -72,21 +80,10 @@ export function SupportAssistantSuccessCardContent({
     refetch: refetchProjectDetail,
   } = useProjectDetailQuery({ ref: request.projectRef }, { enabled: hasAssistantContext })
 
-  // Mirrors the readiness check useProjectDetailQuery itself polls on: a project
-  // still coming up, or one without a usable connection string yet, isn't ready
-  // to receive requests, even though the query already returned some data.
-  const isProjectReady =
-    !!projectDetail &&
-    projectDetail.status !== 'COMING_UP' &&
-    projectDetail.status !== 'UNKNOWN' &&
-    isValidConnString(projectDetail.connectionString)
+  const isProjectReady = isProjectReadyForAssistant(projectDetail)
   const connectionString = projectDetail?.connectionString ?? undefined
 
-  useEffect(() => {
-    if (!hasAssistantContext) return
-    if (!isProjectReady) return
-    if (createdChatIdRef.current) return
-
+  const createSupportChat = useEffectEvent(() => {
     aiAssistantState.setContext({
       projectRef: request.projectRef,
       orgSlug: request.organizationSlug,
@@ -100,9 +97,15 @@ export function SupportAssistantSuccessCardContent({
 
     createdChatIdRef.current = newChatId
     setChatId(newChatId)
-    // aiAssistantState is a stable context value (same identity across renders)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [aiAssistant, assistantPrompt, connectionString, hasAssistantContext, isProjectReady, request])
+  })
+
+  useEffect(() => {
+    if (!hasAssistantContext) return
+    if (!isProjectReady) return
+    if (createdChatIdRef.current) return
+
+    createSupportChat()
+  }, [hasAssistantContext, isProjectReady])
 
   const handleOpenAssistant = () => {
     track(
@@ -153,9 +156,6 @@ export function SupportAssistantSuccessCardContent({
 
   if (!hasAssistantContext) return null
 
-  // Before the chat exists (still loading, or failed) there's nothing for the card to
-  // open — disable its click/keyboard handlers so only "Try again" (while erroring) is
-  // interactive, and clicking mid-load can't open the sidebar with no chat prepared.
   const isInteractive = !!chat
 
   return (

--- a/apps/studio/components/ui/AIAssistantPanel/SupportAssistantSuccessCardContent.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/SupportAssistantSuccessCardContent.tsx
@@ -153,9 +153,10 @@ export function SupportAssistantSuccessCardContent({
 
   if (!hasAssistantContext) return null
 
-  // While the project details request failed, the card has no chat to open — disable
-  // its click/keyboard handlers so only the "Try again" button inside is interactive.
-  const isInteractive = !isProjectDetailError
+  // Before the chat exists (still loading, or failed) there's nothing for the card to
+  // open — disable its click/keyboard handlers so only "Try again" (while erroring) is
+  // interactive, and clicking mid-load can't open the sidebar with no chat prepared.
+  const isInteractive = !!chat
 
   return (
     <Card

--- a/apps/studio/components/ui/AIAssistantPanel/SupportAssistantSuccessCardContent.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/SupportAssistantSuccessCardContent.tsx
@@ -2,10 +2,11 @@ import type { UIMessage as MessageType } from '@ai-sdk/react'
 import { ArrowUpRight } from 'lucide-react'
 import dynamic from 'next/dynamic'
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
-import type { JSX } from 'react'
+import type { JSX, MouseEvent } from 'react'
 import type { StreamdownProps } from 'streamdown'
 import {
   AiIconAnimation,
+  Button,
   Card,
   CardContent,
   CardDescription,
@@ -19,6 +20,7 @@ import { buildSupportAssistantPrompt } from '@/components/interfaces/Support/Sup
 import type { SubmittedSupportRequest } from '@/components/interfaces/Support/SupportForm.state'
 import { NO_PROJECT_MARKER } from '@/components/interfaces/Support/SupportForm.utils'
 import { SIDEBAR_KEYS } from '@/components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider'
+import { isValidConnString } from '@/data/fetchers'
 import { useProjectDetailQuery } from '@/data/projects/project-detail-query'
 import { useTrack } from '@/lib/telemetry/track'
 import {
@@ -64,20 +66,31 @@ export function SupportAssistantSuccessCardContent({
   // The org-view support form resolves projectRef itself (defaulting to the
   // first project in the org) rather than reading it from the URL, so the
   // assistant's context needs the connection string fetched explicitly too.
-  const { data: projectDetail } = useProjectDetailQuery(
-    { ref: request.projectRef },
-    { enabled: hasAssistantContext }
-  )
+  const {
+    data: projectDetail,
+    isError: isProjectDetailError,
+    refetch: refetchProjectDetail,
+  } = useProjectDetailQuery({ ref: request.projectRef }, { enabled: hasAssistantContext })
+
+  // Mirrors the readiness check useProjectDetailQuery itself polls on: a project
+  // still coming up, or one without a usable connection string yet, isn't ready
+  // to receive requests, even though the query already returned some data.
+  const isProjectReady =
+    !!projectDetail &&
+    projectDetail.status !== 'COMING_UP' &&
+    projectDetail.status !== 'UNKNOWN' &&
+    isValidConnString(projectDetail.connectionString)
+  const connectionString = projectDetail?.connectionString ?? undefined
 
   useEffect(() => {
     if (!hasAssistantContext) return
-    if (!projectDetail?.connectionString) return
+    if (!isProjectReady) return
     if (createdChatIdRef.current) return
 
     aiAssistantState.setContext({
       projectRef: request.projectRef,
       orgSlug: request.organizationSlug,
-      connectionString: projectDetail.connectionString,
+      connectionString,
     })
 
     const newChatId = aiAssistant.newChat({
@@ -89,7 +102,7 @@ export function SupportAssistantSuccessCardContent({
     setChatId(newChatId)
     // aiAssistantState is a stable context value (same identity across renders)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [aiAssistant, assistantPrompt, hasAssistantContext, projectDetail?.connectionString, request])
+  }, [aiAssistant, assistantPrompt, connectionString, hasAssistantContext, isProjectReady, request])
 
   const handleOpenAssistant = () => {
     track(
@@ -113,6 +126,7 @@ export function SupportAssistantSuccessCardContent({
           severity: request.severity,
           organizationSlug: request.organizationSlug,
           projectRef: request.projectRef,
+          connectionString,
           library: request.library,
           affectedServices: request.affectedServices,
           allowSupportAccess: request.allowSupportAccess,
@@ -176,6 +190,13 @@ export function SupportAssistantSuccessCardContent({
       </CardHeader>
       {chat ? (
         <SupportAssistantResponsePreview chat={chat as SupportAssistantPreviewChat} />
+      ) : isProjectDetailError ? (
+        <SupportAssistantResponseErrorState
+          onRetry={(event) => {
+            event.stopPropagation()
+            refetchProjectDetail()
+          }}
+        />
       ) : (
         <CardContent>
           <SupportAssistantResponseLoadingSkeleton />
@@ -257,5 +278,20 @@ function SupportAssistantResponseLoadingSkeleton() {
       <Skeleton className="h-4 w-[92%]" />
       <Skeleton className="h-4 w-[68%]" />
     </div>
+  )
+}
+
+function SupportAssistantResponseErrorState({
+  onRetry,
+}: {
+  onRetry: (event: MouseEvent<HTMLButtonElement>) => void
+}) {
+  return (
+    <CardContent className="flex items-center justify-between gap-4">
+      <span className="text-sm text-foreground-light">Couldn't load the assistant response.</span>
+      <Button variant="default" size="tiny" onClick={onRetry}>
+        Try again
+      </Button>
+    </CardContent>
   )
 }

--- a/apps/studio/components/ui/AIAssistantPanel/SupportAssistantSuccessCardContent.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/SupportAssistantSuccessCardContent.tsx
@@ -126,7 +126,6 @@ export function SupportAssistantSuccessCardContent({
           severity: request.severity,
           organizationSlug: request.organizationSlug,
           projectRef: request.projectRef,
-          connectionString,
           library: request.library,
           affectedServices: request.affectedServices,
           allowSupportAccess: request.allowSupportAccess,
@@ -154,20 +153,29 @@ export function SupportAssistantSuccessCardContent({
 
   if (!hasAssistantContext) return null
 
+  // While the project details request failed, the card has no chat to open — disable
+  // its click/keyboard handlers so only the "Try again" button inside is interactive.
+  const isInteractive = !isProjectDetailError
+
   return (
     <Card
-      role="button"
-      tabIndex={0}
-      aria-label="Open assistant response"
-      onClick={handleOpenAssistant}
-      onKeyDown={(event) => {
-        if (event.key === 'Enter' || event.key === ' ') {
-          event.preventDefault()
-          handleOpenAssistant()
-        }
-      }}
+      role={isInteractive ? 'button' : undefined}
+      tabIndex={isInteractive ? 0 : undefined}
+      aria-label={isInteractive ? 'Open assistant response' : undefined}
+      onClick={isInteractive ? handleOpenAssistant : undefined}
+      onKeyDown={
+        isInteractive
+          ? (event) => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault()
+                handleOpenAssistant()
+              }
+            }
+          : undefined
+      }
       className={cn(
-        'group cursor-pointer bg-muted/50 transition-colors hover:bg-muted/50 focus-ring',
+        'group bg-muted/50 transition-colors',
+        isInteractive && 'cursor-pointer hover:bg-muted/50 focus-ring',
         className
       )}
     >

--- a/apps/studio/components/ui/AIAssistantPanel/SupportAssistantSuccessCardContent.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/SupportAssistantSuccessCardContent.tsx
@@ -19,6 +19,7 @@ import { buildSupportAssistantPrompt } from '@/components/interfaces/Support/Sup
 import type { SubmittedSupportRequest } from '@/components/interfaces/Support/SupportForm.state'
 import { NO_PROJECT_MARKER } from '@/components/interfaces/Support/SupportForm.utils'
 import { SIDEBAR_KEYS } from '@/components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider'
+import { useProjectDetailQuery } from '@/data/projects/project-detail-query'
 import { useTrack } from '@/lib/telemetry/track'
 import {
   useAiAssistantState,
@@ -60,9 +61,24 @@ export function SupportAssistantSuccessCardContent({
 
   const assistantPrompt = useMemo(() => buildSupportAssistantPrompt(request), [request])
 
+  // The org-view support form resolves projectRef itself (defaulting to the
+  // first project in the org) rather than reading it from the URL, so the
+  // assistant's context needs the connection string fetched explicitly too.
+  const { data: projectDetail } = useProjectDetailQuery(
+    { ref: request.projectRef },
+    { enabled: hasAssistantContext }
+  )
+
   useEffect(() => {
     if (!hasAssistantContext) return
+    if (!projectDetail?.connectionString) return
     if (createdChatIdRef.current) return
+
+    aiAssistantState.setContext({
+      projectRef: request.projectRef,
+      orgSlug: request.organizationSlug,
+      connectionString: projectDetail.connectionString,
+    })
 
     const newChatId = aiAssistant.newChat({
       name: 'Support request',
@@ -71,7 +87,9 @@ export function SupportAssistantSuccessCardContent({
 
     createdChatIdRef.current = newChatId
     setChatId(newChatId)
-  }, [aiAssistant, assistantPrompt, hasAssistantContext])
+    // aiAssistantState is a stable context value (same identity across renders)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [aiAssistant, assistantPrompt, hasAssistantContext, projectDetail?.connectionString, request])
 
   const handleOpenAssistant = () => {
     track(

--- a/apps/studio/state/ai-assistant-state.tsx
+++ b/apps/studio/state/ai-assistant-state.tsx
@@ -45,10 +45,6 @@ export type SupportChatMetadata = {
   severity: string
   organizationSlug?: string
   projectRef?: string
-  // Captured alongside projectRef so this chat's assistant context can be
-  // restored (e.g. after switching chats or reopening the panel) without
-  // depending on a project being resolvable from the current URL.
-  connectionString?: string
   library?: string
   affectedServices?: string
   allowSupportAccess: boolean

--- a/apps/studio/state/ai-assistant-state.tsx
+++ b/apps/studio/state/ai-assistant-state.tsx
@@ -45,6 +45,10 @@ export type SupportChatMetadata = {
   severity: string
   organizationSlug?: string
   projectRef?: string
+  // Captured alongside projectRef so this chat's assistant context can be
+  // restored (e.g. after switching chats or reopening the panel) without
+  // depending on a project being resolvable from the current URL.
+  connectionString?: string
   library?: string
   affectedServices?: string
   allowSupportAccess: boolean


### PR DESCRIPTION
Fixes FE-4200. 

## What is the current behavior?

When submitting a support ticket from the org-level view (/org/<org_slug>, no project in the URL), the embedded AI assistant ("While you wait" card) fails to respond, the request to /api/ai/sql/generate-v4 returns a 400 (Invalid request body, missing projectRef/connectionString), and the assistant appears to just load forever with no visible error.

Root cause: the assistant's outgoing request reads projectRef/orgSlug/connectionString from a shared context (ai-assistant-state.tsx) that's normally kept in sync with the currently viewed project by reading the URL (AssistantChat.tsx). The support form, however, resolves its own projectRef (defaulting to the first project in the org) independently of the URL. In org view there's no project in the URL, so the shared context never gets populated, and the assistant's request goes out with projectRef: undefined and no connectionString.

## What is the new behavior?

Chat creation is gated until the connection string & project reference have loaded, so no request fires until the context is valid. Table/schema-browsing context, message rating, and error reporting also now resolve the support chat's own project instead of the (undefined) URL-based one.

## Additional context

This fix is scoped to the support-ticket flow; general (non-support) assistant chats in org view are unaffected and still clear projectRef as before. Note: actually opening the assistant sidebar by clicking the card from an org page requires #49430, stacked on this branch — that's a separate bug (the sidebar was never registered on org pages at all).

## How to test

  1. Go to /org/<your_org_slug> (org-level view, not a project page).
  2. Open the support form and submit a ticket (any category that shows the "While you wait" AI assistant card).
  3. Confirm the assistant card loads a response instead of spinning indefinitely.
  4. Ask a schema-specific follow-up (e.g. "what columns does the `<table>` table have?") — confirm it answers using the real schema rather than hedging/guessing.
  5. Thumbs up/down a message — confirm the rating actually submits (check the network request) rather than silently no-op'ing.
  6. Submit a ticket for a project that's still provisioning (`COMING_UP`) — confirm the card shows a loading state, not an empty/broken one, until the project is ready.
  7. Simulate a project-detail fetch failure (e.g. block the request in DevTools) — confirm the card shows a "Couldn't load... Try again" error state, and clicking elsewhere on the card doesn't open an empty sidebar.
  8. Submit two tickets from org view, open the sidebar (requires #49430), and switch between the two chats — confirm the project context follows whichever chat is active rather than getting stuck on the first one.
  9. Regression check: submit a ticket from a project-level view (/project/<ref>/support) and confirm the assistant still works as before.
  10. Regression check: open the assistant sidebar directly (not via a support ticket) on a project page and confirm it still behaves as before for a normal, non-support chat.
