### PR TITLE
fix(www): point the Nuxt server routes card at a live docs page

### DIFF
--- a/apps/www/app/(home)/_components/FrameworksSection.tsx
+++ b/apps/www/app/(home)/_components/FrameworksSection.tsx
@@ -321,7 +321,7 @@ const frameworkExamples: Record<
     {
       title: 'Server Routes',
       description: 'Service role access from server.',
-      url: '/docs/guides/auth/server-side/nuxt',
+      url: '/docs/guides/auth/server-side/creating-a-client?queryGroups=framework&framework=nuxt',
       icon: 'Server',
     },
   ],


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix — dead link on the homepage.

## What is the current behavior?

The "Server Routes" card under Nuxt in the homepage framework section links to
`/docs/guides/auth/server-side/nuxt`, which returns 404 with no redirect.

That path has never existed. The only framework pages ever published under
`auth/server-side/` were `nextjs.mdx` and `sveltekit.mdx`, both removed in
#38405 when the per-framework guides were consolidated into
`creating-a-client`. Redirects were added for those two at the time; there was
no Nuxt page in that set, so the card has pointed at a non-existent page since
it was written.

Spotted by @lazerg in #49143, which flags this dead link but deliberately
leaves the choice of target open.

## What is the new behavior?

The card points at
`/docs/guides/auth/server-side/creating-a-client?queryGroups=framework&framework=nuxt`
(verified 200).

This is the same destination the existing `server-side/nextjs` and
`server-side/sveltekit` redirects resolve to, so the Nuxt card now lands in the
same place as its sibling cards rather than using a URL shape of its own. The
Nuxt tab on that page opens on a "Server route" panel showing
`server/api/hello.ts` with `createServerClient`, which matches what the card
advertises.

## Additional context

I deliberately did not add a redirect for `server-side/nuxt`. The redirects
that exist are there to preserve URLs for pages that were deleted; adding one
for a page that never existed would create a permanent alias for a path nothing
ever published. The same reasoning covers `astro`, `remix`, `react-router` and
`express` — `creating-a-client` has tabs for all of them and none has a
`server-side/<framework>` redirect, which is correct.

This touches the same file as #49143 but a different card, so the two do not
conflict.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Nuxt “Server Routes” example link to point to the current query-based authentication client documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->