### PR TITLE
docs(database): verify and correct remaining RLS guide claims

### DIFF
--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -41,13 +41,13 @@ That policy translates to this whenever a user selects from the todos table:
 ```sql
 select *
 from todos
-where auth.uid() = todos.user_id;
+where (select auth.uid()) = todos.user_id;
 -- Policy is implicitly added.
 ```
 
 You write RLS rules in SQL, so a rule can express whatever access logic your app needs. Because RLS is a Postgres primitive, it also protects your data when it is reached through third-party tooling, which is what makes it "[defense in depth](<https://en.wikipedia.org/wiki/Defense_in_depth_(computing)>)". Combine RLS with [Supabase Auth](/docs/guides/auth) for end-to-end user security from the browser to the database.
 
-Multiple policies for the same role and operation are permissive by default: if any one of them passes, the row is allowed. A second policy widens access; it never narrows it. To require two checks at once, mark one `as restrictive`. See [MFA](#mfa).
+Multiple policies for the same role and operation are permissive by default: if any one of them passes, the row is allowed. A second permissive policy widens access; it does not narrow it. To require two checks at once, mark one `as restrictive`. See [MFA](#mfa). Restrictive policies only reduce access after at least one permissive policy has granted it.
 
 ### Grants and policies
 
@@ -67,7 +67,7 @@ Not every project grants these automatically. See [Default privileges](/docs/gui
 
 A missing grant raises a `42501` error before any policy runs. When a request fails that your policy should allow, check the grants before you change the policy. To set them, see [Lock down the table](#lock-down-the-table).
 
-Table owners, superusers, and roles with `bypassrls` skip RLS unless you force it. The Dashboard SQL Editor typically runs as `postgres`, the table owner, which is why [Test your policies](#test-your-policies) switches role. Add `alter table ... force row level security` only when the owning role must also obey policies. Don't force it on a lookup table that a `security definer` helper reads as the owner.
+Table owners skip RLS unless you force it. Superusers and roles with `bypassrls` always skip RLS; `force row level security` does not apply to them. On Supabase, `postgres` is not a superuser, but it has `bypassrls`, so the Dashboard SQL Editor skips policies even after you force them. That is why [Test your policies](#test-your-policies) switches role. Add `alter table ... force row level security` only when a table owner without `bypassrls` must also obey policies.
 
 ### Authenticated and unauthenticated roles
 
@@ -102,7 +102,7 @@ A policy that reads `to anon using ( true )` grants every unauthenticated visito
 
 ### Views and RLS
 
-Views bypass RLS by default because they are usually created with the `postgres` user. This is a feature of Postgres, which automatically creates views with `security definer`. A view over a protected table hands out every row its policies were meant to withhold, so a view needs the same attention as a table. To create one safely, see [Expose a view safely](#expose-a-view-safely).
+Views bypass RLS by default because they are usually created with the `postgres` user. Postgres creates views with the owner's rights (`security_invoker` defaults to false), so a view over a protected table hands out every row its policies were meant to withhold. A view needs the same attention as a table. To create one safely, see [Expose a view safely](#expose-a-view-safely).
 
 ## Secure a table with RLS
 
@@ -205,7 +205,7 @@ If no `with check` expression is defined, the `using` expression decides both wh
 
 <Admonition type="caution">
 
-Postgres can update a row with only an `update` policy. The Data API also needs a matching [`select` policy](#select-policies) to return the updated row. Without one, the write can succeed and the client still receives no representation.
+An `update` that reads the row also needs a matching [`select` policy](#select-policies). That includes a `where` clause, a `returning` clause, and Data API updates, which filter by column and return the updated row. Without a `select` policy, the update matches zero rows rather than raising an error. A SQL `update` that assigns constants and has no `where` or `returning` clause can succeed with only an `update` policy.
 
 </Admonition>
 
@@ -259,7 +259,7 @@ on test_table
 using btree (user_id);
 ```
 
-A column counts as indexed only when it comes first in a `btree` index. Postgres can't use a multi-column index to filter on a column that isn't the leading one, so a composite primary key indexes its first column and no others. A membership table keyed on `(team_id, user_id)` has no index on `user_id`:
+A policy filter uses a `btree` index most efficiently when the filter column leads the index. A composite primary key on `(team_id, user_id)` leads with `team_id`, so a policy that filters on `user_id` still needs its own index:
 
 ```sql
 create table team_members (
@@ -302,7 +302,7 @@ You can only use this technique if the results of the query or function do not c
 
 ### Expose a view safely
 
-In Postgres 15 and above, make a view obey the RLS policies of its underlying tables when invoked by `anon` and `authenticated` by setting `security_invoker = true`.
+In Postgres 15 or later, make a view obey the RLS policies of its underlying tables when invoked by `anon` and `authenticated` by setting `security_invoker = true`.
 
 ```sql
 create view <VIEW_NAME>
@@ -339,7 +339,7 @@ Each case sets an identity, runs one statement as that identity, and asserts the
 1. Create a test file:
 
    ```bash
-   supabase test new profiles_rls
+   supabase test new profiles_rls.test
    ```
 
 2. Write the tests. Cover `select`, `insert`, `update`, and `delete` twice each, once for a request the policy allows and once for a request it denies, for `anon` as well as `authenticated`.
@@ -433,7 +433,7 @@ Not all information present in the JWT should be used in RLS policies. For insta
 
 </Admonition>
 
-Returns the JWT of the user making the request. Anything that you store in the user's `raw_app_meta_data` column or the `raw_user_meta_data` column will be accessible using this function. It's important to know the distinction between these two:
+Returns the JWT claims of the user making the request as `jsonb`. Anything that you store in the user's `raw_app_meta_data` column or the `raw_user_meta_data` column is copied into those claims. It's important to know the distinction between these two:
 
 - `raw_user_meta_data` - can be updated by the authenticated user using [`updateUser()`](/docs/reference/javascript/auth-updateuser). It is not a good place to store authorization data.
 - `raw_app_meta_data` - cannot be updated by the user, so it's a good place to store authorization data.
@@ -471,9 +471,11 @@ to authenticated using (
 );
 ```
 
+This restrictive check only applies after a permissive update policy has allowed the row. A table with only restrictive policies denies every row.
+
 ### Use security definer functions
 
-A "security definer" function runs using the same role that _created_ the function. This means that if you create a role with a superuser (like `postgres`), then that function will have `bypassrls` privileges. For example, if you had a policy like this:
+A `security definer` function runs as the role that owns it, not the caller. Functions you create as `postgres` skip RLS because `postgres` has `bypassrls`. That is useful for looking up roles without paying RLS on the lookup table, and dangerous if the function is callable without checking `(select auth.uid())`. For example, if you had a policy like this:
 
 ```sql
 create policy "rls_test_select" on test_table
@@ -486,13 +488,13 @@ using (
 );
 ```
 
-We can instead create a `security definer` function which can scan `roles_table` without any RLS penalties:
+You can instead create a `security definer` function which can scan `roles_table` without any RLS penalties:
 
 ```sql
 create function private.has_good_role()
 returns boolean
 language plpgsql
-security definer -- will run as the creator
+security definer -- runs as the owner
 set search_path = '' -- every name inside must be schema-qualified
 as $$
 begin
@@ -503,7 +505,9 @@ begin
 end;
 $$;
 
-revoke execute on function private.has_good_role() from public, anon, authenticated, service_role;
+revoke execute on function private.has_good_role() from public;
+grant usage on schema private to authenticated;
+grant execute on function private.has_good_role() to authenticated;
 
 -- Update our policy to use this function:
 create policy "rls_test_select"
@@ -512,7 +516,7 @@ to authenticated
 using ( (select private.has_good_role()) );
 ```
 
-Set `search_path = ''` on every `security definer` function and schema-qualify the names inside it. Without a pinned `search_path`, a caller can point an unqualified name at their own object and run it with the function owner's privileges. Check `(select auth.uid())` inside the function body, and revoke `execute` from `public` and the client roles. New functions grant `execute` to `public` by default.
+Set `search_path = ''` on every `security definer` function and schema-qualify the names inside it. Without a pinned `search_path`, a caller can point an unqualified name at their own object and run it with the function owner's privileges. Check `(select auth.uid())` inside the function body. Revoke `execute` from `public`, then grant `usage` on the schema and `execute` on the function to the role the policy uses. Policy expressions run as the caller, so that role needs both. Keep the function in an unexposed schema so it is not an RPC. New functions grant `execute` to `public` by default.
 
 <Admonition type="caution">
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update (claim-by-claim verification), stacked on #49268, which is stacked on #49017.

Review #49017, then #49268, then this PR.

**Stack (bottom → top):** `#49017` (`docs/rls-restructure` → `master`) → `#49268` (`cursor/rls-accuracy-f756` → `docs/rls-restructure`) → this PR (`cursor/rls-claim-verify-f756` → `cursor/rls-accuracy-f756`).

Local tracking is via `gh stack` (`gh stack add` / `gh stack submit`). Creating the GitHub Stack object failed here with `Resource not accessible by integration`. To attach official GitHub Stack metadata from a token that can write stacks:

```
gh stack link --base master 49017 49268 49269
```

## What is the current behavior?

A claim-by-claim check of the restructured RLS guide against Postgres, the Auth helpers, and the Supabase role catalog found several remaining inaccuracies in #49268 (some introduced by the previous accuracy pass).

## What is the new behavior?

Accuracy-only edits to `row-level-security.mdx`:

- **FORCE RLS:** only table owners without `bypassrls` are subject to FORCE. Superusers and `bypassrls` always skip. On Supabase, `postgres` is not a superuser but has `bypassrls` ([demote-postgres.sql](https://github.com/supabase/postgres/blob/develop/migrations/db/migrations/10000000000000_demote-postgres.sql)), so the SQL Editor skips policies even after FORCE.
- **Permissive vs restrictive:** a second *permissive* policy widens access. Restrictive policies only reduce access after at least one permissive policy has granted it. The MFA example now says so.
- **UPDATE + SELECT:** an update that reads the row (`where`, `returning`, Data API filters) also needs a SELECT policy. Without one, the update matches zero rows. The previous “representation-only / Data API” wording was wrong for typical API updates ([CREATE POLICY](https://www.postgresql.org/docs/current/sql-createpolicy.html), PostgREST #2423).
- **EXECUTE on helpers:** policy expressions run as the caller, so revoke `execute` from `public` and grant `usage` + `execute` to the policy’s role. Revoking from `authenticated` breaks the policy that calls the function ([CREATE POLICY notes](https://www.postgresql.org/docs/current/sql-createpolicy.html)).
- **`auth.jwt()`** returns claims as `jsonb`, not the token string.
- **Views:** owner rights (`security_invoker` defaults to false), not `security definer` syntax.
- **Indexes:** a composite PK leads with its first column; a `user_id` filter still needs its own index (without claiming Postgres can never use a non-leading column).
- **`supabase test new profiles_rls.test`** matches the example filename and the testing overview.

Claims that checked out and were left alone include: grants-before-policies, default-deny with no policy, `to authenticated` short-circuit, `auth.uid()` null = unknown, initPlan wrapping, `with check` vs `using`, 42501 for missing grants and WITH CHECK, secret key → `service_role` + `bypassrls`, JWT `?` for a text array of team IDs, `updateUser()` on `user_metadata`, cookie 4096, MFA `aal2`.

## Additional context

Base is `cursor/rls-accuracy-f756` (#49268), not `master`. Files changed vs that PR is this verification commit only.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f03b502-d237-4d3d-8e59-da4e746af756?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f03b502-d237-4d3d-8e59-da4e746af756&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

