### PR TITLE
docs(database): correct the RLS guide and close its remaining gaps

### DIFF
--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -67,7 +67,7 @@ Not every project grants these automatically. See [Default privileges](/docs/gui
 
 A missing grant raises a `42501` error before any policy runs. When a request fails that your policy should allow, check the grants before you change the policy. To set them, see [Lock down the table](#lock-down-the-table).
 
-Table owners skip RLS unless you force it. Superusers and roles with `bypassrls` always skip RLS; `force row level security` does not apply to them. On Supabase, `postgres` is not a superuser, but it has `bypassrls`, so the Dashboard SQL Editor skips policies even after you force them. That is why [Test your policies](#test-your-policies) switches role. Add `alter table ... force row level security` only when a table owner without `bypassrls` must also obey policies.
+Table owners skip RLS unless you force it. Superusers and roles with `bypassrls` always skip RLS; `force row level security` does not apply to them. On Supabase, `postgres` is not a superuser, but it has `bypassrls`, so the Dashboard SQL Editor skips policies even after you force them. That is why the test files switch role. Add `alter table ... force row level security` only when a table owner without `bypassrls` must also obey policies.
 
 ### Authenticated and unauthenticated roles
 
@@ -142,23 +142,78 @@ Enable RLS, then set the grants to match what each role does in your app:
    grant select, insert, update, delete on table public.reports to authenticated;
    ```
 
-Data that clients read but never write, such as a feed a backend job populates, gets no write grant at all:
+Data that clients read but never write, such as a feed a backend job populates, gets select only. The policy and the test file are part of the same change:
 
 ```sql
+alter table public.weather_readings enable row level security;
 revoke all on table public.weather_readings from anon, authenticated;
 grant select on table public.weather_readings to anon, authenticated;
+
+create policy "Anyone can read weather readings"
+on public.weather_readings for select
+to anon, authenticated
+using ( true );
+```
+
+```sql supabase/tests/weather_readings_rls.test.sql
+-- File: supabase/tests/weather_readings_rls.test.sql
+-- Repeat for every public-read table you secured. Do not add a table only the tests use.
+begin;
+select plan(8);
+
+set local role anon;
+select lives_ok(
+  $$select * from weather_readings$$,
+  'anon can read the feed'
+);
+select throws_ok(
+  $$insert into weather_readings select * from weather_readings$$,
+  '42501',
+  null,
+  'anon cannot insert into the feed'
+);
+select throws_ok(
+  $$update weather_readings set id = id$$,
+  '42501',
+  null,
+  'anon cannot update the feed'
+);
+select throws_ok(
+  $$delete from weather_readings$$,
+  '42501',
+  null,
+  'anon cannot delete from the feed'
+);
+
+set local role authenticated;
+select lives_ok(
+  $$select * from weather_readings$$,
+  'authenticated can read the feed'
+);
+select throws_ok(
+  $$insert into weather_readings select * from weather_readings$$,
+  '42501',
+  null,
+  'authenticated cannot insert into the feed'
+);
+select throws_ok(
+  $$update weather_readings set id = id$$,
+  '42501',
+  null,
+  'authenticated cannot update the feed'
+);
+select throws_ok(
+  $$delete from weather_readings$$,
+  '42501',
+  null,
+  'authenticated cannot delete from the feed'
+);
+
+select * from finish();
+rollback;
 ```
 
 If new tables still receive automatic grants, see [Revoke default privileges](/docs/guides/api/securing-your-api#revoke-default-privileges). To enable RLS automatically on every new table, see [Event triggers](/docs/guides/database/postgres/event-triggers).
-
-After the policies, create a test file for the table and run the suite in the same change:
-
-```bash
-supabase test new reports_rls.test
-supabase test db
-```
-
-Cover allow and deny for `select`, `insert`, `update`, and `delete`, for `anon` as well as `authenticated`. See [Test your policies](#test-your-policies).
 
 ### Write a policy for each operation
 
@@ -234,69 +289,12 @@ to authenticated
 using ( (select auth.uid()) = user_id );
 ```
 
-These four policies are not done until tests prove them. Put a `.sql` file under `supabase/tests/` and run `supabase test db`. See [Test your policies](#test-your-policies).
-
-### Specify roles in your policies
-
-Always name the role a policy applies to, using the `to` clause. Instead of this:
-
-```sql
-create policy "rls_test_select" on rls_test
-using ( auth.uid() = user_id );
-```
-
-Use:
-
-```sql
-create policy "rls_test_select" on rls_test
-to authenticated
-using ( (select auth.uid()) = user_id );
-```
-
-This prevents the policy `( (select auth.uid()) = user_id )` from running for any `anon` users, since the execution stops at the `to authenticated` step.
-
-### Test your policies
-
-Create a `.sql` file under `supabase/tests/` for every table you enabled RLS on. Run `supabase test db` in the same change. Do not ship grants and policies without a passing suite.
-
-```bash
-supabase test new profiles_rls.test
-supabase test db
-```
-
-Supabase runs those files with [pgTAP](/docs/guides/database/extensions/pgtap) through the CLI.
-
-A wrong policy fails quietly. Too permissive, and a query returns rows it shouldn't. Too strict, and it returns nothing and raises no error. Neither case surfaces as an error, so tests are how you find out.
-
-Assert against the tables whose grants and policies you set. Do not introduce a scratch table only the tests use.
-
-Write allow and deny cases for `select`, `insert`, `update`, and `delete`, for `anon` as well as `authenticated`. Switch role and identity between cases. Repeat that suite for every table you enabled RLS on.
-
-For a public-read table, assert that `anon` and `authenticated` can select and that every write is denied. For a table users share, assert that a member who is not the owner can read and write, and that a non-member cannot.
-
-[`supabase-test-helpers`](https://github.com/usebasejump/supabase-test-helpers/tree/main) removes most of the setup below. It adds `tests.create_supabase_user()`, `tests.authenticate_as()`, and `tests.rls_enabled()`, so you don't hand-roll user seeding or role switching. See [Advanced pgTAP testing](/docs/guides/local-development/testing/pgtap-extended) for schema-wide assertions and a worked multi-tenant example.
-
-Stop only when `supabase test db` reports a passing result.
-
-#### Anatomy of a policy test
-
-Each case sets an identity, runs one statement as that identity, and asserts the outcome. Three things decide whether the assertion means anything.
-
-**Identity.** Switch role and identity between cases with `set local role` and `set local request.jwt.claim.sub`, so each assertion runs as the user it describes. Without the switch, every case runs as the same role and proves nothing about access.
-
-**Denials.** A denied request doesn't always raise an error, so match the assertion to the way the denial happens:
-
-- A missing grant raises `42501`. Assert it with `throws_ok`.
-- A `with check` violation raises `42501`. Assert it with `throws_ok`.
-- A `using` clause that filters the target row out raises nothing. The update or delete matches zero rows instead. Assert that no row changed.
-
-**Allowed writes.** The absence of an error doesn't prove that anything changed. Add `returning` to the statement so one assertion covers both directions. An allowed write returns the changed row, and a write the policy filters out returns nothing.
-
-#### Example
-
-This example covers all four operations against a `profiles` table where `authenticated` holds every privilege, `anon` holds none, and each user reads and writes only their own row. Copy the pattern onto each table you secured:
+When you adapt those four policies to a table, add this file for that table. The path is `supabase/tests/<table>_rls.test.sql`. For a table users share, also assert that a member who is not the owner can read and write, and that a non-member cannot.
 
 ```sql supabase/tests/profiles_rls.test.sql
+-- File: supabase/tests/profiles_rls.test.sql
+-- One file per table you enabled RLS on. Name that table in the assertions.
+-- Do not create a table only the tests use.
 begin;
 select plan(12);
 
@@ -400,7 +398,32 @@ select * from finish();
 rollback;
 ```
 
-For CLI setup and more pgTAP helpers, see [Testing your database](/docs/guides/database/testing).
+A missing grant or a `with check` violation raises `42501`; assert it with `throws_ok`. A `using` clause that filters the row out raises nothing, so assert that the update or delete changed no rows. An allowed write needs `returning`. Switch role and identity with `set local role` and `set local request.jwt.claim.sub`.
+
+### Specify roles in your policies
+
+Always name the role a policy applies to, using the `to` clause. Instead of this:
+
+```sql
+create policy "rls_test_select" on rls_test
+using ( auth.uid() = user_id );
+```
+
+Use:
+
+```sql
+create policy "rls_test_select" on rls_test
+to authenticated
+using ( (select auth.uid()) = user_id );
+```
+
+This prevents the policy `( (select auth.uid()) = user_id )` from running for any `anon` users, since the execution stops at the `to authenticated` step.
+
+### Test your policies
+
+The files above live under `supabase/tests/` and run through [pgTAP](/docs/guides/database/extensions/pgtap). Create them with `supabase test new <table>_rls.test`. Run the suite with `supabase test db`. Stop only when it reports a passing result.
+
+[`supabase-test-helpers`](https://github.com/usebasejump/supabase-test-helpers/tree/main) adds `tests.create_supabase_user()`, `tests.authenticate_as()`, and `tests.rls_enabled()`. See [Advanced pgTAP testing](/docs/guides/local-development/testing/pgtap-extended) and [Testing your database](/docs/guides/database/testing).
 
 Index the filter columns and wrap helper calls so policies stay fast as a table grows. For the measured impact and for tuning beyond them, see [Row Level Security performance](/docs/guides/database/postgres/row-level-security-performance).
 
@@ -585,6 +608,8 @@ on test_table
 to authenticated
 using ( (select private.has_good_role()) );
 ```
+
+Add member and non-member cases to that table's file under `supabase/tests/`. A member who is not the owner must be allowed; a non-member must not.
 
 Set `search_path = ''` on every `security definer` function and schema-qualify the names inside it. Without a pinned `search_path`, a caller can point an unqualified name at their own object and run it with the function owner's privileges. Check `(select auth.uid())` inside the function body. Revoke `execute` from `public`, then grant `usage` on the schema and `execute` on the function to the role the policy uses. Policy expressions run as the caller, so that role needs both. Keep the function in an unexposed schema so it is not an RPC. New functions grant `execute` to `public` by default.
 

--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -498,6 +498,20 @@ as select <QUERY>
 
 In older versions of Postgres, protect your views by revoking access from the `anon` and `authenticated` roles, or by putting them in an unexposed schema.
 
+A materialized view has none of these options. It stores its own copy of the rows, so it doesn't consult the policies on the tables it was built from, and Postgres rejects both `security_invoker` and `enable row level security` on one. Granting `select` on a materialized view hands the client every row it holds:
+
+```sql
+-- Reject: the client reads rows the base table's policies withhold.
+create materialized view reports_summary as select * from public.reports;
+grant select on reports_summary to authenticated;
+```
+
+Keep materialized views out of exposed schemas, or grant no client role access to them:
+
+```sql
+revoke all on reports_summary from anon, authenticated;
+```
+
 ## RLS reference
 
 These are the functions and patterns available inside a policy expression.
@@ -611,13 +625,80 @@ using ( (select private.has_good_role()) );
 
 Add member and non-member cases to that table's file under `supabase/tests/`. A member who is not the owner must be allowed; a non-member must not.
 
-Set `search_path = ''` on every `security definer` function and schema-qualify the names inside it. Without a pinned `search_path`, a caller can point an unqualified name at their own object and run it with the function owner's privileges. Check `(select auth.uid())` inside the function body. Revoke `execute` from `public`, then grant `usage` on the schema and `execute` on the function to the role the policy uses. Policy expressions run as the caller, so that role needs both. Keep the function in an unexposed schema so it is not an RPC. New functions grant `execute` to `public` by default.
+Pin `search_path` on every `security definer` function to a schema its callers can't write to, and schema-qualify the names inside it. `search_path = ''` is the usual choice, and it still resolves `pg_catalog`, which Postgres always searches. Without a pinned `search_path`, a caller can point an unqualified name at their own object and run it with the function owner's privileges. Check `(select auth.uid())` inside the function body. Revoke `execute` from `public`, then grant `usage` on the schema and `execute` on the function to the role the policy uses. Policy expressions run as the caller, so that role needs both. Keep the function in an unexposed schema so it is not an RPC. New functions grant `execute` to `public` by default.
 
 <Admonition type="caution">
 
 A `security definer` function in an exposed schema is callable over the Data API with the creator's privileges. Never create one in a schema listed under "Exposed schemas" in your [API settings](/dashboard/project/_/settings/api).
 
 </Admonition>
+
+### Avoid recursive policies
+
+Two tables whose policies read each other deadlock. Postgres raises `42P17`, `infinite recursion detected in policy for relation`, and the query fails for every role the policies apply to.
+
+Sharing features produce this shape. A policy on `lists` checks `list_members` to find who the list is shared with, and a policy on `list_members` checks `lists` to find who owns it:
+
+```sql
+-- Reject: each policy reads the table the other one protects.
+create policy "members read lists" on lists for select
+to authenticated
+using (
+  exists (
+    select 1 from list_members m
+    where m.list_id = lists.id and m.user_id = (select auth.uid())
+  )
+);
+
+create policy "members read membership" on list_members for select
+to authenticated
+using (
+  exists (
+    select 1 from lists l
+    where l.id = list_members.list_id and l.owner_id = (select auth.uid())
+  )
+);
+```
+
+Break the cycle with a [security definer function](#use-security-definer-functions). It reads the membership table as its owner, so the second policy never runs and there's nothing to recurse into:
+
+```sql
+create function private.user_list_ids()
+returns setof uuid
+language sql
+security definer
+set search_path = ''
+stable
+as $$
+  select list_id from public.list_members
+  where user_id = (select auth.uid())
+$$;
+
+revoke execute on function private.user_list_ids() from public;
+grant usage on schema private to authenticated;
+grant execute on function private.user_list_ids() to authenticated;
+
+create policy "members read lists" on lists for select
+to authenticated
+using ( id in (select private.user_list_ids()) );
+
+create policy "members read membership" on list_members for select
+to authenticated
+using ( list_id in (select private.user_list_ids()) );
+```
+
+The function filters on `(select auth.uid())`, so it returns only the caller's lists. A member who doesn't own the list still reads it, and a non-member reads nothing.
+
+### Debug a policy
+
+A policy that denies too much returns no rows and raises no error, so start by establishing which of the two layers stopped the request.
+
+1. Confirm which role ran the query. `select current_user, (select auth.uid());` inside the same session as the failing statement. The Dashboard SQL Editor runs as `postgres`, which has `bypassrls`, so it can't reproduce a client's result. Switch role first, the way the test files do.
+2. Read the policies on the table. `select * from pg_policies where tablename = 'reports';` shows the command, the roles, the mode, and both expressions for each policy.
+3. Compare a privileged read against the client's read. If a [secret key](/docs/guides/getting-started/api-keys) returns the row and `authenticated` doesn't, the row exists and a policy is hiding it. If neither returns it, the row isn't there and the policy is not your problem.
+4. Check the grants before rewriting anything. A missing grant raises `42501` before any policy runs. See [Grants and policies](#grants-and-policies).
+
+An empty array from the Data API is not proof that no matching row exists. See [Why is my select returning an empty data array?](/docs/guides/troubleshooting/why-is-my-select-returning-an-empty-data-array-and-i-have-data-in-the-table-xvOPgx) for the same problem from the client side.
 
 ### Bypassing Row Level Security
 
@@ -646,4 +727,7 @@ This can be useful for system-level access. **Never** share login credentials fo
 - [Testing your database](/docs/guides/database/testing): the CLI test workflow that `supabase test db` runs.
 - [Securing your API](/docs/guides/api/securing-your-api): grants, dedicated schemas, and pre-request checks around the Data API.
 - [Column Level Security](/docs/guides/database/postgres/column-level-security): restrict access to individual columns.
+- [Custom claims and RBAC](/docs/guides/api/custom-claims-and-role-based-access-control-rbac): model roles and permissions in tables when ownership isn't enough.
+- [Storage access control](/docs/guides/storage/security/access-control): RLS on `storage.objects`, where the policy targets a bucket and a path.
+- [Realtime authorization](/docs/guides/realtime/authorization): RLS on channels, which reads claims differently from a table policy.
 - [`supabase-test-helpers`](https://github.com/usebasejump/supabase-test-helpers/tree/main): a community extension that adds user creation and role impersonation helpers to pgTAP.

--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -16,7 +16,7 @@ A table in an exposed schema without RLS is readable and writable by any role wi
 Use the guide in three parts:
 
 - [Understand Row Level Security](#understand-row-level-security) explains how grants and policies combine to control access.
-- [Secure a table with RLS](#secure-a-table-with-rls) is the procedure to follow for every table in an exposed schema.
+- [Secure a table with RLS](#secure-a-table-with-rls) is the procedure to follow for every table in an exposed schema: grants, policies, and `supabase test db`.
 - [RLS reference](#rls-reference) documents the helper functions and patterns you use inside a policy expression.
 
 Read the first section when you're deciding how to model access. Go directly to the second section when you're ready to secure a table.
@@ -106,7 +106,14 @@ Views bypass RLS by default because they are usually created with the `postgres`
 
 ## Secure a table with RLS
 
-Follow these steps for every table in an exposed schema.
+Follow these steps for every table in an exposed schema:
+
+1. Enable RLS and set the grants to match the app.
+2. Write a policy per operation.
+3. Create a `.sql` file under `supabase/tests/` that asserts allow and deny for `select`, `insert`, `update`, and `delete`, for `anon` and `authenticated`.
+4. Run `supabase test db` and stop only when it passes.
+
+A table is not secured until that suite passes.
 
 ### Lock down the table
 
@@ -144,7 +151,14 @@ grant select on table public.weather_readings to anon, authenticated;
 
 If new tables still receive automatic grants, see [Revoke default privileges](/docs/guides/api/securing-your-api#revoke-default-privileges). To enable RLS automatically on every new table, see [Event triggers](/docs/guides/database/postgres/event-triggers).
 
-Write the tests for this table in the same change. See [Test your policies](#test-your-policies).
+After the policies, create a test file for the table and run the suite in the same change:
+
+```bash
+supabase test new reports_rls.test
+supabase test db
+```
+
+Cover allow and deny for `select`, `insert`, `update`, and `delete`, for `anon` as well as `authenticated`. See [Test your policies](#test-your-policies).
 
 ### Write a policy for each operation
 
@@ -220,6 +234,8 @@ to authenticated
 using ( (select auth.uid()) = user_id );
 ```
 
+These four policies are not done until tests prove them. Put a `.sql` file under `supabase/tests/` and run `supabase test db`. See [Test your policies](#test-your-policies).
+
 ### Specify roles in your policies
 
 Always name the role a policy applies to, using the `to` clause. Instead of this:
@@ -239,7 +255,154 @@ using ( (select auth.uid()) = user_id );
 
 This prevents the policy `( (select auth.uid()) = user_id )` from running for any `anon` users, since the execution stops at the `to authenticated` step.
 
-These three rules keep policies correct as a table grows. For the measured impact and for tuning beyond them, see [Row Level Security performance](/docs/guides/database/postgres/row-level-security-performance).
+### Test your policies
+
+Create a `.sql` file under `supabase/tests/` for every table you enabled RLS on. Run `supabase test db` in the same change. Do not ship grants and policies without a passing suite.
+
+```bash
+supabase test new profiles_rls.test
+supabase test db
+```
+
+Supabase runs those files with [pgTAP](/docs/guides/database/extensions/pgtap) through the CLI.
+
+A wrong policy fails quietly. Too permissive, and a query returns rows it shouldn't. Too strict, and it returns nothing and raises no error. Neither case surfaces as an error, so tests are how you find out.
+
+Assert against the tables whose grants and policies you set. Do not introduce a scratch table only the tests use.
+
+Write allow and deny cases for `select`, `insert`, `update`, and `delete`, for `anon` as well as `authenticated`. Switch role and identity between cases. Repeat that suite for every table you enabled RLS on.
+
+For a public-read table, assert that `anon` and `authenticated` can select and that every write is denied. For a table users share, assert that a member who is not the owner can read and write, and that a non-member cannot.
+
+[`supabase-test-helpers`](https://github.com/usebasejump/supabase-test-helpers/tree/main) removes most of the setup below. It adds `tests.create_supabase_user()`, `tests.authenticate_as()`, and `tests.rls_enabled()`, so you don't hand-roll user seeding or role switching. See [Advanced pgTAP testing](/docs/guides/local-development/testing/pgtap-extended) for schema-wide assertions and a worked multi-tenant example.
+
+Stop only when `supabase test db` reports a passing result.
+
+#### Anatomy of a policy test
+
+Each case sets an identity, runs one statement as that identity, and asserts the outcome. Three things decide whether the assertion means anything.
+
+**Identity.** Switch role and identity between cases with `set local role` and `set local request.jwt.claim.sub`, so each assertion runs as the user it describes. Without the switch, every case runs as the same role and proves nothing about access.
+
+**Denials.** A denied request doesn't always raise an error, so match the assertion to the way the denial happens:
+
+- A missing grant raises `42501`. Assert it with `throws_ok`.
+- A `with check` violation raises `42501`. Assert it with `throws_ok`.
+- A `using` clause that filters the target row out raises nothing. The update or delete matches zero rows instead. Assert that no row changed.
+
+**Allowed writes.** The absence of an error doesn't prove that anything changed. Add `returning` to the statement so one assertion covers both directions. An allowed write returns the changed row, and a write the policy filters out returns nothing.
+
+#### Example
+
+This example covers all four operations against a `profiles` table where `authenticated` holds every privilege, `anon` holds none, and each user reads and writes only their own row. Copy the pattern onto each table you secured:
+
+```sql supabase/tests/profiles_rls.test.sql
+begin;
+select plan(12);
+
+insert into auth.users (id, email)
+values
+  ('11111111-1111-1111-1111-111111111111', 'owner@example.com'),
+  ('22222222-2222-2222-2222-222222222222', 'other@example.com');
+
+-- anon holds no grant, so the request stops before any policy runs.
+set local role anon;
+select throws_ok(
+  $$select * from profiles$$,
+  '42501',
+  null,
+  'anon cannot read profiles'
+);
+select throws_ok(
+  $$insert into profiles (id, user_id, avatar_url)
+    values (
+      gen_random_uuid(),
+      '11111111-1111-1111-1111-111111111111',
+      'anon.png'
+    )$$,
+  '42501',
+  null,
+  'anon cannot create a profile'
+);
+select throws_ok(
+  $$update profiles set avatar_url = 'anon.png'$$,
+  '42501',
+  null,
+  'anon cannot update profiles'
+);
+select throws_ok(
+  $$delete from profiles$$,
+  '42501',
+  null,
+  'anon cannot delete profiles'
+);
+
+-- The owner writes their own row. returning proves the row changed.
+set local role authenticated;
+set local request.jwt.claim.sub = '11111111-1111-1111-1111-111111111111';
+select results_eq(
+  $$insert into profiles (id, user_id, avatar_url)
+    values (
+      gen_random_uuid(),
+      '11111111-1111-1111-1111-111111111111',
+      'owner.png'
+    )
+    returning avatar_url$$,
+  array['owner.png'],
+  'the owner creates their own profile'
+);
+select results_eq(
+  $$select avatar_url from profiles$$,
+  array['owner.png'],
+  'the owner reads their own profile'
+);
+select results_eq(
+  $$update profiles set avatar_url = 'updated.png' returning avatar_url$$,
+  array['updated.png'],
+  'the owner updates their own profile'
+);
+
+-- A signed-in stranger holds the grant, so the policy is what stops them.
+set local request.jwt.claim.sub = '22222222-2222-2222-2222-222222222222';
+select throws_ok(
+  $$insert into profiles (id, user_id, avatar_url)
+    values (
+      gen_random_uuid(),
+      '11111111-1111-1111-1111-111111111111',
+      'stolen.png'
+    )$$,
+  '42501',
+  null,
+  'another user cannot create a profile for the owner'
+);
+select is_empty(
+  $$select * from profiles$$,
+  'another user reads no profiles'
+);
+select is_empty(
+  $$update profiles set avatar_url = 'stolen.png' returning avatar_url$$,
+  'another user updates no profiles'
+);
+select is_empty(
+  $$delete from profiles returning avatar_url$$,
+  'another user deletes no profiles'
+);
+
+-- Owner delete last so earlier cases still have a row to assert against.
+set local request.jwt.claim.sub = '11111111-1111-1111-1111-111111111111';
+select results_eq(
+  $$delete from profiles returning avatar_url$$,
+  array['updated.png'],
+  'the owner deletes their own profile'
+);
+
+select * from finish();
+rollback;
+```
+
+For CLI setup and more pgTAP helpers, see [Testing your database](/docs/guides/database/testing).
+
+Index the filter columns and wrap helper calls so policies stay fast as a table grows. For the measured impact and for tuning beyond them, see [Row Level Security performance](/docs/guides/database/postgres/row-level-security-performance).
 
 ### Add indexes
 
@@ -311,99 +474,6 @@ as select <QUERY>
 ```
 
 In older versions of Postgres, protect your views by revoking access from the `anon` and `authenticated` roles, or by putting them in an unexposed schema.
-
-### Test your policies
-
-We recommend writing tests for every policy, in the same change that sets the grants and creates the policies. Tests are a fundamental part of a secure setup, and they give you a repeatable way to prove a policy behaves the way you intended.
-
-A wrong policy fails quietly. Too permissive, and a query returns rows it shouldn't. Too strict, and it returns nothing and raises no error. Neither case surfaces as an error, so tests are how you find out.
-
-Supabase runs database tests with [pgTAP](/docs/guides/database/extensions/pgtap) through the CLI. Test files are `.sql` files under `supabase/tests/`.
-
-#### Anatomy of a policy test
-
-Each case sets an identity, runs one statement as that identity, and asserts the outcome. Three things decide whether the assertion means anything.
-
-**Identity.** Switch role and identity between cases with `set local role` and `set local request.jwt.claim.sub`, so each assertion runs as the user it describes. Without the switch, every case runs as the same role and proves nothing about access.
-
-**Denials.** A denied request doesn't always raise an error, so match the assertion to the way the denial happens:
-
-- A missing grant raises `42501`. Assert it with `throws_ok`.
-- A `with check` violation raises `42501`. Assert it with `throws_ok`.
-- A `using` clause that filters the target row out raises nothing. The update or delete matches zero rows instead. Assert that no row changed.
-
-**Allowed writes.** The absence of an error doesn't prove that anything changed. Add `returning` to the statement so one assertion covers both directions. An allowed write returns the changed row, and a write the policy filters out returns nothing.
-
-#### Write and run the tests
-
-1. Create a test file:
-
-   ```bash
-   supabase test new profiles_rls.test
-   ```
-
-2. Write the tests. Cover `select`, `insert`, `update`, and `delete` twice each, once for a request the policy allows and once for a request it denies, for `anon` as well as `authenticated`.
-
-   [`supabase-test-helpers`](https://github.com/usebasejump/supabase-test-helpers/tree/main) removes most of the setup below. It adds `tests.create_supabase_user()`, `tests.authenticate_as()`, and `tests.rls_enabled()`, so you don't hand-roll user seeding or role switching. See [Advanced pgTAP testing](/docs/guides/local-development/testing/pgtap-extended) for schema-wide assertions and a worked multi-tenant example.
-
-3. Run the suite:
-
-   ```bash
-   supabase test db
-   ```
-
-This example shows each of those techniques against a `profiles` table where `authenticated` holds every privilege, `anon` holds none, and each user reads and writes only their own row. Extend it to the remaining operations:
-
-```sql supabase/tests/profiles_rls.test.sql
-begin;
-select plan(4);
-
-insert into auth.users (id, email)
-values
-  ('11111111-1111-1111-1111-111111111111', 'owner@example.com'),
-  ('22222222-2222-2222-2222-222222222222', 'other@example.com');
-
--- anon holds no grant, so the request stops before any policy runs.
-set local role anon;
-select throws_ok(
-  $$select * from profiles$$,
-  '42501',
-  null,
-  'anon cannot read profiles'
-);
-
--- The owner writes their own row. returning proves the row changed.
-set local role authenticated;
-set local request.jwt.claim.sub = '11111111-1111-1111-1111-111111111111';
-select results_eq(
-  $$insert into profiles (id, user_id, avatar_url)
-    values (
-      gen_random_uuid(),
-      '11111111-1111-1111-1111-111111111111',
-      'owner.png'
-    )
-    returning avatar_url$$,
-  array['owner.png'],
-  'the owner creates their own profile'
-);
-
--- A signed-in stranger holds the grant, so the policy is what stops them. The
--- using clause filters the row out, so these match nothing and raise nothing.
-set local request.jwt.claim.sub = '22222222-2222-2222-2222-222222222222';
-select is_empty(
-  $$select * from profiles$$,
-  'another user reads no profiles'
-);
-select is_empty(
-  $$update profiles set avatar_url = 'stolen.png' returning avatar_url$$,
-  'another user updates no profiles'
-);
-
-select * from finish();
-rollback;
-```
-
-For CLI setup and more pgTAP helpers, see [Testing your database](/docs/guides/database/testing).
 
 ## RLS reference
 

--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -47,6 +47,8 @@ where auth.uid() = todos.user_id;
 
 You write RLS rules in SQL, so a rule can express whatever access logic your app needs. Because RLS is a Postgres primitive, it also protects your data when it is reached through third-party tooling, which is what makes it "[defense in depth](<https://en.wikipedia.org/wiki/Defense_in_depth_(computing)>)". Combine RLS with [Supabase Auth](/docs/guides/auth) for end-to-end user security from the browser to the database.
 
+Multiple policies for the same role and operation are permissive by default: if any one of them passes, the row is allowed. A second policy widens access; it never narrows it. To require two checks at once, mark one `as restrictive`. See [MFA](#mfa).
+
 ### Grants and policies
 
 Postgres runs two checks before a client touches a table. Grants decide whether a role can run an operation on the table at all. Policies decide which rows that operation applies to. Set both for every table you expose.
@@ -64,6 +66,8 @@ Adding policies doesn't take those grants back. A table protected only by polici
 Not every project grants these automatically. See [Default privileges](/docs/guides/api/securing-your-api#default-privileges). Grant each role only the operations it needs.
 
 A missing grant raises a `42501` error before any policy runs. When a request fails that your policy should allow, check the grants before you change the policy. To set them, see [Lock down the table](#lock-down-the-table).
+
+Table owners, superusers, and roles with `bypassrls` skip RLS unless you force it. The Dashboard SQL Editor typically runs as `postgres`, the table owner, which is why [Test your policies](#test-your-policies) switches role. Add `alter table ... force row level security` only when the owning role must also obey policies. Don't force it on a lookup table that a `security definer` helper reads as the owner.
 
 ### Authenticated and unauthenticated roles
 
@@ -144,7 +148,7 @@ Write the tests for this table in the same change. See [Test your policies](#tes
 
 ### Write a policy for each operation
 
-Write a separate policy for `select`, `insert`, `update`, and `delete`. Postgres does not accept multiple operations in one `for` clause, and a `for all` policy hides which operation each rule was meant to cover.
+Write a separate policy for `select`, `insert`, `update`, and `delete`. Postgres does not accept multiple operations in one `for` clause, and a `for all` policy hides which operation each rule was meant to cover. To deny an operation, grant nothing and write no policy for it.
 
 These examples use a `profiles` table where each user manages only their own row:
 
@@ -201,7 +205,7 @@ If no `with check` expression is defined, the `using` expression decides both wh
 
 <Admonition type="caution">
 
-To perform an `UPDATE` operation, a corresponding [`SELECT` policy](#select-policies) is required. Without a `SELECT` policy, the `UPDATE` operation will not work as expected.
+Postgres can update a row with only an `update` policy. The Data API also needs a matching [`select` policy](#select-policies) to return the updated row. Without one, the write can succeed and the client still receives no representation.
 
 </Admonition>
 
@@ -413,29 +417,11 @@ Supabase provides some helper functions that make it easier to write policies.
 
 Returns the ID of the user making the request.
 
-<Admonition type="caution" title="`auth.uid()` Returns `null` When Unauthenticated">
+<Admonition type="caution" title="`auth.uid()` returns `null` when unauthenticated">
 
-When a request is made without an authenticated user (e.g., no access token is provided or the session has expired), `auth.uid()` returns `null`.
+When a request has no signed-in user, `auth.uid()` returns `null`. `null = user_id` is unknown in SQL, so a policy like `using (auth.uid() = user_id)` filters the row out instead of raising an error.
 
-This means that a policy like:
-
-```sql
-USING (auth.uid() = user_id)
-```
-
-will silently fail for unauthenticated users, because:
-
-```sql
-null = user_id
-```
-
-is always false in SQL.
-
-To avoid confusion and make your intention clear, we recommend explicitly checking for authentication:
-
-```sql
-USING (auth.uid() IS NOT NULL AND auth.uid() = user_id)
-```
+Scope the policy with `to authenticated` so the expression does not run for `anon`. That is both the correct intention and the cheaper plan. See [Specify roles in your policies](#specify-roles-in-your-policies).
 
 </Admonition>
 
@@ -449,16 +435,18 @@ Not all information present in the JWT should be used in RLS policies. For insta
 
 Returns the JWT of the user making the request. Anything that you store in the user's `raw_app_meta_data` column or the `raw_user_meta_data` column will be accessible using this function. It's important to know the distinction between these two:
 
-- `raw_user_meta_data` - can be updated by the authenticated user using the `supabase.auth.update()` function. It is not a good place to store authorization data.
+- `raw_user_meta_data` - can be updated by the authenticated user using [`updateUser()`](/docs/reference/javascript/auth-updateuser). It is not a good place to store authorization data.
 - `raw_app_meta_data` - cannot be updated by the user, so it's a good place to store authorization data.
 
-The `auth.jwt()` function is extremely versatile. For example, if you store some team data inside `app_metadata`, you can use it to determine whether a particular user belongs to a team. For example, if this was an array of IDs:
+The `auth.jwt()` function is extremely versatile. For example, if you store some team data inside `app_metadata`, you can use it to determine whether a particular user belongs to a team. If `teams` is a JSON array of IDs:
 
 ```sql
 create policy "User is in team"
 on my_table
 to authenticated
-using ( team_id in (select auth.jwt() -> 'app_metadata' -> 'teams'));
+using (
+  ((select auth.jwt()) -> 'app_metadata' -> 'teams') ? team_id::text
+);
 ```
 
 <Admonition type="caution">
@@ -515,6 +503,8 @@ begin
 end;
 $$;
 
+revoke execute on function private.has_good_role() from public, anon, authenticated, service_role;
+
 -- Update our policy to use this function:
 create policy "rls_test_select"
 on test_table
@@ -522,7 +512,7 @@ to authenticated
 using ( (select private.has_good_role()) );
 ```
 
-Set `search_path = ''` on every `security definer` function and schema-qualify the names inside it. Without a pinned `search_path`, a caller can point an unqualified name at their own object and run it with the function owner's privileges.
+Set `search_path = ''` on every `security definer` function and schema-qualify the names inside it. Without a pinned `search_path`, a caller can point an unqualified name at their own object and run it with the function owner's privileges. Check `(select auth.uid())` inside the function body, and revoke `execute` from `public` and the client roles. New functions grant `execute` to `public` by default.
 
 <Admonition type="caution">
 

--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -41,13 +41,13 @@ That policy translates to this whenever a user selects from the todos table:
 ```sql
 select *
 from todos
-where auth.uid() = todos.user_id;
+where (select auth.uid()) = todos.user_id;
 -- Policy is implicitly added.
 ```
 
 You write RLS rules in SQL, so a rule can express whatever access logic your app needs. Because RLS is a Postgres primitive, it also protects your data when it is reached through third-party tooling, which is what makes it "[defense in depth](<https://en.wikipedia.org/wiki/Defense_in_depth_(computing)>)". Combine RLS with [Supabase Auth](/docs/guides/auth) for end-to-end user security from the browser to the database.
 
-Multiple policies for the same role and operation are permissive by default: if any one of them passes, the row is allowed. A second policy widens access; it never narrows it. To require two checks at once, mark one `as restrictive`. See [MFA](#mfa).
+Multiple policies for the same role and operation are permissive by default: if any one of them passes, the row is allowed. A second permissive policy widens access; it does not narrow it. To require two checks at once, mark one `as restrictive`. See [MFA](#mfa). Restrictive policies only reduce access after at least one permissive policy has granted it.
 
 ### Grants and policies
 
@@ -67,7 +67,7 @@ Not every project grants these automatically. See [Default privileges](/docs/gui
 
 A missing grant raises a `42501` error before any policy runs. When a request fails that your policy should allow, check the grants before you change the policy. To set them, see [Lock down the table](#lock-down-the-table).
 
-Table owners, superusers, and roles with `bypassrls` skip RLS unless you force it. The Dashboard SQL Editor typically runs as `postgres`, the table owner, which is why [Test your policies](#test-your-policies) switches role. Add `alter table ... force row level security` only when the owning role must also obey policies. Don't force it on a lookup table that a `security definer` helper reads as the owner.
+Table owners skip RLS unless you force it. Superusers and roles with `bypassrls` always skip RLS; `force row level security` does not apply to them. On Supabase, `postgres` is not a superuser, but it has `bypassrls`, so the Dashboard SQL Editor skips policies even after you force them. That is why [Test your policies](#test-your-policies) switches role. Add `alter table ... force row level security` only when a table owner without `bypassrls` must also obey policies.
 
 ### Authenticated and unauthenticated roles
 
@@ -102,7 +102,7 @@ A policy that reads `to anon using ( true )` grants every unauthenticated visito
 
 ### Views and RLS
 
-Views bypass RLS by default because they are usually created with the `postgres` user. This is a feature of Postgres, which automatically creates views with `security definer`. A view over a protected table hands out every row its policies were meant to withhold, so a view needs the same attention as a table. To create one safely, see [Expose a view safely](#expose-a-view-safely).
+Views bypass RLS by default because they are usually created with the `postgres` user. Postgres creates views with the owner's rights (`security_invoker` defaults to false), so a view over a protected table hands out every row its policies were meant to withhold. A view needs the same attention as a table. To create one safely, see [Expose a view safely](#expose-a-view-safely).
 
 ## Secure a table with RLS
 
@@ -205,7 +205,7 @@ If no `with check` expression is defined, the `using` expression decides both wh
 
 <Admonition type="caution">
 
-Postgres can update a row with only an `update` policy. The Data API also needs a matching [`select` policy](#select-policies) to return the updated row. Without one, the write can succeed and the client still receives no representation.
+An `update` that reads the row also needs a matching [`select` policy](#select-policies). That includes a `where` clause, a `returning` clause, and Data API updates, which filter by column and return the updated row. Without a `select` policy, the update matches zero rows rather than raising an error. A SQL `update` that assigns constants and has no `where` or `returning` clause can succeed with only an `update` policy.
 
 </Admonition>
 
@@ -259,7 +259,7 @@ on test_table
 using btree (user_id);
 ```
 
-A column counts as indexed only when it comes first in a `btree` index. Postgres can't use a multi-column index to filter on a column that isn't the leading one, so a composite primary key indexes its first column and no others. A membership table keyed on `(team_id, user_id)` has no index on `user_id`:
+A policy filter uses a `btree` index most efficiently when the filter column leads the index. A composite primary key on `(team_id, user_id)` leads with `team_id`, so a policy that filters on `user_id` still needs its own index:
 
 ```sql
 create table team_members (
@@ -302,7 +302,7 @@ You can only use this technique if the results of the query or function do not c
 
 ### Expose a view safely
 
-In Postgres 15 and above, make a view obey the RLS policies of its underlying tables when invoked by `anon` and `authenticated` by setting `security_invoker = true`.
+In Postgres 15 or later, make a view obey the RLS policies of its underlying tables when invoked by `anon` and `authenticated` by setting `security_invoker = true`.
 
 ```sql
 create view <VIEW_NAME>
@@ -339,7 +339,7 @@ Each case sets an identity, runs one statement as that identity, and asserts the
 1. Create a test file:
 
    ```bash
-   supabase test new profiles_rls
+   supabase test new profiles_rls.test
    ```
 
 2. Write the tests. Cover `select`, `insert`, `update`, and `delete` twice each, once for a request the policy allows and once for a request it denies, for `anon` as well as `authenticated`.
@@ -433,7 +433,7 @@ Not all information present in the JWT should be used in RLS policies. For insta
 
 </Admonition>
 
-Returns the JWT of the user making the request. Anything that you store in the user's `raw_app_meta_data` column or the `raw_user_meta_data` column will be accessible using this function. It's important to know the distinction between these two:
+Returns the JWT claims of the user making the request as `jsonb`. Anything that you store in the user's `raw_app_meta_data` column or the `raw_user_meta_data` column is copied into those claims. It's important to know the distinction between these two:
 
 - `raw_user_meta_data` - can be updated by the authenticated user using [`updateUser()`](/docs/reference/javascript/auth-updateuser). It is not a good place to store authorization data.
 - `raw_app_meta_data` - cannot be updated by the user, so it's a good place to store authorization data.
@@ -471,9 +471,11 @@ to authenticated using (
 );
 ```
 
+This restrictive check only applies after a permissive update policy has allowed the row. A table with only restrictive policies denies every row.
+
 ### Use security definer functions
 
-A "security definer" function runs using the same role that _created_ the function. This means that if you create a role with a superuser (like `postgres`), then that function will have `bypassrls` privileges. For example, if you had a policy like this:
+A `security definer` function runs as the role that owns it, not the caller. Functions you create as `postgres` skip RLS because `postgres` has `bypassrls`. That is useful for looking up roles without paying RLS on the lookup table, and dangerous if the function is callable without checking `(select auth.uid())`. For example, if you had a policy like this:
 
 ```sql
 create policy "rls_test_select" on test_table
@@ -486,13 +488,13 @@ using (
 );
 ```
 
-We can instead create a `security definer` function which can scan `roles_table` without any RLS penalties:
+You can instead create a `security definer` function which can scan `roles_table` without any RLS penalties:
 
 ```sql
 create function private.has_good_role()
 returns boolean
 language plpgsql
-security definer -- will run as the creator
+security definer -- runs as the owner
 set search_path = '' -- every name inside must be schema-qualified
 as $$
 begin
@@ -503,7 +505,9 @@ begin
 end;
 $$;
 
-revoke execute on function private.has_good_role() from public, anon, authenticated, service_role;
+revoke execute on function private.has_good_role() from public;
+grant usage on schema private to authenticated;
+grant execute on function private.has_good_role() to authenticated;
 
 -- Update our policy to use this function:
 create policy "rls_test_select"
@@ -512,7 +516,7 @@ to authenticated
 using ( (select private.has_good_role()) );
 ```
 
-Set `search_path = ''` on every `security definer` function and schema-qualify the names inside it. Without a pinned `search_path`, a caller can point an unqualified name at their own object and run it with the function owner's privileges. Check `(select auth.uid())` inside the function body, and revoke `execute` from `public` and the client roles. New functions grant `execute` to `public` by default.
+Set `search_path = ''` on every `security definer` function and schema-qualify the names inside it. Without a pinned `search_path`, a caller can point an unqualified name at their own object and run it with the function owner's privileges. Check `(select auth.uid())` inside the function body. Revoke `execute` from `public`, then grant `usage` on the schema and `execute` on the function to the role the policy uses. Policy expressions run as the caller, so that role needs both. Keep the function in an unexposed schema so it is not an RPC. New functions grant `execute` to `public` by default.
 
 <Admonition type="caution">
 


### PR DESCRIPTION
Stacked on #49017. Review that first.

## Problem

Three things were wrong with the restructured guide.

**It had inaccuracies.** Checked claim by claim against the [RLS basics](https://github.com/supabase/agent-skills/blob/main/skills/supabase-postgres-best-practices/references/security-rls-basics.md) and [RLS performance](https://github.com/supabase/agent-skills/blob/main/skills/supabase-postgres-best-practices/references/security-rls-performance.md) skill references, the Supacademy RLS course, and Postgres. The worst one: the team membership policy never ran at all. `team_id in (select auth.jwt() -> 'app_metadata' -> 'teams')` fails at `create policy` with `operator does not exist: uuid = jsonb`.

**Agents read it and wrote no tests.** `build-docs-002-rls-guide` fails only its three pgTAP checks now; grants, policies, access probes, indexes, and security-definer helpers all pass. The guide already had a `Test your policies` section, so the problem isn't strength. Agents fetch the page through an LLM extraction guided by their own query, and that query asks about enabling RLS, policy syntax, and `auth.uid()`. A separate testing section never enters the extract. More testing prose can't fix that.

**It was silent on three failure modes** that the eval measures or the reference sources treat as core: recursive policies, materialized views, and how to debug a policy that denies too much.

## Solution

**Correct the claims.** Permissive vs restrictive combination, `force row level security` and who it doesn't apply to, revoking `execute` on helper functions without breaking the policy that calls them, `null = user_id` being unknown rather than false, updates needing a select policy, `auth.jwt()` returning jsonb, views running with owner rights, composite index leading columns, `updateUser()`, and the broken team policy.

**Move the tests into the examples the extract carries.** The public-read example gains its policy and `weather_readings_rls.test.sql`; the four policy examples are followed immediately by `profiles_rls.test.sql`. `Test your policies` shrinks to creating and running the files.

**Add what was missing.** `Avoid recursive policies` shows the cycle a sharing feature produces and breaks it with a security definer helper. `Expose a view safely` covers materialized views. `Debug a policy` covers which role ran the query, `pg_policies`, and separating a hidden row from an absent one. Three links added to `Related content`.

## Verification

Everything asserted here was executed against a local Postgres 17 before it was written down.

| Claim | Result |
| --- | --- |
| Published team policy is broken | `ERROR: operator does not exist: uuid = jsonb`, at `create policy` |
| Its replacement works | Member of a team sees exactly their row; member of none sees zero |
| Both pgTAP files run | `Files=2, Tests=20, Result: PASS` |
| …and aren't vacuous | Sabotaging one expected value produced `Failed test 2` |
| Mutually recursive policies fail | `ERROR: 42P17: infinite recursion detected in policy for relation "lists"` |
| The helper breaks the cycle | Member who isn't the owner reads the list; non-member reads nothing |
| `security_invoker` on a matview | `ERROR: unrecognized parameter "security_invoker"` |
| RLS on a matview | `ERROR: ALTER action ENABLE ROW SECURITY cannot be performed` |
| `create policy` on a matview | `ERROR: "mv2" is not a table` |
| A granted matview leaks | Non-owner reads 0 rows from the base table, 1 from the matview |
| `search_path = ''` resolves `pg_catalog` | `format()` and `current_setting()` resolve unqualified |

The SQL was then re-extracted from the rendered MDX and run again, to confirm the published blocks are the ones that were tested.

Two hypotheses were **refuted** by running them and are not in this PR: `results_eq` over `INSERT … RETURNING` and `insert into auth.users (id, email)` both work fine.

## Note on the `search_path` rule

The guide said to set `search_path = ''` on *every* security definer function, which the event trigger recipe in `event-triggers.mdx` doesn't do. It now states the principle — pin it to a schema callers can't write to — which resolves the contradiction without changing the recipe or Studio's copy of it.

## Manual testing

1. Open the [Row Level Security guide](https://docs-git-docs-rls-guide-corrections-supabase.vercel.app/docs/guides/database/postgres/row-level-security) on the preview. `Avoid recursive policies` and `Debug a policy` appear under `RLS reference`.
2. Scroll to `Lock down the table`. The public-read example is followed by its test file, not by a pointer to a later section.
3. Scroll to `DELETE policies`. The four policies are followed immediately by `profiles_rls.test.sql`.
4. Select the [security definer function](https://docs-git-docs-rls-guide-corrections-supabase.vercel.app/docs/guides/database/postgres/row-level-security#use-security-definer-functions) link inside `Avoid recursive policies`. It jumps to that section.
5. Open the [markdown version](https://docs-git-docs-rls-guide-corrections-supabase.vercel.app/docs/guides/database/postgres/row-level-security.md), which is what agents fetch. Both test files are present.
