### PR TITLE
fix(studio): preserve JSON values when exporting SQL

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/TableEntity.utils.test.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/TableEntity.utils.test.ts
@@ -89,6 +89,37 @@ describe('TableEntity.utils: formatTableRowsToSQL', () => {
     expect(result).toBe(expected)
   })
 
+  it('should correctly format JSON/JSONB values with nested quotes, backslashes, and objects', () => {
+    const table: SupaTable = {
+      id: 1,
+      type: ENTITY_TYPE.TABLE,
+      columns: [
+        { name: 'id', dataType: 'bigint', format: 'int8', position: 0 },
+        { name: 'metadata', dataType: 'jsonb', format: 'jsonb', position: 1 },
+      ],
+      name: 'demo',
+      schema: 'public',
+      comment: undefined,
+      estimateRowCount: 1,
+    }
+    const rows = [
+      { id: 1, metadata: '{"note": "say \\"hi\\""}' },
+      { id: 2, metadata: '{"path": "C:\\\\Users\\\\me"}' },
+      {
+        id: 3,
+        metadata: {
+          note: 'say "hi"',
+          user: "O'Neil",
+          path: 'C:\\Users\\me',
+        },
+      },
+    ]
+
+    const result = formatTableRowsToSQL(table, rows)
+    const expected = `INSERT INTO "public"."demo" ("id", "metadata") VALUES (1, '{"note": "say \\"hi\\""}'), (2, '{"path": "C:\\\\Users\\\\me"}'), (3, '{"note":"say \\"hi\\"","user":"O''Neil","path":"C:\\\\Users\\\\me"}');`
+    expect(result).toBe(expected)
+  })
+
   it('should emit valid Postgres literals for booleans, numbers and text arrays', () => {
     const table: SupaTable = {
       id: 1,

--- a/apps/studio/components/interfaces/TableGridEditor/TableEntity.utils.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/TableEntity.utils.ts
@@ -58,7 +58,9 @@ export const formatTableRowsToSQL = (table: SupaTable, rows: any[]) => {
           const array = Array.isArray(val) ? val : JSON.parse(val as string)
           return `${formatArrayForSql(array as unknown[])}`
         } else if (format?.includes('json')) {
-          return `${JSON.stringify(val).replace(/\\"/g, '"').replace(/'/g, "''").replace('"', "'").replace(/.$/, "'")}`
+          const jsonStr =
+            typeof val === 'object' && val !== null ? JSON.stringify(val) : String(val)
+          return `'${jsonStr.replaceAll("'", "''")}'`
         } else if (
           typeof format === 'string' &&
           typeof val === 'string' &&


### PR DESCRIPTION
## Description

Fixes an issue where exporting JSON/JSONB rows as SQL could corrupt values containing quotes or backslashes.

The previous implementation applied ad-hoc replacements to `JSON.stringify()` output, which could remove JSON escape characters and produce invalid or corrupted JSON.

This change:

- Preserves JSON escaping for double quotes and backslashes.
- Serializes JavaScript objects/arrays using `JSON.stringify()`.
- Escapes single quotes for PostgreSQL SQL string literals.
- Adds regression coverage for quoted JSON, backslashes, and apostrophes.

## Related Issue

Fixes #49196

## Testing

The targeted Vitest suite could not be run locally because the repository requires Node >= 22.13 and pnpm >= 11.13, while the local environment has Node 20.19.4 and pnpm 10.5.2.

The affected formatting logic was additionally validated with isolated Node assertions covering:

- JSON containing escaped double quotes
- JSON containing backslashes
- JSON objects containing quotes, apostrophes, and backslashes

`git diff --check` passes cleanly.

## Files Changed

- `apps/studio/components/interfaces/TableGridEditor/TableEntity.utils.ts`
- `apps/studio/components/interfaces/TableGridEditor/TableEntity.utils.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of JSON and JSONB values when generating SQL, including nested quotes, backslashes, and object values.
  * Ensured single quotes are escaped correctly to produce valid PostgreSQL literals.

* **Tests**
  * Added coverage for complex JSON and JSONB formatting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->