### PR TITLE
fix(realtime): add pg changes pool to realtime settings

### DIFF
--- a/apps/docs/content/guides/realtime/settings.mdx
+++ b/apps/docs/content/guides/realtime/settings.mdx
@@ -49,7 +49,7 @@ See [Database connections](/docs/guides/realtime/concepts#database-connections) 
 
 ### Postgres Changes connection pool size
 
-Determines the number of connections used to create [Postgres Changes](/docs/guides/realtime/postgres-changes) subscriptions when clients subscribe. It's only used while subscriptions are created; streaming the changes uses a separate connection.
+Determines the number of connections used to create [Postgres Changes](/docs/guides/realtime/postgres-changes) subscriptions when clients subscribe. It's only used while subscriptions are created; streaming the changes uses a separate connection. The default is 2 connections.
 
 - **Too low**: subscription creation times out during bursts. Clients receive a `postgres_changes` system error with `Too many database timeouts` and retry after 5 to 10 seconds.
 - **Too high**: it counts toward the same connection budget as every other Realtime pool. The maximum is 20.

--- a/apps/docs/content/guides/realtime/settings.mdx
+++ b/apps/docs/content/guides/realtime/settings.mdx
@@ -27,18 +27,25 @@ You can set the following settings using the Realtime Settings screen in your Da
 
 ### Enable Realtime service
 
+**Type:** Toggle · **Options:** Enabled, Disabled · **Default:** Enabled
+
 Determines if the Realtime service is enabled or disabled for your project.
 
-**If you disable it**, connected clients are disconnected, new connections are rejected with `403` and `Realtime was disabled for this tenant`, joins receive `RealtimeDisabledForTenant`, and Broadcast REST requests are rejected with `403`. Realtime also releases the database connections and Postgres Changes replication slot it holds for your project, and reopens them on the first connection after you enable it again.
+- **Enabled**: normal operation.
+- **Disabled**: connected clients are disconnected, new connections are rejected with `403` and `Realtime was disabled for this tenant`, joins receive `RealtimeDisabledForTenant`, and Broadcast REST requests are rejected with `403`. Realtime also releases the database connections and Postgres Changes replication slot it holds for your project, and reopens them on the first connection after you enable it again.
 
 ### Allow public access to channels
 
-You can toggle this setting to set Realtime to allow public channels or set it to use only private channels with [Realtime Authorization](/docs/guides/realtime/authorization).
+**Type:** Toggle · **Options:** Enabled, Disabled · **Default:** Enabled
 
-- **Private only**: every join is checked against the Row Level Security policies on `realtime.messages`, so each join costs one authorization query. Clients that don't set `config.private` to `true` are rejected with `PrivateOnly`. With no policies, clients connect but receive no messages.
-- **Public allowed**: no policy check runs, but anyone holding your project's anon key can subscribe to and broadcast on any public channel.
+Determines whether Realtime allows public channels, or restricts your project to private channels with [Realtime Authorization](/docs/guides/realtime/authorization).
+
+- **Enabled**: no policy check runs, but anyone holding your project's anon key can subscribe to and broadcast on any public channel.
+- **Disabled**: every join is checked against the Row Level Security policies on `realtime.messages`, so each join costs one authorization query. Clients that don't set `config.private` to `true` are rejected with `PrivateOnly`. With no policies, clients connect but receive no messages.
 
 ### Database connection pool size
+
+**Type:** Number of connections · **Range:** 1 to your database's `max_connections` · **Default:** varies by compute size
 
 Determines the number of connections used for Realtime Authorization RLS checking. Results are cached per client, so the pool is used on each private channel join, each `access_token` refresh, and each private Broadcast REST request.
 
@@ -49,16 +56,20 @@ See [Database connections](/docs/guides/realtime/concepts#database-connections) 
 
 ### Postgres Changes connection pool size
 
-Determines the number of connections used to create [Postgres Changes](/docs/guides/realtime/postgres-changes) subscriptions when clients subscribe. It's only used while subscriptions are created; streaming the changes uses a separate connection. The default is 2 connections.
+**Type:** Number of connections · **Range:** 1 to 20 · **Default:** 2
+
+Determines the number of connections used to create [Postgres Changes](/docs/guides/realtime/postgres-changes) subscriptions when clients subscribe. It's only used while subscriptions are created; streaming the changes uses a separate connection.
 
 - **Too low**: subscription creation times out during bursts. Clients receive a `postgres_changes` system error with `Too many database timeouts` and retry after 5 to 10 seconds.
-- **Too high**: it counts toward the same connection budget as every other Realtime pool. The maximum is 20.
+- **Too high**: it counts toward the same connection budget as every other Realtime pool.
 
 Raise this value if many clients subscribe at the same time, such as after a deploy or a mass reconnect.
 
 {/* supa-mdx-lint-disable-next-line Rule004ExcludeWords */}
 
 ### Max concurrent clients
+
+**Type:** Number of clients · **Range:** 1 to your plan's [concurrent connections](/docs/guides/realtime/limits#limits-by-plan) limit · **Default:** your plan's limit
 
 Determines the maximum number of clients that can be connected. A client is one WebSocket connection, no matter how many channels it joins.
 
@@ -67,12 +78,16 @@ Determines the maximum number of clients that can be connected. A client is one 
 
 ### Max events per second
 
+**Type:** Number of events per second · **Range:** 1 to your plan's [messages per second](/docs/guides/realtime/limits#limits-by-plan) limit · **Default:** your plan's limit
+
 Determines the maximum number of events per second that can be sent, measured as a rolling average over the previous minute. An event is a message sent by a client or delivered to one, so one broadcast to 100 subscribers counts as 100 events.
 
 - **Too low**: channels that exceed the average are closed with `Too many messages per second`, which `supabase-js` recovers from by rejoining. Broadcast REST requests are rejected with `429`; those responses carry `x-rate-limit` and `x-rate-limit-remaining` headers you can use to slow down first.
 - **Too high**: Realtime stops throttling broadcast fan-out, which removes the protection against a runaway loop or a mass reconnect, and raises the ceiling on your Realtime spend.
 
 ### Max presence events per second
+
+**Type:** Number of events per second · **Range:** 1 to your plan's [presence messages per second](/docs/guides/realtime/limits#limits-by-plan) limit · **Default:** your plan's limit
 
 Determines the maximum number of presence events per second that can be sent, using the same rolling average as [Max events per second](#max-events-per-second) but checked before the event is sent rather than after delivery.
 
@@ -86,6 +101,8 @@ A separate per-client limit also applies to presence, independent of this projec
 </Admonition>
 
 ### Max payload size in KB
+
+**Type:** Size in KB · **Range:** 1 to your plan's [broadcast payload size](/docs/guides/realtime/limits#limits-by-plan) limit · **Default:** your plan's limit
 
 Determines the maximum payload size in KB that can be sent.
 

--- a/apps/docs/content/guides/realtime/settings.mdx
+++ b/apps/docs/content/guides/realtime/settings.mdx
@@ -23,13 +23,71 @@ width={4600}
 height={2600}
 />
 
-You can set the following settings using the Realtime Settings screen in your Dashboard:
+You can set the following settings using the Realtime Settings screen in your Dashboard. For the ceilings your plan allows, see [Realtime Limits](/docs/guides/realtime/limits); the rate and payload limits are only editable while your organization's spend cap is disabled. For the errors below, see [Operational Error Codes](/docs/guides/realtime/error_codes).
 
-- Enable Realtime service: Determines if the Realtime service is enabled or disabled for your project.
-- Channel Restrictions: You can toggle this settings to set Realtime to allow public channels or set it to use only private channels with [Realtime Authorization](/docs/guides/realtime/authorization).
-- Database connection pool size: Determines the number of connections used for Realtime Authorization RLS checking
-  {/* supa-mdx-lint-disable-next-line Rule004ExcludeWords */}
-- Max concurrent clients: Determines the maximum number of clients that can be connected
-- Max events per second: Determines the maximum number of events per second that can be sent
-- Max presence events per second: Determines the maximum number of presence events per second that can be sent
-- Max payload size in KB: Determines the maximum number of payload size in KB that can be sent
+### Enable Realtime service
+
+Determines if the Realtime service is enabled or disabled for your project.
+
+**If you disable it**, connected clients are disconnected, new connections are rejected with `403` and `Realtime was disabled for this tenant`, joins receive `RealtimeDisabledForTenant`, and Broadcast REST requests are rejected with `403`. Realtime also releases the database connections and Postgres Changes replication slot it holds for your project, and reopens them on the first connection after you enable it again.
+
+### Allow public access to channels
+
+You can toggle this setting to set Realtime to allow public channels or set it to use only private channels with [Realtime Authorization](/docs/guides/realtime/authorization).
+
+- **Private only**: every join is checked against the Row Level Security policies on `realtime.messages`, so each join costs one authorization query. Clients that don't set `config.private` to `true` are rejected with `PrivateOnly`. With no policies, clients connect but receive no messages.
+- **Public allowed**: no policy check runs, but anyone holding your project's anon key can subscribe to and broadcast on any public channel.
+
+### Database connection pool size
+
+Determines the number of connections used for Realtime Authorization RLS checking. Results are cached per client, so the pool is used on each private channel join, each `access_token` refresh, and each private Broadcast REST request.
+
+- **Too low**: checks queue and time out. Clients receive `IncreaseConnectionPool`, broadcasts are dropped, and presence calls fail. Once timeouts in a 30-second window reach the pool size, later checks fail immediately without reaching the database.
+- **Too high**: the pool competes with your application for your database's `max_connections`. If Realtime's total requirement doesn't fit, it refuses to start with `DatabaseLackOfConnections`.
+
+See [Database connections](/docs/guides/realtime/concepts#database-connections) for the defaults per compute size.
+
+### Postgres Changes connection pool size
+
+Determines the number of connections used to create [Postgres Changes](/docs/guides/realtime/postgres-changes) subscriptions when clients subscribe. It's only used while subscriptions are created; streaming the changes uses a separate connection.
+
+- **Too low**: subscription creation times out during bursts. Clients receive a `postgres_changes` system error with `Too many database timeouts` and retry after 5 to 10 seconds.
+- **Too high**: it counts toward the same connection budget as every other Realtime pool. The maximum is 20.
+
+Raise this value if many clients subscribe at the same time, such as after a deploy or a mass reconnect.
+
+{/* supa-mdx-lint-disable-next-line Rule004ExcludeWords */}
+
+### Max concurrent clients
+
+Determines the maximum number of clients that can be connected. A client is one WebSocket connection, no matter how many channels it joins.
+
+- **Too low**: new connections are rejected with `429` and `Too many connected users`. Existing clients are unaffected.
+- **Too high**: each connection consumes memory on the Realtime nodes, so this setting acts as a capacity and cost control.
+
+### Max events per second
+
+Determines the maximum number of events per second that can be sent, measured as a rolling average over the previous minute. An event is a message sent by a client or delivered to one, so one broadcast to 100 subscribers counts as 100 events.
+
+- **Too low**: channels that exceed the average are closed with `Too many messages per second`, which `supabase-js` recovers from by rejoining. Broadcast REST requests are rejected with `429`; those responses carry `x-rate-limit` and `x-rate-limit-remaining` headers you can use to slow down first.
+- **Too high**: Realtime stops throttling broadcast fan-out, which removes the protection against a runaway loop or a mass reconnect, and raises the ceiling on your Realtime spend.
+
+### Max presence events per second
+
+Determines the maximum number of presence events per second that can be sent, using the same rolling average as [Max events per second](#max-events-per-second) but checked before the event is sent rather than after delivery.
+
+- **Too low**: presence tracking and syncing fail and the channel is closed with `Too many presence messages per second`.
+- **Too high**: rapid `track` and `untrack` cycles can generate presence storms, because each change is broadcast to every client on the channel and also counts toward [Max events per second](#max-events-per-second).
+
+<Admonition type="note">
+
+A separate per-client limit also applies to presence, independent of this project-wide setting. A client that exceeds it is closed with `Client presence rate limit exceeded`. See [Realtime Limits](/docs/guides/realtime/limits) for the value on your plan.
+
+</Admonition>
+
+### Max payload size in KB
+
+Determines the maximum payload size in KB that can be sent.
+
+- **Too low**: oversized broadcasts are dropped, and the sender only learns about it if it set `ack_broadcast` to `true`. Broadcast REST requests are rejected with `422`, and an oversized presence `track` closes the channel with `Track message size exceeded`.
+- **Too high**: large messages increase memory and bandwidth usage on every subscriber, since each message is delivered to all clients on the channel. Postgres Changes payloads have a [separate limit](/docs/guides/realtime/limits#postgres-changes-payload-limit).

--- a/apps/studio/components/interfaces/Realtime/RealtimeSettings.test.tsx
+++ b/apps/studio/components/interfaces/Realtime/RealtimeSettings.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import type { components } from 'api-types'
 import { mockAnimationsApi } from 'jsdom-testing-mocks'
 import { HttpResponse } from 'msw'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
@@ -121,7 +122,10 @@ describe('RealtimeSettings', () => {
     addAPIMock({
       method: 'get',
       path: '/platform/projects/:ref/config/realtime',
-      response: () => HttpResponse.json(configWithoutPool),
+      response: () =>
+        HttpResponse.json<components['schemas']['RealtimeConfigResponse']>(
+          configWithoutPool as any
+        ),
     })
 
     customRender(<RealtimeSettings />)

--- a/apps/studio/components/interfaces/Realtime/RealtimeSettings.test.tsx
+++ b/apps/studio/components/interfaces/Realtime/RealtimeSettings.test.tsx
@@ -8,7 +8,7 @@ import { z } from 'zod'
 
 import { RealtimeSettings } from './RealtimeSettings'
 import type { Entitlement, FeatureKey } from '@/data/entitlements/entitlements-query'
-import type { RealtimeConfiguration } from '@/data/realtime/realtime-config-query'
+import type { RealtimeConfigurationData } from '@/data/realtime/realtime-config-query'
 import { customRender } from '@/tests/lib/custom-render'
 import { addAPIMock } from '@/tests/lib/msw'
 
@@ -53,7 +53,7 @@ vi.mock('@/lib/constants', async (importOriginal) => {
   return { ...actual, IS_PLATFORM: true }
 })
 
-const REALTIME_CONFIG: RealtimeConfiguration = {
+const REALTIME_CONFIG = {
   connection_pool: 2,
   postgres_changes_pool: 2,
   max_bytes_per_second: 100000,
@@ -66,7 +66,7 @@ const REALTIME_CONFIG: RealtimeConfiguration = {
   presence_enabled: true,
   private_only: false,
   suspend: false,
-}
+} as const satisfies RealtimeConfigurationData
 
 const REALTIME_ENTITLEMENTS: Entitlement[] = (
   [
@@ -100,7 +100,7 @@ describe('RealtimeSettings', () => {
     addAPIMock({
       method: 'get',
       path: '/platform/projects/:ref/config/realtime',
-      response: () => HttpResponse.json<RealtimeConfiguration>(REALTIME_CONFIG),
+      response: () => HttpResponse.json<RealtimeConfigurationData>(REALTIME_CONFIG),
     })
 
     addAPIMock({

--- a/apps/studio/components/interfaces/Realtime/RealtimeSettings.test.tsx
+++ b/apps/studio/components/interfaces/Realtime/RealtimeSettings.test.tsx
@@ -1,0 +1,147 @@
+import { fireEvent, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { mockAnimationsApi } from 'jsdom-testing-mocks'
+import { HttpResponse } from 'msw'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { z } from 'zod'
+
+import { RealtimeSettings } from './RealtimeSettings'
+import type { Entitlement, FeatureKey } from '@/data/entitlements/entitlements-query'
+import type { RealtimeConfiguration } from '@/data/realtime/realtime-config-query'
+import { customRender } from '@/tests/lib/custom-render'
+import { addAPIMock } from '@/tests/lib/msw'
+
+mockAnimationsApi()
+
+const {
+  mockUseAsyncCheckPermissions,
+  mockUseMaxConnectionsQuery,
+  mockUseSelectedOrganizationQuery,
+  mockUseSelectedProjectQuery,
+  mockUseDatabasePoliciesQuery,
+} = vi.hoisted(() => ({
+  mockUseAsyncCheckPermissions: vi.fn(),
+  mockUseMaxConnectionsQuery: vi.fn(),
+  mockUseSelectedOrganizationQuery: vi.fn(),
+  mockUseSelectedProjectQuery: vi.fn(),
+  mockUseDatabasePoliciesQuery: vi.fn(),
+}))
+
+vi.mock('@/hooks/misc/useCheckPermissions', () => ({
+  useAsyncCheckPermissions: mockUseAsyncCheckPermissions,
+}))
+
+vi.mock('@/hooks/misc/useSelectedProject', () => ({
+  useSelectedProjectQuery: mockUseSelectedProjectQuery,
+}))
+
+vi.mock('@/hooks/misc/useSelectedOrganization', () => ({
+  useSelectedOrganizationQuery: mockUseSelectedOrganizationQuery,
+}))
+
+vi.mock('@/data/database/max-connections-query', () => ({
+  useMaxConnectionsQuery: mockUseMaxConnectionsQuery,
+}))
+
+vi.mock('@/data/database-policies/database-policies-query', () => ({
+  useDatabasePoliciesQuery: mockUseDatabasePoliciesQuery,
+}))
+
+vi.mock('@/lib/constants', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return { ...actual, IS_PLATFORM: true }
+})
+
+const REALTIME_CONFIG: RealtimeConfiguration = {
+  connection_pool: 2,
+  postgres_changes_pool: 2,
+  max_bytes_per_second: 100000,
+  max_channels_per_client: 100,
+  max_concurrent_users: 200,
+  max_events_per_second: 100,
+  max_joins_per_second: 100,
+  max_payload_size_in_kb: 100,
+  max_presence_events_per_second: 100,
+  presence_enabled: true,
+  private_only: false,
+  suspend: false,
+}
+
+const REALTIME_ENTITLEMENTS: Entitlement[] = (
+  [
+    ['realtime.max_concurrent_users', 50_000],
+    ['realtime.max_events_per_second', 50_000],
+    ['realtime.max_presence_events_per_second', 5_000],
+    ['realtime.max_payload_size_in_kb', 3_000],
+  ] satisfies [FeatureKey, number][]
+).map(([key, value]) => ({
+  config: { enabled: true, unit: '', unlimited: false, value },
+  feature: { key, type: 'numeric' },
+  hasAccess: true,
+  type: 'numeric',
+}))
+
+describe('RealtimeSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockUseAsyncCheckPermissions.mockReturnValue({ can: true, isSuccess: true })
+    mockUseSelectedProjectQuery.mockReturnValue({
+      data: { ref: 'default', connectionString: 'postgresql://example' },
+    })
+    mockUseSelectedOrganizationQuery.mockReturnValue({
+      data: { slug: 'default', plan: { id: 'pro' }, usage_billing_enabled: true },
+      isSuccess: true,
+    })
+    mockUseMaxConnectionsQuery.mockReturnValue({ data: { maxConnections: 20 } })
+    mockUseDatabasePoliciesQuery.mockReturnValue({ data: [], isSuccess: true })
+
+    addAPIMock({
+      method: 'get',
+      path: '/platform/projects/:ref/config/realtime',
+      response: () => HttpResponse.json<RealtimeConfiguration>(REALTIME_CONFIG),
+    })
+
+    addAPIMock({
+      method: 'get',
+      path: '/platform/organizations/:slug/entitlements',
+      response: { entitlements: REALTIME_ENTITLEMENTS },
+    })
+  })
+
+  test('renders the fetched postgres changes pool value', async () => {
+    customRender(<RealtimeSettings />)
+
+    expect(await screen.findByLabelText('Postgres Changes connection pool size')).toHaveValue(2)
+  })
+
+  test('submits the postgres changes pool value when saving', async () => {
+    const updateBodySchema = z.object({ postgres_changes_pool: z.number() })
+
+    const requests: z.infer<typeof updateBodySchema>[] = []
+    addAPIMock({
+      method: 'patch',
+      path: '/platform/projects/:ref/config/realtime',
+      response: async ({ request }) => {
+        requests.push(updateBodySchema.parse(await request.json()))
+        return new HttpResponse(null, { status: 204 })
+      },
+    })
+
+    customRender(<RealtimeSettings />)
+
+    const postgresChangesPoolInput = await screen.findByLabelText(
+      'Postgres Changes connection pool size'
+    )
+    await userEvent.clear(postgresChangesPoolInput)
+    await userEvent.type(postgresChangesPoolInput, '5')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }))
+
+    const dialog = await screen.findByRole('dialog')
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Save changes' }))
+
+    await waitFor(() => expect(requests).toHaveLength(1))
+    expect(requests[0]).toMatchObject({ postgres_changes_pool: 5 })
+  })
+})

--- a/apps/studio/components/interfaces/Realtime/RealtimeSettings.test.tsx
+++ b/apps/studio/components/interfaces/Realtime/RealtimeSettings.test.tsx
@@ -115,6 +115,20 @@ describe('RealtimeSettings', () => {
     expect(await screen.findByLabelText('Postgres Changes connection pool size')).toHaveValue(2)
   })
 
+  test('falls back to the default postgres changes pool value when omitted', async () => {
+    const { postgres_changes_pool, ...configWithoutPool } = REALTIME_CONFIG
+
+    addAPIMock({
+      method: 'get',
+      path: '/platform/projects/:ref/config/realtime',
+      response: () => HttpResponse.json(configWithoutPool),
+    })
+
+    customRender(<RealtimeSettings />)
+
+    expect(await screen.findByLabelText('Postgres Changes connection pool size')).toHaveValue(2)
+  })
+
   test('submits the postgres changes pool value when saving', async () => {
     const updateBodySchema = z.object({ postgres_changes_pool: z.number() })
 
@@ -143,5 +157,44 @@ describe('RealtimeSettings', () => {
 
     await waitFor(() => expect(requests).toHaveLength(1))
     expect(requests[0]).toMatchObject({ postgres_changes_pool: 5 })
+  })
+
+  test.each([
+    { value: '1', accepted: true },
+    { value: '20', accepted: true },
+    { value: '0', accepted: false },
+    { value: '21', accepted: false },
+  ])('$accepted for postgres changes pool value of $value', async ({ value, accepted }) => {
+    const requests: unknown[] = []
+    addAPIMock({
+      method: 'patch',
+      path: '/platform/projects/:ref/config/realtime',
+      response: async ({ request }) => {
+        requests.push(await request.json())
+        return new HttpResponse(null, { status: 204 })
+      },
+    })
+
+    customRender(<RealtimeSettings />)
+
+    const postgresChangesPoolInput = await screen.findByLabelText(
+      'Postgres Changes connection pool size'
+    )
+    await userEvent.clear(postgresChangesPoolInput)
+    await userEvent.type(postgresChangesPoolInput, value)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }))
+
+    if (accepted) {
+      const dialog = await screen.findByRole('dialog')
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Save changes' }))
+
+      await waitFor(() => expect(requests).toHaveLength(1))
+      expect(requests[0]).toMatchObject({ postgres_changes_pool: Number(value) })
+    } else {
+      await waitFor(() => expect(postgresChangesPoolInput).toHaveAttribute('aria-invalid', 'true'))
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+      expect(requests).toHaveLength(0)
+    }
   })
 })

--- a/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
+++ b/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
@@ -50,6 +50,8 @@ const REALTIME_SOFT_LIMITS = {
   max_payload_size_in_kb: 3_000,
 }
 
+const MAX_POSTGRES_CHANGES_POOL = 20
+
 export const RealtimeSettings = () => {
   const { ref: projectRef } = useParams()
   const { data: project } = useSelectedProjectQuery()
@@ -141,6 +143,7 @@ export const RealtimeSettings = () => {
         .min(1)
         .max(maxConn?.maxConnections ?? 100)
         .optional(),
+      postgres_changes_pool: z.coerce.number().min(1).max(MAX_POSTGRES_CHANGES_POOL).optional(),
       max_concurrent_users: z.coerce
         .number()
         .min(1)
@@ -186,6 +189,7 @@ export const RealtimeSettings = () => {
         .number()
         .min(1)
         .max(maxConn?.maxConnections ?? 100),
+      postgres_changes_pool: z.coerce.number().min(1).max(MAX_POSTGRES_CHANGES_POOL),
       max_concurrent_users: z.coerce
         .number()
         .min(1)
@@ -226,6 +230,8 @@ export const RealtimeSettings = () => {
   const configValues = data ?? REALTIME_DEFAULT_CONFIG
   const sharedFormValues = {
     connection_pool: configValues.connection_pool ?? REALTIME_DEFAULT_CONFIG.connection_pool,
+    postgres_changes_pool:
+      configValues.postgres_changes_pool ?? REALTIME_DEFAULT_CONFIG.postgres_changes_pool,
     max_concurrent_users:
       configValues.max_concurrent_users ?? REALTIME_DEFAULT_CONFIG.max_concurrent_users,
     max_events_per_second:
@@ -277,6 +283,11 @@ export const RealtimeSettings = () => {
       private_only: !values.allow_public,
       connection_pool: Number(
         values.connection_pool ?? data?.connection_pool ?? REALTIME_DEFAULT_CONFIG.connection_pool
+      ),
+      postgres_changes_pool: Number(
+        values.postgres_changes_pool ??
+          data?.postgres_changes_pool ??
+          REALTIME_DEFAULT_CONFIG.postgres_changes_pool
       ),
       max_concurrent_users: Number(
         values.max_concurrent_users ??
@@ -465,6 +476,35 @@ export const RealtimeSettings = () => {
                               />
                             )}
                         </>
+                      )}
+                    />
+                  </CardContent>
+                  <CardContent>
+                    <FormField
+                      control={form.control}
+                      name="postgres_changes_pool"
+                      render={({ field }) => (
+                        <FormItemLayout
+                          id="postgres_changes_pool"
+                          layout="flex-row-reverse"
+                          label="Postgres Changes connection pool size"
+                          description="Postgres Changes uses this database pool to create subscriptions when clients subscribe"
+                        >
+                          <FormControl>
+                            <InputGroup>
+                              <FormInputGroupInput
+                                {...field}
+                                id="postgres_changes_pool"
+                                type="number"
+                                disabled={!canUpdateConfig}
+                                value={field.value || ''}
+                              />
+                              <InputGroupAddon align="inline-end">
+                                <InputGroupText>connections</InputGroupText>
+                              </InputGroupAddon>
+                            </InputGroup>
+                          </FormControl>
+                        </FormItemLayout>
                       )}
                     />
                   </CardContent>

--- a/apps/studio/data/lint/lint-rules-query.ts
+++ b/apps/studio/data/lint/lint-rules-query.ts
@@ -10,7 +10,7 @@ import type { ResponseError, UseCustomQueryOptions } from '@/types'
 type ProjectLintRulesVariables = {
   projectRef?: string
 }
-type LintDismissalResponse = components['schemas']['ListNotificationExceptionsResponse']
+type LintDismissalResponse = components['schemas']['ListNotificationExceptionsResponse_Output']
 export type LintException = LintDismissalResponse['exceptions'][0]
 
 export async function getProjectLintRules(

--- a/apps/studio/data/realtime/realtime-config-mutation.ts
+++ b/apps/studio/data/realtime/realtime-config-mutation.ts
@@ -6,14 +6,19 @@ import type { components } from '@/data/api'
 import { handleError, patch } from '@/data/fetchers'
 import type { ResponseError, UseCustomMutationOptions } from '@/types'
 
+export type RealtimeConfigurationUpdateBody = components['schemas']['UpdateRealtimeConfigBody'] & {
+  postgres_changes_pool?: number
+}
+
 export type RealtimeConfigurationUpdateVariables = {
   ref: string
-} & components['schemas']['UpdateRealtimeConfigBody']
+} & RealtimeConfigurationUpdateBody
 
 export async function updateRealtimeConfiguration({
   ref,
   private_only,
   connection_pool,
+  postgres_changes_pool,
   max_concurrent_users,
   max_events_per_second,
   max_bytes_per_second,
@@ -30,6 +35,7 @@ export async function updateRealtimeConfiguration({
     body: {
       private_only,
       connection_pool,
+      postgres_changes_pool,
       max_concurrent_users,
       max_events_per_second,
       max_bytes_per_second,

--- a/apps/studio/data/realtime/realtime-config-query.ts
+++ b/apps/studio/data/realtime/realtime-config-query.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
+import type { components } from 'api-types'
 
 import { realtimeKeys } from './keys'
 import { get, handleError } from '@/data/fetchers'
@@ -9,9 +10,14 @@ export type RealtimeConfigurationVariables = {
   projectRef?: string
 }
 
+export type RealtimeConfiguration = components['schemas']['RealtimeConfigResponse'] & {
+  postgres_changes_pool?: number
+}
+
 export const REALTIME_DEFAULT_CONFIG = {
   private_only: false,
   connection_pool: 2,
+  postgres_changes_pool: 2,
   max_concurrent_users: 200,
   max_events_per_second: 100,
   max_bytes_per_second: 100000,
@@ -25,7 +31,7 @@ export const REALTIME_DEFAULT_CONFIG = {
 export async function getRealtimeConfiguration(
   { projectRef }: RealtimeConfigurationVariables,
   signal?: AbortSignal
-) {
+): Promise<RealtimeConfiguration | typeof REALTIME_DEFAULT_CONFIG | undefined> {
   if (!projectRef) throw new Error('Project ref is required')
 
   const { data, error } = await get(`/platform/projects/{ref}/config/realtime`, {

--- a/apps/studio/data/realtime/realtime-config-query.ts
+++ b/apps/studio/data/realtime/realtime-config-query.ts
@@ -6,12 +6,10 @@ import { get, handleError } from '@/data/fetchers'
 import { IS_PLATFORM } from '@/lib/constants'
 import type { ResponseError, UseCustomQueryOptions } from '@/types'
 
+type RealtimeConfigResponse = components['schemas']['RealtimeConfigResponse']
+
 export type RealtimeConfigurationVariables = {
   projectRef?: string
-}
-
-export type RealtimeConfiguration = components['schemas']['RealtimeConfigResponse'] & {
-  postgres_changes_pool?: number
 }
 
 export const REALTIME_DEFAULT_CONFIG = {
@@ -26,7 +24,8 @@ export const REALTIME_DEFAULT_CONFIG = {
   max_presence_events_per_second: 100,
   max_payload_size_in_kb: 100,
   suspend: false,
-}
+  presence_enabled: true,
+} as const satisfies RealtimeConfigResponse
 
 export async function getRealtimeConfiguration(
   { projectRef }: RealtimeConfigurationVariables,

--- a/apps/studio/data/realtime/realtime-config-query.ts
+++ b/apps/studio/data/realtime/realtime-config-query.ts
@@ -31,7 +31,7 @@ export const REALTIME_DEFAULT_CONFIG = {
 export async function getRealtimeConfiguration(
   { projectRef }: RealtimeConfigurationVariables,
   signal?: AbortSignal
-): Promise<RealtimeConfiguration | typeof REALTIME_DEFAULT_CONFIG | undefined> {
+) {
   if (!projectRef) throw new Error('Project ref is required')
 
   const { data, error } = await get(`/platform/projects/{ref}/config/realtime`, {

--- a/packages/api-types/types/api-v1.d.ts
+++ b/packages/api-types/types/api-v1.d.ts
@@ -4048,6 +4048,8 @@ export interface components {
       max_payload_size_in_kb: number | null
       /** @description Sets maximum number of presence events per second rate limit */
       max_presence_events_per_second: number | null
+      /** @description Sets connection pool size used to create Postgres Changes subscriptions */
+      postgres_changes_pool: number | null
       /** @description Whether to enable presence */
       presence_enabled: boolean
       /** @description Whether to only allow private channels */
@@ -4885,6 +4887,8 @@ export interface components {
       max_payload_size_in_kb?: number
       /** @description Sets maximum number of presence events per second rate limit */
       max_presence_events_per_second?: number
+      /** @description Sets connection pool size used to create Postgres Changes subscriptions */
+      postgres_changes_pool?: number
       /** @description Whether to enable presence */
       presence_enabled?: boolean
       /** @description Whether to only allow private channels */
@@ -5298,6 +5302,7 @@ export interface components {
             | 'project_restore_after_expiry'
             | 'assistant.advance_model'
             | 'integrations.github_connections'
+            | 'integrations.github_push_webhooks_limit'
             | 'dedicated_pooler'
             | 'observability.dashboard_advanced_metrics'
             | 'api.members.invitations'
@@ -7223,6 +7228,13 @@ export interface operations {
           'application/openmetrics-text': string
           'text/plain': string
         }
+      }
+      /** @description Project must be active and healthy, or metrics are not available for this project */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
       }
       /** @description Unauthorized */
       401: {

--- a/packages/api-types/types/api-v2.d.ts
+++ b/packages/api-types/types/api-v2.d.ts
@@ -24,7 +24,7 @@ export interface paths {
      *     `meta.idempotency_key` is used to ensure idempotency when retrying the requests and so it
      *     must always be provided.
      */
-    post: operations['postV1WebhooksEvents']
+    post: operations['v1-webhooks-events-post']
     delete?: never
     options?: never
     head?: never
@@ -174,7 +174,7 @@ export interface paths {
      * Get delivery
      * @description Get details of a specific delivery attempt.
      */
-    get: operations['allV2OrganizationsBySlugWebhooks']
+    get: operations['v2-organizations-slug-webhooks-deliveries-id-get']
     put?: never
     post?: never
     delete?: never
@@ -200,7 +200,7 @@ export interface paths {
      *
      *     This endpoint is heavy rate-limited to allow for 10 request within 60 seconds.
      */
-    post: operations['allV2OrganizationsBySlugWebhooks']
+    post: operations['v2-organizations-slug-webhooks-deliveries-id-retry-post']
     delete?: never
     options?: never
     head?: never
@@ -218,20 +218,20 @@ export interface paths {
      * List endpoints
      * @description List all Webhook endpoints based on a project's ref or an organization's slug.
      */
-    get: operations['allV2OrganizationsBySlugWebhooks']
+    get: operations['v2-organizations-slug-webhooks-endpoints-get']
     put?: never
     /**
      * Create endpoint
      * @description Create new endpoint configuration to subscribe to specific webhook events.
      */
-    post: operations['allV2OrganizationsBySlugWebhooks']
+    post: operations['v2-organizations-slug-webhooks-endpoints-post']
     /**
      * Delete all endpoints
      * @description Delete all endpoints including all events and deliveries.
      *
      *     Any in-flight webhooks will result in a no-op.
      */
-    delete: operations['allV2OrganizationsBySlugWebhooks']
+    delete: operations['v2-organizations-slug-webhooks-endpoints-delete']
     options?: never
     head?: never
     patch?: never
@@ -248,7 +248,7 @@ export interface paths {
      * Get endpoint
      * @description Get details of a specific endpoint.
      */
-    get: operations['allV2OrganizationsBySlugWebhooks']
+    get: operations['v2-organizations-slug-webhooks-endpoints-id-get']
     put?: never
     post?: never
     /**
@@ -257,14 +257,14 @@ export interface paths {
      *
      *     Any in-flight webhooks will result in a no-op.
      */
-    delete: operations['allV2OrganizationsBySlugWebhooks']
+    delete: operations['v2-organizations-slug-webhooks-endpoints-id-delete']
     options?: never
     head?: never
     /**
      * Update endpoint
      * @description Update endpoint's configuration.
      */
-    patch: operations['allV2OrganizationsBySlugWebhooks']
+    patch: operations['v2-organizations-slug-webhooks-endpoints-id-patch']
     trace?: never
   }
   '/v2/organizations/{slug}/webhooks/endpoints/{id}/deliveries': {
@@ -280,7 +280,7 @@ export interface paths {
      *
      *     Deliveries which has expired are no longer available and will not be listed.
      */
-    get: operations['allV2OrganizationsBySlugWebhooks']
+    get: operations['v2-organizations-slug-webhooks-endpoints-id-deliveries-get']
     put?: never
     post?: never
     delete?: never
@@ -309,7 +309,7 @@ export interface paths {
      *
      *     This endpoint is heavy rate-limited to allow for 10 request within 60 seconds.
      */
-    post: operations['allV2OrganizationsBySlugWebhooks']
+    post: operations['v2-organizations-slug-webhooks-endpoints-id-test-post']
     delete?: never
     options?: never
     head?: never
@@ -478,7 +478,7 @@ export interface paths {
      * Get delivery
      * @description Get details of a specific delivery attempt.
      */
-    get: operations['allV2ProjectsByRefWebhooks']
+    get: operations['v2-projects-ref-webhooks-deliveries-id-get']
     put?: never
     post?: never
     delete?: never
@@ -504,7 +504,7 @@ export interface paths {
      *
      *     This endpoint is heavy rate-limited to allow for 10 request within 60 seconds.
      */
-    post: operations['allV2ProjectsByRefWebhooks']
+    post: operations['v2-projects-ref-webhooks-deliveries-id-retry-post']
     delete?: never
     options?: never
     head?: never
@@ -522,20 +522,20 @@ export interface paths {
      * List endpoints
      * @description List all Webhook endpoints based on a project's ref or an organization's slug.
      */
-    get: operations['allV2ProjectsByRefWebhooks']
+    get: operations['v2-projects-ref-webhooks-endpoints-get']
     put?: never
     /**
      * Create endpoint
      * @description Create new endpoint configuration to subscribe to specific webhook events.
      */
-    post: operations['allV2ProjectsByRefWebhooks']
+    post: operations['v2-projects-ref-webhooks-endpoints-post']
     /**
      * Delete all endpoints
      * @description Delete all endpoints including all events and deliveries.
      *
      *     Any in-flight webhooks will result in a no-op.
      */
-    delete: operations['allV2ProjectsByRefWebhooks']
+    delete: operations['v2-projects-ref-webhooks-endpoints-delete']
     options?: never
     head?: never
     patch?: never
@@ -552,7 +552,7 @@ export interface paths {
      * Get endpoint
      * @description Get details of a specific endpoint.
      */
-    get: operations['allV2ProjectsByRefWebhooks']
+    get: operations['v2-projects-ref-webhooks-endpoints-id-get']
     put?: never
     post?: never
     /**
@@ -561,14 +561,14 @@ export interface paths {
      *
      *     Any in-flight webhooks will result in a no-op.
      */
-    delete: operations['allV2ProjectsByRefWebhooks']
+    delete: operations['v2-projects-ref-webhooks-endpoints-id-delete']
     options?: never
     head?: never
     /**
      * Update endpoint
      * @description Update endpoint's configuration.
      */
-    patch: operations['allV2ProjectsByRefWebhooks']
+    patch: operations['v2-projects-ref-webhooks-endpoints-id-patch']
     trace?: never
   }
   '/v2/projects/{ref}/webhooks/endpoints/{id}/deliveries': {
@@ -584,7 +584,7 @@ export interface paths {
      *
      *     Deliveries which has expired are no longer available and will not be listed.
      */
-    get: operations['allV2ProjectsByRefWebhooks']
+    get: operations['v2-projects-ref-webhooks-endpoints-id-deliveries-get']
     put?: never
     post?: never
     delete?: never
@@ -613,7 +613,7 @@ export interface paths {
      *
      *     This endpoint is heavy rate-limited to allow for 10 request within 60 seconds.
      */
-    post: operations['allV2ProjectsByRefWebhooks']
+    post: operations['v2-projects-ref-webhooks-endpoints-id-test-post']
     delete?: never
     options?: never
     head?: never
@@ -1261,7 +1261,6 @@ export interface components {
           /** @description Id of a build context staged through the uploads endpoint. Required unless `runtime` is set. */
           context_upload_id?: string
           spec: {
-            backend?: string
             /** @example public */
             exposure: string
             /** @example 1 */
@@ -1614,7 +1613,6 @@ export interface components {
           instances_error?: string
           secret_generation: string
           spec: {
-            backend?: string
             /** @example public */
             exposure: string
             /** @example 1 */
@@ -1899,7 +1897,6 @@ export interface components {
           instances_error?: string
           secret_generation: string
           spec: {
-            backend?: string
             /** @example public */
             exposure: string
             /** @example 1 */
@@ -1954,7 +1951,7 @@ export interface components {
 }
 export type $defs = Record<string, never>
 export interface operations {
-  postV1WebhooksEvents: {
+  'v1-webhooks-events-post': {
     parameters: {
       query?: never
       header?: never
@@ -2709,7 +2706,7 @@ export interface operations {
       }
     }
   }
-  allV2OrganizationsBySlugWebhooks: {
+  'v2-organizations-slug-webhooks-deliveries-id-get': {
     parameters: {
       query?: never
       header?: never
@@ -3156,7 +3153,7 @@ export interface operations {
       }
     }
   }
-  allV2OrganizationsBySlugWebhooks: {
+  'v2-organizations-slug-webhooks-deliveries-id-retry-post': {
     parameters: {
       query?: never
       header?: never
@@ -3499,7 +3496,7 @@ export interface operations {
       }
     }
   }
-  allV2OrganizationsBySlugWebhooks: {
+  'v2-organizations-slug-webhooks-endpoints-get': {
     parameters: {
       query?: {
         /** @description Up to how many records to return. */
@@ -3908,7 +3905,7 @@ export interface operations {
       }
     }
   }
-  allV2OrganizationsBySlugWebhooks: {
+  'v2-organizations-slug-webhooks-endpoints-post': {
     parameters: {
       query?: never
       header?: never
@@ -4362,7 +4359,7 @@ export interface operations {
       }
     }
   }
-  allV2OrganizationsBySlugWebhooks: {
+  'v2-organizations-slug-webhooks-endpoints-delete': {
     parameters: {
       query?: never
       header?: never
@@ -4742,7 +4739,7 @@ export interface operations {
       }
     }
   }
-  allV2OrganizationsBySlugWebhooks: {
+  'v2-organizations-slug-webhooks-endpoints-id-get': {
     parameters: {
       query?: never
       header?: never
@@ -5161,7 +5158,7 @@ export interface operations {
       }
     }
   }
-  allV2OrganizationsBySlugWebhooks: {
+  'v2-organizations-slug-webhooks-endpoints-id-delete': {
     parameters: {
       query?: never
       header?: never
@@ -5580,7 +5577,7 @@ export interface operations {
       }
     }
   }
-  allV2OrganizationsBySlugWebhooks: {
+  'v2-organizations-slug-webhooks-endpoints-id-patch': {
     parameters: {
       query?: never
       header?: never
@@ -6070,7 +6067,7 @@ export interface operations {
       }
     }
   }
-  allV2OrganizationsBySlugWebhooks: {
+  'v2-organizations-slug-webhooks-endpoints-id-deliveries-get': {
     parameters: {
       query?: {
         /** @description Cursor in cursor-based pagination to return up to `page[size]` records after (exclusive) the entry specified by this query param. */
@@ -6482,7 +6479,7 @@ export interface operations {
       }
     }
   }
-  allV2OrganizationsBySlugWebhooks: {
+  'v2-organizations-slug-webhooks-endpoints-id-test-post': {
     parameters: {
       query?: never
       header?: never
@@ -7584,7 +7581,7 @@ export interface operations {
       }
     }
   }
-  allV2ProjectsByRefWebhooks: {
+  'v2-projects-ref-webhooks-deliveries-id-get': {
     parameters: {
       query?: never
       header?: never
@@ -8031,7 +8028,7 @@ export interface operations {
       }
     }
   }
-  allV2ProjectsByRefWebhooks: {
+  'v2-projects-ref-webhooks-deliveries-id-retry-post': {
     parameters: {
       query?: never
       header?: never
@@ -8374,7 +8371,7 @@ export interface operations {
       }
     }
   }
-  allV2ProjectsByRefWebhooks: {
+  'v2-projects-ref-webhooks-endpoints-get': {
     parameters: {
       query?: {
         /** @description Up to how many records to return. */
@@ -8783,7 +8780,7 @@ export interface operations {
       }
     }
   }
-  allV2ProjectsByRefWebhooks: {
+  'v2-projects-ref-webhooks-endpoints-post': {
     parameters: {
       query?: never
       header?: never
@@ -9237,7 +9234,7 @@ export interface operations {
       }
     }
   }
-  allV2ProjectsByRefWebhooks: {
+  'v2-projects-ref-webhooks-endpoints-delete': {
     parameters: {
       query?: never
       header?: never
@@ -9617,7 +9614,7 @@ export interface operations {
       }
     }
   }
-  allV2ProjectsByRefWebhooks: {
+  'v2-projects-ref-webhooks-endpoints-id-get': {
     parameters: {
       query?: never
       header?: never
@@ -10036,7 +10033,7 @@ export interface operations {
       }
     }
   }
-  allV2ProjectsByRefWebhooks: {
+  'v2-projects-ref-webhooks-endpoints-id-delete': {
     parameters: {
       query?: never
       header?: never
@@ -10455,7 +10452,7 @@ export interface operations {
       }
     }
   }
-  allV2ProjectsByRefWebhooks: {
+  'v2-projects-ref-webhooks-endpoints-id-patch': {
     parameters: {
       query?: never
       header?: never
@@ -10945,7 +10942,7 @@ export interface operations {
       }
     }
   }
-  allV2ProjectsByRefWebhooks: {
+  'v2-projects-ref-webhooks-endpoints-id-deliveries-get': {
     parameters: {
       query?: {
         /** @description Cursor in cursor-based pagination to return up to `page[size]` records after (exclusive) the entry specified by this query param. */
@@ -11357,7 +11354,7 @@ export interface operations {
       }
     }
   }
-  allV2ProjectsByRefWebhooks: {
+  'v2-projects-ref-webhooks-endpoints-id-test-post': {
     parameters: {
       query?: never
       header?: never

--- a/packages/api-types/types/platform.d.ts
+++ b/packages/api-types/types/platform.d.ts
@@ -5001,6 +5001,26 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/platform/warehouse/{ref}/setup': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * Set up Warehouse
+     * @description Ensure the project Warehouse pipeline exists, add the requested schemas and tables to its publication, and start syncing. Schema targets include the currently eligible tables in that schema. Warehouse FDW installation is opt-in.
+     */
+    post: operations['WarehouseController_setup']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/platform/warehouse/{ref}/setup-status': {
     parameters: {
       query?: never
@@ -5034,11 +5054,7 @@ export interface paths {
      */
     get: operations['WarehouseController_getTables']
     put?: never
-    /**
-     * Copy a table to Warehouse
-     * @description Ensure the project Warehouse pipeline exists, add the table to its publication, and start syncing. Warehouse FDW installation is opt-in.
-     */
-    post: operations['WarehouseController_linkTable']
+    post?: never
     delete?: never
     options?: never
     head?: never
@@ -5695,8 +5711,8 @@ export interface components {
         note?: string
       }[]
     }
-    CreateNotificationExceptionsResponse: {
-      exceptions: {
+    CreateNotificationExceptionsResponse_Output: {
+      exceptions: ({
         /** Format: uuid */
         assigned_to: string | null
         /** Format: uuid */
@@ -5709,11 +5725,13 @@ export interface components {
         lint_category: string | null
         lint_metadata?: {
           [key: string]: unknown
-        }
+        } | null
         lint_name: string | null
         note: string | null
         project_ref: string
-      }[]
+      } & {
+        [key: string]: unknown
+      })[]
     }
     CreateOAuthAppBody: {
       icon?: string
@@ -8688,6 +8706,7 @@ export interface components {
             | 'project_restore_after_expiry'
             | 'assistant.advance_model'
             | 'integrations.github_connections'
+            | 'integrations.github_push_webhooks_limit'
             | 'dedicated_pooler'
             | 'observability.dashboard_advanced_metrics'
             | 'api.members.invitations'
@@ -8736,8 +8755,8 @@ export interface components {
         name: string
       }[]
     }
-    ListNotificationExceptionsResponse: {
-      exceptions: {
+    ListNotificationExceptionsResponse_Output: {
+      exceptions: ({
         /** Format: uuid */
         assigned_to: string | null
         /** Format: uuid */
@@ -8750,11 +8769,13 @@ export interface components {
         lint_category: string | null
         lint_metadata?: {
           [key: string]: unknown
-        }
+        } | null
         lint_name: string | null
         note: string | null
         project_ref: string
-      }[]
+      } & {
+        [key: string]: unknown
+      })[]
     }
     ListOAuthAppClientSecretsResponse: {
       client_secrets: {
@@ -10249,6 +10270,8 @@ export interface components {
       max_payload_size_in_kb: number | null
       /** @description Sets maximum number of presence events per second rate limit */
       max_presence_events_per_second: number | null
+      /** @description Sets connection pool size used to create Postgres Changes subscriptions */
+      postgres_changes_pool: number | null
       /** @description Whether to enable presence */
       presence_enabled: boolean
       /** @description Whether to only allow private channels */
@@ -11768,7 +11791,7 @@ export interface components {
       project_ref?: string
       user_id: string
     }
-    TemporaryApiKeyResponse: {
+    TemporaryApiKeyResponse_Output: {
       api_key: string
     }
     TransferProjectBody: {
@@ -12618,6 +12641,8 @@ export interface components {
       max_payload_size_in_kb?: number
       /** @description Sets maximum number of presence events per second rate limit */
       max_presence_events_per_second?: number
+      /** @description Sets connection pool size used to create Postgres Changes subscriptions */
+      postgres_changes_pool?: number
       /** @description Whether to enable presence */
       presence_enabled?: boolean
       /** @description Whether to only allow private channels */
@@ -13672,7 +13697,8 @@ export interface components {
        * @default false
        */
       favorite?: boolean
-      folder_id?: (null | (string | null)) | null
+      /** Format: uuid */
+      folder_id?: string | null
       id?: string
       name: string
       owner_id?: number
@@ -14405,61 +14431,85 @@ export interface components {
       /** @description Whether external catalog access is enabled */
       enabled: boolean
     }
-    WarehouseLinkedTable: {
-      /**
-       * @description Warehouse-facing table name
-       * @example warehouse.orders
-       */
-      copy_name: string
-      /**
-       * @description Replication lag in milliseconds, when available
-       * @example 12000
-       */
-      lag_ms?: number
-      /**
-       * Format: date-time
-       * @description Last sync timestamp, when available
-       * @example 2026-06-23T17:48:00Z
-       */
-      last_synced_at?: string
-      /**
-       * @description Postgres table name
-       * @example orders
-       */
-      name: string
-      /**
-       * @description Postgres schema name
-       * @example public
-       */
-      schema: string
-      /**
-       * @description Warehouse copy sync state derived from replication status
-       * @example live
-       * @enum {string}
-       */
-      state: 'syncing' | 'live' | 'error'
-      /**
-       * @description Warehouse table size in bytes, when available
-       * @example 197912092672
-       */
-      warehouse_size_bytes?: number
-    }
-    WarehouseLinkTableBody: {
+    WarehouseSetupBody: {
       /**
        * @description Whether to configure and install the Warehouse FDW in the project database. Defaults to false.
        * @example false
        */
       install_fdw?: boolean
+      /** @description Schemas and individual tables to copy. Schema targets expand to the eligible tables present when the request is processed. */
+      targets: (
+        | {
+            /**
+             * @description Postgres schema whose currently eligible tables should be copied
+             * @example public
+             */
+            schema: string
+            /** @enum {string} */
+            type: 'schema'
+          }
+        | {
+            /**
+             * @description Postgres table name
+             * @example orders
+             */
+            name: string
+            /**
+             * @description Postgres schema name
+             * @example public
+             */
+            schema: string
+            /** @enum {string} */
+            type: 'table'
+          }
+      )[]
+    }
+    WarehouseSetupResponse: {
       /**
-       * @description Postgres table name
-       * @example orders
+       * @description Warehouse replication pipeline id
+       * @example 101
        */
-      name: string
-      /**
-       * @description Postgres schema name
-       * @example public
-       */
-      schema: string
+      pipeline_id: number
+      /** @description Tables with Warehouse copies */
+      tables: {
+        /**
+         * @description DuckLake schema-qualified table name
+         * @example public.orders
+         */
+        copy_name: string
+        /**
+         * @description Replication lag in milliseconds, when available
+         * @example 12000
+         */
+        lag_ms?: number
+        /**
+         * Format: date-time
+         * @description Last sync timestamp, when available
+         * @example 2026-06-23T17:48:00Z
+         */
+        last_synced_at?: string
+        /**
+         * @description Postgres table name
+         * @example orders
+         */
+        name: string
+        /**
+         * @description Postgres schema name
+         * @example public
+         */
+        schema: string
+        /**
+         * @description Warehouse copy sync state derived from replication status
+         * @example live
+         * @enum {string}
+         */
+        state: 'syncing' | 'live' | 'error'
+        /**
+         * @description Warehouse table size in bytes, when available
+         * @example 197912092672
+         */
+        warehouse_size_bytes?: number
+      }[]
     }
     WarehouseSetupStatusResponse: {
       /** @description Project database FDW setup markers used to derive the Warehouse FDW phase */
@@ -14529,8 +14579,8 @@ export interface components {
       /** @description Warehouse linked tables and replication-derived sync state */
       tables: {
         /**
-         * @description Warehouse-facing table name
-         * @example warehouse.orders
+         * @description DuckLake schema-qualified table name
+         * @example public.orders
          */
         copy_name: string
         /**
@@ -14602,8 +14652,8 @@ export interface components {
       /** @description Tables with Warehouse copies */
       tables: {
         /**
-         * @description Warehouse-facing table name
-         * @example warehouse.orders
+         * @description DuckLake schema-qualified table name
+         * @example public.orders
          */
         copy_name: string
         /**
@@ -22576,6 +22626,7 @@ export interface operations {
           | 'project_restore_after_expiry'
           | 'assistant.advance_model'
           | 'integrations.github_connections'
+          | 'integrations.github_push_webhooks_limit'
           | 'dedicated_pooler'
           | 'observability.dashboard_advanced_metrics'
           | 'api.members.invitations'
@@ -24396,6 +24447,13 @@ export interface operations {
           'text/plain': string
         }
       }
+      /** @description Project must be active and healthy, or metrics are not available for this project */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
       /** @description Unauthorized */
       401: {
         headers: {
@@ -24447,7 +24505,7 @@ export interface operations {
           [name: string]: unknown
         }
         content: {
-          'application/json': components['schemas']['TemporaryApiKeyResponse']
+          'application/json': components['schemas']['TemporaryApiKeyResponse_Output']
         }
       }
       /** @description Unauthorized */
@@ -26699,7 +26757,7 @@ export interface operations {
           [name: string]: unknown
         }
         content: {
-          'application/json': components['schemas']['ListNotificationExceptionsResponse']
+          'application/json': components['schemas']['ListNotificationExceptionsResponse_Output']
         }
       }
       /** @description Unauthorized */
@@ -26753,7 +26811,7 @@ export interface operations {
           [name: string]: unknown
         }
         content: {
-          'application/json': components['schemas']['CreateNotificationExceptionsResponse']
+          'application/json': components['schemas']['CreateNotificationExceptionsResponse_Output']
         }
       }
       /** @description Unauthorized */
@@ -32508,6 +32566,77 @@ export interface operations {
       }
     }
   }
+  WarehouseController_setup: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description Project ref */
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['WarehouseSetupBody']
+      }
+    }
+    responses: {
+      /** @description Warehouse setup accepted. */
+      202: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['WarehouseSetupResponse']
+        }
+      }
+      /** @description A requested table or schema is not eligible for Warehouse replication. */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description This feature requires the Pro, Team, or Enterprise organization plan. */
+      402: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PlanGateErrorBody']
+        }
+      }
+      /** @description Forbidden action */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Rate limit exceeded */
+      429: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Unexpected error while setting up Warehouse. */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
   WarehouseController_getSetupStatus: {
     parameters: {
       query?: never
@@ -32602,70 +32731,6 @@ export interface operations {
         content?: never
       }
       /** @description Unexpected error while listing Warehouse tables. */
-      500: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-    }
-  }
-  WarehouseController_linkTable: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        /** @description Project ref */
-        ref: string
-      }
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['WarehouseLinkTableBody']
-      }
-    }
-    responses: {
-      /** @description Warehouse table link accepted. */
-      202: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': components['schemas']['WarehouseLinkedTable']
-        }
-      }
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description This feature requires the Pro, Team, or Enterprise organization plan. */
-      402: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': components['schemas']['PlanGateErrorBody']
-        }
-      }
-      /** @description Forbidden action */
-      403: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Rate limit exceeded */
-      429: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Unexpected error while linking Warehouse table. */
       500: {
         headers: {
           [name: string]: unknown


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Feature — adds a new Realtime setting to configure the Postgres Changes connection pool size.

## What is the current behavior?

The Realtime settings page only exposes the connection pool used for Realtime Authorization (`connection_pool`). The pool that Realtime uses for Postgres Changes is not surfaced anywhere in the dashboard, so projects that need to tune it have no self-serve way to do so — the only option is to contact support.

## What is the new behavior?

The Realtime settings page now includes a **Postgres Changes connection pool size** field:

- Reads `postgres_changes_pool` from the project's Realtime config, falling back to a default of `2` when no override is stored.
- Validates input from `1` through `20` (`MAX_POSTGRES_CHANGES_POOL`), and submits the value as a number in the config `PATCH` payload.
- Docs (`apps/docs/content/guides/realtime/settings.mdx`) are expanded with sizing guidance for both connection pools, plus limits, resource-usage notes, and the operational error codes to look for.

<img width="1160" height="166" alt="Screenshot 2026-08-19 at 13 59 04" src="https://github.com/user-attachments/assets/fd3ee29e-e9bf-438b-970f-8008ec57020f" />

## Additional context

The named `RealtimeConfigResponse` / `UpdateRealtimeConfigBody` schemas in the generated `api-types` package do not carry `postgres_changes_pool` yet, so both the query and mutation types extend the generated schema locally — the same pattern already used elsewhere in `apps/studio/data/`. Once the platform OpenAPI spec ships the field and `api-types` is regenerated, those two local intersections can be dropped.

Covered by component tests in `RealtimeSettings.test.tsx` for both the fetch and save paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Realtime setting to configure the Postgres Changes connection pool size.
  * Connection pools support 1–20 connections, with a default of 2.
  * Saving the setting now applies the configured value correctly.

* **Documentation**
  * Expanded Realtime Settings guidance with configuration limits, resource usage, channel access, payload and presence limits, plan ceilings, spend-cap restrictions, and operational error codes.
  * Added guidance for sizing authorization and Postgres Changes connection pools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
