### PR TITLE
feat(studio): filter organization usage by branch

### DIFF
--- a/apps/docs/content/guides/platform/manage-your-usage/branching.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/branching.mdx
@@ -19,7 +19,7 @@ Refer to individual [usage items](/docs/guides/platform/manage-your-usage) for d
 
 ### Usage on your invoice
 
-Compute incurred by Preview branches is shown as "Branching Compute Hours" on your invoice. Other usage items are not shown separately for branches and are rolled up into the project.
+Compute incurred by Preview branches is shown as "Branching Compute Hours" on your invoice. Other usage items are recorded against the branch itself and count toward your organization total, but are not listed separately per branch on your invoice. To see them, select the parent project on the [usage page](/dashboard/org/_/usage), then select the branch from the branch list.
 
 ## Pricing
 

--- a/apps/docs/content/guides/platform/manage-your-usage/egress.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/egress.mdx
@@ -121,6 +121,8 @@ The organization's Egress usage exceeds the uncached egress quota by 50 GB and t
 
 You can view Egress usage on the [organization's usage page](/dashboard/org/_/usage). The page shows the usage of all projects by default. To view the usage for a specific project, select it from the dropdown. You can also select a different time period.
 
+Each [Preview branch](/docs/guides/deployment/branching) records its own Egress, which counts toward the organization total but is not included in the parent project's usage. To see a branch's Egress, select the parent project, then select the branch from the branch list.
+
 <Image
   alt="Usage page navigation bar"
   src={{

--- a/apps/studio/components/interfaces/Organization/Usage/Usage.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/Usage.tsx
@@ -2,11 +2,9 @@ import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useParams } from 'common'
 import dayjs from 'dayjs'
 import { ChartArea, Check, ChevronDown } from 'lucide-react'
-import Link from 'next/link'
 import { useQueryState } from 'nuqs'
 import { useMemo, useState } from 'react'
 import { Button, cn, CommandGroup, CommandItem } from 'ui'
-import { Admonition } from 'ui-patterns/Admonition'
 import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 
 import { Restriction } from '../BillingSettings/Restriction'
@@ -18,8 +16,9 @@ import OrgLogUsage from './OrgLogUsage'
 import { Pipelines } from './Pipelines'
 import SizeAndCounts from './SizeAndCounts'
 import { TotalUsage } from './TotalUsage'
-import { getUsageBranchOptions } from './Usage.utils'
+import { getUsageBranchOptions, resolveUsageProjectRef } from './Usage.utils'
 import { UsageBranchFilter } from './UsageBranchFilter'
+import { UsageFilterNotice } from './UsageFilterNotice'
 import {
   ScaffoldContainer,
   ScaffoldHeader,
@@ -48,9 +47,15 @@ export const Usage = () => {
   const [selectedBranchRef, setSelectedBranchRef] = useQueryState('branchRef')
   const [openProjectSelector, setOpenProjectSelector] = useState(false)
 
-  const { data: branches } = useBranchesQuery({ projectRef: selectedProjectRef ?? undefined })
+  const { data: branches, isLoading: isLoadingBranches } = useBranchesQuery({
+    projectRef: selectedProjectRef ?? undefined,
+  })
   const branchOptions = useMemo(() => getUsageBranchOptions(branches), [branches])
-  const usageProjectRef = selectedProjectRef ? (selectedBranchRef ?? selectedProjectRef) : null
+  const usageProjectRef = resolveUsageProjectRef(
+    selectedProjectRef,
+    branchOptions,
+    selectedBranchRef
+  )
   const selectedBranch = branchOptions.find((branch) => branch.project_ref === selectedBranchRef)
 
   const { data: selectedProject, isPending: isLoadingSelectedProject } = useProjectDetailQuery({
@@ -242,7 +247,9 @@ export const Usage = () => {
                     )}
                   />
 
-                  {!!selectedProjectRef && (
+                  {isLoadingBranches && <ShimmeringLoader className="w-[180px] py-3.5" />}
+
+                  {!isLoadingBranches && !!selectedProjectRef && (
                     <UsageBranchFilter
                       branchOptions={branchOptions}
                       projectRef={selectedProjectRef}
@@ -295,45 +302,11 @@ export const Usage = () => {
       )}
 
       {selectedProject ? (
-        <ScaffoldContainer className="mt-5">
-          <Admonition
-            type="default"
-            title={selectedBranch ? 'Usage filtered by branch' : 'Usage filtered by project'}
-            description={
-              <div className="space-y-2">
-                <p>
-                  You are currently viewing usage for the{' '}
-                  <span className="font-medium text-foreground">
-                    {selectedProject?.name || selectedProjectRef}
-                  </span>{' '}
-                  project
-                  {selectedBranch && (
-                    <>
-                      , branch{' '}
-                      <span className="font-medium text-foreground">{selectedBranch.name}</span>
-                    </>
-                  )}
-                  . Supabase uses{' '}
-                  <Link
-                    href="/docs/guides/platform/billing-on-supabase#organization-based-billing"
-                    target="_blank"
-                  >
-                    organization-level billing
-                  </Link>{' '}
-                  and quotas. For billing purposes, we sum up usage from all your projects. To view
-                  your usage quota, set the project filter above back to "All Projects".
-                </p>
-                {branchOptions.length > 0 && (
-                  <p>
-                    Each branch records its own usage, so this view excludes the project's branches.
-                    Select a branch above to see its usage. Usage from deleted branches still counts
-                    toward the organization total.
-                  </p>
-                )}
-              </div>
-            }
-          />
-        </ScaffoldContainer>
+        <UsageFilterNotice
+          projectName={selectedProject.name || (selectedProjectRef ?? '')}
+          branchName={selectedBranch?.name}
+          hasBranches={branchOptions.length > 0}
+        />
       ) : (
         <ScaffoldContainer id="restriction" className="mt-5">
           <Restriction />

--- a/apps/studio/components/interfaces/Organization/Usage/Usage.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/Usage.tsx
@@ -5,17 +5,7 @@ import { ChartArea, Check, ChevronDown } from 'lucide-react'
 import Link from 'next/link'
 import { useQueryState } from 'nuqs'
 import { useMemo, useState } from 'react'
-import {
-  Button,
-  cn,
-  CommandGroup,
-  CommandItem,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from 'ui'
+import { Button, cn, CommandGroup, CommandItem } from 'ui'
 import { Admonition } from 'ui-patterns/Admonition'
 import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 
@@ -29,6 +19,7 @@ import { Pipelines } from './Pipelines'
 import SizeAndCounts from './SizeAndCounts'
 import { TotalUsage } from './TotalUsage'
 import { getUsageBranchOptions } from './Usage.utils'
+import { UsageBranchFilter } from './UsageBranchFilter'
 import {
   ScaffoldContainer,
   ScaffoldHeader,
@@ -251,28 +242,13 @@ export const Usage = () => {
                     )}
                   />
 
-                  {branchOptions.length > 0 && (
-                    <Select
-                      value={usageProjectRef ?? undefined}
-                      onValueChange={(value) =>
-                        setSelectedBranchRef(value === selectedProjectRef ? null : value)
-                      }
-                    >
-                      <SelectTrigger
-                        size="tiny"
-                        className="w-[180px]"
-                        aria-label="Filter by branch"
-                      >
-                        <SelectValue placeholder="Select branch" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {branchOptions.map((branch) => (
-                          <SelectItem key={branch.project_ref} value={branch.project_ref}>
-                            {branch.name}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                  {!!selectedProjectRef && (
+                    <UsageBranchFilter
+                      branchOptions={branchOptions}
+                      projectRef={selectedProjectRef}
+                      branchRef={selectedBranchRef}
+                      onSelectBranch={setSelectedBranchRef}
+                    />
                   )}
                 </div>
 

--- a/apps/studio/components/interfaces/Organization/Usage/Usage.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/Usage.tsx
@@ -59,7 +59,7 @@ export const Usage = () => {
 
   const { data: branches } = useBranchesQuery({ projectRef: selectedProjectRef ?? undefined })
   const branchOptions = useMemo(() => getUsageBranchOptions(branches), [branches])
-  const usageProjectRef = selectedBranchRef ?? selectedProjectRef
+  const usageProjectRef = selectedProjectRef ? (selectedBranchRef ?? selectedProjectRef) : null
   const selectedBranch = branchOptions.find((branch) => branch.project_ref === selectedBranchRef)
 
   const { data: selectedProject, isPending: isLoadingSelectedProject } = useProjectDetailQuery({

--- a/apps/studio/components/interfaces/Organization/Usage/Usage.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/Usage.tsx
@@ -5,7 +5,17 @@ import { ChartArea, Check, ChevronDown } from 'lucide-react'
 import Link from 'next/link'
 import { useQueryState } from 'nuqs'
 import { useMemo, useState } from 'react'
-import { Button, cn, CommandGroup, CommandItem } from 'ui'
+import {
+  Button,
+  cn,
+  CommandGroup,
+  CommandItem,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from 'ui'
 import { Admonition } from 'ui-patterns/Admonition'
 import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 
@@ -18,6 +28,7 @@ import OrgLogUsage from './OrgLogUsage'
 import { Pipelines } from './Pipelines'
 import SizeAndCounts from './SizeAndCounts'
 import { TotalUsage } from './TotalUsage'
+import { getUsageBranchOptions } from './Usage.utils'
 import {
   ScaffoldContainer,
   ScaffoldHeader,
@@ -30,6 +41,7 @@ import { HighAvailabilityDisabledEmptyState } from '@/components/ui/HighAvailabi
 import { NoPermission } from '@/components/ui/NoPermission'
 import { OrganizationProjectSelector } from '@/components/ui/OrganizationProjectSelector'
 import { useOrgDailyStatsQuery } from '@/data/analytics/org-daily-stats-query'
+import { useBranchesQuery } from '@/data/branches/branches-query'
 import { useProjectDetailQuery } from '@/data/projects/project-detail-query'
 import { useOrgSubscriptionQuery } from '@/data/subscriptions/org-subscription-query'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
@@ -42,7 +54,13 @@ export const Usage = () => {
   const [dateRange, setDateRange] = useState<any>()
 
   const [selectedProjectRef, setSelectedProjectRef] = useQueryState('projectRef')
+  const [selectedBranchRef, setSelectedBranchRef] = useQueryState('branchRef')
   const [openProjectSelector, setOpenProjectSelector] = useState(false)
+
+  const { data: branches } = useBranchesQuery({ projectRef: selectedProjectRef ?? undefined })
+  const branchOptions = useMemo(() => getUsageBranchOptions(branches), [branches])
+  const usageProjectRef = selectedBranchRef ?? selectedProjectRef
+  const selectedBranch = branchOptions.find((branch) => branch.project_ref === selectedBranchRef)
 
   const { data: selectedProject, isPending: isLoadingSelectedProject } = useProjectDetailQuery({
     ref: selectedProjectRef ?? undefined,
@@ -114,7 +132,7 @@ export const Usage = () => {
   } = useOrgDailyStatsQuery(
     {
       orgSlug: slug,
-      projectRef: selectedProjectRef ?? undefined,
+      projectRef: usageProjectRef ?? undefined,
       startDate,
       endDate,
     },
@@ -182,6 +200,7 @@ export const Usage = () => {
                     selectedRef={selectedProjectRef}
                     onSelect={(project) => {
                       setSelectedProjectRef(project.ref)
+                      setSelectedBranchRef(null)
                     }}
                     renderTrigger={({ listboxId, open }) => {
                       return (
@@ -217,10 +236,12 @@ export const Usage = () => {
                           onSelect={() => {
                             setOpenProjectSelector(false)
                             setSelectedProjectRef(null)
+                            setSelectedBranchRef(null)
                           }}
                           onClick={() => {
                             setOpenProjectSelector(false)
                             setSelectedProjectRef(null)
+                            setSelectedBranchRef(null)
                           }}
                         >
                           All projects
@@ -229,6 +250,30 @@ export const Usage = () => {
                       </CommandGroup>
                     )}
                   />
+
+                  {branchOptions.length > 0 && (
+                    <Select
+                      value={usageProjectRef ?? undefined}
+                      onValueChange={(value) =>
+                        setSelectedBranchRef(value === selectedProjectRef ? null : value)
+                      }
+                    >
+                      <SelectTrigger
+                        size="tiny"
+                        className="w-[180px]"
+                        aria-label="Filter by branch"
+                      >
+                        <SelectValue placeholder="Select branch" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {branchOptions.map((branch) => (
+                          <SelectItem key={branch.project_ref} value={branch.project_ref}>
+                            {branch.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  )}
                 </div>
 
                 <div className="flex items-center gap-2">
@@ -277,22 +322,38 @@ export const Usage = () => {
         <ScaffoldContainer className="mt-5">
           <Admonition
             type="default"
-            title="Usage filtered by project"
+            title={selectedBranch ? 'Usage filtered by branch' : 'Usage filtered by project'}
             description={
-              <div>
-                You are currently viewing usage for the{' '}
-                <span className="font-medium text-foreground">
-                  {selectedProject?.name || selectedProjectRef}
-                </span>{' '}
-                project. Supabase uses{' '}
-                <Link
-                  href="/docs/guides/platform/billing-on-supabase#organization-based-billing"
-                  target="_blank"
-                >
-                  organization-level billing
-                </Link>{' '}
-                and quotas. For billing purposes, we sum up usage from all your projects. To view
-                your usage quota, set the project filter above back to "All Projects".
+              <div className="space-y-2">
+                <p>
+                  You are currently viewing usage for the{' '}
+                  <span className="font-medium text-foreground">
+                    {selectedProject?.name || selectedProjectRef}
+                  </span>{' '}
+                  project
+                  {selectedBranch && (
+                    <>
+                      , branch{' '}
+                      <span className="font-medium text-foreground">{selectedBranch.name}</span>
+                    </>
+                  )}
+                  . Supabase uses{' '}
+                  <Link
+                    href="/docs/guides/platform/billing-on-supabase#organization-based-billing"
+                    target="_blank"
+                  >
+                    organization-level billing
+                  </Link>{' '}
+                  and quotas. For billing purposes, we sum up usage from all your projects. To view
+                  your usage quota, set the project filter above back to "All Projects".
+                </p>
+                {branchOptions.length > 0 && (
+                  <p>
+                    Each branch records its own usage, so this view excludes the project's branches.
+                    Select a branch above to see its usage. Usage from deleted branches still counts
+                    toward the organization total.
+                  </p>
+                )}
               </div>
             }
           />
@@ -305,7 +366,7 @@ export const Usage = () => {
 
       <TotalUsage
         orgSlug={slug as string}
-        projectRef={selectedProjectRef}
+        projectRef={usageProjectRef}
         subscription={subscription}
         startDate={startDate}
         endDate={endDate}
@@ -325,7 +386,7 @@ export const Usage = () => {
 
       <Egress
         orgSlug={slug as string}
-        projectRef={selectedProjectRef}
+        projectRef={usageProjectRef}
         subscription={subscription}
         currentBillingCycleSelected={currentBillingCycleSelected}
         orgDailyStats={orgDailyStats}
@@ -336,7 +397,7 @@ export const Usage = () => {
 
       <SizeAndCounts
         orgSlug={slug as string}
-        projectRef={selectedProjectRef}
+        projectRef={usageProjectRef}
         subscription={subscription}
         currentBillingCycleSelected={currentBillingCycleSelected}
         orgDailyStats={orgDailyStats}
@@ -347,7 +408,7 @@ export const Usage = () => {
 
       <Activity
         orgSlug={slug as string}
-        projectRef={selectedProjectRef}
+        projectRef={usageProjectRef}
         subscription={subscription}
         startDate={startDate}
         endDate={endDate}
@@ -359,7 +420,7 @@ export const Usage = () => {
       {subscription?.plan.id === 'platform' && (
         <OrgLogUsage
           orgSlug={slug as string}
-          projectRef={selectedProjectRef}
+          projectRef={usageProjectRef}
           subscription={subscription}
           startDate={startDate}
           endDate={endDate}
@@ -371,7 +432,7 @@ export const Usage = () => {
 
       <Pipelines
         orgSlug={slug as string}
-        projectRef={selectedProjectRef}
+        projectRef={usageProjectRef}
         subscription={subscription}
         startDate={startDate}
         endDate={endDate}

--- a/apps/studio/components/interfaces/Organization/Usage/Usage.utils.test.ts
+++ b/apps/studio/components/interfaces/Organization/Usage/Usage.utils.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { dailyUsageToDataPoints, getUsageBranchOptions } from './Usage.utils'
 import { PricingMetric } from '@/data/analytics/org-daily-stats-query'
 import type { OrgDailyUsageResponse } from '@/data/analytics/org-daily-stats-query'
-import type { Branch } from '@/data/branches/branches-query'
+import { createTestBranch } from '@/tests/lib/branch-test-utils'
 
 describe('dailyUsageToDataPoints', () => {
   it('returns empty array when dailyUsage is undefined', () => {
@@ -252,24 +252,29 @@ describe('dailyUsageToDataPoints', () => {
 })
 
 describe('getUsageBranchOptions', () => {
-  const createBranch = (branch: Partial<Branch>) =>
-    ({ created_at: '2026-01-01T00:00:00Z', is_default: false, ...branch }) as Branch
-
   it('returns no options when there are no branches', () => {
     expect(getUsageBranchOptions(undefined)).toEqual([])
     expect(getUsageBranchOptions([])).toEqual([])
   })
 
   it('returns no options when the project only has a main branch', () => {
-    const branches = [createBranch({ name: 'main', project_ref: 'parent', is_default: true })]
+    const branches = [createTestBranch({ name: 'main', project_ref: 'parent', is_default: true })]
     expect(getUsageBranchOptions(branches)).toEqual([])
   })
 
   it('puts the main branch first, then the newest branches', () => {
     const branches = [
-      createBranch({ name: 'older', project_ref: 'older-ref', created_at: '2026-01-01T00:00:00Z' }),
-      createBranch({ name: 'main', project_ref: 'parent', is_default: true }),
-      createBranch({ name: 'newer', project_ref: 'newer-ref', created_at: '2026-02-01T00:00:00Z' }),
+      createTestBranch({
+        name: 'older',
+        project_ref: 'older-ref',
+        created_at: '2026-01-01T00:00:00Z',
+      }),
+      createTestBranch({ name: 'main', project_ref: 'parent', is_default: true }),
+      createTestBranch({
+        name: 'newer',
+        project_ref: 'newer-ref',
+        created_at: '2026-02-01T00:00:00Z',
+      }),
     ]
 
     expect(getUsageBranchOptions(branches).map((branch) => branch.name)).toEqual([
@@ -281,8 +286,8 @@ describe('getUsageBranchOptions', () => {
 
   it('returns branches without a main branch', () => {
     const branches = [
-      createBranch({ name: 'one', project_ref: 'one-ref' }),
-      createBranch({ name: 'two', project_ref: 'two-ref' }),
+      createTestBranch({ name: 'one', project_ref: 'one-ref' }),
+      createTestBranch({ name: 'two', project_ref: 'two-ref' }),
     ]
 
     expect(getUsageBranchOptions(branches).map((branch) => branch.name)).toEqual(['one', 'two'])

--- a/apps/studio/components/interfaces/Organization/Usage/Usage.utils.test.ts
+++ b/apps/studio/components/interfaces/Organization/Usage/Usage.utils.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
-import { dailyUsageToDataPoints } from './Usage.utils'
+import { dailyUsageToDataPoints, getUsageBranchOptions } from './Usage.utils'
 import { PricingMetric } from '@/data/analytics/org-daily-stats-query'
 import type { OrgDailyUsageResponse } from '@/data/analytics/org-daily-stats-query'
+import type { Branch } from '@/data/branches/branches-query'
 
 describe('dailyUsageToDataPoints', () => {
   it('returns empty array when dailyUsage is undefined', () => {
@@ -247,5 +248,43 @@ describe('dailyUsageToDataPoints', () => {
       periodStartFormatted: '01 Oct',
       egress: 0,
     })
+  })
+})
+
+describe('getUsageBranchOptions', () => {
+  const createBranch = (branch: Partial<Branch>) =>
+    ({ created_at: '2026-01-01T00:00:00Z', is_default: false, ...branch }) as Branch
+
+  it('returns no options when there are no branches', () => {
+    expect(getUsageBranchOptions(undefined)).toEqual([])
+    expect(getUsageBranchOptions([])).toEqual([])
+  })
+
+  it('returns no options when the project only has a main branch', () => {
+    const branches = [createBranch({ name: 'main', project_ref: 'parent', is_default: true })]
+    expect(getUsageBranchOptions(branches)).toEqual([])
+  })
+
+  it('puts the main branch first, then the newest branches', () => {
+    const branches = [
+      createBranch({ name: 'older', project_ref: 'older-ref', created_at: '2026-01-01T00:00:00Z' }),
+      createBranch({ name: 'main', project_ref: 'parent', is_default: true }),
+      createBranch({ name: 'newer', project_ref: 'newer-ref', created_at: '2026-02-01T00:00:00Z' }),
+    ]
+
+    expect(getUsageBranchOptions(branches).map((branch) => branch.name)).toEqual([
+      'main',
+      'newer',
+      'older',
+    ])
+  })
+
+  it('returns branches without a main branch', () => {
+    const branches = [
+      createBranch({ name: 'one', project_ref: 'one-ref' }),
+      createBranch({ name: 'two', project_ref: 'two-ref' }),
+    ]
+
+    expect(getUsageBranchOptions(branches).map((branch) => branch.name)).toEqual(['one', 'two'])
   })
 })

--- a/apps/studio/components/interfaces/Organization/Usage/Usage.utils.test.ts
+++ b/apps/studio/components/interfaces/Organization/Usage/Usage.utils.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { dailyUsageToDataPoints, getUsageBranchOptions } from './Usage.utils'
+import {
+  dailyUsageToDataPoints,
+  getUsageBranchOptions,
+  resolveUsageProjectRef,
+} from './Usage.utils'
 import { PricingMetric } from '@/data/analytics/org-daily-stats-query'
 import type { OrgDailyUsageResponse } from '@/data/analytics/org-daily-stats-query'
 import { createTestBranch } from '@/tests/lib/branch-test-utils'
@@ -291,5 +295,36 @@ describe('getUsageBranchOptions', () => {
     ]
 
     expect(getUsageBranchOptions(branches).map((branch) => branch.name)).toEqual(['one', 'two'])
+  })
+
+  it('returns a lone branch that is not the main branch', () => {
+    const branches = [createTestBranch({ name: 'only', project_ref: 'only-ref' })]
+
+    expect(getUsageBranchOptions(branches).map((branch) => branch.name)).toEqual(['only'])
+  })
+})
+
+describe('resolveUsageProjectRef', () => {
+  const branchOptions = [
+    createTestBranch({ name: 'main', project_ref: 'parent-ref', is_default: true }),
+    createTestBranch({ name: 'preview', project_ref: 'branch-ref' }),
+  ]
+
+  it('returns null when no project is selected', () => {
+    expect(resolveUsageProjectRef(null, [], 'branch-ref')).toBe(null)
+  })
+
+  it('returns the selected branch ref', () => {
+    expect(resolveUsageProjectRef('parent-ref', branchOptions, 'branch-ref')).toBe('branch-ref')
+  })
+
+  it('falls back to the project when the branch ref is not one of its branches', () => {
+    expect(resolveUsageProjectRef('parent-ref', branchOptions, 'other-org-branch-ref')).toBe(
+      'parent-ref'
+    )
+  })
+
+  it('falls back to the project while its branches are still unknown', () => {
+    expect(resolveUsageProjectRef('parent-ref', [], 'branch-ref')).toBe('parent-ref')
   })
 })

--- a/apps/studio/components/interfaces/Organization/Usage/Usage.utils.ts
+++ b/apps/studio/components/interfaces/Organization/Usage/Usage.utils.ts
@@ -21,14 +21,24 @@ export const generateUsageData = (attribute: string, days: number): DataPoint[] 
 
 // Usage is recorded against each branch's own project ref, so a branch is only visible when selected
 export function getUsageBranchOptions(branches: Branch[] | undefined) {
-  if (!branches || branches.length < 2) return []
-
-  const mainBranch = branches.find((branch) => branch.is_default)
-  const previewBranches = branches
+  const previewBranches = (branches ?? [])
     .filter((branch) => !branch.is_default)
     .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
 
+  if (previewBranches.length === 0) return []
+
+  const mainBranch = branches?.find((branch) => branch.is_default)
+
   return mainBranch ? [mainBranch, ...previewBranches] : previewBranches
+}
+
+export function resolveUsageProjectRef(
+  selectedProjectRef: string | null,
+  branchOptions: Branch[],
+  selectedBranchRef: string | null
+) {
+  const selectedBranch = branchOptions.find((branch) => branch.project_ref === selectedBranchRef)
+  return selectedBranch?.project_ref ?? selectedProjectRef
 }
 
 export function useGetUpgradeUrl(slug: string, subscription?: OrgSubscription, source?: string) {

--- a/apps/studio/components/interfaces/Organization/Usage/Usage.utils.ts
+++ b/apps/studio/components/interfaces/Organization/Usage/Usage.utils.ts
@@ -3,6 +3,7 @@ import { groupBy } from 'lodash'
 
 import { DataPoint } from '@/data/analytics/constants'
 import type { OrgDailyUsageResponse, PricingMetric } from '@/data/analytics/org-daily-stats-query'
+import type { Branch } from '@/data/branches/branches-query'
 import type { OrgSubscription } from '@/data/subscriptions/types'
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
 
@@ -16,6 +17,18 @@ export const generateUsageData = (attribute: string, days: number): DataPoint[] 
       [attribute]: Math.floor(Math.random() * 100).toString(),
     }
   })
+}
+
+// Usage is recorded against each branch's own project ref, so a branch is only visible when selected
+export function getUsageBranchOptions(branches: Branch[] | undefined) {
+  if (!branches || branches.length < 2) return []
+
+  const mainBranch = branches.find((branch) => branch.is_default)
+  const previewBranches = branches
+    .filter((branch) => !branch.is_default)
+    .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
+
+  return mainBranch ? [mainBranch, ...previewBranches] : previewBranches
 }
 
 export function useGetUpgradeUrl(slug: string, subscription?: OrgSubscription, source?: string) {

--- a/apps/studio/components/interfaces/Organization/Usage/UsageBranchFilter.test.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/UsageBranchFilter.test.tsx
@@ -1,0 +1,69 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import { UsageBranchFilter } from './UsageBranchFilter'
+import { createTestBranch } from '@/tests/lib/branch-test-utils'
+import { customRender } from '@/tests/lib/custom-render'
+
+const mainBranch = createTestBranch({
+  id: 'main-id',
+  name: 'main',
+  project_ref: 'parent-ref',
+  is_default: true,
+})
+
+const previewBranch = createTestBranch({ name: 'marvo-app-dev', project_ref: 'branch-ref' })
+
+describe('UsageBranchFilter', () => {
+  it('renders nothing when the project has no branches to filter by', () => {
+    customRender(
+      <UsageBranchFilter
+        branchOptions={[]}
+        projectRef="parent-ref"
+        branchRef={null}
+        onSelectBranch={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByLabelText('Filter by branch')).not.toBeInTheDocument()
+  })
+
+  it('selects a branch by its own project ref', async () => {
+    const onSelectBranch = vi.fn()
+    customRender(
+      <UsageBranchFilter
+        branchOptions={[mainBranch, previewBranch]}
+        projectRef="parent-ref"
+        branchRef={null}
+        onSelectBranch={onSelectBranch}
+      />
+    )
+
+    expect(screen.getByLabelText('Filter by branch')).toHaveTextContent('main')
+
+    await userEvent.click(screen.getByLabelText('Filter by branch'))
+    await userEvent.click(await screen.findByRole('option', { name: 'marvo-app-dev' }))
+
+    expect(onSelectBranch).toHaveBeenCalledWith('branch-ref')
+  })
+
+  it('clears the branch filter when the main branch is selected', async () => {
+    const onSelectBranch = vi.fn()
+    customRender(
+      <UsageBranchFilter
+        branchOptions={[mainBranch, previewBranch]}
+        projectRef="parent-ref"
+        branchRef="branch-ref"
+        onSelectBranch={onSelectBranch}
+      />
+    )
+
+    expect(screen.getByLabelText('Filter by branch')).toHaveTextContent('marvo-app-dev')
+
+    await userEvent.click(screen.getByLabelText('Filter by branch'))
+    await userEvent.click(await screen.findByRole('option', { name: 'main' }))
+
+    expect(onSelectBranch).toHaveBeenCalledWith(null)
+  })
+})

--- a/apps/studio/components/interfaces/Organization/Usage/UsageBranchFilter.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/UsageBranchFilter.tsx
@@ -1,0 +1,37 @@
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from 'ui'
+
+import type { Branch } from '@/data/branches/branches-query'
+
+export interface UsageBranchFilterProps {
+  branchOptions: Branch[]
+  projectRef: string
+  branchRef: string | null
+  onSelectBranch: (branchRef: string | null) => void
+}
+
+export const UsageBranchFilter = ({
+  branchOptions,
+  projectRef,
+  branchRef,
+  onSelectBranch,
+}: UsageBranchFilterProps) => {
+  if (branchOptions.length === 0) return null
+
+  return (
+    <Select
+      value={branchRef ?? projectRef}
+      onValueChange={(value) => onSelectBranch(value === projectRef ? null : value)}
+    >
+      <SelectTrigger size="tiny" className="w-[180px]" aria-label="Filter by branch">
+        <SelectValue placeholder="Select branch" />
+      </SelectTrigger>
+      <SelectContent>
+        {branchOptions.map((branch) => (
+          <SelectItem key={branch.project_ref} value={branch.project_ref}>
+            {branch.name}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}

--- a/apps/studio/components/interfaces/Organization/Usage/UsageBranchFilter.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/UsageBranchFilter.tsx
@@ -22,7 +22,11 @@ export const UsageBranchFilter = ({
       value={branchRef ?? projectRef}
       onValueChange={(value) => onSelectBranch(value === projectRef ? null : value)}
     >
-      <SelectTrigger size="tiny" className="w-[180px]" aria-label="Filter by branch">
+      <SelectTrigger
+        size="tiny"
+        className="w-auto min-w-[140px] max-w-[280px]"
+        aria-label="Filter by branch"
+      >
         <SelectValue placeholder="Select branch" />
       </SelectTrigger>
       <SelectContent>

--- a/apps/studio/components/interfaces/Organization/Usage/UsageFilterNotice.test.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/UsageFilterNotice.test.tsx
@@ -1,0 +1,35 @@
+import { screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { UsageFilterNotice } from './UsageFilterNotice'
+import { customRender } from '@/tests/lib/custom-render'
+
+describe('UsageFilterNotice', () => {
+  it('tells the reader that branch usage is excluded from the project view', () => {
+    customRender(<UsageFilterNotice projectName="Marvo app" hasBranches />)
+
+    expect(screen.getByText('Usage filtered by project')).toBeInTheDocument()
+    expect(
+      screen.getByText(/Each branch records its own usage, so this view excludes/)
+    ).toBeInTheDocument()
+  })
+
+  it('omits the branch note for a project without branches', () => {
+    customRender(<UsageFilterNotice projectName="Marvo app" hasBranches={false} />)
+
+    expect(screen.queryByText(/Each branch records its own usage/)).not.toBeInTheDocument()
+  })
+
+  it('names the branch and drops the select-a-branch prompt once a branch is filtered', () => {
+    customRender(
+      <UsageFilterNotice projectName="Marvo app" branchName="marvo-app-dev" hasBranches />
+    )
+
+    expect(screen.getByText('Usage filtered by branch')).toBeInTheDocument()
+    expect(screen.getByText('marvo-app-dev')).toBeInTheDocument()
+    expect(
+      screen.getByText(/This branch's usage counts toward the organization total/)
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/Select a branch above/)).not.toBeInTheDocument()
+  })
+})

--- a/apps/studio/components/interfaces/Organization/Usage/UsageFilterNotice.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/UsageFilterNotice.tsx
@@ -1,0 +1,60 @@
+import Link from 'next/link'
+import { Admonition } from 'ui-patterns/Admonition'
+
+import { ScaffoldContainer } from '@/components/layouts/Scaffold'
+
+export interface UsageFilterNoticeProps {
+  projectName: string
+  branchName?: string
+  hasBranches: boolean
+}
+
+export const UsageFilterNotice = ({
+  projectName,
+  branchName,
+  hasBranches,
+}: UsageFilterNoticeProps) => {
+  return (
+    <ScaffoldContainer className="mt-5">
+      <Admonition
+        type="default"
+        title={branchName ? 'Usage filtered by branch' : 'Usage filtered by project'}
+        description={
+          <div className="space-y-2">
+            <p>
+              You are currently viewing usage for the{' '}
+              <span className="font-medium text-foreground">{projectName}</span> project
+              {!!branchName && (
+                <>
+                  , branch <span className="font-medium text-foreground">{branchName}</span>
+                </>
+              )}
+              . Supabase uses{' '}
+              <Link
+                href="/docs/guides/platform/billing-on-supabase#organization-based-billing"
+                target="_blank"
+              >
+                organization-level billing
+              </Link>{' '}
+              and quotas. For billing purposes, we sum up usage from all your projects. To view your
+              usage quota, set the project filter above back to "All projects".
+            </p>
+            {!!branchName && (
+              <p>
+                This branch's usage counts toward the organization total, but is not included in the
+                parent project's usage.
+              </p>
+            )}
+            {!branchName && hasBranches && (
+              <p>
+                Each branch records its own usage, so this view excludes the project's branches.
+                Select a branch above to see its usage. Usage from deleted branches still counts
+                toward the organization total.
+              </p>
+            )}
+          </div>
+        }
+      />
+    </ScaffoldContainer>
+  )
+}

--- a/apps/studio/components/interfaces/Organization/Usage/UsageSection/DiskUsage.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/UsageSection/DiskUsage.tsx
@@ -50,12 +50,16 @@ export const DiskUsage = ({
             const isBranchExceedingFreeQuota =
               project.is_branch && project.databases.some((db) => (db.disk_volume_size_gb ?? 8) > 8)
 
+            const isFilteredBranch = project.is_branch && project.ref === projectRef
+
             const isActiveProject = project.status !== PROJECT_STATUS.INACTIVE
 
             const isHostedOnAws = project.databases.every((db) => db.cloud_provider === 'AWS')
 
             return (
-              (!project.is_branch || isBranchExceedingFreeQuota) && isActiveProject && isHostedOnAws
+              (!project.is_branch || isBranchExceedingFreeQuota || isFilteredBranch) &&
+              isActiveProject &&
+              isHostedOnAws
             )
           })
           .filter((it) => it.ref === projectRef || !projectRef)

--- a/apps/studio/tests/lib/branch-test-utils.ts
+++ b/apps/studio/tests/lib/branch-test-utils.ts
@@ -1,0 +1,15 @@
+import type { Branch } from '@/data/branches/branches-query'
+
+export const createTestBranch = (overrides: Partial<Branch> = {}): Branch => ({
+  created_at: '2026-01-01T00:00:00Z',
+  id: 'branch-id',
+  is_default: false,
+  name: 'branch',
+  parent_project_ref: 'parent-ref',
+  persistent: false,
+  project_ref: 'branch-ref',
+  status: 'MIGRATIONS_PASSED',
+  updated_at: '2026-01-01T00:00:00Z',
+  with_data: false,
+  ...overrides,
+})


### PR DESCRIPTION
## What

The org Usage page could only be filtered by project, and usage is recorded against each branch's own project ref. Filtering by the parent project therefore hid every branch's usage, with no dashboard surface that attributed it — customers hitting a branch-driven egress overage had no way to see where the usage came from.

- Adds a branch filter next to the project selector on the org Usage page, shown when the selected project has more than its main branch. Selecting a branch filters every usage section (egress included) to that branch.
- The "Usage filtered by project" notice now states that each branch records its own usage, that the project view excludes it, and that usage from deleted branches still counts toward the organization total.
- Disk usage now shows a branch's row when that branch is the active filter (it was previously hidden unless the branch exceeded the 8 GB included disk).
- Docs: `manage-your-usage/branching.mdx` no longer says non-compute branch usage is "rolled up into the project"; `manage-your-usage/egress.mdx` explains that branch egress is tracked separately and how to view it.

## Not included

A per-project egress breakdown that sums to the org total needs `GET /platform/organizations/{slug}/usage/daily` to support grouping by project. This PR uses the existing endpoints only.

Deleted branches still don't appear in the filter, since the branches endpoint only returns live ones. Their usage stays in the org total, which the notice now says.

## Testing

Unit tests cover the branch option list and the resolution of a `branchRef` against the selected project's branches. Component tests cover the branch filter (selecting a branch, clearing back to main) and the three states of the filtered-usage notice.

The pre-existing `Usage.test.tsx` suite doesn't load on my machine (missing `@tailwindcss/postcss` breaks the PostCSS config, on master too), so there's no page-level test asserting the sections swap refs; the logic behind that is unit tested instead.

FE-4153