### PR TITLE
Add delete chat functionality to explorer chats

### DIFF
--- a/apps/studio/components/interfaces/Explorer/ExplorerChatToolbar.tsx
+++ b/apps/studio/components/interfaces/Explorer/ExplorerChatToolbar.tsx
@@ -1,4 +1,4 @@
-import { Clipboard, MessageSquare, MoreVertical, Settings } from 'lucide-react'
+import { Clipboard, MessageSquare, MoreVertical, Settings, Trash } from 'lucide-react'
 import { useState } from 'react'
 import { toast } from 'sonner'
 import {
@@ -9,6 +9,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from 'ui'
+import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 
 import {
   ExplorerToolbar,
@@ -41,6 +42,7 @@ export const ExplorerChatToolbar = ({
   const snap = useAiAssistantStateSnapshot()
   const chat = snap.chats[chatId]
   const [isOptInModalOpen, setIsOptInModalOpen] = useState(false)
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
 
   const handleCopyChatId = () => {
     copyToClipboard(chatId, () => toast.success(`Copied chat ID for ${chat?.name}`))
@@ -48,6 +50,12 @@ export const ExplorerChatToolbar = ({
 
   const handleSaveName = (name: string) => {
     if (name.trim()) snap.renameChat(chatId, name.trim())
+  }
+
+  const handleDeleteChat = () => {
+    snap.deleteChat(chatId)
+    setIsDeleteModalOpen(false)
+    toast.success(`Deleted "${chat?.name}"`)
   }
 
   useShortcut(SHORTCUT_IDS.AI_ASSISTANT_COPY_CHAT_ID, handleCopyChatId, {
@@ -83,7 +91,6 @@ export const ExplorerChatToolbar = ({
                   sequence={SHORTCUT_DEFINITIONS[SHORTCUT_IDS.AI_ASSISTANT_COPY_CHAT_ID].sequence}
                 />
               </DropdownMenuItem>
-              <DropdownMenuSeparator />
               <DropdownMenuItem
                 className="justify-between"
                 onClick={() => setIsOptInModalOpen(true)}
@@ -98,10 +105,16 @@ export const ExplorerChatToolbar = ({
                   }
                 />
               </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem className="gap-x-2" onClick={() => setIsDeleteModalOpen(true)}>
+                <Trash size={14} />
+                <span>Delete chat</span>
+              </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
         </ExplorerToolbarActions>
       </ExplorerToolbar>
+
       <AIAssistantMetadataWarning
         visible={isOptInModalOpen}
         onVisibleChange={setIsOptInModalOpen}
@@ -110,6 +123,20 @@ export const ExplorerChatToolbar = ({
         isHipaaProjectDisallowed={isHipaaProjectDisallowed}
         aiOptInLevel={aiOptInLevel}
       />
+
+      <ConfirmationModal
+        variant="destructive"
+        visible={isDeleteModalOpen}
+        title={`Delete "${chat?.name}"?`}
+        confirmLabel="Delete chat"
+        onCancel={() => setIsDeleteModalOpen(false)}
+        onConfirm={handleDeleteChat}
+      >
+        <p className="text-sm text-foreground-light">
+          This will permanently delete this chat and its message history. This action cannot be
+          undone.
+        </p>
+      </ConfirmationModal>
     </div>
   )
 }


### PR DESCRIPTION
## Context

Just realised that chats in the new Explorer UI have no delete functionality so this patches it
<img width="296" height="184" alt="image" src="https://github.com/user-attachments/assets/90a79b6b-55a8-4122-8cd8-05fc13e9f4a5" />

Also added a confirmation modal for deletion
<img width="473" height="266" alt="image" src="https://github.com/user-attachments/assets/56a1e400-2a1c-48b7-b6b8-0104af49b1a9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to delete Explorer chats from the chat toolbar.
  - Added a confirmation prompt before permanently deleting chat history.
  - Added success feedback after deletion is completed.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->