### PR TITLE
fix(table-editor): correct json export escaping and identity sequence casing

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/TableEntity.utils.test.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/TableEntity.utils.test.ts
@@ -89,6 +89,46 @@ describe('TableEntity.utils: formatTableRowsToSQL', () => {
     expect(result).toBe(expected)
   })
 
+  it('should preserve embedded double quotes in json/jsonb values', () => {
+    const table: SupaTable = {
+      id: 1,
+      type: ENTITY_TYPE.TABLE,
+      columns: [
+        { name: 'id', dataType: 'bigint', format: 'int8', position: 0 },
+        { name: 'metadata', dataType: 'jsonb', format: 'jsonb', position: 1 },
+      ],
+      name: 'demo',
+      schema: 'public',
+      comment: undefined,
+      estimateRowCount: 1,
+    }
+    const rows = [{ id: 1, metadata: '{"note": "say \\"hi\\""}' }]
+
+    const result = formatTableRowsToSQL(table, rows)
+    const expected = `INSERT INTO "public"."demo" ("id", "metadata") VALUES (1, '{"note": "say \\"hi\\""}');`
+    expect(result).toBe(expected)
+  })
+
+  it('should not double backslashes in json/jsonb values', () => {
+    const table: SupaTable = {
+      id: 1,
+      type: ENTITY_TYPE.TABLE,
+      columns: [
+        { name: 'id', dataType: 'bigint', format: 'int8', position: 0 },
+        { name: 'metadata', dataType: 'jsonb', format: 'jsonb', position: 1 },
+      ],
+      name: 'demo',
+      schema: 'public',
+      comment: undefined,
+      estimateRowCount: 1,
+    }
+    const rows = [{ id: 1, metadata: '{"path": "C:\\\\Users\\\\me"}' }]
+
+    const result = formatTableRowsToSQL(table, rows)
+    const expected = `INSERT INTO "public"."demo" ("id", "metadata") VALUES (1, '{"path": "C:\\\\Users\\\\me"}');`
+    expect(result).toBe(expected)
+  })
+
   it('should emit valid Postgres literals for booleans, numbers and text arrays', () => {
     const table: SupaTable = {
       id: 1,

--- a/apps/studio/components/interfaces/TableGridEditor/TableEntity.utils.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/TableEntity.utils.ts
@@ -58,7 +58,8 @@ export const formatTableRowsToSQL = (table: SupaTable, rows: any[]) => {
           const array = Array.isArray(val) ? val : JSON.parse(val as string)
           return `${formatArrayForSql(array as unknown[])}`
         } else if (format?.includes('json')) {
-          return `${JSON.stringify(val).replace(/\\"/g, '"').replace(/'/g, "''").replace('"', "'").replace(/.$/, "'")}`
+          const jsonText = typeof val === 'string' ? val : JSON.stringify(val)
+          return `'${jsonText.replaceAll("'", "''")}'`
         } else if (
           typeof format === 'string' &&
           typeof val === 'string' &&

--- a/packages/pg-meta/src/sql/studio/table-editor/identity.ts
+++ b/packages/pg-meta/src/sql/studio/table-editor/identity.ts
@@ -10,7 +10,7 @@ export const getUpdateIdentitySequenceSQL = ({
   column: string
 }): SafeSqlFragment => {
   return safeSql`WITH sequence_reference AS (
-  SELECT pg_get_serial_sequence(${literal(`${schema}.${table}`)}, ${literal(column)}) AS sequence_name
+  SELECT pg_get_serial_sequence(${literal(`${ident(schema)}.${ident(table)}`)}, ${literal(column)}) AS sequence_name
 )
 SELECT setval(
   sequence_reference.sequence_name,

--- a/packages/pg-meta/test/sql/studio/identity.test.ts
+++ b/packages/pg-meta/test/sql/studio/identity.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from 'vitest'
+
+import { getUpdateIdentitySequenceSQL } from '../../../src'
+
+test('quotes schema and table for pg_get_serial_sequence so uppercase names resolve', () => {
+  const sql = getUpdateIdentitySequenceSQL({ schema: 'App', table: 'Users', column: 'Id' })
+
+  expect(sql).toContain(`pg_get_serial_sequence('"App"."Users"', 'Id')`)
+})
+
+test('leaves lowercase identifiers unquoted, matching the FROM clause below it', () => {
+  const sql = getUpdateIdentitySequenceSQL({ schema: 'public', table: 'people', column: 'id' })
+
+  expect(sql).toContain(`pg_get_serial_sequence('public.people', 'id')`)
+  expect(sql).toContain('FROM public.people')
+})


### PR DESCRIPTION
## Summary
- `formatTableRowsToSQL` re-`JSON.stringify`'d json/jsonb values that were already JSON text, then hacked the escaping back with regex replaces. This produced invalid SQL for values containing embedded quotes and silently doubled backslashes on reimport. It now escapes the JSON text for the SQL literal directly (single-quote doubling only), matching how the text/varchar branch already works.
- `getUpdateIdentitySequenceSQL` built the `pg_get_serial_sequence()` argument as an unquoted `schema.table` string. Postgres case-folds unquoted identifiers, so tables/schemas with uppercase names (e.g. `"App"."Users"`, common when coming from Prisma/TypeORM) failed to resolve, leaving the sequence unraised after import and causing duplicate-key errors on the next insert. Both parts are now quoted with `ident()`, matching the sibling `getDuplicateIdentitySequenceSQL`.

Fixes #49196
Fixes #49190

## Test plan
- [x] `packages/pg-meta/test/sql/studio/identity.test.ts` (new) — asserts uppercase schema/table names are quoted in the `pg_get_serial_sequence` argument, and lowercase names stay unquoted
- [x] `apps/studio/components/interfaces/TableGridEditor/TableEntity.utils.test.ts` — added regression tests for embedded double quotes and backslashes in json/jsonb export; full file passes (13/13)
- [x] `pnpm --filter @supabase/pg-meta typecheck` clean
- [x] Studio typecheck clean (no new errors from these files)
- [x] `eslint` on changed Studio files — no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of JSON and JSONB values containing double quotes and Windows-style backslashes when editing table data.
  * Fixed identity sequence updates for tables and schemas with uppercase names.
  * Preserved correct behavior for lowercase table and schema identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->