### PR TITLE
[MUL-1338] fix(studio): lock compute size to large for HA projects

### DIFF
--- a/apps/studio/components/interfaces/ProjectCreation/ComputeSizeSelector.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/ComputeSizeSelector.tsx
@@ -63,9 +63,6 @@ export const ComputeSizeSelector = ({ form }: ComputeSizeSelectorProps) => {
               </p>
             }
           >
-            {/* Radix fires onValueChange('') when the value and the option list change in
-                the same tick (its hidden native select briefly holds stale options). No
-                item here has an empty value, so an empty change is always spurious. */}
             <Select
               value={field.value}
               onValueChange={(value) => value !== '' && field.onChange(value)}

--- a/apps/studio/components/interfaces/ProjectCreation/ComputeSizeSelector.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/ComputeSizeSelector.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { UseFormReturn } from 'react-hook-form'
 import { CloudProvider } from 'shared-data'
 import {
@@ -8,11 +9,12 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  useWatch,
 } from 'ui'
 import { ComputeBadge } from 'ui-patterns/ComputeBadge'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
-import { sizes } from './ProjectCreation.constants'
+import { HIGH_AVAILABILITY_INSTANCE_SIZE, sizes } from './ProjectCreation.constants'
 import { CreateProjectForm } from './ProjectCreation.schema'
 import { InlineLink } from '@/components/ui/InlineLink'
 import Panel from '@/components/ui/Panel'
@@ -24,6 +26,19 @@ interface ComputeSizeSelectorProps {
 }
 
 export const ComputeSizeSelector = ({ form }: ComputeSizeSelectorProps) => {
+  const cloudProvider = useWatch({ control: form.control, name: 'cloudProvider' }) as CloudProvider
+  const highAvailability = useWatch({ control: form.control, name: 'highAvailability' })
+
+  const sizeOptions = useMemo(
+    () =>
+      highAvailability
+        ? [HIGH_AVAILABILITY_INSTANCE_SIZE]
+        : sizes.filter((option) =>
+            instanceSizeSpecs[option].cloud_providers.includes(cloudProvider)
+          ),
+    [highAvailability, cloudProvider]
+  )
+
   return (
     <Panel.Content>
       <FormField
@@ -35,19 +50,17 @@ export const ComputeSizeSelector = ({ form }: ComputeSizeSelectorProps) => {
             layout="horizontal"
             label="Compute size"
             description={
-              <>
-                <p>
-                  The size for your dedicated database. You can change this later. Learn more about{' '}
-                  <InlineLink href={`${DOCS_URL}/guides/platform/compute-add-ons`}>
-                    compute add-ons
-                  </InlineLink>{' '}
-                  and{' '}
-                  <InlineLink href={`${DOCS_URL}/guides/platform/manage-your-usage/compute`}>
-                    compute billing
-                  </InlineLink>
-                  .
-                </p>
-              </>
+              <p>
+                The size for your dedicated database. You can change this later. Learn more about{' '}
+                <InlineLink href={`${DOCS_URL}/guides/platform/compute-add-ons`}>
+                  compute add-ons
+                </InlineLink>{' '}
+                and{' '}
+                <InlineLink href={`${DOCS_URL}/guides/platform/manage-your-usage/compute`}>
+                  compute billing
+                </InlineLink>
+                .
+              </p>
             }
           >
             <Select value={field.value} onValueChange={(value) => field.onChange(value)}>
@@ -59,43 +72,39 @@ export const ComputeSizeSelector = ({ form }: ComputeSizeSelectorProps) => {
               </SelectTrigger>
               <SelectContent>
                 <SelectGroup>
-                  {sizes
-                    .filter((option) =>
-                      instanceSizeSpecs[option].cloud_providers.includes(
-                        form.getValues('cloudProvider') as CloudProvider
-                      )
-                    )
-                    .map((option) => {
-                      return (
-                        <SelectItem key={option} value={option}>
-                          <div className="flex flex-row gap-4 items-center">
-                            <div className="w-14 flex items-center">
-                              <ComputeBadge infraComputeSize={option} />
-                            </div>
-
-                            <div className="text-sm">
-                              <span className="text-foreground">
-                                {instanceSizeSpecs[option].ram} RAM /{' '}
-                                {instanceSizeSpecs[option].cpu} CPU
-                              </span>
-                              <p
-                                translate="no"
-                                className="text-xs text-foreground-light"
-                                data-field="instance-details"
-                              >
-                                ${instanceSizeSpecs[option].priceHourly}/hour (~$
-                                {instanceSizeSpecs[option].priceMonthly}/month)
-                              </p>
-                            </div>
+                  {sizeOptions.map((option) => {
+                    return (
+                      <SelectItem key={option} value={option}>
+                        <div className="flex flex-row gap-4 items-center">
+                          <div className="w-14 flex items-center">
+                            <ComputeBadge infraComputeSize={option} />
                           </div>
-                        </SelectItem>
-                      )
-                    })}
-                  <SelectItem key={'disabled'} value={'disabled'} disabled>
-                    <div className="flex items-center justify-center w-full">
-                      <span>Larger instance sizes available after creation</span>
-                    </div>
-                  </SelectItem>
+
+                          <div className="text-sm">
+                            <span className="text-foreground">
+                              {instanceSizeSpecs[option].ram} RAM / {instanceSizeSpecs[option].cpu}{' '}
+                              CPU
+                            </span>
+                            <p
+                              translate="no"
+                              className="text-xs text-foreground-light"
+                              data-field="instance-details"
+                            >
+                              ${instanceSizeSpecs[option].priceHourly}/hour (~$
+                              {instanceSizeSpecs[option].priceMonthly}/month)
+                            </p>
+                          </div>
+                        </div>
+                      </SelectItem>
+                    )
+                  })}
+                  {!highAvailability && (
+                    <SelectItem key={'disabled'} value={'disabled'} disabled>
+                      <div className="flex items-center justify-center w-full">
+                        <span>Larger instance sizes available after creation</span>
+                      </div>
+                    </SelectItem>
+                  )}
                 </SelectGroup>
               </SelectContent>
             </Select>

--- a/apps/studio/components/interfaces/ProjectCreation/ComputeSizeSelector.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/ComputeSizeSelector.tsx
@@ -63,7 +63,13 @@ export const ComputeSizeSelector = ({ form }: ComputeSizeSelectorProps) => {
               </p>
             }
           >
-            <Select value={field.value} onValueChange={(value) => field.onChange(value)}>
+            {/* Radix fires onValueChange('') when the value and the option list change in
+                the same tick (its hidden native select briefly holds stale options). No
+                item here has an empty value, so an empty change is always spurious. */}
+            <Select
+              value={field.value}
+              onValueChange={(value) => value !== '' && field.onChange(value)}
+            >
               <SelectTrigger
                 id="instanceSize"
                 className="[&>span>div>div>[data-field=instance-details]]:hidden"

--- a/apps/studio/components/interfaces/ProjectCreation/HighAvailabilityInput.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/HighAvailabilityInput.tsx
@@ -4,6 +4,7 @@ import { type CloudProvider } from 'shared-data'
 import { Badge, FormControl, FormField, Switch, useWatch } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
+import { HIGH_AVAILABILITY_INSTANCE_SIZE } from './ProjectCreation.constants'
 import { CreateProjectForm } from './ProjectCreation.schema'
 import Panel from '@/components/ui/Panel'
 import { useCheckEntitlements } from '@/hooks/misc/useCheckEntitlements'
@@ -28,10 +29,12 @@ export const HighAvailabilityInput = ({
     cloudProvider: CloudProvider | undefined
     postgresVersionSelection: string | undefined
     dbRegion: string | null
+    instanceSize: string | null
   }>({
     cloudProvider: undefined,
     postgresVersionSelection: undefined,
     dbRegion: null,
+    instanceSize: null,
   })
 
   const handleHighAvailabilityChange = (checked: boolean) => {
@@ -75,6 +78,23 @@ export const HighAvailabilityInput = ({
       }
     }
   }
+
+  // instanceSize can't be set in the toggle handler like the fields above: the compute size
+  // Select's options swap in the same render, and Radix clears a value assigned in the same
+  // tick its option mounts (the hidden native select's options update one render later).
+  // Setting it from an effect runs after the option list has rendered.
+  useEffect(() => {
+    if (highAvailability) {
+      const currentInstanceSize = getValues('instanceSize')
+      if (currentInstanceSize !== HIGH_AVAILABILITY_INSTANCE_SIZE) {
+        beforeHighAvailability.current.instanceSize = currentInstanceSize ?? null
+        setValue('instanceSize', HIGH_AVAILABILITY_INSTANCE_SIZE)
+      }
+    } else if (beforeHighAvailability.current.instanceSize !== null) {
+      setValue('instanceSize', beforeHighAvailability.current.instanceSize)
+      beforeHighAvailability.current.instanceSize = null
+    }
+  }, [highAvailability, getValues, setValue])
 
   // Catches the case where highAvailabilityRegionName wasn't loaded yet at the moment the
   // toggle fired above (the org's available-regions query for AWS_K8S may still be in

--- a/apps/studio/components/interfaces/ProjectCreation/HighAvailabilityInput.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/HighAvailabilityInput.tsx
@@ -58,6 +58,12 @@ export const HighAvailabilityInput = ({
         beforeHighAvailability.current.dbRegion = currentRegion ?? null
         setValue('dbRegion', highAvailabilityRegionName)
       }
+
+      const currentInstanceSize = getValues('instanceSize')
+      if (currentInstanceSize !== HIGH_AVAILABILITY_INSTANCE_SIZE) {
+        beforeHighAvailability.current.instanceSize = currentInstanceSize ?? null
+        setValue('instanceSize', HIGH_AVAILABILITY_INSTANCE_SIZE)
+      }
     } else {
       if (beforeHighAvailability.current.cloudProvider !== undefined) {
         setValue('cloudProvider', beforeHighAvailability.current.cloudProvider)
@@ -76,25 +82,13 @@ export const HighAvailabilityInput = ({
         setValue('dbRegion', beforeHighAvailability.current.dbRegion)
         beforeHighAvailability.current.dbRegion = null
       }
+
+      if (beforeHighAvailability.current.instanceSize !== null) {
+        setValue('instanceSize', beforeHighAvailability.current.instanceSize)
+        beforeHighAvailability.current.instanceSize = null
+      }
     }
   }
-
-  // instanceSize can't be set in the toggle handler like the fields above: the compute size
-  // Select's options swap in the same render, and Radix clears a value assigned in the same
-  // tick its option mounts (the hidden native select's options update one render later).
-  // Setting it from an effect runs after the option list has rendered.
-  useEffect(() => {
-    if (highAvailability) {
-      const currentInstanceSize = getValues('instanceSize')
-      if (currentInstanceSize !== HIGH_AVAILABILITY_INSTANCE_SIZE) {
-        beforeHighAvailability.current.instanceSize = currentInstanceSize ?? null
-        setValue('instanceSize', HIGH_AVAILABILITY_INSTANCE_SIZE)
-      }
-    } else if (beforeHighAvailability.current.instanceSize !== null) {
-      setValue('instanceSize', beforeHighAvailability.current.instanceSize)
-      beforeHighAvailability.current.instanceSize = null
-    }
-  }, [highAvailability, getValues, setValue])
 
   // Catches the case where highAvailabilityRegionName wasn't loaded yet at the moment the
   // toggle fired above (the org's available-regions query for AWS_K8S may still be in

--- a/apps/studio/components/interfaces/ProjectCreation/ProjectCreation.constants.ts
+++ b/apps/studio/components/interfaces/ProjectCreation/ProjectCreation.constants.ts
@@ -6,6 +6,7 @@ import type {
 
 export const HIGH_AVAILABILITY_POSTGRES_ENGINE = '17' satisfies PostgresEngine
 export const HIGH_AVAILABILITY_RELEASE_CHANNEL = 'ga' satisfies ReleaseChannel
+export const HIGH_AVAILABILITY_INSTANCE_SIZE: DesiredInstanceSize = 'large'
 
 // [Joshen] Obtained from https://gist.github.com/tadast/8827699
 export const COUNTRY_LAT_LON = {

--- a/apps/studio/components/interfaces/ProjectCreation/ProjectCreation.utils.test.ts
+++ b/apps/studio/components/interfaces/ProjectCreation/ProjectCreation.utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  HIGH_AVAILABILITY_INSTANCE_SIZE,
   HIGH_AVAILABILITY_POSTGRES_ENGINE,
   HIGH_AVAILABILITY_RELEASE_CHANNEL,
 } from './ProjectCreation.constants'
@@ -10,9 +11,10 @@ import {
 } from './ProjectCreation.utils'
 
 describe('High Availability project creation constraints', () => {
-  it('pins the Alpha Postgres engine and release channel', () => {
+  it('pins the Alpha Postgres engine, release channel, and compute size', () => {
     expect(HIGH_AVAILABILITY_POSTGRES_ENGINE).toBe('17')
     expect(HIGH_AVAILABILITY_RELEASE_CHANNEL).toBe('ga')
+    expect(HIGH_AVAILABILITY_INSTANCE_SIZE).toBe('large')
   })
 
   it.each([

--- a/apps/studio/components/interfaces/ProjectCreation/ProjectCreationForm.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/ProjectCreationForm.tsx
@@ -371,7 +371,14 @@ export const ProjectCreationForm = ({
       values.instanceSize &&
       !sizesWithNoCostConfirmationRequired.includes(values.instanceSize as DesiredInstanceSize)
 
-    if (additionalMonthlySpend > 0 && (hasOAuthApps || launchingLargerInstance)) {
+    // High availability projects are free during Alpha, so the forced large compute
+    // doesn't incur the usual compute costs.
+    const requiresCostConfirmation =
+      !values.highAvailability &&
+      additionalMonthlySpend > 0 &&
+      (hasOAuthApps || launchingLargerInstance)
+
+    if (requiresCostConfirmation) {
       track('project_creation_simple_version_confirm_modal_opened', {
         instanceSize: values.instanceSize,
       })

--- a/apps/studio/components/interfaces/ProjectCreation/RegionSelector.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/RegionSelector.tsx
@@ -231,7 +231,14 @@ export const RegionSelector = ({
                 }
               >
                 <FormControl>
-                  <Select value={dbRegion} onValueChange={field.onChange} disabled={isLoading}>
+                  {/* Radix fires onValueChange('') when the value and the option list change
+                      in the same tick (its hidden native select briefly holds stale options).
+                      No item here has an empty value, so an empty change is always spurious. */}
+                  <Select
+                    value={dbRegion}
+                    onValueChange={(value) => value !== '' && field.onChange(value)}
+                    disabled={isLoading}
+                  >
                     <SelectTrigger
                       id="region"
                       className="[&>:nth-child(1)]:w-full [&>:nth-child(1)]:flex [&>:nth-child(1)]:items-start"

--- a/apps/studio/components/interfaces/ProjectCreation/RegionSelector.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/RegionSelector.tsx
@@ -231,9 +231,6 @@ export const RegionSelector = ({
                 }
               >
                 <FormControl>
-                  {/* Radix fires onValueChange('') when the value and the option list change
-                      in the same tick (its hidden native select briefly holds stale options).
-                      No item here has an empty value, so an empty change is always spurious. */}
                   <Select
                     value={dbRegion}
                     onValueChange={(value) => value !== '' && field.onChange(value)}


### PR DESCRIPTION
When the High availability (Multigres) toggle is enabled in the New Project form, the Compute size dropdown now offers only **Large** and the form value is forced to `large`. Previously HA projects showed the same micro/small/medium options as regular projects.

**Added:**
- `HIGH_AVAILABILITY_INSTANCE_SIZE` constant (`'large'`) alongside the other `HIGH_AVAILABILITY_*` constants

**Changed:**
- `ComputeSizeSelector` watches `highAvailability` and renders only Large when it's on (hiding the "Larger instance sizes available after creation" row); the `cloudProvider` read is now a reactive `useWatch` instead of a render-time `getValues()`, so the list re-filters when HA forces the provider to `AWS_K8S`
- `HighAvailabilityInput` forces `instanceSize` to `large` when HA toggles on and restores the previously selected size when it toggles off, alongside the existing `dbRegion`/`cloudProvider` handling
- The compute size and region selects ignore Radix's spurious `onValueChange('')` — Radix emits it when a select's value and option list change in the same tick, which wiped the forced value (details in the inline comments)
- HA projects skip the "Confirm compute costs" modal on submit — HA is free during Alpha, so the forced large size shouldn't trigger the $110/mo confirmation

## To test

- On a paid org, open the New Project form: with HA off, the Compute size dropdown shows micro/small/medium plus the disabled "Larger instance sizes available after creation" row
- Toggle High availability on: the dropdown shows only Large, the trigger reads "large / 8 GB RAM / 2-core CPU" (not the placeholder), the region locks as before, and the footer shows $110/m
- Check the network tab: the `available-regions` request goes out with `desired_instance_size=large` and returns 200 (no request with an empty `desired_instance_size`)
- Select medium first, toggle HA on then off: medium is restored (same for other sizes); rapid toggling shouldn't leave the field blank
- With HA on, submitting goes straight through without the "Confirm compute costs" modal; a non-HA medium project still shows it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * High-availability projects now automatically use the required dedicated instance size.
  * Disabling high availability restores the previously selected instance size.
  * Compute size options are filtered based on cloud provider and high-availability settings.

* **Bug Fixes**
  * Prevented accidental clearing of compute size or region selections during option updates.
  * Compute-cost confirmation is no longer required for high-availability projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->