### PR TITLE
Scoped PAT: use CSS for the long text reveal animation

### DIFF
--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/TokenCapabilities/EndpointRow.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/TokenCapabilities/EndpointRow.tsx
@@ -75,7 +75,7 @@ export const EndpointRow = ({
             'font-mono text-xs',
             // This is necessary for the reveal on hover animation
             'block inline-[max-content] whitespace-nowrap text-nowrap',
-            'transition-transform ease-linear motion-reduce:transition-none duration-500 delay-400',
+            'transition-transform ease-linear motion-reduce:transition-none duration-1000 delay-400',
             // This ensure no GPU jump when non-scrolling items are hovered
             'translate-0',
             // If the content (102% to have a small right margin) exceeds the container size (100cqi), the calc result will be a negative number

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/TokenCapabilities/EndpointRow.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/TokenCapabilities/EndpointRow.tsx
@@ -13,9 +13,6 @@ interface EndpointRowProps {
   methodColumnWidth: string
 }
 
-/** Pan slowly enough to read while revealing (~70px/s), but never snap for short distances. */
-const panDurationMs = (distance: number) => Math.max(300, Math.round(distance * 14))
-
 /**
  * One copyable endpoint. The muted prefix span shrinks with an end-ellipsis while the
  * distinguishing segment stays fixed-width — visually equivalent to truncating the full path in
@@ -33,22 +30,11 @@ export const EndpointRow = ({
   const { prefix, distinguishing } = splitEndpointPath(path, sharedPrefix)
 
   const pathContainerRef = useRef<HTMLSpanElement>(null)
-  const [panDistance, setPanDistance] = useState(0)
-  const [isRevealed, setIsRevealed] = useState(false)
   const [isCopied, setIsCopied] = useState(false)
   const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
   const [showCopiedIcon, setShowCopiedIcon] = useState(false)
 
   useEffect(() => () => clearTimeout(copiedTimerRef.current), [])
-
-  // Measured when the reveal starts, not on mount: rows live inside accordion content that mounts
-  // collapsed, so resting measurements are taken before the row has its real width.
-  const handleRevealStart = () => {
-    const container = pathContainerRef.current
-    if (container) setPanDistance(Math.max(0, container.scrollWidth - container.clientWidth))
-    setIsRevealed(true)
-  }
-  const handleRevealEnd = () => setIsRevealed(false)
 
   const handleCopy = () => {
     copyToClipboard(path, () => {
@@ -64,10 +50,6 @@ export const EndpointRow = ({
       type="button"
       tabIndex={0}
       onClick={handleCopy}
-      onMouseEnter={handleRevealStart}
-      onMouseLeave={handleRevealEnd}
-      onFocus={handleRevealStart}
-      onBlur={handleRevealEnd}
       aria-label={`Copy ${method} ${path}`}
       className="group flex w-full items-center gap-2 py-1.5 text-left"
     >
@@ -80,27 +62,35 @@ export const EndpointRow = ({
       <span
         ref={pathContainerRef}
         className={cn(
-          'flex min-w-0 flex-1 overflow-hidden whitespace-nowrap font-mono text-xs',
-          // The fade only paints over text that reaches the container's right edge, so short rows
-          // are unaffected; dropped while panning so the revealed tail stays readable.
-          !isRevealed && '[mask-image:linear-gradient(to_right,black_calc(100%-2rem),transparent)]'
+          'block inline-full overflow-hidden',
+          // group allows to have the hover effect on children (see below)
+          'group',
+          // container to allow hover effect size computations
+          '@container',
+          '[mask-image:linear-gradient(to_right,black_calc(100%-2rem),transparent)]'
         )}
       >
         <span
-          className="flex min-w-0 transition-transform ease-linear motion-reduce:transition-none"
-          style={{
-            transform:
-              isRevealed && panDistance > 0 ? `translateX(-${panDistance}px)` : 'translateX(0)',
-            // Pausing before panning lets a quick mouse pass leave the row untouched; the pan
-            // back starts immediately and faster, so the row settles as soon as it's left.
-            transitionDuration: isRevealed ? `${panDurationMs(panDistance)}ms` : '200ms',
-            transitionDelay: isRevealed ? '400ms' : '0ms',
-          }}
-        >
-          {prefix !== '' && (
-            <span className="overflow-hidden text-ellipsis text-foreground-lighter">{prefix}</span>
+          className={cn(
+            'font-mono text-xs',
+            // This is necessary for the reveal on hover animation
+            'block inline-[max-content] whitespace-nowrap text-nowrap',
+            'transition-transform ease-linear motion-reduce:transition-none duration-500 delay-400',
+            // This ensure no GPU jump when non-scrolling items are hovered
+            'translate-0',
+            // If the content (102% to have a small right margin) exceeds the container size (100cqi), the calc result will be a negative number
+            // This ensures small items don't translate
+            'group-hover:translate-x-[min(0px,calc(100cqi-102%))]'
           )}
-          <span className="shrink-0 text-foreground">{distinguishing}</span>
+        >
+          <span>
+            {prefix !== '' && (
+              <span className="overflow-hidden text-ellipsis text-foreground-lighter">
+                {prefix}
+              </span>
+            )}
+            <span className="shrink-0 text-foreground">{distinguishing}</span>
+          </span>
         </span>
       </span>
       <span className="shrink-0 pl-2">


### PR DESCRIPTION
Simplify the code for the long text reveal animation on hover using only CSS. This also improves performances on some devices

## How to test

- Open https://studio-staging-git-gildas-scoped-pat-css-only-a-1d2de2-supabase.vercel.app/dashboard/account/tokens
- Create a token with project settings read/write permissions
- In the review step, ensure you can hover long URL to trigger a scrolling animation showing its end
- In the review step, ensure short URL don't have this animation on hover
- Create the token
- Open its permissions and check the hover effects again

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved endpoint path reveal animations with smoother transitions and masking.
  - Added responsive behavior based on available container space.
  - Increased transition duration for easier reading.
  - Added support for reduced-motion preferences.
- **Bug Fixes**
  - Improved endpoint path visibility and hover behavior while preserving the existing copy interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->