### PR TITLE
docs(database): correct RLS guide against skills and academy rules

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -1118,6 +1118,10 @@ export const database: NavMenuConstant = {
           url: '/guides/database/postgres/row-level-security' as `/${string}`,
         },
         {
+          name: 'Row Level Security Performance',
+          url: '/guides/database/postgres/row-level-security-performance' as `/${string}`,
+        },
+        {
           name: 'Column Level Security',
           url: '/guides/database/postgres/column-level-security' as `/${string}`,
         },

--- a/apps/docs/content/guides/api/custom-claims-and-role-based-access-control-rbac.mdx
+++ b/apps/docs/content/guides/api/custom-claims-and-role-based-access-control-rbac.mdx
@@ -181,7 +181,7 @@ $$ language plpgsql stable security definer set search_path = '';
 
 <Admonition type="note">
 
-You can read more about using functions in RLS policies in the [RLS guide](/docs/guides/database/postgres/row-level-security#using-functions).
+You can read more about using functions in RLS policies in the [RLS guide](/docs/guides/database/postgres/row-level-security#use-security-definer-functions).
 
 </Admonition>
 
@@ -219,5 +219,5 @@ You now have a robust system in place to manage user roles and permissions withi
 
 - [Auth Hooks](/docs/guides/auth/auth-hooks)
 - [Row Level Security](/docs/guides/database/postgres/row-level-security)
-- [RLS Functions](/docs/guides/database/postgres/row-level-security#using-functions)
+- [RLS helper functions](/docs/guides/database/postgres/row-level-security#helper-functions)
 - [Next.js Slack Clone Example](https://github.com/supabase/supabase/tree/master/examples/slack-clone/nextjs-slack-clone)

--- a/apps/docs/content/guides/database/postgres/event-triggers.mdx
+++ b/apps/docs/content/guides/database/postgres/event-triggers.mdx
@@ -55,7 +55,47 @@ EXECUTE FUNCTION dont_drop_function();
 
 ### Example trigger function - auto enable Row Level Security
 
-See how to [auto enable RLS for new tables](/docs/guides/database/postgres/row-level-security#auto-enable-rls-for-new-tables).
+If you want [Row Level Security](/docs/guides/database/postgres/row-level-security) enabled automatically for new tables, create an event trigger that runs after table creation and calls `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` on each newly created table.
+
+```sql
+CREATE OR REPLACE FUNCTION rls_auto_enable()
+RETURNS EVENT_TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  cmd record;
+BEGIN
+  FOR cmd IN
+    SELECT *
+    FROM pg_event_trigger_ddl_commands()
+    WHERE command_tag IN ('CREATE TABLE', 'CREATE TABLE AS', 'SELECT INTO')
+      AND object_type IN ('table','partitioned table')
+  LOOP
+     IF cmd.schema_name IS NOT NULL AND cmd.schema_name IN ('public') AND cmd.schema_name NOT IN ('pg_catalog','information_schema') AND cmd.schema_name NOT LIKE 'pg_toast%' AND cmd.schema_name NOT LIKE 'pg_temp%' THEN
+      BEGIN
+        EXECUTE format('alter table if exists %s enable row level security', cmd.object_identity);
+        RAISE LOG 'rls_auto_enable: enabled RLS on %', cmd.object_identity;
+      EXCEPTION
+        WHEN OTHERS THEN
+          RAISE LOG 'rls_auto_enable: failed to enable RLS on %', cmd.object_identity;
+      END;
+     ELSE
+        RAISE LOG 'rls_auto_enable: skip % (either system schema or not in enforced list: %.)', cmd.object_identity, cmd.schema_name;
+     END IF;
+  END LOOP;
+END;
+$$;
+
+DROP EVENT TRIGGER IF EXISTS ensure_rls;
+CREATE EVENT TRIGGER ensure_rls
+ON ddl_command_end
+WHEN TAG IN ('CREATE TABLE', 'CREATE TABLE AS', 'SELECT INTO')
+EXECUTE FUNCTION rls_auto_enable();
+```
+
+Note that this applies to tables created after the trigger is installed. Existing tables still need RLS enabled manually.
 
 ### Event trigger Functions and firing events
 

--- a/apps/docs/content/guides/database/postgres/event-triggers.mdx
+++ b/apps/docs/content/guides/database/postgres/event-triggers.mdx
@@ -80,6 +80,7 @@ BEGIN
       EXCEPTION
         WHEN OTHERS THEN
           RAISE LOG 'rls_auto_enable: failed to enable RLS on %', cmd.object_identity;
+          RAISE;
       END;
      ELSE
         RAISE LOG 'rls_auto_enable: skip % (either system schema or not in enforced list: %.)', cmd.object_identity, cmd.schema_name;

--- a/apps/docs/content/guides/database/postgres/row-level-security-performance.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security-performance.mdx
@@ -91,7 +91,7 @@ Policies are implicit `where` clauses, so it's common to run `select` statements
 
 {/* prettier-ignore */}
 ```js
-const { data } = supabase
+const { data } = await supabase
   .from('table')
   .select()
 ```
@@ -100,7 +100,7 @@ Always add a filter:
 
 {/* prettier-ignore */}
 ```js
-const { data } = supabase
+const { data } = await supabase
   .from('table')
   .select()
   .eq('user_id', userId)
@@ -121,7 +121,7 @@ using (
   (select auth.uid()) in (
     select user_id
     from team_user
-    where team_user.team_id = team_id -- joins to the source "test_table.team_id"
+    where team_user.team_id = test_table.team_id -- joins to the source table
   )
 );
 ```
@@ -162,7 +162,7 @@ These numbers come from a series of [tests](https://github.com/GaryAustin1/RLS-P
 | [test2e-wrappedSQL-sd-fun-array](https://github.com/GaryAustin1/RLS-Performance/tree/main/tests/test2e-wrappedSQL-sd-fun-array)   | 173,000     | 16         | 99.991%       | `team_id = any(user_teams())`, then `team_id = any(array(select user_teams()))`     |
 | [test3-addfilter](https://github.com/GaryAustin1/RLS-Performance/tree/main/tests/test3-addfilter)                                 | 171         | 9          | 94.74%        | No client filter, then `.eq` or `where` on `user_id`                                |
 | [test5-fixed-join](https://github.com/GaryAustin1/RLS-Performance/tree/main/tests/test5-fixed-join)                               | 9,000       | 20         | 99.78%        | `auth.uid()` in a table join on a column, then the column in a join on `auth.uid()` |
-| [test6-To-role](https://github.com/GaryAustin1/RLS-Performance/tree/main/tests/test6-To-role)                                     | 170         | < 0.1      | 99.78%        | No `to` clause, then `to authenticated` with `anon` accessing                       |
+| [test6-To-role](https://github.com/GaryAustin1/RLS-Performance/tree/main/tests/test6-To-role)                                     | 170         | < 0.1      | 99.94%        | No `to` clause, then `to authenticated` with `anon` accessing                       |
 
 ## More resources
 

--- a/apps/docs/content/guides/database/postgres/row-level-security-performance.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security-performance.mdx
@@ -1,0 +1,171 @@
+---
+id: 'row-level-security-performance'
+title: 'Row Level Security performance'
+description: 'Measure and tune Postgres Row Level Security policies.'
+subtitle: 'Measure and tune Postgres Row Level Security policies.'
+---
+
+This guide explains how to measure the cost of Row Level Security (RLS) and tune policies that are already correct. To learn how to write correct policies, see [Row Level Security](/docs/guides/database/postgres/row-level-security).
+
+Postgres evaluates a policy expression against each candidate row, so the cost scales with the rows a query scans. This matters most for queries that scan every row in a table, like many `select` operations, including those using limit, offset, and ordering.
+
+Three policy rules affect performance enough that they belong with the policy itself rather than here. The RLS guide covers each one, and the [benchmarks](#benchmarks) on this page measure them:
+
+- [Index the columns your policies filter on](/docs/guides/database/postgres/row-level-security#add-indexes)
+- [Call functions with `select`](/docs/guides/database/postgres/row-level-security#call-functions-with-select)
+- [Specify roles in your policies](/docs/guides/database/postgres/row-level-security#specify-roles-in-your-policies)
+
+## Diagnose whether RLS is the bottleneck
+
+Confirm that policies are the cost before you rewrite one. Run the query with RLS enabled, then again with it disabled, and compare. If the times are similar, the query itself is the problem.
+
+<Admonition type="caution">
+
+Disabling RLS exposes every row in the table to any role with a matching grant. Only do this in a non-production environment.
+
+</Admonition>
+
+To reproduce an API request, set the JWT claims and switch to the role the request runs as:
+
+```sql
+set session role authenticated;
+set request.jwt.claims to '{"role":"authenticated", "sub":"5950b438-b07c-4012-8190-6ce79e4bd8e5"}';
+
+explain analyze select count(*) from rlstest;
+
+set session role postgres;
+```
+
+The output shows the policy expression as a filter, and the execution time is the number to compare:
+
+```
+Seq Scan on rlstest  (cost=0.00..4334.00 rows=1 width=35) (actual time=170.999..170.999 rows=0 loops=1)
+  Filter: ((COALESCE(NULLIF(current_setting('request.jwt.claim.sub'::text, true), ''::text), ((NULLIF(current_setting('request.jwt.claims'::text, true), ''::text))::jsonb ->> 'sub'::text)))::uuid = user_id)
+  Rows Removed by Filter: 100000
+Planning Time: 0.216 ms
+Execution Time: 171.033 ms
+```
+
+`Rows Removed by Filter` is the signal to watch. A policy that removes most of the table on every read is a policy whose filter column needs an index.
+
+### Measure through the Data API
+
+PostgREST can return the query plan to a Supabase client. Enable it first:
+
+```sql
+alter role authenticator set pgrst.db_plan_enabled to true;
+notify pgrst, 'reload config';
+```
+
+<Admonition type="caution">
+
+`pgrst.db_plan_enabled` exposes query plans over your Data API. Don't enable it in production.
+
+</Admonition>
+
+Then add the `.explain()` modifier to a query:
+
+```js
+const { data, error } = await supabase
+  .from('projects')
+  .select('*')
+  .eq('id', 1)
+  .explain({ analyze: true })
+
+console.log(data)
+```
+
+```
+Aggregate  (cost=8.18..8.20 rows=1 width=112) (actual time=0.017..0.018 rows=1 loops=1)
+  ->  Index Scan using projects_pkey on projects  (cost=0.15..8.17 rows=1 width=40) (actual time=0.012..0.012 rows=0 loops=1)
+        Index Cond: (id = 1)
+        Filter: false
+        Rows Removed by Filter: 1
+Planning Time: 0.092 ms
+Execution Time: 0.046 ms
+```
+
+## Filter in the client query too
+
+Policies are implicit `where` clauses, so it's common to run `select` statements without any filters. That's a bad pattern for performance. Instead of this:
+
+{/* prettier-ignore */}
+```js
+const { data } = supabase
+  .from('table')
+  .select()
+```
+
+Always add a filter:
+
+{/* prettier-ignore */}
+```js
+const { data } = supabase
+  .from('table')
+  .select()
+  .eq('user_id', userId)
+```
+
+Even though this duplicates the contents of the policy, Postgres can use the filter to construct a better query plan.
+
+## Avoid joins in policy expressions
+
+You can often rewrite a policy to avoid a join between the source and the target table. Fetch the relevant data from the target table into an array or set instead, then use an `in` or `any` operation in your filter.
+
+This policy joins the source `test_table` to the target `team_user`:
+
+```sql
+create policy "rls_test_select" on test_table
+to authenticated
+using (
+  (select auth.uid()) in (
+    select user_id
+    from team_user
+    where team_user.team_id = team_id -- joins to the source "test_table.team_id"
+  )
+);
+```
+
+Rewriting it selects the filter criteria into a set instead:
+
+```sql
+create policy "rls_test_select" on test_table
+to authenticated
+using (
+  team_id in (
+    select team_id
+    from team_user
+    where user_id = (select auth.uid()) -- no join
+  )
+);
+```
+
+You can also use a [security definer function](/docs/guides/database/postgres/row-level-security#use-security-definer-functions) to bypass RLS on the join table.
+
+<Admonition type="note">
+
+If the list exceeds 1000 items, a different approach may be needed, or you may need to analyze the approach to ensure that the performance is acceptable.
+
+</Admonition>
+
+## Benchmarks
+
+These numbers come from a series of [tests](https://github.com/GaryAustin1/RLS-Performance) run against a 100,000-row table. Each row links to the test that produced it.
+
+| Test                                                                                                                              | Before (ms) | After (ms) | % Improvement | Change                                                                              |
+| --------------------------------------------------------------------------------------------------------------------------------- | ----------- | ---------- | ------------- | ----------------------------------------------------------------------------------- |
+| [test1-indexed](https://github.com/GaryAustin1/RLS-Performance/tree/main/tests/test1-indexed)                                     | 171         | < 0.1      | 99.94%        | No index, then `user_id` indexed                                                    |
+| [test2a-wrappedSQL-uid](<https://github.com/GaryAustin1/RLS-Performance/tree/main/tests/test2a-wrappedSQL-uid()>)                 | 179         | 9          | 94.97%        | `auth.uid() = user_id`, then `(select auth.uid()) = user_id`                        |
+| [test2b-wrappedSQL-isadmin](<https://github.com/GaryAustin1/RLS-Performance/tree/main/tests/test2b-wrappedSQL-isadmin()>)         | 11,000      | 7          | 99.94%        | `is_admin()` table join, then `(select is_admin())` table join                      |
+| [test2c-wrappedSQL-two-functions](https://github.com/GaryAustin1/RLS-Performance/tree/main/tests/test2c-wrappedSQL-two-functions) | 11,000      | 10         | 99.91%        | Two bare function calls, then both wrapped in `select`                              |
+| [test2d-wrappedSQL-sd-fun](https://github.com/GaryAustin1/RLS-Performance/tree/main/tests/test2d-wrappedSQL-sd-fun)               | 178,000     | 12         | 99.993%       | `has_role() = role`, then `(select has_role()) = role`                              |
+| [test2e-wrappedSQL-sd-fun-array](https://github.com/GaryAustin1/RLS-Performance/tree/main/tests/test2e-wrappedSQL-sd-fun-array)   | 173,000     | 16         | 99.991%       | `team_id = any(user_teams())`, then `team_id = any(array(select user_teams()))`     |
+| [test3-addfilter](https://github.com/GaryAustin1/RLS-Performance/tree/main/tests/test3-addfilter)                                 | 171         | 9          | 94.74%        | No client filter, then `.eq` or `where` on `user_id`                                |
+| [test5-fixed-join](https://github.com/GaryAustin1/RLS-Performance/tree/main/tests/test5-fixed-join)                               | 9,000       | 20         | 99.78%        | `auth.uid()` in a table join on a column, then the column in a join on `auth.uid()` |
+| [test6-To-role](https://github.com/GaryAustin1/RLS-Performance/tree/main/tests/test6-To-role)                                     | 170         | < 0.1      | 99.78%        | No `to` clause, then `to authenticated` with `anon` accessing                       |
+
+## More resources
+
+- [Row Level Security](/docs/guides/database/postgres/row-level-security)
+- [Managing indexes in Postgres](/docs/guides/database/postgres/indexes)
+- [Query optimization](/docs/guides/database/query-optimization)

--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -557,11 +557,9 @@ rollback;
 
 For CLI setup and more pgTAP helpers, see [Testing your database](/docs/guides/database/testing).
 
-## RLS performance recommendations
+## Write policies that scale
 
-Every authorization system has an impact on performance. Postgres evaluates a policy expression against each candidate row, so the cost scales with the rows a query scans. This matters most for queries that scan every row in a table, like many `select` operations, including those using limit, offset, and ordering.
-
-Based on a series of [tests](https://github.com/GaryAustin1/RLS-Performance), these are the recommendations for RLS:
+Postgres evaluates a policy expression against each candidate row, so the cost scales with the rows a query scans. Three rules keep that cost from growing with your table. Apply all three to every policy you write.
 
 ### Add indexes
 
@@ -596,12 +594,6 @@ on team_members
 using btree (user_id);
 ```
 
-#### Benchmarks
-
-| Test                                                                                          | Before (ms) | After (ms) | % Improvement | Change                                                                                                   |
-| --------------------------------------------------------------------------------------------- | ----------- | ---------- | ------------- | -------------------------------------------------------------------------------------------------------- |
-| [test1-indexed](https://github.com/GaryAustin1/RLS-Performance/tree/main/tests/test1-indexed) | 171         | < 0.1      | 99.94%        | <details className="cursor-pointer">Before:<br/>No index<br/><br/>After:<br/>`user_id` indexed</details> |
-
 ### Call functions with `select`
 
 You can use `select` statement to improve policies that use functions. For example, instead of this:
@@ -628,44 +620,26 @@ You can only use this technique if the results of the query or function do not c
 
 </Admonition>
 
-#### Benchmarks
+### Specify roles in your policies
 
-| Test                                                                                                                              | Before (ms) | After (ms) | % Improvement | Change                                                                                                                                                                    |
-| --------------------------------------------------------------------------------------------------------------------------------- | ----------- | ---------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [test2a-wrappedSQL-uid](<https://github.com/GaryAustin1/RLS-Performance/tree/main/tests/test2a-wrappedSQL-uid()>)                 | 179         | 9          | 94.97%        | <details className="cursor-pointer">Before:<br/>`auth.uid() = user_id` <br/><br/>After:<br/> `(select auth.uid()) = user_id`</details>                                    |
-| [test2b-wrappedSQL-isadmin](<https://github.com/GaryAustin1/RLS-Performance/tree/main/tests/test2b-wrappedSQL-isadmin()>)         | 11,000      | 7          | 99.94%        | <details className="cursor-pointer">Before:<br/>`is_admin()` _table join_<br/><br/>After:<br/>`(select is_admin())` _table join_</details>                                |
-| [test2c-wrappedSQL-two-functions](https://github.com/GaryAustin1/RLS-Performance/tree/main/tests/test2c-wrappedSQL-two-functions) | 11,000      | 10         | 99.91%        | <details className="cursor-pointer">Before:<br/>`is_admin() OR auth.uid() = user_id`<br/><br/>After:<br/>`(select is_admin()) OR (select auth.uid() = user_id)`</details> |
-| [test2d-wrappedSQL-sd-fun](https://github.com/GaryAustin1/RLS-Performance/tree/main/tests/test2d-wrappedSQL-sd-fun)               | 178,000     | 12         | 99.993%       | <details className="cursor-pointer">Before:<br/>`has_role() = role` <br/><br/>After:<br/>(select has_role()) = role</details>                                             |
-| [test2e-wrappedSQL-sd-fun-array](https://github.com/GaryAustin1/RLS-Performance/tree/main/tests/test2e-wrappedSQL-sd-fun-array)   | 173000      | 16         | 99.991%       | <details className="cursor-pointer">Before:<br/>`team_id=any(user_teams())` <br/><br/>After:<br/>team_id=any(array(select user_teams()))</details>                        |
+Always name the role a policy applies to, using the `to` clause. Instead of this:
 
-### Add filters to every query
-
-Policies are "implicit where clauses," so it's common to run `select` statements without any filters. This is a bad pattern for performance. Instead of doing this (JS client example):
-
-{/* prettier-ignore */}
-```js
-const { data } = supabase
-  .from('table')
-  .select()
+```sql
+create policy "rls_test_select" on rls_test
+using ( auth.uid() = user_id );
 ```
 
-You should always add a filter:
+Use:
 
-{/* prettier-ignore */}
-```js
-const { data } = supabase
-  .from('table')
-  .select()
-  .eq('user_id', userId)
+```sql
+create policy "rls_test_select" on rls_test
+to authenticated
+using ( (select auth.uid()) = user_id );
 ```
 
-Even though this duplicates the contents of the Policy, Postgres can use the filter to construct a better query plan.
+This prevents the policy `( (select auth.uid()) = user_id )` from running for any `anon` users, since the execution stops at the `to authenticated` step.
 
-#### Benchmarks
-
-| Test                                                                                              | Before (ms) | After (ms) | % Improvement | Change                                                                                                                                 |
-| ------------------------------------------------------------------------------------------------- | ----------- | ---------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| [test3-addfilter](https://github.com/GaryAustin1/RLS-Performance/tree/main/tests/test3-addfilter) | 171         | 9          | 94.74%        | <details className="cursor-pointer">Before:<br/>`auth.uid() = user_id`<br/><br/>After:<br/>add `.eq` or `where` on `user_id`</details> |
+These three rules keep policies correct as a table grows. For the measured impact and for tuning beyond them, see [Row Level Security performance](/docs/guides/database/postgres/row-level-security-performance).
 
 ### Use security definer functions
 
@@ -714,79 +688,11 @@ A `security definer` function in an exposed schema is callable over the Data API
 
 </Admonition>
 
-### Minimize joins
+## Related content
 
-You can often rewrite your Policies to avoid joins between the source and the target table. Instead, try to organize your policy to fetch all the relevant data from the target table into an array or set, then you can use an `IN` or `ANY` operation in your filter.
-
-For example, this is an example of a slow policy which joins the source `test_table` to the target `team_user`:
-
-```sql
-create policy "rls_test_select" on test_table
-to authenticated
-using (
-  (select auth.uid()) in (
-    select user_id
-    from team_user
-    where team_user.team_id = team_id -- joins to the source "test_table.team_id"
-  )
-);
-```
-
-We can rewrite this to avoid this join, and instead select the filter criteria into a set:
-
-```sql
-create policy "rls_test_select" on test_table
-to authenticated
-using (
-  team_id in (
-    select team_id
-    from team_user
-    where user_id = (select auth.uid()) -- no join
-  )
-);
-```
-
-In this case you can also consider [using a `security definer` function](#use-security-definer-functions) to bypass RLS on the join table:
-
-<Admonition type="note">
-
-If the list exceeds 1000 items, a different approach may be needed or you may need to analyze the approach to ensure that the performance is acceptable.
-
-</Admonition>
-
-#### Benchmarks
-
-| Test                                                                                                | Before (ms) | After (ms) | % Improvement | Change                                                                                                                                            |
-| --------------------------------------------------------------------------------------------------- | ----------- | ---------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [test5-fixed-join](https://github.com/GaryAustin1/RLS-Performance/tree/main/tests/test5-fixed-join) | 9,000       | 20         | 99.78%        | <details className="cursor-pointer">Before:<br/>`auth.uid()` in table join on col<br/><br/>After:<br/>col in table join on `auth.uid()`</details> |
-
-### Specify roles in your policies
-
-Always use the Role of inside your policies, specified by the `TO` operator. For example, instead of this query:
-
-```sql
-create policy "rls_test_select" on rls_test
-using ( auth.uid() = user_id );
-```
-
-Use:
-
-```sql
-create policy "rls_test_select" on rls_test
-to authenticated
-using ( (select auth.uid()) = user_id );
-```
-
-This prevents the policy `( (select auth.uid()) = user_id )` from running for any `anon` users, since the execution stops at the `to authenticated` step.
-
-#### Benchmarks
-
-| Test                                                                                          | Before (ms) | After (ms) | % Improvement | Change                                                                                                                           |
-| --------------------------------------------------------------------------------------------- | ----------- | ---------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| [test6-To-role](https://github.com/GaryAustin1/RLS-Performance/tree/main/tests/test6-To-role) | 170         | < 0.1      | 99.78%        | <details className="cursor-pointer">Before:<br/>No `TO` policy<br/><br/>After:<br/>`TO authenticated` (anon accessing)</details> |
-
-## More resources
-
-- [Testing your database](/docs/guides/database/testing)
-- [RLS Guide and Best Practices](https://github.com/orgs/supabase/discussions/14576)
-- Community repo on testing RLS using [pgTAP and dbdev](https://github.com/usebasejump/supabase-test-helpers/tree/main)
+- [Row Level Security performance](/docs/guides/database/postgres/row-level-security-performance): diagnose whether policies are your bottleneck, and tune ones that are already correct.
+- [Advanced pgTAP testing](/docs/guides/local-development/testing/pgtap-extended): schema-wide RLS test helpers and a worked multi-tenant example.
+- [Testing your database](/docs/guides/database/testing): the CLI test workflow that `supabase test db` runs.
+- [Securing your API](/docs/guides/api/securing-your-api): grants, dedicated schemas, and pre-request checks around the Data API.
+- [Column Level Security](/docs/guides/database/postgres/column-level-security): restrict access to individual columns.
+- [`supabase-test-helpers`](https://github.com/usebasejump/supabase-test-helpers/tree/main): a community extension that adds user creation and role impersonation helpers to pgTAP.

--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -428,18 +428,19 @@ A wrong policy fails quietly. Too permissive, and a query returns rows it should
 
 Supabase runs database tests with [pgTAP](/docs/guides/database/extensions/pgtap) through the CLI. Test files are `.sql` files under `supabase/tests/`.
 
-### How policy tests work
+### Anatomy of a policy test
 
-Switch role and identity between cases with `set local role` and `set local request.jwt.claim.sub`, so each assertion runs as the user it describes.
+Each case sets an identity, runs one statement as that identity, and asserts the outcome. Three things decide whether the assertion means anything.
 
-Match the assertion to the way the denial happens:
+**Identity.** Switch role and identity between cases with `set local role` and `set local request.jwt.claim.sub`, so each assertion runs as the user it describes. Without the switch, every case runs as the same role and proves nothing about access.
+
+**Denials.** A denied request doesn't always raise an error, so match the assertion to the way the denial happens:
 
 - A missing grant raises `42501`. Assert it with `throws_ok`.
 - A `with check` violation raises `42501`. Assert it with `throws_ok`.
-- A `using` clause that filters the target row out raises nothing. The update or delete matches zero rows instead. Assert that no row changed, not that an error was raised.
-- An allowed write needs an assertion on the resulting row. The absence of an error doesn't prove that anything changed.
+- A `using` clause that filters the target row out raises nothing. The update or delete matches zero rows instead. Assert that no row changed.
 
-Add `returning` to an allowed write so a single assertion proves the row changed. A denied write returns no rows, so the same shape asserts the denial.
+**Allowed writes.** The absence of an error doesn't prove that anything changed. Add `returning` to the statement so one assertion covers both directions. An allowed write returns the changed row, and a write the policy filters out returns nothing.
 
 ### Write and run the tests
 

--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -138,6 +138,8 @@ grant select on table public.weather_readings to anon, authenticated;
 
 To stop new tables from receiving the automatic grants in the first place, see [Revoke default privileges](/docs/guides/api/securing-your-api#revoke-default-privileges). To enable RLS automatically on every new table, see [Event triggers](/docs/guides/database/postgres/event-triggers).
 
+Write the tests for this table in the same change. See [Test your policies](#test-your-policies).
+
 ### Write a policy for each operation
 
 Write a separate policy for `select`, `insert`, `update`, and `delete`. Postgres does not accept multiple operations in one `for` clause, and a `for all` policy hides which operation each rule was meant to cover.
@@ -306,7 +308,9 @@ In older versions of Postgres, protect your views by revoking access from the `a
 
 ### Test your policies
 
-We recommend writing tests for every policy. A wrong policy fails quietly. Too permissive, and a query returns rows it shouldn't. Too strict, and it returns nothing and raises no error. Neither case surfaces as a failure, so tests are how you find out.
+We recommend writing tests for every policy, in the same change that sets the grants and creates the policies. Treat the tests as part of securing the table, not as a follow-up.
+
+A wrong policy fails quietly. Too permissive, and a query returns rows it shouldn't. Too strict, and it returns nothing and raises no error. Neither case surfaces as an error, so tests are how you find out.
 
 Supabase runs database tests with [pgTAP](/docs/guides/database/extensions/pgtap) through the CLI. Test files are `.sql` files under `supabase/tests/`.
 

--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -306,18 +306,19 @@ In older versions of Postgres, protect your views by revoking access from the `a
 
 ### Test your policies
 
-A wrong policy fails quietly. Too permissive, and a query returns rows it shouldn't. Too strict, and it returns nothing and raises no error. Test both directions before you ship a policy.
+We recommend writing tests for every policy. A wrong policy fails quietly. Too permissive, and a query returns rows it shouldn't. Too strict, and it returns nothing and raises no error. Neither case surfaces as a failure, so tests are how you find out.
 
 Supabase runs database tests with [pgTAP](/docs/guides/database/extensions/pgtap) through the CLI. Test files are `.sql` files under `supabase/tests/`.
 
-1. Create the tests directory and a test file:
+1. Create a test file:
 
    ```bash
-   mkdir -p supabase/tests
-   touch supabase/tests/profiles_rls.test.sql
+   supabase test new profiles_rls
    ```
 
-2. Write the tests. Cover `select`, `insert`, `update`, and `delete` twice each, once for a request the policy allows and once for a request it denies. Cover `anon` as well as `authenticated`.
+2. Write the tests. Cover `select`, `insert`, `update`, and `delete` twice each, once for a request the policy allows and once for a request it denies, for `anon` as well as `authenticated`. A table with four policies needs at least eight assertions.
+
+   [`supabase-test-helpers`](https://github.com/usebasejump/supabase-test-helpers/tree/main) removes most of the setup below. It adds `tests.create_supabase_user()`, `tests.authenticate_as()`, and `tests.rls_enabled()`, so you don't hand-roll user seeding or role switching. See [Advanced pgTAP testing](/docs/guides/local-development/testing/pgtap-extended) for schema-wide assertions and a worked multi-tenant example.
 
 3. Run the suite:
 
@@ -334,21 +335,20 @@ Match the assertion to the way the denial happens:
 - A `using` clause that filters the target row out raises nothing. The update or delete matches zero rows instead. Assert that no row changed, not that an error was raised.
 - An allowed write needs an assertion on the resulting row. The absence of an error doesn't prove that anything changed.
 
-Add `returning` to an allowed write so a single assertion proves the row changed. A denied write returns no rows, so the same shape asserts the denial.
+Add `returning` to a write so one assertion covers both directions. An allowed write returns the changed row, and a write the policy filters out returns nothing.
 
-This example tests a `profiles` table where `authenticated` holds every privilege, `anon` holds none, and each user reads and writes only their own row:
+This example shows each of those techniques against a `profiles` table where `authenticated` holds every privilege, `anon` holds none, and each user reads and writes only their own row. Extend it to the remaining operations:
 
 ```sql supabase/tests/profiles_rls.test.sql
 begin;
-select plan(11);
+select plan(4);
 
--- Seed two users. The rows come later, through the policies under test.
 insert into auth.users (id, email)
 values
   ('11111111-1111-1111-1111-111111111111', 'owner@example.com'),
   ('22222222-2222-2222-2222-222222222222', 'other@example.com');
 
--- Signed-out visitors hold no grant, so the request stops before any policy runs.
+-- anon holds no grant, so the request stops before any policy runs.
 set local role anon;
 select throws_ok(
   $$select * from profiles$$,
@@ -356,15 +356,8 @@ select throws_ok(
   null,
   'anon cannot read profiles'
 );
-select throws_ok(
-  $$insert into profiles (id, user_id)
-    values (gen_random_uuid(), '11111111-1111-1111-1111-111111111111')$$,
-  '42501',
-  null,
-  'anon cannot insert a profile'
-);
 
--- The owner reads and writes their own row.
+-- The owner writes their own row. returning proves the row changed.
 set local role authenticated;
 set local request.jwt.claim.sub = '11111111-1111-1111-1111-111111111111';
 select results_eq(
@@ -378,25 +371,6 @@ select results_eq(
   array['owner.png'],
   'the owner creates their own profile'
 );
-select results_eq(
-  $$select avatar_url from profiles$$,
-  array['owner.png'],
-  'the owner reads their own profile'
-);
-select results_eq(
-  $$update profiles set avatar_url = 'updated.png' returning avatar_url$$,
-  array['updated.png'],
-  'the owner updates their own profile'
-);
-
--- The with check clause rejects the row, which raises.
-select throws_ok(
-  $$insert into profiles (id, user_id)
-    values (gen_random_uuid(), '22222222-2222-2222-2222-222222222222')$$,
-  '42501',
-  null,
-  'the owner cannot create a profile for someone else'
-);
 
 -- A signed-in stranger holds the grant, so the policy is what stops them. The
 -- using clause filters the row out, so these match nothing and raise nothing.
@@ -408,23 +382,6 @@ select is_empty(
 select is_empty(
   $$update profiles set avatar_url = 'stolen.png' returning avatar_url$$,
   'another user updates no profiles'
-);
-select is_empty(
-  $$delete from profiles returning id$$,
-  'another user deletes no profiles'
-);
-
--- The row is still there, still holding the owner's value.
-set local request.jwt.claim.sub = '11111111-1111-1111-1111-111111111111';
-select results_eq(
-  $$select avatar_url from profiles$$,
-  array['updated.png'],
-  'the other user changed nothing'
-);
-select results_eq(
-  $$delete from profiles returning avatar_url$$,
-  array['updated.png'],
-  'the owner deletes their own profile'
 );
 
 select * from finish();

--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -11,20 +11,23 @@ When you need granular authorization rules, nothing beats Postgres's [Row Level 
 
 <Admonition type="danger">
 
-Supabase allows convenient and secure data access from the browser, as long as you enable RLS.
+A table in an exposed schema without RLS is readable and writable by anyone with your publishable key. RLS _must_ always be enabled on any table stored in an exposed schema. By default, this is the `public` schema.
 
-RLS _must_ always be enabled on any tables stored in an exposed schema. By default, this is the `public` schema.
-
-RLS is enabled by default on tables created with the Table Editor in the dashboard. If you create one in raw SQL or with the SQL editor, remember to enable RLS yourself and grant only the permissions each Postgres role needs.
+RLS is enabled by default on tables created with the Table Editor in the dashboard. If you create a table in raw SQL or with the SQL editor, enable RLS yourself and leave each role only the privileges it needs:
 
 ```sql
-GRANT SELECT ON <schema_name>.<table_name> TO anon;
-GRANT SELECT, INSERT, UPDATE, DELETE ON <schema_name>.<table_name> TO authenticated;
-GRANT SELECT, INSERT, UPDATE, DELETE ON <schema_name>.<table_name> TO service_role;
+-- Take back the privileges granted automatically to client roles.
+revoke all on table <schema_name>.<table_name> from anon, authenticated;
+
+-- Grant back only what each role needs.
+grant select on table <schema_name>.<table_name> to anon, authenticated;
+grant insert, update, delete on table <schema_name>.<table_name> to authenticated;
 
 alter table <schema_name>.<table_name>
 enable row level security;
 ```
+
+Policies alone don't do this. See [Grants and policies](#grants-and-policies).
 
 </Admonition>
 
@@ -62,6 +65,38 @@ alter table "table_name" enable row level security;
 ```
 
 Once you have enabled RLS, no data will be accessible via the [API](/docs/guides/api) when using a publishable key, until you create policies.
+
+## Grants and policies
+
+Postgres runs two checks before a client touches a table. Grants decide whether a role can run an operation on the table at all. Policies decide which rows that operation applies to. Set both for every table you expose.
+
+On existing projects, a new table in `public` receives `select`, `insert`, `update`, and `delete` for `anon`, `authenticated`, and `service_role` automatically. Both client roles start out able to write to your table, and adding policies doesn't take those grants back. A table protected only by policies still hands `anon` an insert path if you never revoke the grant.
+
+Set the grants to match what each role does in your app:
+
+1. Revoke the automatic grants from both client roles.
+
+   ```sql
+   revoke all on table public.reports from anon, authenticated;
+   ```
+
+2. Grant back only the privileges the role needs.
+
+   ```sql
+   -- Signed-in users manage reports. Signed-out visitors get nothing.
+   grant select, insert, update, delete on table public.reports to authenticated;
+   ```
+
+3. Enable RLS on the table and write policies that decide which rows each role reaches.
+
+Data that clients read but never write, such as a feed a backend job populates, gets no write grant at all:
+
+```sql
+revoke all on table public.weather_readings from anon, authenticated;
+grant select on table public.weather_readings to anon, authenticated;
+```
+
+A missing grant raises a `42501` error before any policy runs, so check the grants first when a request fails that your policy should allow. To stop new tables from receiving the automatic grants, see [Revoke default privileges](/docs/guides/api/securing-your-api#revoke-default-privileges).
 
 ## Auto-enable RLS for new tables
 
@@ -369,6 +404,135 @@ alter role "role_name" with bypassrls;
 
 This can be useful for system-level access. You should _never_ share login credentials for any Postgres Role with this privilege.
 
+## Test your policies
+
+A wrong policy fails quietly. Too permissive, and a query returns rows it shouldn't. Too strict, and it returns nothing and raises no error. Test both directions before you ship a policy.
+
+Supabase runs database tests with [pgTAP](/docs/guides/database/extensions/pgtap) through the CLI. Test files are `.sql` files under `supabase/tests/`.
+
+1. Create the tests directory and a test file:
+
+   ```bash
+   mkdir -p supabase/tests
+   touch supabase/tests/profiles_rls.test.sql
+   ```
+
+2. Write the tests. Cover `select`, `insert`, `update`, and `delete` twice each, once for a request the policy allows and once for a request it denies. Cover `anon` as well as `authenticated`.
+
+3. Run the suite:
+
+   ```bash
+   supabase test db
+   ```
+
+Switch role and identity between cases with `set local role` and `set local request.jwt.claim.sub`, so each assertion runs as the user it describes.
+
+Match the assertion to the way the denial happens:
+
+- A missing grant raises `42501`. Assert it with `throws_ok`.
+- A `with check` violation raises `42501`. Assert it with `throws_ok`.
+- A `using` clause that filters the target row out raises nothing. The update or delete matches zero rows instead. Assert that no row changed, not that an error was raised.
+- An allowed write needs an assertion on the resulting row. The absence of an error doesn't prove that anything changed.
+
+Add `returning` to an allowed write so a single assertion proves the row changed. A denied write returns no rows, so the same shape asserts the denial.
+
+This example tests a `profiles` table where `authenticated` holds every privilege, `anon` holds none, and each user reads and writes only their own row:
+
+```sql supabase/tests/profiles_rls.test.sql
+begin;
+select plan(11);
+
+-- Seed two users. The rows come later, through the policies under test.
+insert into auth.users (id, email)
+values
+  ('11111111-1111-1111-1111-111111111111', 'owner@example.com'),
+  ('22222222-2222-2222-2222-222222222222', 'other@example.com');
+
+-- Signed-out visitors hold no grant, so the request stops before any policy runs.
+set local role anon;
+select throws_ok(
+  $$select * from profiles$$,
+  '42501',
+  null,
+  'anon cannot read profiles'
+);
+select throws_ok(
+  $$insert into profiles (id, user_id)
+    values (gen_random_uuid(), '11111111-1111-1111-1111-111111111111')$$,
+  '42501',
+  null,
+  'anon cannot insert a profile'
+);
+
+-- The owner reads and writes their own row.
+set local role authenticated;
+set local request.jwt.claim.sub = '11111111-1111-1111-1111-111111111111';
+select results_eq(
+  $$insert into profiles (id, user_id, avatar_url)
+    values (
+      gen_random_uuid(),
+      '11111111-1111-1111-1111-111111111111',
+      'owner.png'
+    )
+    returning avatar_url$$,
+  array['owner.png'],
+  'the owner creates their own profile'
+);
+select results_eq(
+  $$select avatar_url from profiles$$,
+  array['owner.png'],
+  'the owner reads their own profile'
+);
+select results_eq(
+  $$update profiles set avatar_url = 'updated.png' returning avatar_url$$,
+  array['updated.png'],
+  'the owner updates their own profile'
+);
+
+-- The with check clause rejects the row, which raises.
+select throws_ok(
+  $$insert into profiles (id, user_id)
+    values (gen_random_uuid(), '22222222-2222-2222-2222-222222222222')$$,
+  '42501',
+  null,
+  'the owner cannot create a profile for someone else'
+);
+
+-- A signed-in stranger holds the grant, so the policy is what stops them. The
+-- using clause filters the row out, so these match nothing and raise nothing.
+set local request.jwt.claim.sub = '22222222-2222-2222-2222-222222222222';
+select is_empty(
+  $$select * from profiles$$,
+  'another user reads no profiles'
+);
+select is_empty(
+  $$update profiles set avatar_url = 'stolen.png' returning avatar_url$$,
+  'another user updates no profiles'
+);
+select is_empty(
+  $$delete from profiles returning id$$,
+  'another user deletes no profiles'
+);
+
+-- The row is still there, still holding the owner's value.
+set local request.jwt.claim.sub = '11111111-1111-1111-1111-111111111111';
+select results_eq(
+  $$select avatar_url from profiles$$,
+  array['updated.png'],
+  'the other user changed nothing'
+);
+select results_eq(
+  $$delete from profiles returning avatar_url$$,
+  array['updated.png'],
+  'the owner deletes their own profile'
+);
+
+select * from finish();
+rollback;
+```
+
+For CLI setup and more pgTAP helpers, see [Testing your database](/docs/guides/database/testing).
+
 ## RLS performance recommendations
 
 Every authorization system has an impact on performance. While row level security is powerful, the performance impact is important to keep in mind. This is especially true for queries that scan every row in a table - like many `select` operations, including those using limit, offset, and ordering.
@@ -377,7 +541,7 @@ Based on a series of [tests](https://github.com/GaryAustin1/RLS-Performance), we
 
 ### Add indexes
 
-Make sure you've added [indexes](/docs/guides/database/postgres/indexes) on any columns used within the Policies which are not already indexed (or primary keys). For a Policy like this:
+Add an [index](/docs/guides/database/postgres/indexes) on every column your policies filter on. Postgres evaluates the policy against each candidate row, so an unindexed filter column turns a read into a sequential scan. For a policy like this:
 
 ```sql
 create policy "rls_test_select" on test_table
@@ -390,6 +554,21 @@ You can add an index like:
 ```sql
 create index userid
 on test_table
+using btree (user_id);
+```
+
+A column counts as indexed only when it comes first in a `btree` index. Postgres can't use a multi-column index to filter on a column that isn't the leading one, so a composite primary key indexes its first column and no others. A membership table keyed on `(team_id, user_id)` has no index on `user_id`:
+
+```sql
+create table team_members (
+  team_id uuid references teams (id),
+  user_id uuid references auth.users (id),
+  primary key (team_id, user_id)
+);
+
+-- The primary key covers team_id. A policy filtering on user_id needs its own index.
+create index team_members_user_id_idx
+on team_members
 using btree (user_id);
 ```
 

--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -316,7 +316,7 @@ Supabase runs database tests with [pgTAP](/docs/guides/database/extensions/pgtap
    supabase test new profiles_rls
    ```
 
-2. Write the tests. Cover `select`, `insert`, `update`, and `delete` twice each, once for a request the policy allows and once for a request it denies, for `anon` as well as `authenticated`. A table with four policies needs at least eight assertions.
+2. Write the tests. Cover `select`, `insert`, `update`, and `delete` twice each, once for a request the policy allows and once for a request it denies, for `anon` as well as `authenticated`.
 
    [`supabase-test-helpers`](https://github.com/usebasejump/supabase-test-helpers/tree/main) removes most of the setup below. It adds `tests.create_supabase_user()`, `tests.authenticate_as()`, and `tests.rls_enabled()`, so you don't hand-roll user seeding or role switching. See [Advanced pgTAP testing](/docs/guides/local-development/testing/pgtap-extended) for schema-wide assertions and a worked multi-tenant example.
 

--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -13,8 +13,6 @@ A table in an exposed schema without RLS is readable and writable by anyone with
 
 </Admonition>
 
-This guide explains how to secure a table with Postgres Row Level Security (RLS), from enabling it through testing the policies you write.
-
 Use the guide in three parts:
 
 - [Understand Row Level Security](#understand-row-level-security) explains how grants and policies combine to control access.

--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -9,7 +9,7 @@ Postgres [Row Level Security (RLS)](https://www.postgresql.org/docs/current/ddl-
 
 <Admonition type="danger">
 
-A table in an exposed schema without RLS is readable and writable by anyone with your publishable key. Enable RLS on every table in an exposed schema, and revoke the default grants that let `anon` and `authenticated` write to it. Adding policies doesn't remove those grants.
+A table in an exposed schema without RLS is readable and writable by any role with a grant on it. Enable RLS on every table in an exposed schema. On projects that still grant `anon` and `authenticated` by default, revoke those grants. Adding policies doesn't remove them.
 
 </Admonition>
 
@@ -61,6 +61,8 @@ On existing projects, a new table in `public` starts with every privilege alread
 
 Adding policies doesn't take those grants back. A table protected only by policies still hands `anon` an insert path if you never revoke the grant.
 
+Not every project grants these automatically. See [Default privileges](/docs/guides/api/securing-your-api#default-privileges). Grant each role only the operations it needs.
+
 A missing grant raises a `42501` error before any policy runs. When a request fails that your policy should allow, check the grants before you change the policy. To set them, see [Lock down the table](#lock-down-the-table).
 
 ### Authenticated and unauthenticated roles
@@ -92,7 +94,7 @@ Using the `anon` Postgres role is different from an [anonymous user](/docs/guide
 
 </Admonition>
 
-A policy that reads `to anon using ( true )` grants every unauthenticated visitor read access to every row. Use it only for data that is meant to be public.
+A policy that reads `to anon using ( true )` grants every unauthenticated visitor read access to every row the role can already reach through grants. Use it only for data that is meant to be public.
 
 ### Views and RLS
 
@@ -116,7 +118,7 @@ Enable RLS, then set the grants to match what each role does in your app:
 
    Once RLS is enabled, no data is accessible through the [API](/docs/guides/api) when using a publishable key, until you create policies.
 
-2. Revoke the automatic grants from both client roles.
+2. Revoke any existing grants from both client roles.
 
    ```sql
    revoke all on table public.reports from anon, authenticated;
@@ -136,7 +138,7 @@ revoke all on table public.weather_readings from anon, authenticated;
 grant select on table public.weather_readings to anon, authenticated;
 ```
 
-To stop new tables from receiving the automatic grants in the first place, see [Revoke default privileges](/docs/guides/api/securing-your-api#revoke-default-privileges). To enable RLS automatically on every new table, see [Event triggers](/docs/guides/database/postgres/event-triggers).
+If new tables still receive automatic grants, see [Revoke default privileges](/docs/guides/api/securing-your-api#revoke-default-privileges). To enable RLS automatically on every new table, see [Event triggers](/docs/guides/database/postgres/event-triggers).
 
 Write the tests for this table in the same change. See [Test your policies](#test-your-policies).
 

--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -27,7 +27,7 @@ Read the first section when you're deciding how to model access. Go directly to 
 
 [Policies](https://www.postgresql.org/docs/current/sql-createpolicy.html) are Postgres's rule engine. Each policy is attached to a table, and the policy is executed every time a table is accessed.
 
-Think of a policy as adding a `WHERE` clause to every query. A policy like this ...
+Think of a policy as adding a `WHERE` clause to every query. A policy like this:
 
 ```sql
 create policy "Individuals can view their own todos."
@@ -36,7 +36,7 @@ to authenticated
 using ( (select auth.uid()) = user_id );
 ```
 
-.. translates to this whenever a user selects from the todos table:
+That policy translates to this whenever a user selects from the todos table:
 
 ```sql
 select *
@@ -461,7 +461,7 @@ using ( team_id in (select auth.jwt() -> 'app_metadata' -> 'teams'));
 
 <Admonition type="caution">
 
-Keep in mind that a JWT is not always "fresh". In the example above, even if you remove a user from a team and update the `app_metadata` field, that will not be reflected using `auth.jwt()` until the user's JWT is refreshed.
+Keep in mind that a JWT is not always up-to-date. In the team policy example, even if you remove a user from a team and update the `app_metadata` field, that will not be reflected using `auth.jwt()` until the user's JWT is refreshed.
 
 Also, if you are using Cookies for Auth, then you must be mindful of the JWT size. Some browsers are limited to 4096 bytes for each cookie, and so the total size of your JWT should be small enough to fit inside this limitation.
 
@@ -530,11 +530,13 @@ A `security definer` function in an exposed schema is callable over the Data API
 
 ### Bypassing Row Level Security
 
-Supabase provides special "Service" keys, which can be used to bypass RLS. These should never be used in the browser or exposed to customers, but they are useful for administrative tasks.
+Use a [secret key](/docs/guides/getting-started/api-keys) for administrative tasks that need to bypass RLS. A secret key authorizes access through the `service_role` Postgres role, which has the `bypassrls` attribute. Never use a secret key in the browser or expose it to customers.
+
+The JWT-based `service_role` key is a legacy alternative. Prefer a secret key where possible.
 
 <Admonition type="note">
 
-A Service Key bypasses RLS only when the request carries no user access token. If the request carries one, it runs under the RLS policies of that signed-in user, even when the client library was initialized with a Service Key.
+A secret key bypasses RLS only when the request carries no user access token. If the request carries one, it runs under the RLS policies of that signed-in user, even when the client library was initialized with a secret key.
 
 </Admonition>
 

--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -308,11 +308,26 @@ In older versions of Postgres, protect your views by revoking access from the `a
 
 ### Test your policies
 
-We recommend writing tests for every policy, in the same change that sets the grants and creates the policies. Treat the tests as part of securing the table, not as a follow-up.
+We recommend writing tests for every policy, in the same change that sets the grants and creates the policies. Tests are a fundamental part of a secure setup, and they give you a repeatable way to prove a policy behaves the way you intended.
 
 A wrong policy fails quietly. Too permissive, and a query returns rows it shouldn't. Too strict, and it returns nothing and raises no error. Neither case surfaces as an error, so tests are how you find out.
 
 Supabase runs database tests with [pgTAP](/docs/guides/database/extensions/pgtap) through the CLI. Test files are `.sql` files under `supabase/tests/`.
+
+#### How policy tests work
+
+Switch role and identity between cases with `set local role` and `set local request.jwt.claim.sub`, so each assertion runs as the user it describes.
+
+Match the assertion to the way the denial happens:
+
+- A missing grant raises `42501`. Assert it with `throws_ok`.
+- A `with check` violation raises `42501`. Assert it with `throws_ok`.
+- A `using` clause that filters the target row out raises nothing. The update or delete matches zero rows instead. Assert that no row changed, not that an error was raised.
+- An allowed write needs an assertion on the resulting row. The absence of an error doesn't prove that anything changed.
+
+Add `returning` to a write so one assertion covers both directions. An allowed write returns the changed row, and a write the policy filters out returns nothing.
+
+#### Write and run the tests
 
 1. Create a test file:
 
@@ -329,17 +344,6 @@ Supabase runs database tests with [pgTAP](/docs/guides/database/extensions/pgtap
    ```bash
    supabase test db
    ```
-
-Switch role and identity between cases with `set local role` and `set local request.jwt.claim.sub`, so each assertion runs as the user it describes.
-
-Match the assertion to the way the denial happens:
-
-- A missing grant raises `42501`. Assert it with `throws_ok`.
-- A `with check` violation raises `42501`. Assert it with `throws_ok`.
-- A `using` clause that filters the target row out raises nothing. The update or delete matches zero rows instead. Assert that no row changed, not that an error was raised.
-- An allowed write needs an assertion on the resulting row. The absence of an error doesn't prove that anything changed.
-
-Add `returning` to a write so one assertion covers both directions. An allowed write returns the changed row, and a write the policy filters out returns nothing.
 
 This example shows each of those techniques against a `profiles` table where `authenticated` holds every privilege, `anon` holds none, and each user reads and writes only their own row. Extend it to the remaining operations:
 

--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -5,7 +5,7 @@ description: 'Secure your data using Postgres Row Level Security.'
 subtitle: 'Secure your data using Postgres Row Level Security.'
 ---
 
-When you need granular authorization rules, nothing beats Postgres's [Row Level Security (RLS)](https://www.postgresql.org/docs/current/ddl-rowsecurity.html).
+Postgres [Row Level Security (RLS)](https://www.postgresql.org/docs/current/ddl-rowsecurity.html) gives you granular authorization rules that run inside the database.
 
 ## Row Level Security in Supabase
 
@@ -31,15 +31,15 @@ Policies alone don't do this. See [Grants and policies](#grants-and-policies).
 
 </Admonition>
 
-RLS is incredibly powerful and flexible, allowing you to write complex SQL rules that fit your unique business needs. RLS can be combined with [Supabase Auth](/docs/guides/auth) for end-to-end user security from the browser to the database.
+You write RLS rules in SQL, so a rule can express whatever access logic your app needs. Combine RLS with [Supabase Auth](/docs/guides/auth) for end-to-end user security from the browser to the database.
 
 RLS is a Postgres primitive and can provide "[defense in depth](<https://en.wikipedia.org/wiki/Defense_in_depth_(computing)>)" to protect your data from malicious actors even when accessed through third-party tooling.
 
 ## Policies
 
-[Policies](https://www.postgresql.org/docs/current/sql-createpolicy.html) are Postgres's rule engine. Policies are easy to understand once you get the hang of them. Each policy is attached to a table, and the policy is executed every time a table is accessed.
+[Policies](https://www.postgresql.org/docs/current/sql-createpolicy.html) are Postgres's rule engine. Each policy is attached to a table, and the policy is executed every time a table is accessed.
 
-You can just think of them as adding a `WHERE` clause to every query. For example a policy like this ...
+Think of a policy as adding a `WHERE` clause to every query. For example a policy like this ...
 
 ```sql
 create policy "Individuals can view their own todos."
@@ -217,7 +217,7 @@ Using the `anon` Postgres role is different from an [anonymous user](/docs/guide
 
 Policies are SQL logic that you attach to a Postgres table. You can attach as many policies as you want to each table.
 
-Supabase provides some [helpers](#helper-functions) that simplify RLS if you're using Supabase Auth. We'll use these helpers to illustrate some basic policies:
+Supabase provides some [helpers](#helper-functions) that simplify RLS if you're using Supabase Auth. The examples below use these helpers.
 
 ### SELECT policies
 
@@ -247,15 +247,16 @@ Alternatively, if you only wanted users to be able to see their own profiles:
 
 ```sql
 create policy "User can see their own profile only."
-on profiles
-for select using ( (select auth.uid()) = user_id );
+on profiles for select
+to authenticated
+using ( (select auth.uid()) = user_id );
 ```
 
 ### INSERT policies
 
 You can specify insert policies with the `with check` clause. The `with check` expression ensures that any new row data adheres to the policy constraints.
 
-Say you have a table called `profiles` in the public schema and you only want users to create a profile for themselves. In that case, we want to check their User ID matches the value that they are trying to insert:
+Say you have a table called `profiles` in the public schema and you only want users to create a profile for themselves. In that case, check that their user ID matches the value they are trying to insert:
 
 ```sql
 -- 1. Create table
@@ -408,7 +409,7 @@ Supabase provides special "Service" keys, which can be used to bypass RLS. These
 
 <Admonition type="note">
 
-Supabase will adhere to the RLS policy of the signed-in user, even if the client library is initialized with a Service Key.
+A Service Key bypasses RLS only when the request carries no user access token. If the request carries one, it runs under the RLS policies of that signed-in user, even when the client library was initialized with a Service Key.
 
 </Admonition>
 
@@ -418,7 +419,7 @@ You can also create new [Postgres Roles](/docs/guides/database/postgres/roles) w
 alter role "role_name" with bypassrls;
 ```
 
-This can be useful for system-level access. You should _never_ share login credentials for any Postgres Role with this privilege.
+This can be useful for system-level access. **Never** share login credentials for any Postgres Role with this privilege.
 
 ## Test your policies
 
@@ -558,9 +559,9 @@ For CLI setup and more pgTAP helpers, see [Testing your database](/docs/guides/d
 
 ## RLS performance recommendations
 
-Every authorization system has an impact on performance. While row level security is powerful, the performance impact is important to keep in mind. This is especially true for queries that scan every row in a table - like many `select` operations, including those using limit, offset, and ordering.
+Every authorization system has an impact on performance. Postgres evaluates a policy expression against each candidate row, so the cost scales with the rows a query scans. This matters most for queries that scan every row in a table, like many `select` operations, including those using limit, offset, and ordering.
 
-Based on a series of [tests](https://github.com/GaryAustin1/RLS-Performance), we have a few recommendations for RLS:
+Based on a series of [tests](https://github.com/GaryAustin1/RLS-Performance), these are the recommendations for RLS:
 
 ### Add indexes
 
@@ -688,10 +689,11 @@ create function private.has_good_role()
 returns boolean
 language plpgsql
 security definer -- will run as the creator
+set search_path = '' -- every name inside must be schema-qualified
 as $$
 begin
   return exists (
-    select 1 from roles_table
+    select 1 from public.roles_table
     where (select auth.uid()) = user_id and role = 'good_role'
   );
 end;
@@ -704,9 +706,11 @@ to authenticated
 using ( (select private.has_good_role()) );
 ```
 
+Set `search_path = ''` on every `security definer` function and schema-qualify the names inside it. Without a pinned `search_path`, a caller can point an unqualified name at their own object and run it with the function owner's privileges.
+
 <Admonition type="caution">
 
-Security-definer functions should never be created in a schema in the "Exposed schemas" inside your [API settings](/dashboard/project/_/settings/api)`.
+A `security definer` function in an exposed schema is callable over the Data API with the creator's privileges. Never create one in a schema listed under "Exposed schemas" in your [API settings](/dashboard/project/_/settings/api).
 
 </Admonition>
 

--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -47,6 +47,8 @@ where auth.uid() = todos.user_id;
 
 You write RLS rules in SQL, so a rule can express whatever access logic your app needs. Because RLS is a Postgres primitive, it also protects your data when it is reached through third-party tooling, which is what makes it "[defense in depth](<https://en.wikipedia.org/wiki/Defense_in_depth_(computing)>)". Combine RLS with [Supabase Auth](/docs/guides/auth) for end-to-end user security from the browser to the database.
 
+Multiple policies for the same role and operation are permissive by default: if any one of them passes, the row is allowed. A second policy widens access; it never narrows it. To require two checks at once, mark one `as restrictive`. See [MFA](#mfa).
+
 ### Grants and policies
 
 Postgres runs two checks before a client touches a table. Grants decide whether a role can run an operation on the table at all. Policies decide which rows that operation applies to. Set both for every table you expose.
@@ -64,6 +66,8 @@ Adding policies doesn't take those grants back. A table protected only by polici
 Not every project grants these automatically. See [Default privileges](/docs/guides/api/securing-your-api#default-privileges). Grant each role only the operations it needs.
 
 A missing grant raises a `42501` error before any policy runs. When a request fails that your policy should allow, check the grants before you change the policy. To set them, see [Lock down the table](#lock-down-the-table).
+
+Table owners, superusers, and roles with `bypassrls` skip RLS unless you force it. The Dashboard SQL Editor typically runs as `postgres`, the table owner, which is why [Test your policies](#test-your-policies) switches role. Add `alter table ... force row level security` only when the owning role must also obey policies. Don't force it on a lookup table that a `security definer` helper reads as the owner.
 
 ### Authenticated and unauthenticated roles
 
@@ -144,7 +148,7 @@ Write the tests for this table in the same change. See [Test your policies](#tes
 
 ### Write a policy for each operation
 
-Write a separate policy for `select`, `insert`, `update`, and `delete`. Postgres does not accept multiple operations in one `for` clause, and a `for all` policy hides which operation each rule was meant to cover.
+Write a separate policy for `select`, `insert`, `update`, and `delete`. Postgres does not accept multiple operations in one `for` clause, and a `for all` policy hides which operation each rule was meant to cover. To deny an operation, grant nothing and write no policy for it.
 
 These examples use a `profiles` table where each user manages only their own row:
 
@@ -201,7 +205,7 @@ If no `with check` expression is defined, the `using` expression decides both wh
 
 <Admonition type="caution">
 
-To perform an `UPDATE` operation, a corresponding [`SELECT` policy](#select-policies) is required. Without a `SELECT` policy, the `UPDATE` operation will not work as expected.
+Postgres can update a row with only an `update` policy. The Data API also needs a matching [`select` policy](#select-policies) to return the updated row. Without one, the write can succeed and the client still receives no representation.
 
 </Admonition>
 
@@ -413,29 +417,11 @@ Supabase provides some helper functions that make it easier to write policies.
 
 Returns the ID of the user making the request.
 
-<Admonition type="caution" title="`auth.uid()` Returns `null` When Unauthenticated">
+<Admonition type="caution" title="`auth.uid()` returns `null` when unauthenticated">
 
-When a request is made without an authenticated user (e.g., no access token is provided or the session has expired), `auth.uid()` returns `null`.
+When a request has no signed-in user, `auth.uid()` returns `null`. `null = user_id` is unknown in SQL, so a policy like `using (auth.uid() = user_id)` filters the row out instead of raising an error.
 
-This means that a policy like:
-
-```sql
-USING (auth.uid() = user_id)
-```
-
-will silently fail for unauthenticated users, because:
-
-```sql
-null = user_id
-```
-
-is always false in SQL.
-
-To avoid confusion and make your intention clear, we recommend explicitly checking for authentication:
-
-```sql
-USING (auth.uid() IS NOT NULL AND auth.uid() = user_id)
-```
+Scope the policy with `to authenticated` so the expression does not run for `anon`. That is both the correct intention and the cheaper plan. See [Specify roles in your policies](#specify-roles-in-your-policies).
 
 </Admonition>
 
@@ -449,16 +435,18 @@ Not all information present in the JWT should be used in RLS policies. For insta
 
 Returns the JWT of the user making the request. Anything that you store in the user's `raw_app_meta_data` column or the `raw_user_meta_data` column will be accessible using this function. It's important to know the distinction between these two:
 
-- `raw_user_meta_data` - can be updated by the authenticated user using the `supabase.auth.update()` function. It is not a good place to store authorization data.
+- `raw_user_meta_data` - can be updated by the authenticated user using [`updateUser()`](/docs/reference/javascript/auth-updateuser). It is not a good place to store authorization data.
 - `raw_app_meta_data` - cannot be updated by the user, so it's a good place to store authorization data.
 
-The `auth.jwt()` function is extremely versatile. For example, if you store some team data inside `app_metadata`, you can use it to determine whether a particular user belongs to a team. For example, if this was an array of IDs:
+The `auth.jwt()` function is extremely versatile. For example, if you store some team data inside `app_metadata`, you can use it to determine whether a particular user belongs to a team. If `teams` is a JSON array of IDs:
 
 ```sql
 create policy "User is in team"
 on my_table
 to authenticated
-using ( team_id in (select auth.jwt() -> 'app_metadata' -> 'teams'));
+using (
+  ((select auth.jwt()) -> 'app_metadata' -> 'teams') ? team_id::text
+);
 ```
 
 <Admonition type="caution">
@@ -515,6 +503,8 @@ begin
 end;
 $$;
 
+revoke execute on function private.has_good_role() from public, anon, authenticated, service_role;
+
 -- Update our policy to use this function:
 create policy "rls_test_select"
 on test_table
@@ -522,7 +512,7 @@ to authenticated
 using ( (select private.has_good_role()) );
 ```
 
-Set `search_path = ''` on every `security definer` function and schema-qualify the names inside it. Without a pinned `search_path`, a caller can point an unqualified name at their own object and run it with the function owner's privileges.
+Set `search_path = ''` on every `security definer` function and schema-qualify the names inside it. Without a pinned `search_path`, a caller can point an unqualified name at their own object and run it with the function owner's privileges. Check `(select auth.uid())` inside the function body, and revoke `execute` from `public` and the client roles. New functions grant `execute` to `public` by default.
 
 <Admonition type="caution">
 

--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -70,7 +70,15 @@ Once you have enabled RLS, no data will be accessible via the [API](/docs/guides
 
 Postgres runs two checks before a client touches a table. Grants decide whether a role can run an operation on the table at all. Policies decide which rows that operation applies to. Set both for every table you expose.
 
-On existing projects, a new table in `public` receives `select`, `insert`, `update`, and `delete` for `anon`, `authenticated`, and `service_role` automatically. Both client roles start out able to write to your table, and adding policies doesn't take those grants back. A table protected only by policies still hands `anon` an insert path if you never revoke the grant.
+On existing projects, a new table in `public` starts with every privilege already granted to all three roles:
+
+| Role            | Granted automatically                  | What it should keep                                     |
+| --------------- | -------------------------------------- | ------------------------------------------------------- |
+| `anon`          | `select`, `insert`, `update`, `delete` | Only what signed-out visitors are meant to read         |
+| `authenticated` | `select`, `insert`, `update`, `delete` | Only the operations your app exposes to signed-in users |
+| `service_role`  | `select`, `insert`, `update`, `delete` | Full access. It bypasses RLS, so keep it server-side    |
+
+Adding policies doesn't take those grants back. A table protected only by policies still hands `anon` an insert path if you never revoke the grant.
 
 A missing grant raises a `42501` error before any policy runs. When a request fails that your policy should allow, check the grants before you change the policy.
 

--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -76,6 +76,8 @@ A missing grant raises a `42501` error before any policy runs. When a request fa
 
 ### Set the grants for a table
 
+Run these statements in the [SQL Editor](/dashboard/project/_/sql/new) for a one-off change, or in a [migration](/docs/guides/deployment/database-migrations) to keep the change reproducible across environments. Grants and RLS belong in the same migration.
+
 Set the grants to match what each role does in your app:
 
 1. Revoke the automatic grants from both client roles.

--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -7,47 +7,38 @@ subtitle: 'Secure your data using Postgres Row Level Security.'
 
 Postgres [Row Level Security (RLS)](https://www.postgresql.org/docs/current/ddl-rowsecurity.html) gives you granular authorization rules that run inside the database.
 
-## Row Level Security in Supabase
-
 <Admonition type="danger">
 
-A table in an exposed schema without RLS is readable and writable by anyone with your publishable key. RLS must always be enabled on any table stored in an exposed schema. By default, this is the `public` schema.
-
-RLS is enabled by default on tables created with the Table Editor in the dashboard. If you create a table in raw SQL or with the SQL editor, enable RLS yourself and leave each role only the privileges it needs:
-
-```sql
--- Take back the privileges granted automatically to client roles.
-revoke all on table <schema_name>.<table_name> from anon, authenticated;
-
--- Grant back only what each role needs.
-grant select on table <schema_name>.<table_name> to anon, authenticated;
-grant insert, update, delete on table <schema_name>.<table_name> to authenticated;
-
-alter table <schema_name>.<table_name>
-enable row level security;
-```
-
-Policies alone don't do this. See [Grants and policies](#grants-and-policies).
+A table in an exposed schema without RLS is readable and writable by anyone with your publishable key. Enable RLS on every table in an exposed schema, and revoke the default grants that let `anon` and `authenticated` write to it. Adding policies doesn't remove those grants.
 
 </Admonition>
 
-You write RLS rules in SQL, so a rule can express whatever access logic your app needs. Combine RLS with [Supabase Auth](/docs/guides/auth) for end-to-end user security from the browser to the database.
+This guide explains how to secure a table with Postgres Row Level Security (RLS), from enabling it through testing the policies you write.
 
-RLS is a Postgres primitive and can provide "[defense in depth](<https://en.wikipedia.org/wiki/Defense_in_depth_(computing)>)" to protect your data from malicious actors even when accessed through third-party tooling.
+Use the guide in three parts:
 
-## Policies
+- [Understand Row Level Security](#understand-row-level-security) explains how grants and policies combine to control access.
+- [Secure a table with RLS](#secure-a-table-with-rls) is the procedure to follow for every table in an exposed schema.
+- [RLS reference](#rls-reference) documents the helper functions and patterns you use inside a policy expression.
+
+Read the first section when you're deciding how to model access. Go directly to the second section when you're ready to secure a table.
+
+## Understand Row Level Security
+
+### What a policy does
 
 [Policies](https://www.postgresql.org/docs/current/sql-createpolicy.html) are Postgres's rule engine. Each policy is attached to a table, and the policy is executed every time a table is accessed.
 
-Think of a policy as adding a `WHERE` clause to every query. For example a policy like this ...
+Think of a policy as adding a `WHERE` clause to every query. A policy like this ...
 
 ```sql
 create policy "Individuals can view their own todos."
 on todos for select
+to authenticated
 using ( (select auth.uid()) = user_id );
 ```
 
-.. would translate to this whenever a user tries to select from the todos table:
+.. translates to this whenever a user selects from the todos table:
 
 ```sql
 select *
@@ -56,17 +47,9 @@ where auth.uid() = todos.user_id;
 -- Policy is implicitly added.
 ```
 
-## Enabling Row Level Security
+You write RLS rules in SQL, so a rule can express whatever access logic your app needs. Because RLS is a Postgres primitive, it also protects your data when it is reached through third-party tooling, which is what makes it "[defense in depth](<https://en.wikipedia.org/wiki/Defense_in_depth_(computing)>)". Combine RLS with [Supabase Auth](/docs/guides/auth) for end-to-end user security from the browser to the database.
 
-You can enable RLS for any table using the `enable row level security` clause:
-
-```sql
-alter table "table_name" enable row level security;
-```
-
-Once you have enabled RLS, no data will be accessible via the [API](/docs/guides/api) when using a publishable key, until you create policies.
-
-## Grants and policies
+### Grants and policies
 
 Postgres runs two checks before a client touches a table. Grants decide whether a role can run an operation on the table at all. Policies decide which rows that operation applies to. Set both for every table you expose.
 
@@ -80,111 +63,9 @@ On existing projects, a new table in `public` starts with every privilege alread
 
 Adding policies doesn't take those grants back. A table protected only by policies still hands `anon` an insert path if you never revoke the grant.
 
-A missing grant raises a `42501` error before any policy runs. When a request fails that your policy should allow, check the grants before you change the policy.
+A missing grant raises a `42501` error before any policy runs. When a request fails that your policy should allow, check the grants before you change the policy. To set them, see [Lock down the table](#lock-down-the-table).
 
-### Set the grants for a table
-
-Run these statements in the [SQL Editor](/dashboard/project/_/sql/new) for a one-off change, or in a [migration](/docs/guides/deployment/database-migrations) to keep the change reproducible across environments. Grants and RLS belong in the same migration.
-
-Set the grants to match what each role does in your app:
-
-1. Revoke the automatic grants from both client roles.
-
-   ```sql
-   revoke all on table public.reports from anon, authenticated;
-   ```
-
-2. Grant back only the privileges the role needs.
-
-   ```sql
-   -- Signed-in users manage reports. Signed-out visitors get nothing.
-   grant select, insert, update, delete on table public.reports to authenticated;
-   ```
-
-3. Enable RLS on the table and write policies that decide which rows each role reaches.
-
-For data that clients read but never write, such as a feed a backend job populates, grant no writes in step 2:
-
-```sql
-revoke all on table public.weather_readings from anon, authenticated;
-grant select on table public.weather_readings to anon, authenticated;
-```
-
-To stop new tables from receiving the automatic grants in the first place, see [Revoke default privileges](/docs/guides/api/securing-your-api#revoke-default-privileges).
-
-Write the tests for this table in the same change. See [Test your policies](#test-your-policies).
-
-## Auto-enable RLS for new tables
-
-If you want RLS enabled automatically for new tables, you can create an event trigger that runs after table creation. This uses a Postgres [event trigger](/docs/guides/database/postgres/event-triggers) to call `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` on each newly created table.
-
-```sql
-CREATE OR REPLACE FUNCTION rls_auto_enable()
-RETURNS EVENT_TRIGGER
-LANGUAGE plpgsql
-SECURITY DEFINER
-SET search_path = pg_catalog
-AS $$
-DECLARE
-  cmd record;
-BEGIN
-  FOR cmd IN
-    SELECT *
-    FROM pg_event_trigger_ddl_commands()
-    WHERE command_tag IN ('CREATE TABLE', 'CREATE TABLE AS', 'SELECT INTO')
-      AND object_type IN ('table','partitioned table')
-  LOOP
-     IF cmd.schema_name IS NOT NULL AND cmd.schema_name IN ('public') AND cmd.schema_name NOT IN ('pg_catalog','information_schema') AND cmd.schema_name NOT LIKE 'pg_toast%' AND cmd.schema_name NOT LIKE 'pg_temp%' THEN
-      BEGIN
-        EXECUTE format('alter table if exists %s enable row level security', cmd.object_identity);
-        RAISE LOG 'rls_auto_enable: enabled RLS on %', cmd.object_identity;
-      EXCEPTION
-        WHEN OTHERS THEN
-          RAISE LOG 'rls_auto_enable: failed to enable RLS on %', cmd.object_identity;
-      END;
-     ELSE
-        RAISE LOG 'rls_auto_enable: skip % (either system schema or not in enforced list: %.)', cmd.object_identity, cmd.schema_name;
-     END IF;
-  END LOOP;
-END;
-$$;
-
-DROP EVENT TRIGGER IF EXISTS ensure_rls;
-CREATE EVENT TRIGGER ensure_rls
-ON ddl_command_end
-WHEN TAG IN ('CREATE TABLE', 'CREATE TABLE AS', 'SELECT INTO')
-EXECUTE FUNCTION rls_auto_enable();
-```
-
-Note that this applies to tables created after the trigger is installed. Existing tables still need RLS enabled manually.
-
-<Admonition type="caution" title="`auth.uid()` Returns `null` When Unauthenticated">
-
-When a request is made without an authenticated user (e.g., no access token is provided or the session has expired), `auth.uid()` returns `null`.
-
-This means that a policy like:
-
-```sql
-USING (auth.uid() = user_id)
-```
-
-will silently fail for unauthenticated users, because:
-
-```sql
-null = user_id
-```
-
-is always false in SQL.
-
-To avoid confusion and make your intention clear, we recommend explicitly checking for authentication:
-
-```sql
-USING (auth.uid() IS NOT NULL AND auth.uid() = user_id)
-```
-
-</Admonition>
-
-## Authenticated and unauthenticated roles
+### Authenticated and unauthenticated roles
 
 Supabase maps every request to one of the roles:
 
@@ -213,99 +94,108 @@ Using the `anon` Postgres role is different from an [anonymous user](/docs/guide
 
 </Admonition>
 
-## Creating policies
+A policy that reads `to anon using ( true )` grants every unauthenticated visitor read access to every row. Use it only for data that is meant to be public.
 
-Policies are SQL logic that you attach to a Postgres table. You can attach as many policies as you want to each table.
+### Views and RLS
 
-Supabase provides some [helpers](#helper-functions) that simplify RLS if you're using Supabase Auth. The examples below use these helpers.
+Views bypass RLS by default because they are usually created with the `postgres` user. This is a feature of Postgres, which automatically creates views with `security definer`. A view over a protected table hands out every row its policies were meant to withhold, so a view needs the same attention as a table. To create one safely, see [Expose a view safely](#expose-a-view-safely).
 
-### SELECT policies
+## Secure a table with RLS
 
-You can specify select policies with the `using` clause.
+Follow these steps for every table in an exposed schema.
 
-Say you have a table called `profiles` in the public schema and you want to enable read access to everyone.
+### Lock down the table
+
+Run these statements in the [SQL Editor](/dashboard/project/_/sql/new) for a one-off change, or in a [migration](/docs/guides/deployment/database-migrations) to keep the change reproducible across environments. Grants and RLS belong in the same migration.
+
+Enable RLS, then set the grants to match what each role does in your app:
+
+1. Enable RLS on the table.
+
+   ```sql
+   alter table public.reports enable row level security;
+   ```
+
+   Once RLS is enabled, no data is accessible through the [API](/docs/guides/api) when using a publishable key, until you create policies.
+
+2. Revoke the automatic grants from both client roles.
+
+   ```sql
+   revoke all on table public.reports from anon, authenticated;
+   ```
+
+3. Grant back only the privileges the role needs.
+
+   ```sql
+   -- Signed-in users manage reports. Signed-out visitors get nothing.
+   grant select, insert, update, delete on table public.reports to authenticated;
+   ```
+
+Data that clients read but never write, such as a feed a backend job populates, gets no write grant at all:
 
 ```sql
--- 1. Create table
+revoke all on table public.weather_readings from anon, authenticated;
+grant select on table public.weather_readings to anon, authenticated;
+```
+
+To stop new tables from receiving the automatic grants in the first place, see [Revoke default privileges](/docs/guides/api/securing-your-api#revoke-default-privileges). To enable RLS automatically on every new table, see [Event triggers](/docs/guides/database/postgres/event-triggers).
+
+### Write a policy for each operation
+
+Write a separate policy for `select`, `insert`, `update`, and `delete`. Postgres does not accept multiple operations in one `for` clause, and a `for all` policy hides which operation each rule was meant to cover.
+
+These examples use a `profiles` table where each user manages only their own row:
+
+```sql
 create table profiles (
   id uuid primary key,
   user_id uuid references auth.users,
   avatar_url text
 );
 
--- 2. Enable RLS
 alter table profiles enable row level security;
 
--- 3. Create Policy
-create policy "Public profiles are visible to everyone."
-on profiles for select
-to anon         -- the Postgres Role (recommended)
-using ( true ); -- the actual Policy
+revoke all on table profiles from anon, authenticated;
+grant select, insert, update, delete on table profiles to authenticated;
 ```
 
-Alternatively, if you only wanted users to be able to see their own profiles:
+Supabase provides [helper functions](#helper-functions) that simplify RLS if you are using Supabase Auth. `auth.uid()` returns the ID of the user making the request.
+
+#### SELECT policies
+
+You can specify select policies with the `using` clause.
 
 ```sql
-create policy "User can see their own profile only."
+create policy "Users can view their own profile."
 on profiles for select
 to authenticated
 using ( (select auth.uid()) = user_id );
 ```
 
-### INSERT policies
+#### INSERT policies
 
-You can specify insert policies with the `with check` clause. The `with check` expression ensures that any new row data adheres to the policy constraints.
-
-Say you have a table called `profiles` in the public schema and you only want users to create a profile for themselves. In that case, check that their user ID matches the value they are trying to insert:
+You can specify insert policies with the `with check` clause. The `with check` expression ensures that any new row adheres to the policy constraints, so a user cannot create a row that belongs to someone else.
 
 ```sql
--- 1. Create table
-create table profiles (
-  id uuid primary key,
-  user_id uuid references auth.users,
-  avatar_url text
-);
-
--- 2. Enable RLS
-alter table profiles enable row level security;
-
--- 3. Create Policy
-create policy "Users can create a profile."
+create policy "Users can create their own profile."
 on profiles for insert
-to authenticated                          -- the Postgres Role (recommended)
-with check ( (select auth.uid()) = user_id );      -- the actual Policy
+to authenticated
+with check ( (select auth.uid()) = user_id );
 ```
 
-### UPDATE policies
+#### UPDATE policies
 
-You can specify update policies by combining both the `using` and `with check` expressions.
-
-The `using` clause represents the condition that must be true for the update to be allowed, and `with check` clause ensures that the updates made adhere to the policy constraints.
-
-Say you have a table called `profiles` in the public schema and you only want users to update their own profile.
-
-You can create a policy where the `using` clause checks if the user owns the profile being updated. And the `with check` clause ensures that, in the resultant row, users do not change the `user_id` to a value that is not equal to their User ID, maintaining that the modified profile still meets the ownership condition.
+You can specify update policies by combining the `using` and `with check` expressions. The `using` clause decides which existing rows can be updated. The `with check` clause decides what the resulting row is allowed to look like, which stops a user from reassigning `user_id` to someone else.
 
 ```sql
--- 1. Create table
-create table profiles (
-  id uuid primary key,
-  user_id uuid references auth.users,
-  avatar_url text
-);
-
--- 2. Enable RLS
-alter table profiles enable row level security;
-
--- 3. Create Policy
 create policy "Users can update their own profile."
 on profiles for update
-to authenticated                    -- the Postgres Role (recommended)
-using ( (select auth.uid()) = user_id )       -- checks if the existing row complies with the policy expression
-with check ( (select auth.uid()) = user_id ); -- checks if the new row complies with the policy expression
+to authenticated
+using ( (select auth.uid()) = user_id )       -- checks the existing row
+with check ( (select auth.uid()) = user_id ); -- checks the resulting row
 ```
 
-If no `with check` expression is defined, then the `using` expression will be used both to determine which rows are visible (normal USING case) and which new rows will be allowed to be added (WITH CHECK case).
+If no `with check` expression is defined, the `using` expression decides both which rows are visible and which new rows are allowed.
 
 <Admonition type="caution">
 
@@ -313,35 +203,100 @@ To perform an `UPDATE` operation, a corresponding [`SELECT` policy](#select-poli
 
 </Admonition>
 
-### DELETE policies
+#### DELETE policies
 
 You can specify delete policies with the `using` clause.
 
-Say you have a table called `profiles` in the public schema and you only want users to be able to delete their own profile:
-
 ```sql
--- 1. Create table
-create table profiles (
-  id uuid primary key,
-  user_id uuid references auth.users,
-  avatar_url text
-);
-
--- 2. Enable RLS
-alter table profiles enable row level security;
-
--- 3. Create Policy
-create policy "Users can delete a profile."
+create policy "Users can delete their own profile."
 on profiles for delete
-to authenticated                     -- the Postgres Role (recommended)
-using ( (select auth.uid()) = user_id );      -- the actual Policy
+to authenticated
+using ( (select auth.uid()) = user_id );
 ```
 
-### Views
+### Specify roles in your policies
 
-Views bypass RLS by default because they are usually created with the `postgres` user. This is a feature of Postgres, which automatically creates views with `security definer`.
+Always name the role a policy applies to, using the `to` clause. Instead of this:
 
-In Postgres 15 and above, you can make a view obey the RLS policies of the underlying tables when invoked by `anon` and `authenticated` roles by setting `security_invoker = true`.
+```sql
+create policy "rls_test_select" on rls_test
+using ( auth.uid() = user_id );
+```
+
+Use:
+
+```sql
+create policy "rls_test_select" on rls_test
+to authenticated
+using ( (select auth.uid()) = user_id );
+```
+
+This prevents the policy `( (select auth.uid()) = user_id )` from running for any `anon` users, since the execution stops at the `to authenticated` step.
+
+These three rules keep policies correct as a table grows. For the measured impact and for tuning beyond them, see [Row Level Security performance](/docs/guides/database/postgres/row-level-security-performance).
+
+### Add indexes
+
+Add an [index](/docs/guides/database/postgres/indexes) on every column your policies filter on. Postgres evaluates the policy against each candidate row, so an unindexed filter column turns a read into a sequential scan. For a policy like this:
+
+```sql
+create policy "rls_test_select" on test_table
+to authenticated
+using ( (select auth.uid()) = user_id );
+```
+
+You can add an index like:
+
+```sql
+create index userid
+on test_table
+using btree (user_id);
+```
+
+A column counts as indexed only when it comes first in a `btree` index. Postgres can't use a multi-column index to filter on a column that isn't the leading one, so a composite primary key indexes its first column and no others. A membership table keyed on `(team_id, user_id)` has no index on `user_id`:
+
+```sql
+create table team_members (
+  team_id uuid references teams (id),
+  user_id uuid references auth.users (id),
+  primary key (team_id, user_id)
+);
+
+-- The primary key covers team_id. A policy filtering on user_id needs its own index.
+create index team_members_user_id_idx
+on team_members
+using btree (user_id);
+```
+
+### Call functions with `select`
+
+You can use `select` statement to improve policies that use functions. For example, instead of this:
+
+```sql
+create policy "rls_test_select" on test_table
+to authenticated
+using ( auth.uid() = user_id );
+```
+
+You can do:
+
+```sql
+create policy "rls_test_select" on test_table
+to authenticated
+using ( (select auth.uid()) = user_id );
+```
+
+This method works well for JWT functions like `auth.uid()` and `auth.jwt()` as well as `security definer` Functions. Wrapping the function causes an `initPlan` to be run by the Postgres optimizer, which allows it to "cache" the results per-statement, rather than calling the function on each row.
+
+<Admonition type="caution">
+
+You can only use this technique if the results of the query or function do not change based on the row data.
+
+</Admonition>
+
+### Expose a view safely
+
+In Postgres 15 and above, make a view obey the RLS policies of its underlying tables when invoked by `anon` and `authenticated` by setting `security_invoker = true`.
 
 ```sql
 create view <VIEW_NAME>
@@ -351,99 +306,11 @@ as select <QUERY>
 
 In older versions of Postgres, protect your views by revoking access from the `anon` and `authenticated` roles, or by putting them in an unexposed schema.
 
-## Helper functions
+### Test your policies
 
-Supabase provides some helper functions that make it easier to write Policies.
-
-### `auth.uid()`
-
-Returns the ID of the user making the request.
-
-### `auth.jwt()`
-
-<Admonition type="caution">
-
-Not all information present in the JWT should be used in RLS policies. For instance, creating an RLS policy that relies on the `user_metadata` claim can create security issues in your application as this information can be modified by authenticated end users.
-
-</Admonition>
-
-Returns the JWT of the user making the request. Anything that you store in the user's `raw_app_meta_data` column or the `raw_user_meta_data` column will be accessible using this function. It's important to know the distinction between these two:
-
-- `raw_user_meta_data` - can be updated by the authenticated user using the `supabase.auth.update()` function. It is not a good place to store authorization data.
-- `raw_app_meta_data` - cannot be updated by the user, so it's a good place to store authorization data.
-
-The `auth.jwt()` function is extremely versatile. For example, if you store some team data inside `app_metadata`, you can use it to determine whether a particular user belongs to a team. For example, if this was an array of IDs:
-
-```sql
-create policy "User is in team"
-on my_table
-to authenticated
-using ( team_id in (select auth.jwt() -> 'app_metadata' -> 'teams'));
-```
-
-<Admonition type="caution">
-
-Keep in mind that a JWT is not always "fresh". In the example above, even if you remove a user from a team and update the `app_metadata` field, that will not be reflected using `auth.jwt()` until the user's JWT is refreshed.
-
-Also, if you are using Cookies for Auth, then you must be mindful of the JWT size. Some browsers are limited to 4096 bytes for each cookie, and so the total size of your JWT should be small enough to fit inside this limitation.
-
-</Admonition>
-
-### MFA
-
-The `auth.jwt()` function can be used to check for [Multi-Factor Authentication](/docs/guides/auth/auth-mfa#enforce-rules-for-mfa-logins). For example, you could restrict a user from updating their profile unless they have at least 2 levels of authentication (Assurance Level 2):
-
-```sql
-create policy "Restrict updates."
-on profiles
-as restrictive
-for update
-to authenticated using (
-  (select auth.jwt()->>'aal') = 'aal2'
-);
-```
-
-## Bypassing Row Level Security
-
-Supabase provides special "Service" keys, which can be used to bypass RLS. These should never be used in the browser or exposed to customers, but they are useful for administrative tasks.
-
-<Admonition type="note">
-
-A Service Key bypasses RLS only when the request carries no user access token. If the request carries one, it runs under the RLS policies of that signed-in user, even when the client library was initialized with a Service Key.
-
-</Admonition>
-
-You can also create new [Postgres Roles](/docs/guides/database/postgres/roles) which can bypass Row Level Security using the "bypass RLS" privilege:
-
-```sql
-alter role "role_name" with bypassrls;
-```
-
-This can be useful for system-level access. **Never** share login credentials for any Postgres Role with this privilege.
-
-## Test your policies
-
-We recommend writing tests for every policy, in the same change that sets the grants and creates the policies. Tests are a fundamental part of a secure setup, and they give you a repeatable way to prove a policy behaves the way you intended.
-
-A wrong policy fails quietly. Too permissive, and a query returns rows it shouldn't. Too strict, and it returns nothing and raises no error. Neither case surfaces as an error, so tests are how you find out.
+A wrong policy fails quietly. Too permissive, and a query returns rows it shouldn't. Too strict, and it returns nothing and raises no error. Test both directions before you ship a policy.
 
 Supabase runs database tests with [pgTAP](/docs/guides/database/extensions/pgtap) through the CLI. Test files are `.sql` files under `supabase/tests/`.
-
-### Anatomy of a policy test
-
-Each case sets an identity, runs one statement as that identity, and asserts the outcome. Three things decide whether the assertion means anything.
-
-**Identity.** Switch role and identity between cases with `set local role` and `set local request.jwt.claim.sub`, so each assertion runs as the user it describes. Without the switch, every case runs as the same role and proves nothing about access.
-
-**Denials.** A denied request doesn't always raise an error, so match the assertion to the way the denial happens:
-
-- A missing grant raises `42501`. Assert it with `throws_ok`.
-- A `with check` violation raises `42501`. Assert it with `throws_ok`.
-- A `using` clause that filters the target row out raises nothing. The update or delete matches zero rows instead. Assert that no row changed.
-
-**Allowed writes.** The absence of an error doesn't prove that anything changed. Add `returning` to the statement so one assertion covers both directions. An allowed write returns the changed row, and a write the policy filters out returns nothing.
-
-### Write and run the tests
 
 1. Create the tests directory and a test file:
 
@@ -459,6 +326,17 @@ Each case sets an identity, runs one statement as that identity, and asserts the
    ```bash
    supabase test db
    ```
+
+Switch role and identity between cases with `set local role` and `set local request.jwt.claim.sub`, so each assertion runs as the user it describes.
+
+Match the assertion to the way the denial happens:
+
+- A missing grant raises `42501`. Assert it with `throws_ok`.
+- A `with check` violation raises `42501`. Assert it with `throws_ok`.
+- A `using` clause that filters the target row out raises nothing. The update or delete matches zero rows instead. Assert that no row changed, not that an error was raised.
+- An allowed write needs an assertion on the resulting row. The absence of an error doesn't prove that anything changed.
+
+Add `returning` to an allowed write so a single assertion proves the row changed. A denied write returns no rows, so the same shape asserts the denial.
 
 This example tests a `profiles` table where `authenticated` holds every privilege, `anon` holds none, and each user reads and writes only their own row:
 
@@ -557,89 +435,87 @@ rollback;
 
 For CLI setup and more pgTAP helpers, see [Testing your database](/docs/guides/database/testing).
 
-## Write policies that scale
+## RLS reference
 
-Postgres evaluates a policy expression against each candidate row, so the cost scales with the rows a query scans. Three rules keep that cost from growing with your table. Apply all three to every policy you write.
+These are the functions and patterns available inside a policy expression.
 
-### Add indexes
+### Helper functions
 
-Add an [index](/docs/guides/database/postgres/indexes) on every column your policies filter on. Postgres evaluates the policy against each candidate row, so an unindexed filter column turns a read into a sequential scan. For a policy like this:
+Supabase provides some helper functions that make it easier to write policies.
 
-```sql
-create policy "rls_test_select" on test_table
-to authenticated
-using ( (select auth.uid()) = user_id );
-```
+#### `auth.uid()`
 
-You can add an index like:
+Returns the ID of the user making the request.
 
-```sql
-create index userid
-on test_table
-using btree (user_id);
-```
+<Admonition type="caution" title="`auth.uid()` Returns `null` When Unauthenticated">
 
-A column counts as indexed only when it comes first in a `btree` index. Postgres can't use a multi-column index to filter on a column that isn't the leading one, so a composite primary key indexes its first column and no others. A membership table keyed on `(team_id, user_id)` has no index on `user_id`:
+When a request is made without an authenticated user (e.g., no access token is provided or the session has expired), `auth.uid()` returns `null`.
+
+This means that a policy like:
 
 ```sql
-create table team_members (
-  team_id uuid references teams (id),
-  user_id uuid references auth.users (id),
-  primary key (team_id, user_id)
-);
-
--- The primary key covers team_id. A policy filtering on user_id needs its own index.
-create index team_members_user_id_idx
-on team_members
-using btree (user_id);
+USING (auth.uid() = user_id)
 ```
 
-### Call functions with `select`
-
-You can use `select` statement to improve policies that use functions. For example, instead of this:
+will silently fail for unauthenticated users, because:
 
 ```sql
-create policy "rls_test_select" on test_table
-to authenticated
-using ( auth.uid() = user_id );
+null = user_id
 ```
 
-You can do:
+is always false in SQL.
+
+To avoid confusion and make your intention clear, we recommend explicitly checking for authentication:
 
 ```sql
-create policy "rls_test_select" on test_table
-to authenticated
-using ( (select auth.uid()) = user_id );
+USING (auth.uid() IS NOT NULL AND auth.uid() = user_id)
 ```
-
-This method works well for JWT functions like `auth.uid()` and `auth.jwt()` as well as `security definer` Functions. Wrapping the function causes an `initPlan` to be run by the Postgres optimizer, which allows it to "cache" the results per-statement, rather than calling the function on each row.
-
-<Admonition type="caution">
-
-You can only use this technique if the results of the query or function do not change based on the row data.
 
 </Admonition>
 
-### Specify roles in your policies
+#### `auth.jwt()`
 
-Always name the role a policy applies to, using the `to` clause. Instead of this:
+<Admonition type="caution">
+
+Not all information present in the JWT should be used in RLS policies. For instance, creating an RLS policy that relies on the `user_metadata` claim can create security issues in your application as this information can be modified by authenticated end users.
+
+</Admonition>
+
+Returns the JWT of the user making the request. Anything that you store in the user's `raw_app_meta_data` column or the `raw_user_meta_data` column will be accessible using this function. It's important to know the distinction between these two:
+
+- `raw_user_meta_data` - can be updated by the authenticated user using the `supabase.auth.update()` function. It is not a good place to store authorization data.
+- `raw_app_meta_data` - cannot be updated by the user, so it's a good place to store authorization data.
+
+The `auth.jwt()` function is extremely versatile. For example, if you store some team data inside `app_metadata`, you can use it to determine whether a particular user belongs to a team. For example, if this was an array of IDs:
 
 ```sql
-create policy "rls_test_select" on rls_test
-using ( auth.uid() = user_id );
-```
-
-Use:
-
-```sql
-create policy "rls_test_select" on rls_test
+create policy "User is in team"
+on my_table
 to authenticated
-using ( (select auth.uid()) = user_id );
+using ( team_id in (select auth.jwt() -> 'app_metadata' -> 'teams'));
 ```
 
-This prevents the policy `( (select auth.uid()) = user_id )` from running for any `anon` users, since the execution stops at the `to authenticated` step.
+<Admonition type="caution">
 
-These three rules keep policies correct as a table grows. For the measured impact and for tuning beyond them, see [Row Level Security performance](/docs/guides/database/postgres/row-level-security-performance).
+Keep in mind that a JWT is not always "fresh". In the example above, even if you remove a user from a team and update the `app_metadata` field, that will not be reflected using `auth.jwt()` until the user's JWT is refreshed.
+
+Also, if you are using Cookies for Auth, then you must be mindful of the JWT size. Some browsers are limited to 4096 bytes for each cookie, and so the total size of your JWT should be small enough to fit inside this limitation.
+
+</Admonition>
+
+#### MFA
+
+The `auth.jwt()` function can be used to check for [Multi-Factor Authentication](/docs/guides/auth/auth-mfa#enforce-rules-for-mfa-logins). For example, you could restrict a user from updating their profile unless they have at least 2 levels of authentication (Assurance Level 2):
+
+```sql
+create policy "Restrict updates."
+on profiles
+as restrictive
+for update
+to authenticated using (
+  (select auth.jwt()->>'aal') = 'aal2'
+);
+```
 
 ### Use security definer functions
 
@@ -687,6 +563,24 @@ Set `search_path = ''` on every `security definer` function and schema-qualify t
 A `security definer` function in an exposed schema is callable over the Data API with the creator's privileges. Never create one in a schema listed under "Exposed schemas" in your [API settings](/dashboard/project/_/settings/api).
 
 </Admonition>
+
+### Bypassing Row Level Security
+
+Supabase provides special "Service" keys, which can be used to bypass RLS. These should never be used in the browser or exposed to customers, but they are useful for administrative tasks.
+
+<Admonition type="note">
+
+A Service Key bypasses RLS only when the request carries no user access token. If the request carries one, it runs under the RLS policies of that signed-in user, even when the client library was initialized with a Service Key.
+
+</Admonition>
+
+You can also create new [Postgres Roles](/docs/guides/database/postgres/roles) which can bypass Row Level Security using the "bypass RLS" privilege:
+
+```sql
+alter role "role_name" with bypassrls;
+```
+
+This can be useful for system-level access. **Never** share login credentials for any Postgres Role with this privilege.
 
 ## Related content
 

--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -11,7 +11,7 @@ When you need granular authorization rules, nothing beats Postgres's [Row Level 
 
 <Admonition type="danger">
 
-A table in an exposed schema without RLS is readable and writable by anyone with your publishable key. RLS _must_ always be enabled on any table stored in an exposed schema. By default, this is the `public` schema.
+A table in an exposed schema without RLS is readable and writable by anyone with your publishable key. RLS must always be enabled on any table stored in an exposed schema. By default, this is the `public` schema.
 
 RLS is enabled by default on tables created with the Table Editor in the dashboard. If you create a table in raw SQL or with the SQL editor, enable RLS yourself and leave each role only the privileges it needs:
 

--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -104,6 +104,8 @@ grant select on table public.weather_readings to anon, authenticated;
 
 To stop new tables from receiving the automatic grants in the first place, see [Revoke default privileges](/docs/guides/api/securing-your-api#revoke-default-privileges).
 
+Write the tests for this table in the same change. See [Test your policies](#test-your-policies).
+
 ## Auto-enable RLS for new tables
 
 If you want RLS enabled automatically for new tables, you can create an event trigger that runs after table creation. This uses a Postgres [event trigger](/docs/guides/database/postgres/event-triggers) to call `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` on each newly created table.
@@ -412,7 +414,9 @@ This can be useful for system-level access. You should _never_ share login crede
 
 ## Test your policies
 
-A wrong policy fails quietly. Too permissive, and a query returns rows it shouldn't. Too strict, and it returns nothing and raises no error. Test both directions before you ship a policy.
+We recommend writing tests for every policy, in the same change that sets the grants and creates the policies. Treat the tests as part of securing the table, not as a follow-up.
+
+A wrong policy fails quietly. Too permissive, and a query returns rows it shouldn't. Too strict, and it returns nothing and raises no error. Neither case surfaces as an error, so tests are how you find out.
 
 Supabase runs database tests with [pgTAP](/docs/guides/database/extensions/pgtap) through the CLI. Test files are `.sql` files under `supabase/tests/`.
 

--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -72,6 +72,10 @@ Postgres runs two checks before a client touches a table. Grants decide whether 
 
 On existing projects, a new table in `public` receives `select`, `insert`, `update`, and `delete` for `anon`, `authenticated`, and `service_role` automatically. Both client roles start out able to write to your table, and adding policies doesn't take those grants back. A table protected only by policies still hands `anon` an insert path if you never revoke the grant.
 
+A missing grant raises a `42501` error before any policy runs. When a request fails that your policy should allow, check the grants before you change the policy.
+
+### Set the grants for a table
+
 Set the grants to match what each role does in your app:
 
 1. Revoke the automatic grants from both client roles.
@@ -89,14 +93,14 @@ Set the grants to match what each role does in your app:
 
 3. Enable RLS on the table and write policies that decide which rows each role reaches.
 
-Data that clients read but never write, such as a feed a backend job populates, gets no write grant at all:
+For data that clients read but never write, such as a feed a backend job populates, grant no writes in step 2:
 
 ```sql
 revoke all on table public.weather_readings from anon, authenticated;
 grant select on table public.weather_readings to anon, authenticated;
 ```
 
-A missing grant raises a `42501` error before any policy runs, so check the grants first when a request fails that your policy should allow. To stop new tables from receiving the automatic grants, see [Revoke default privileges](/docs/guides/api/securing-your-api#revoke-default-privileges).
+To stop new tables from receiving the automatic grants in the first place, see [Revoke default privileges](/docs/guides/api/securing-your-api#revoke-default-privileges).
 
 ## Auto-enable RLS for new tables
 

--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -314,18 +314,19 @@ A wrong policy fails quietly. Too permissive, and a query returns rows it should
 
 Supabase runs database tests with [pgTAP](/docs/guides/database/extensions/pgtap) through the CLI. Test files are `.sql` files under `supabase/tests/`.
 
-#### How policy tests work
+#### Anatomy of a policy test
 
-Switch role and identity between cases with `set local role` and `set local request.jwt.claim.sub`, so each assertion runs as the user it describes.
+Each case sets an identity, runs one statement as that identity, and asserts the outcome. Three things decide whether the assertion means anything.
 
-Match the assertion to the way the denial happens:
+**Identity.** Switch role and identity between cases with `set local role` and `set local request.jwt.claim.sub`, so each assertion runs as the user it describes. Without the switch, every case runs as the same role and proves nothing about access.
+
+**Denials.** A denied request doesn't always raise an error, so match the assertion to the way the denial happens:
 
 - A missing grant raises `42501`. Assert it with `throws_ok`.
 - A `with check` violation raises `42501`. Assert it with `throws_ok`.
-- A `using` clause that filters the target row out raises nothing. The update or delete matches zero rows instead. Assert that no row changed, not that an error was raised.
-- An allowed write needs an assertion on the resulting row. The absence of an error doesn't prove that anything changed.
+- A `using` clause that filters the target row out raises nothing. The update or delete matches zero rows instead. Assert that no row changed.
 
-Add `returning` to a write so one assertion covers both directions. An allowed write returns the changed row, and a write the policy filters out returns nothing.
+**Allowed writes.** The absence of an error doesn't prove that anything changed. Add `returning` to the statement so one assertion covers both directions. An allowed write returns the changed row, and a write the policy filters out returns nothing.
 
 #### Write and run the tests
 

--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -422,11 +422,26 @@ This can be useful for system-level access. You should _never_ share login crede
 
 ## Test your policies
 
-We recommend writing tests for every policy, in the same change that sets the grants and creates the policies. Treat the tests as part of securing the table, not as a follow-up.
+We recommend writing tests for every policy, in the same change that sets the grants and creates the policies. Tests are a fundamental part of a secure setup, and they give you a repeatable way to prove a policy behaves the way you intended.
 
 A wrong policy fails quietly. Too permissive, and a query returns rows it shouldn't. Too strict, and it returns nothing and raises no error. Neither case surfaces as an error, so tests are how you find out.
 
 Supabase runs database tests with [pgTAP](/docs/guides/database/extensions/pgtap) through the CLI. Test files are `.sql` files under `supabase/tests/`.
+
+### How policy tests work
+
+Switch role and identity between cases with `set local role` and `set local request.jwt.claim.sub`, so each assertion runs as the user it describes.
+
+Match the assertion to the way the denial happens:
+
+- A missing grant raises `42501`. Assert it with `throws_ok`.
+- A `with check` violation raises `42501`. Assert it with `throws_ok`.
+- A `using` clause that filters the target row out raises nothing. The update or delete matches zero rows instead. Assert that no row changed, not that an error was raised.
+- An allowed write needs an assertion on the resulting row. The absence of an error doesn't prove that anything changed.
+
+Add `returning` to an allowed write so a single assertion proves the row changed. A denied write returns no rows, so the same shape asserts the denial.
+
+### Write and run the tests
 
 1. Create the tests directory and a test file:
 
@@ -442,17 +457,6 @@ Supabase runs database tests with [pgTAP](/docs/guides/database/extensions/pgtap
    ```bash
    supabase test db
    ```
-
-Switch role and identity between cases with `set local role` and `set local request.jwt.claim.sub`, so each assertion runs as the user it describes.
-
-Match the assertion to the way the denial happens:
-
-- A missing grant raises `42501`. Assert it with `throws_ok`.
-- A `with check` violation raises `42501`. Assert it with `throws_ok`.
-- A `using` clause that filters the target row out raises nothing. The update or delete matches zero rows instead. Assert that no row changed, not that an error was raised.
-- An allowed write needs an assertion on the resulting row. The absence of an error doesn't prove that anything changed.
-
-Add `returning` to an allowed write so a single assertion proves the row changed. A denied write returns no rows, so the same shape asserts the denial.
 
 This example tests a `profiles` table where `authenticated` holds every privilege, `anon` holds none, and each user reads and writes only their own row:
 

--- a/apps/docs/content/troubleshooting/interpreting-supabase-grafana-io-charts-MUynDR.mdx
+++ b/apps/docs/content/troubleshooting/interpreting-supabase-grafana-io-charts-MUynDR.mdx
@@ -42,7 +42,7 @@ Excessive IO usage is highly problematic as it clarifies that your database is e
 
 - **Excessive and needless sequential scans:** poorly indexed tables force requests to scan disk ([guide to resolve](https://github.com/orgs/supabase/discussions/22449))
 - **Too little cache**: There is not enough memory, so instead of reading data from the memory cache, it is accessed from disk ([guide to inspect](https://github.com/orgs/supabase/discussions/22449))
-- **Poorly optimized RLS policies**: RLS that rely heavily on joins are more likely to hit disk. If possible, they should optimized ([RLS best practice guide](/docs/guides/database/postgres/row-level-security#rls-performance-recommendations))
+- **Poorly optimized RLS policies**: RLS that rely heavily on joins are more likely to hit disk. If possible, they should optimized ([RLS performance guide](/docs/guides/database/postgres/row-level-security-performance))
 - **Excessive bloat**: This is the least likely to cause major issues, but bloat can take up space, preventing data on disk from being placed in the same locality. This can force the database to scan more pages than necessary. ([explainer guide](/blog/postgres-bloat))
 - **Uploading high amounts of data:** temporarily increase compute add-on size for the duration of the uploads
 - **Insufficient memory**: Sometimes an inadequate amount of memory forces queries to hit disk instead of the memory cache. Address memory issues ([guide](https://github.com/orgs/supabase/discussions/27021)) can reduce disk strain.

--- a/apps/docs/content/troubleshooting/interpreting-supabase-grafana-io-charts-MUynDR.mdx
+++ b/apps/docs/content/troubleshooting/interpreting-supabase-grafana-io-charts-MUynDR.mdx
@@ -42,7 +42,7 @@ Excessive IO usage is highly problematic as it clarifies that your database is e
 
 - **Excessive and needless sequential scans:** poorly indexed tables force requests to scan disk ([guide to resolve](https://github.com/orgs/supabase/discussions/22449))
 - **Too little cache**: There is not enough memory, so instead of reading data from the memory cache, it is accessed from disk ([guide to inspect](https://github.com/orgs/supabase/discussions/22449))
-- **Poorly optimized RLS policies**: RLS that rely heavily on joins are more likely to hit disk. If possible, they should optimized ([RLS performance guide](/docs/guides/database/postgres/row-level-security-performance))
+- **Poorly optimized RLS policies**: RLS that rely heavily on joins are more likely to hit disk. If possible, they should be optimized ([RLS performance guide](/docs/guides/database/postgres/row-level-security-performance))
 - **Excessive bloat**: This is the least likely to cause major issues, but bloat can take up space, preventing data on disk from being placed in the same locality. This can force the database to scan more pages than necessary. ([explainer guide](/blog/postgres-bloat))
 - **Uploading high amounts of data:** temporarily increase compute add-on size for the duration of the uploads
 - **Insufficient memory**: Sometimes an inadequate amount of memory forces queries to hit disk instead of the memory cache. Address memory issues ([guide](https://github.com/orgs/supabase/discussions/27021)) can reduce disk strain.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update (technical accuracy), stacked on #49017.

Review #49017 first. This PR only adds the accuracy pass after that restructure.

**Stack (bottom → top):** `#49017` (`docs/rls-restructure` → `master`) → this PR (`cursor/rls-accuracy-f756` → `docs/rls-restructure`).

Local tracking is via `gh stack` (`gh stack init` / `gh stack add` / `gh stack submit`). Creating the GitHub Stack object failed here with `Resource not accessible by integration`. After merge of #49017, retarget this PR to `master` if GitHub does not do that automatically. To attach official GitHub Stack metadata from a token that can write stacks:

```
gh stack link --base master 49017 49268
```

## What is the current behavior?

The restructured RLS guide in #49017 still had a few technical mismatches with:

- [security-rls-basics.md](https://github.com/supabase/agent-skills/blob/main/skills/supabase-postgres-best-practices/references/security-rls-basics.md)
- [security-rls-performance.md](https://github.com/supabase/agent-skills/blob/main/skills/supabase-postgres-best-practices/references/security-rls-performance.md)
- Academy / `supabase/supacademy` rules reconstructed from #48710 and #49011 (the academy repo is private from this environment)

## What is the new behavior?

Accuracy-only edits to `row-level-security.mdx`:

- Permissive policies OR together; `as restrictive` to AND (link `#mfa`)
- FORCE RLS: owners / superusers / `bypassrls` skip RLS; do not force on lookup tables a `security definer` helper reads as owner
- Revoke `EXECUTE` on helper functions from `public`, `anon`, `authenticated`, and `service_role` (new functions grant `EXECUTE` to `public`)
- `auth.uid()` null: `null = user_id` is unknown, not false; prefer `to authenticated` instead of `IS NOT NULL`
- Update-without-select is a Data API representation issue, not a Postgres requirement
- `supabase.auth.update()` → [`updateUser()`](https://supabase.com/docs/reference/javascript/auth-updateuser)
- Invalid team JWT SQL `team_id in (select jsonb)` → `((select auth.jwt()) -> 'app_metadata' -> 'teams') ? team_id::text`

Did not copy `for all` from security-rls-basics; academy/docs prefer one policy per operation.

## Additional context

Base is `docs/rls-restructure`, not `master`. Files changed vs #49017 is the accuracy commit only.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f03b502-d237-4d3d-8e59-da4e746af756?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f03b502-d237-4d3d-8e59-da4e746af756&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

