### PR TITLE
docs(database): make pgTAP tests a required RLS procedure step

### DIFF
--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -67,7 +67,7 @@ Not every project grants these automatically. See [Default privileges](/docs/gui
 
 A missing grant raises a `42501` error before any policy runs. When a request fails that your policy should allow, check the grants before you change the policy. To set them, see [Lock down the table](#lock-down-the-table).
 
-Table owners skip RLS unless you force it. Superusers and roles with `bypassrls` always skip RLS; `force row level security` does not apply to them. On Supabase, `postgres` is not a superuser, but it has `bypassrls`, so the Dashboard SQL Editor skips policies even after you force them. That is why [Test your policies](#test-your-policies) switches role. Add `alter table ... force row level security` only when a table owner without `bypassrls` must also obey policies.
+Table owners skip RLS unless you force it. Superusers and roles with `bypassrls` always skip RLS; `force row level security` does not apply to them. On Supabase, `postgres` is not a superuser, but it has `bypassrls`, so the Dashboard SQL Editor skips policies even after you force them. That is why the test files switch role. Add `alter table ... force row level security` only when a table owner without `bypassrls` must also obey policies.
 
 ### Authenticated and unauthenticated roles
 
@@ -142,23 +142,78 @@ Enable RLS, then set the grants to match what each role does in your app:
    grant select, insert, update, delete on table public.reports to authenticated;
    ```
 
-Data that clients read but never write, such as a feed a backend job populates, gets no write grant at all:
+Data that clients read but never write, such as a feed a backend job populates, gets select only. The policy and the test file are part of the same change:
 
 ```sql
+alter table public.weather_readings enable row level security;
 revoke all on table public.weather_readings from anon, authenticated;
 grant select on table public.weather_readings to anon, authenticated;
+
+create policy "Anyone can read weather readings"
+on public.weather_readings for select
+to anon, authenticated
+using ( true );
+```
+
+```sql supabase/tests/weather_readings_rls.test.sql
+-- File: supabase/tests/weather_readings_rls.test.sql
+-- Repeat for every public-read table you secured. Do not add a table only the tests use.
+begin;
+select plan(8);
+
+set local role anon;
+select lives_ok(
+  $$select * from weather_readings$$,
+  'anon can read the feed'
+);
+select throws_ok(
+  $$insert into weather_readings select * from weather_readings$$,
+  '42501',
+  null,
+  'anon cannot insert into the feed'
+);
+select throws_ok(
+  $$update weather_readings set id = id$$,
+  '42501',
+  null,
+  'anon cannot update the feed'
+);
+select throws_ok(
+  $$delete from weather_readings$$,
+  '42501',
+  null,
+  'anon cannot delete from the feed'
+);
+
+set local role authenticated;
+select lives_ok(
+  $$select * from weather_readings$$,
+  'authenticated can read the feed'
+);
+select throws_ok(
+  $$insert into weather_readings select * from weather_readings$$,
+  '42501',
+  null,
+  'authenticated cannot insert into the feed'
+);
+select throws_ok(
+  $$update weather_readings set id = id$$,
+  '42501',
+  null,
+  'authenticated cannot update the feed'
+);
+select throws_ok(
+  $$delete from weather_readings$$,
+  '42501',
+  null,
+  'authenticated cannot delete from the feed'
+);
+
+select * from finish();
+rollback;
 ```
 
 If new tables still receive automatic grants, see [Revoke default privileges](/docs/guides/api/securing-your-api#revoke-default-privileges). To enable RLS automatically on every new table, see [Event triggers](/docs/guides/database/postgres/event-triggers).
-
-After the policies, create a test file for the table and run the suite in the same change:
-
-```bash
-supabase test new reports_rls.test
-supabase test db
-```
-
-Cover allow and deny for `select`, `insert`, `update`, and `delete`, for `anon` as well as `authenticated`. See [Test your policies](#test-your-policies).
 
 ### Write a policy for each operation
 
@@ -234,69 +289,12 @@ to authenticated
 using ( (select auth.uid()) = user_id );
 ```
 
-These four policies are not done until tests prove them. Put a `.sql` file under `supabase/tests/` and run `supabase test db`. See [Test your policies](#test-your-policies).
-
-### Specify roles in your policies
-
-Always name the role a policy applies to, using the `to` clause. Instead of this:
-
-```sql
-create policy "rls_test_select" on rls_test
-using ( auth.uid() = user_id );
-```
-
-Use:
-
-```sql
-create policy "rls_test_select" on rls_test
-to authenticated
-using ( (select auth.uid()) = user_id );
-```
-
-This prevents the policy `( (select auth.uid()) = user_id )` from running for any `anon` users, since the execution stops at the `to authenticated` step.
-
-### Test your policies
-
-Create a `.sql` file under `supabase/tests/` for every table you enabled RLS on. Run `supabase test db` in the same change. Do not ship grants and policies without a passing suite.
-
-```bash
-supabase test new profiles_rls.test
-supabase test db
-```
-
-Supabase runs those files with [pgTAP](/docs/guides/database/extensions/pgtap) through the CLI.
-
-A wrong policy fails quietly. Too permissive, and a query returns rows it shouldn't. Too strict, and it returns nothing and raises no error. Neither case surfaces as an error, so tests are how you find out.
-
-Assert against the tables whose grants and policies you set. Do not introduce a scratch table only the tests use.
-
-Write allow and deny cases for `select`, `insert`, `update`, and `delete`, for `anon` as well as `authenticated`. Switch role and identity between cases. Repeat that suite for every table you enabled RLS on.
-
-For a public-read table, assert that `anon` and `authenticated` can select and that every write is denied. For a table users share, assert that a member who is not the owner can read and write, and that a non-member cannot.
-
-[`supabase-test-helpers`](https://github.com/usebasejump/supabase-test-helpers/tree/main) removes most of the setup below. It adds `tests.create_supabase_user()`, `tests.authenticate_as()`, and `tests.rls_enabled()`, so you don't hand-roll user seeding or role switching. See [Advanced pgTAP testing](/docs/guides/local-development/testing/pgtap-extended) for schema-wide assertions and a worked multi-tenant example.
-
-Stop only when `supabase test db` reports a passing result.
-
-#### Anatomy of a policy test
-
-Each case sets an identity, runs one statement as that identity, and asserts the outcome. Three things decide whether the assertion means anything.
-
-**Identity.** Switch role and identity between cases with `set local role` and `set local request.jwt.claim.sub`, so each assertion runs as the user it describes. Without the switch, every case runs as the same role and proves nothing about access.
-
-**Denials.** A denied request doesn't always raise an error, so match the assertion to the way the denial happens:
-
-- A missing grant raises `42501`. Assert it with `throws_ok`.
-- A `with check` violation raises `42501`. Assert it with `throws_ok`.
-- A `using` clause that filters the target row out raises nothing. The update or delete matches zero rows instead. Assert that no row changed.
-
-**Allowed writes.** The absence of an error doesn't prove that anything changed. Add `returning` to the statement so one assertion covers both directions. An allowed write returns the changed row, and a write the policy filters out returns nothing.
-
-#### Example
-
-This example covers all four operations against a `profiles` table where `authenticated` holds every privilege, `anon` holds none, and each user reads and writes only their own row. Copy the pattern onto each table you secured:
+When you adapt those four policies to a table, add this file for that table. The path is `supabase/tests/<table>_rls.test.sql`. For a table users share, also assert that a member who is not the owner can read and write, and that a non-member cannot.
 
 ```sql supabase/tests/profiles_rls.test.sql
+-- File: supabase/tests/profiles_rls.test.sql
+-- One file per table you enabled RLS on. Name that table in the assertions.
+-- Do not create a table only the tests use.
 begin;
 select plan(12);
 
@@ -400,7 +398,32 @@ select * from finish();
 rollback;
 ```
 
-For CLI setup and more pgTAP helpers, see [Testing your database](/docs/guides/database/testing).
+A missing grant or a `with check` violation raises `42501`; assert it with `throws_ok`. A `using` clause that filters the row out raises nothing, so assert that the update or delete changed no rows. An allowed write needs `returning`. Switch role and identity with `set local role` and `set local request.jwt.claim.sub`.
+
+### Specify roles in your policies
+
+Always name the role a policy applies to, using the `to` clause. Instead of this:
+
+```sql
+create policy "rls_test_select" on rls_test
+using ( auth.uid() = user_id );
+```
+
+Use:
+
+```sql
+create policy "rls_test_select" on rls_test
+to authenticated
+using ( (select auth.uid()) = user_id );
+```
+
+This prevents the policy `( (select auth.uid()) = user_id )` from running for any `anon` users, since the execution stops at the `to authenticated` step.
+
+### Test your policies
+
+The files above live under `supabase/tests/` and run through [pgTAP](/docs/guides/database/extensions/pgtap). Create them with `supabase test new <table>_rls.test`. Run the suite with `supabase test db`. Stop only when it reports a passing result.
+
+[`supabase-test-helpers`](https://github.com/usebasejump/supabase-test-helpers/tree/main) adds `tests.create_supabase_user()`, `tests.authenticate_as()`, and `tests.rls_enabled()`. See [Advanced pgTAP testing](/docs/guides/local-development/testing/pgtap-extended) and [Testing your database](/docs/guides/database/testing).
 
 Index the filter columns and wrap helper calls so policies stay fast as a table grows. For the measured impact and for tuning beyond them, see [Row Level Security performance](/docs/guides/database/postgres/row-level-security-performance).
 
@@ -585,6 +608,8 @@ on test_table
 to authenticated
 using ( (select private.has_good_role()) );
 ```
+
+Add member and non-member cases to that table's file under `supabase/tests/`. A member who is not the owner must be allowed; a non-member must not.
 
 Set `search_path = ''` on every `security definer` function and schema-qualify the names inside it. Without a pinned `search_path`, a caller can point an unqualified name at their own object and run it with the function owner's privileges. Check `(select auth.uid())` inside the function body. Revoke `execute` from `public`, then grant `usage` on the schema and `execute` on the function to the role the policy uses. Policy expressions run as the caller, so that role needs both. Keep the function in an unexposed schema so it is not an RPC. New functions grant `execute` to `public` by default.
 

--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -16,7 +16,7 @@ A table in an exposed schema without RLS is readable and writable by any role wi
 Use the guide in three parts:
 
 - [Understand Row Level Security](#understand-row-level-security) explains how grants and policies combine to control access.
-- [Secure a table with RLS](#secure-a-table-with-rls) is the procedure to follow for every table in an exposed schema.
+- [Secure a table with RLS](#secure-a-table-with-rls) is the procedure to follow for every table in an exposed schema: grants, policies, and `supabase test db`.
 - [RLS reference](#rls-reference) documents the helper functions and patterns you use inside a policy expression.
 
 Read the first section when you're deciding how to model access. Go directly to the second section when you're ready to secure a table.
@@ -106,7 +106,14 @@ Views bypass RLS by default because they are usually created with the `postgres`
 
 ## Secure a table with RLS
 
-Follow these steps for every table in an exposed schema.
+Follow these steps for every table in an exposed schema:
+
+1. Enable RLS and set the grants to match the app.
+2. Write a policy per operation.
+3. Create a `.sql` file under `supabase/tests/` that asserts allow and deny for `select`, `insert`, `update`, and `delete`, for `anon` and `authenticated`.
+4. Run `supabase test db` and stop only when it passes.
+
+A table is not secured until that suite passes.
 
 ### Lock down the table
 
@@ -144,7 +151,14 @@ grant select on table public.weather_readings to anon, authenticated;
 
 If new tables still receive automatic grants, see [Revoke default privileges](/docs/guides/api/securing-your-api#revoke-default-privileges). To enable RLS automatically on every new table, see [Event triggers](/docs/guides/database/postgres/event-triggers).
 
-Write the tests for this table in the same change. See [Test your policies](#test-your-policies).
+After the policies, create a test file for the table and run the suite in the same change:
+
+```bash
+supabase test new reports_rls.test
+supabase test db
+```
+
+Cover allow and deny for `select`, `insert`, `update`, and `delete`, for `anon` as well as `authenticated`. See [Test your policies](#test-your-policies).
 
 ### Write a policy for each operation
 
@@ -220,6 +234,8 @@ to authenticated
 using ( (select auth.uid()) = user_id );
 ```
 
+These four policies are not done until tests prove them. Put a `.sql` file under `supabase/tests/` and run `supabase test db`. See [Test your policies](#test-your-policies).
+
 ### Specify roles in your policies
 
 Always name the role a policy applies to, using the `to` clause. Instead of this:
@@ -239,7 +255,154 @@ using ( (select auth.uid()) = user_id );
 
 This prevents the policy `( (select auth.uid()) = user_id )` from running for any `anon` users, since the execution stops at the `to authenticated` step.
 
-These three rules keep policies correct as a table grows. For the measured impact and for tuning beyond them, see [Row Level Security performance](/docs/guides/database/postgres/row-level-security-performance).
+### Test your policies
+
+Create a `.sql` file under `supabase/tests/` for every table you enabled RLS on. Run `supabase test db` in the same change. Do not ship grants and policies without a passing suite.
+
+```bash
+supabase test new profiles_rls.test
+supabase test db
+```
+
+Supabase runs those files with [pgTAP](/docs/guides/database/extensions/pgtap) through the CLI.
+
+A wrong policy fails quietly. Too permissive, and a query returns rows it shouldn't. Too strict, and it returns nothing and raises no error. Neither case surfaces as an error, so tests are how you find out.
+
+Assert against the tables whose grants and policies you set. Do not introduce a scratch table only the tests use.
+
+Write allow and deny cases for `select`, `insert`, `update`, and `delete`, for `anon` as well as `authenticated`. Switch role and identity between cases. Repeat that suite for every table you enabled RLS on.
+
+For a public-read table, assert that `anon` and `authenticated` can select and that every write is denied. For a table users share, assert that a member who is not the owner can read and write, and that a non-member cannot.
+
+[`supabase-test-helpers`](https://github.com/usebasejump/supabase-test-helpers/tree/main) removes most of the setup below. It adds `tests.create_supabase_user()`, `tests.authenticate_as()`, and `tests.rls_enabled()`, so you don't hand-roll user seeding or role switching. See [Advanced pgTAP testing](/docs/guides/local-development/testing/pgtap-extended) for schema-wide assertions and a worked multi-tenant example.
+
+Stop only when `supabase test db` reports a passing result.
+
+#### Anatomy of a policy test
+
+Each case sets an identity, runs one statement as that identity, and asserts the outcome. Three things decide whether the assertion means anything.
+
+**Identity.** Switch role and identity between cases with `set local role` and `set local request.jwt.claim.sub`, so each assertion runs as the user it describes. Without the switch, every case runs as the same role and proves nothing about access.
+
+**Denials.** A denied request doesn't always raise an error, so match the assertion to the way the denial happens:
+
+- A missing grant raises `42501`. Assert it with `throws_ok`.
+- A `with check` violation raises `42501`. Assert it with `throws_ok`.
+- A `using` clause that filters the target row out raises nothing. The update or delete matches zero rows instead. Assert that no row changed.
+
+**Allowed writes.** The absence of an error doesn't prove that anything changed. Add `returning` to the statement so one assertion covers both directions. An allowed write returns the changed row, and a write the policy filters out returns nothing.
+
+#### Example
+
+This example covers all four operations against a `profiles` table where `authenticated` holds every privilege, `anon` holds none, and each user reads and writes only their own row. Copy the pattern onto each table you secured:
+
+```sql supabase/tests/profiles_rls.test.sql
+begin;
+select plan(12);
+
+insert into auth.users (id, email)
+values
+  ('11111111-1111-1111-1111-111111111111', 'owner@example.com'),
+  ('22222222-2222-2222-2222-222222222222', 'other@example.com');
+
+-- anon holds no grant, so the request stops before any policy runs.
+set local role anon;
+select throws_ok(
+  $$select * from profiles$$,
+  '42501',
+  null,
+  'anon cannot read profiles'
+);
+select throws_ok(
+  $$insert into profiles (id, user_id, avatar_url)
+    values (
+      gen_random_uuid(),
+      '11111111-1111-1111-1111-111111111111',
+      'anon.png'
+    )$$,
+  '42501',
+  null,
+  'anon cannot create a profile'
+);
+select throws_ok(
+  $$update profiles set avatar_url = 'anon.png'$$,
+  '42501',
+  null,
+  'anon cannot update profiles'
+);
+select throws_ok(
+  $$delete from profiles$$,
+  '42501',
+  null,
+  'anon cannot delete profiles'
+);
+
+-- The owner writes their own row. returning proves the row changed.
+set local role authenticated;
+set local request.jwt.claim.sub = '11111111-1111-1111-1111-111111111111';
+select results_eq(
+  $$insert into profiles (id, user_id, avatar_url)
+    values (
+      gen_random_uuid(),
+      '11111111-1111-1111-1111-111111111111',
+      'owner.png'
+    )
+    returning avatar_url$$,
+  array['owner.png'],
+  'the owner creates their own profile'
+);
+select results_eq(
+  $$select avatar_url from profiles$$,
+  array['owner.png'],
+  'the owner reads their own profile'
+);
+select results_eq(
+  $$update profiles set avatar_url = 'updated.png' returning avatar_url$$,
+  array['updated.png'],
+  'the owner updates their own profile'
+);
+
+-- A signed-in stranger holds the grant, so the policy is what stops them.
+set local request.jwt.claim.sub = '22222222-2222-2222-2222-222222222222';
+select throws_ok(
+  $$insert into profiles (id, user_id, avatar_url)
+    values (
+      gen_random_uuid(),
+      '11111111-1111-1111-1111-111111111111',
+      'stolen.png'
+    )$$,
+  '42501',
+  null,
+  'another user cannot create a profile for the owner'
+);
+select is_empty(
+  $$select * from profiles$$,
+  'another user reads no profiles'
+);
+select is_empty(
+  $$update profiles set avatar_url = 'stolen.png' returning avatar_url$$,
+  'another user updates no profiles'
+);
+select is_empty(
+  $$delete from profiles returning avatar_url$$,
+  'another user deletes no profiles'
+);
+
+-- Owner delete last so earlier cases still have a row to assert against.
+set local request.jwt.claim.sub = '11111111-1111-1111-1111-111111111111';
+select results_eq(
+  $$delete from profiles returning avatar_url$$,
+  array['updated.png'],
+  'the owner deletes their own profile'
+);
+
+select * from finish();
+rollback;
+```
+
+For CLI setup and more pgTAP helpers, see [Testing your database](/docs/guides/database/testing).
+
+Index the filter columns and wrap helper calls so policies stay fast as a table grows. For the measured impact and for tuning beyond them, see [Row Level Security performance](/docs/guides/database/postgres/row-level-security-performance).
 
 ### Add indexes
 
@@ -311,99 +474,6 @@ as select <QUERY>
 ```
 
 In older versions of Postgres, protect your views by revoking access from the `anon` and `authenticated` roles, or by putting them in an unexposed schema.
-
-### Test your policies
-
-We recommend writing tests for every policy, in the same change that sets the grants and creates the policies. Tests are a fundamental part of a secure setup, and they give you a repeatable way to prove a policy behaves the way you intended.
-
-A wrong policy fails quietly. Too permissive, and a query returns rows it shouldn't. Too strict, and it returns nothing and raises no error. Neither case surfaces as an error, so tests are how you find out.
-
-Supabase runs database tests with [pgTAP](/docs/guides/database/extensions/pgtap) through the CLI. Test files are `.sql` files under `supabase/tests/`.
-
-#### Anatomy of a policy test
-
-Each case sets an identity, runs one statement as that identity, and asserts the outcome. Three things decide whether the assertion means anything.
-
-**Identity.** Switch role and identity between cases with `set local role` and `set local request.jwt.claim.sub`, so each assertion runs as the user it describes. Without the switch, every case runs as the same role and proves nothing about access.
-
-**Denials.** A denied request doesn't always raise an error, so match the assertion to the way the denial happens:
-
-- A missing grant raises `42501`. Assert it with `throws_ok`.
-- A `with check` violation raises `42501`. Assert it with `throws_ok`.
-- A `using` clause that filters the target row out raises nothing. The update or delete matches zero rows instead. Assert that no row changed.
-
-**Allowed writes.** The absence of an error doesn't prove that anything changed. Add `returning` to the statement so one assertion covers both directions. An allowed write returns the changed row, and a write the policy filters out returns nothing.
-
-#### Write and run the tests
-
-1. Create a test file:
-
-   ```bash
-   supabase test new profiles_rls.test
-   ```
-
-2. Write the tests. Cover `select`, `insert`, `update`, and `delete` twice each, once for a request the policy allows and once for a request it denies, for `anon` as well as `authenticated`.
-
-   [`supabase-test-helpers`](https://github.com/usebasejump/supabase-test-helpers/tree/main) removes most of the setup below. It adds `tests.create_supabase_user()`, `tests.authenticate_as()`, and `tests.rls_enabled()`, so you don't hand-roll user seeding or role switching. See [Advanced pgTAP testing](/docs/guides/local-development/testing/pgtap-extended) for schema-wide assertions and a worked multi-tenant example.
-
-3. Run the suite:
-
-   ```bash
-   supabase test db
-   ```
-
-This example shows each of those techniques against a `profiles` table where `authenticated` holds every privilege, `anon` holds none, and each user reads and writes only their own row. Extend it to the remaining operations:
-
-```sql supabase/tests/profiles_rls.test.sql
-begin;
-select plan(4);
-
-insert into auth.users (id, email)
-values
-  ('11111111-1111-1111-1111-111111111111', 'owner@example.com'),
-  ('22222222-2222-2222-2222-222222222222', 'other@example.com');
-
--- anon holds no grant, so the request stops before any policy runs.
-set local role anon;
-select throws_ok(
-  $$select * from profiles$$,
-  '42501',
-  null,
-  'anon cannot read profiles'
-);
-
--- The owner writes their own row. returning proves the row changed.
-set local role authenticated;
-set local request.jwt.claim.sub = '11111111-1111-1111-1111-111111111111';
-select results_eq(
-  $$insert into profiles (id, user_id, avatar_url)
-    values (
-      gen_random_uuid(),
-      '11111111-1111-1111-1111-111111111111',
-      'owner.png'
-    )
-    returning avatar_url$$,
-  array['owner.png'],
-  'the owner creates their own profile'
-);
-
--- A signed-in stranger holds the grant, so the policy is what stops them. The
--- using clause filters the row out, so these match nothing and raise nothing.
-set local request.jwt.claim.sub = '22222222-2222-2222-2222-222222222222';
-select is_empty(
-  $$select * from profiles$$,
-  'another user reads no profiles'
-);
-select is_empty(
-  $$update profiles set avatar_url = 'stolen.png' returning avatar_url$$,
-  'another user updates no profiles'
-);
-
-select * from finish();
-rollback;
-```
-
-For CLI setup and more pgTAP helpers, see [Testing your database](/docs/guides/database/testing).
 
 ## RLS reference
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update, stacked on #49269, which is stacked on #49268, which is stacked on #49017.

Review #49017, then #49268, then #49269, then this PR.

**Stack (bottom → top):** `#49017` (`docs/rls-restructure` → `master`) → `#49268` (`cursor/rls-accuracy-f756` → `docs/rls-restructure`) → `#49269` (`cursor/rls-claim-verify-f756` → `cursor/rls-accuracy-f756`) → this PR (`cursor/rls-eval-tests-f756` → `cursor/rls-claim-verify-f756`).

Local tracking is via `gh stack`. Creating the GitHub Stack object failed here with `Resource not accessible by integration`. To attach official GitHub Stack metadata:

```
gh stack link --base master 49017 49268 49269 49270
```

## What is the current behavior?

The latest `build-docs-002-rls-guide` refresh (evals#215) still fails. Grants, policies, access probes, indexes, and security-definer helpers all pass. The only misses are the three pgTAP checks.

That split is the signal. The guide already taught grants and already had a Test section. Grants are copyable SQL in the “enable RLS / public read” extract the agent actually fetches (`web_fetch`, ~6907 characters). Tests were a later section plus “remember to write tests” prose. The extract query asked for enable RLS, `CREATE POLICY`, `auth.uid()`, indexes, wrapping, roles, security definer functions, ownership, and public read. It did not ask for tests. More testing instructions in a Test section do not enter that extract.

The prompt never says test. Whether the agent writes pgTAP is the measurement.

## What is the new behavior?

Stop adding testing prose. Put the test files in the examples the agent already copies.

- **Public read** (enable-RLS extract): `weather_readings` now has enable + revoke + `grant select` + `using (true)` and the matching `supabase/tests/weather_readings_rls.test.sql` (allow select / deny writes for `anon` and `authenticated`).
- **Owner-private** (`CREATE POLICY` extract): the four policies are followed immediately by `supabase/tests/profiles_rls.test.sql` (`plan(12)`, allow and deny all four operations, `returning` on allowed writes, `is_empty` on `using`-filtered update/delete). A short note covers shared-member cases.
- **Security definer** extract: glue to add member vs non-member cases on that table’s test file.
- **Test your policies** shrinks to how to create and run the files. The skippable later example is gone.

`-- File: supabase/tests/...` is the first line of each test so the path survives if fence metadata is dropped.

The eval still hits the published URL, so this cannot pass until the stack is on `master`.

## Additional context

Does not name the eval’s membership tables. Does not encode “revoke `EXECUTE` from `authenticated`.”

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f03b502-d237-4d3d-8e59-da4e746af756?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f03b502-d237-4d3d-8e59-da4e746af756&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

