### PR TITLE
docs(database): correct the RLS guide and close its remaining gaps

### DIFF
--- a/apps/docs/content/guides/database/postgres/event-triggers.mdx
+++ b/apps/docs/content/guides/database/postgres/event-triggers.mdx
@@ -55,7 +55,48 @@ EXECUTE FUNCTION dont_drop_function();
 
 ### Example trigger function - auto enable Row Level Security
 
-See how to [auto enable RLS for new tables](/docs/guides/database/postgres/row-level-security#auto-enable-rls-for-new-tables).
+If you want [Row Level Security](/docs/guides/database/postgres/row-level-security) enabled automatically for new tables, create an event trigger that runs after table creation and calls `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` on each newly created table.
+
+```sql
+CREATE OR REPLACE FUNCTION rls_auto_enable()
+RETURNS EVENT_TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  cmd record;
+BEGIN
+  FOR cmd IN
+    SELECT *
+    FROM pg_event_trigger_ddl_commands()
+    WHERE command_tag IN ('CREATE TABLE', 'CREATE TABLE AS', 'SELECT INTO')
+      AND object_type IN ('table','partitioned table')
+  LOOP
+     IF cmd.schema_name IS NOT NULL AND cmd.schema_name IN ('public') AND cmd.schema_name NOT IN ('pg_catalog','information_schema') AND cmd.schema_name NOT LIKE 'pg_toast%' AND cmd.schema_name NOT LIKE 'pg_temp%' THEN
+      BEGIN
+        EXECUTE format('alter table if exists %s enable row level security', cmd.object_identity);
+        RAISE LOG 'rls_auto_enable: enabled RLS on %', cmd.object_identity;
+      EXCEPTION
+        WHEN OTHERS THEN
+          RAISE LOG 'rls_auto_enable: failed to enable RLS on %', cmd.object_identity;
+          RAISE;
+      END;
+     ELSE
+        RAISE LOG 'rls_auto_enable: skip % (either system schema or not in enforced list: %.)', cmd.object_identity, cmd.schema_name;
+     END IF;
+  END LOOP;
+END;
+$$;
+
+DROP EVENT TRIGGER IF EXISTS ensure_rls;
+CREATE EVENT TRIGGER ensure_rls
+ON ddl_command_end
+WHEN TAG IN ('CREATE TABLE', 'CREATE TABLE AS', 'SELECT INTO')
+EXECUTE FUNCTION rls_auto_enable();
+```
+
+Note that this applies to tables created after the trigger is installed. Existing tables still need RLS enabled manually.
 
 ### Event trigger Functions and firing events
 

--- a/apps/docs/content/guides/database/postgres/row-level-security-performance.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security-performance.mdx
@@ -91,7 +91,7 @@ Policies are implicit `where` clauses, so it's common to run `select` statements
 
 {/* prettier-ignore */}
 ```js
-const { data } = supabase
+const { data } = await supabase
   .from('table')
   .select()
 ```
@@ -100,7 +100,7 @@ Always add a filter:
 
 {/* prettier-ignore */}
 ```js
-const { data } = supabase
+const { data } = await supabase
   .from('table')
   .select()
   .eq('user_id', userId)
@@ -121,7 +121,7 @@ using (
   (select auth.uid()) in (
     select user_id
     from team_user
-    where team_user.team_id = team_id -- joins to the source "test_table.team_id"
+    where team_user.team_id = test_table.team_id -- joins to the source table
   )
 );
 ```

--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -41,11 +41,13 @@ That policy translates to this whenever a user selects from the todos table:
 ```sql
 select *
 from todos
-where auth.uid() = todos.user_id;
+where (select auth.uid()) = todos.user_id;
 -- Policy is implicitly added.
 ```
 
 You write RLS rules in SQL, so a rule can express whatever access logic your app needs. Because RLS is a Postgres primitive, it also protects your data when it is reached through third-party tooling, which is what makes it "[defense in depth](<https://en.wikipedia.org/wiki/Defense_in_depth_(computing)>)". Combine RLS with [Supabase Auth](/docs/guides/auth) for end-to-end user security from the browser to the database.
+
+Multiple policies for the same role and operation are permissive by default: if any one of them passes, the row is allowed. A second permissive policy widens access; it does not narrow it. To require two checks at once, mark one `as restrictive`. See [MFA](#mfa). Restrictive policies only reduce access after at least one permissive policy has granted it.
 
 ### Grants and policies
 
@@ -64,6 +66,8 @@ Adding policies doesn't take those grants back. A table protected only by polici
 Not every project grants these automatically. See [Default privileges](/docs/guides/api/securing-your-api#default-privileges). Grant each role only the operations it needs.
 
 A missing grant raises a `42501` error before any policy runs. When a request fails that your policy should allow, check the grants before you change the policy. To set them, see [Lock down the table](#lock-down-the-table).
+
+Table owners skip RLS unless you force it. Superusers and roles with `bypassrls` always skip RLS; `force row level security` does not apply to them. On Supabase, `postgres` is not a superuser, but it has `bypassrls`, so the Dashboard SQL Editor skips policies even after you force them. That is why [Test your policies](#test-your-policies) switches role. Add `alter table ... force row level security` only when a table owner without `bypassrls` must also obey policies.
 
 ### Authenticated and unauthenticated roles
 
@@ -98,7 +102,7 @@ A policy that reads `to anon using ( true )` grants every unauthenticated visito
 
 ### Views and RLS
 
-Views bypass RLS by default because they are usually created with the `postgres` user. This is a feature of Postgres, which automatically creates views with `security definer`. A view over a protected table hands out every row its policies were meant to withhold, so a view needs the same attention as a table. To create one safely, see [Expose a view safely](#expose-a-view-safely).
+Views bypass RLS by default because they are usually created with the `postgres` user. Postgres creates views with the owner's rights (`security_invoker` defaults to false), so a view over a protected table hands out every row its policies were meant to withhold. A view needs the same attention as a table. To create one safely, see [Expose a view safely](#expose-a-view-safely).
 
 ## Secure a table with RLS
 
@@ -144,7 +148,7 @@ Write the tests for this table in the same change. See [Test your policies](#tes
 
 ### Write a policy for each operation
 
-Write a separate policy for `select`, `insert`, `update`, and `delete`. Postgres does not accept multiple operations in one `for` clause, and a `for all` policy hides which operation each rule was meant to cover.
+Write a separate policy for `select`, `insert`, `update`, and `delete`. Postgres does not accept multiple operations in one `for` clause, and a `for all` policy hides which operation each rule was meant to cover. To deny an operation, grant nothing and write no policy for it.
 
 These examples use a `profiles` table where each user manages only their own row:
 
@@ -201,7 +205,7 @@ If no `with check` expression is defined, the `using` expression decides both wh
 
 <Admonition type="caution">
 
-To perform an `UPDATE` operation, a corresponding [`SELECT` policy](#select-policies) is required. Without a `SELECT` policy, the `UPDATE` operation will not work as expected.
+An `update` that reads the row also needs a matching [`select` policy](#select-policies). That includes a `where` clause, a `returning` clause, and Data API updates, which filter by column and return the updated row. Without a `select` policy, the update matches zero rows rather than raising an error. A SQL `update` that assigns constants and has no `where` or `returning` clause can succeed with only an `update` policy.
 
 </Admonition>
 
@@ -255,7 +259,7 @@ on test_table
 using btree (user_id);
 ```
 
-A column counts as indexed only when it comes first in a `btree` index. Postgres can't use a multi-column index to filter on a column that isn't the leading one, so a composite primary key indexes its first column and no others. A membership table keyed on `(team_id, user_id)` has no index on `user_id`:
+A policy filter uses a `btree` index most efficiently when the filter column leads the index. A composite primary key on `(team_id, user_id)` leads with `team_id`, so a policy that filters on `user_id` still needs its own index:
 
 ```sql
 create table team_members (
@@ -298,7 +302,7 @@ You can only use this technique if the results of the query or function do not c
 
 ### Expose a view safely
 
-In Postgres 15 and above, make a view obey the RLS policies of its underlying tables when invoked by `anon` and `authenticated` by setting `security_invoker = true`.
+In Postgres 15 or later, make a view obey the RLS policies of its underlying tables when invoked by `anon` and `authenticated` by setting `security_invoker = true`.
 
 ```sql
 create view <VIEW_NAME>
@@ -335,7 +339,7 @@ Each case sets an identity, runs one statement as that identity, and asserts the
 1. Create a test file:
 
    ```bash
-   supabase test new profiles_rls
+   supabase test new profiles_rls.test
    ```
 
 2. Write the tests. Cover `select`, `insert`, `update`, and `delete` twice each, once for a request the policy allows and once for a request it denies, for `anon` as well as `authenticated`.
@@ -413,29 +417,11 @@ Supabase provides some helper functions that make it easier to write policies.
 
 Returns the ID of the user making the request.
 
-<Admonition type="caution" title="`auth.uid()` Returns `null` When Unauthenticated">
+<Admonition type="caution" title="`auth.uid()` returns `null` when unauthenticated">
 
-When a request is made without an authenticated user (e.g., no access token is provided or the session has expired), `auth.uid()` returns `null`.
+When a request has no signed-in user, `auth.uid()` returns `null`. `null = user_id` is unknown in SQL, so a policy like `using (auth.uid() = user_id)` filters the row out instead of raising an error.
 
-This means that a policy like:
-
-```sql
-USING (auth.uid() = user_id)
-```
-
-will silently fail for unauthenticated users, because:
-
-```sql
-null = user_id
-```
-
-is always false in SQL.
-
-To avoid confusion and make your intention clear, we recommend explicitly checking for authentication:
-
-```sql
-USING (auth.uid() IS NOT NULL AND auth.uid() = user_id)
-```
+Scope the policy with `to authenticated` so the expression does not run for `anon`. That is both the correct intention and the cheaper plan. See [Specify roles in your policies](#specify-roles-in-your-policies).
 
 </Admonition>
 
@@ -447,18 +433,20 @@ Not all information present in the JWT should be used in RLS policies. For insta
 
 </Admonition>
 
-Returns the JWT of the user making the request. Anything that you store in the user's `raw_app_meta_data` column or the `raw_user_meta_data` column will be accessible using this function. It's important to know the distinction between these two:
+Returns the JWT claims of the user making the request as `jsonb`. Anything that you store in the user's `raw_app_meta_data` column or the `raw_user_meta_data` column is copied into those claims. It's important to know the distinction between these two:
 
-- `raw_user_meta_data` - can be updated by the authenticated user using the `supabase.auth.update()` function. It is not a good place to store authorization data.
+- `raw_user_meta_data` - can be updated by the authenticated user using [`updateUser()`](/docs/reference/javascript/auth-updateuser). It is not a good place to store authorization data.
 - `raw_app_meta_data` - cannot be updated by the user, so it's a good place to store authorization data.
 
-The `auth.jwt()` function is extremely versatile. For example, if you store some team data inside `app_metadata`, you can use it to determine whether a particular user belongs to a team. For example, if this was an array of IDs:
+The `auth.jwt()` function is extremely versatile. For example, if you store some team data inside `app_metadata`, you can use it to determine whether a particular user belongs to a team. If `teams` is a JSON array of IDs:
 
 ```sql
 create policy "User is in team"
 on my_table
 to authenticated
-using ( team_id in (select auth.jwt() -> 'app_metadata' -> 'teams'));
+using (
+  ((select auth.jwt()) -> 'app_metadata' -> 'teams') ? team_id::text
+);
 ```
 
 <Admonition type="caution">
@@ -483,9 +471,11 @@ to authenticated using (
 );
 ```
 
+This restrictive check only applies after a permissive update policy has allowed the row. A table with only restrictive policies denies every row.
+
 ### Use security definer functions
 
-A "security definer" function runs using the same role that _created_ the function. This means that if you create a role with a superuser (like `postgres`), then that function will have `bypassrls` privileges. For example, if you had a policy like this:
+A `security definer` function runs as the role that owns it, not the caller. Functions you create as `postgres` skip RLS because `postgres` has `bypassrls`. That is useful for looking up roles without paying RLS on the lookup table, and dangerous if the function is callable without checking `(select auth.uid())`. For example, if you had a policy like this:
 
 ```sql
 create policy "rls_test_select" on test_table
@@ -498,13 +488,13 @@ using (
 );
 ```
 
-We can instead create a `security definer` function which can scan `roles_table` without any RLS penalties:
+You can instead create a `security definer` function which can scan `roles_table` without any RLS penalties:
 
 ```sql
 create function private.has_good_role()
 returns boolean
 language plpgsql
-security definer -- will run as the creator
+security definer -- runs as the owner
 set search_path = '' -- every name inside must be schema-qualified
 as $$
 begin
@@ -515,6 +505,10 @@ begin
 end;
 $$;
 
+revoke execute on function private.has_good_role() from public;
+grant usage on schema private to authenticated;
+grant execute on function private.has_good_role() to authenticated;
+
 -- Update our policy to use this function:
 create policy "rls_test_select"
 on test_table
@@ -522,7 +516,7 @@ to authenticated
 using ( (select private.has_good_role()) );
 ```
 
-Set `search_path = ''` on every `security definer` function and schema-qualify the names inside it. Without a pinned `search_path`, a caller can point an unqualified name at their own object and run it with the function owner's privileges.
+Set `search_path = ''` on every `security definer` function and schema-qualify the names inside it. Without a pinned `search_path`, a caller can point an unqualified name at their own object and run it with the function owner's privileges. Check `(select auth.uid())` inside the function body. Revoke `execute` from `public`, then grant `usage` on the schema and `execute` on the function to the role the policy uses. Policy expressions run as the caller, so that role needs both. Keep the function in an unexposed schema so it is not an RPC. New functions grant `execute` to `public` by default.
 
 <Admonition type="caution">
 

--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -498,6 +498,20 @@ as select <QUERY>
 
 In older versions of Postgres, protect your views by revoking access from the `anon` and `authenticated` roles, or by putting them in an unexposed schema.
 
+A materialized view has none of these options. It stores its own copy of the rows, so it doesn't consult the policies on the tables it was built from, and Postgres rejects both `security_invoker` and `enable row level security` on one. Granting `select` on a materialized view hands the client every row it holds:
+
+```sql
+-- Reject: the client reads rows the base table's policies withhold.
+create materialized view reports_summary as select * from public.reports;
+grant select on reports_summary to authenticated;
+```
+
+Keep materialized views out of exposed schemas, or grant no client role access to them:
+
+```sql
+revoke all on reports_summary from anon, authenticated;
+```
+
 ## RLS reference
 
 These are the functions and patterns available inside a policy expression.
@@ -611,13 +625,80 @@ using ( (select private.has_good_role()) );
 
 Add member and non-member cases to that table's file under `supabase/tests/`. A member who is not the owner must be allowed; a non-member must not.
 
-Set `search_path = ''` on every `security definer` function and schema-qualify the names inside it. Without a pinned `search_path`, a caller can point an unqualified name at their own object and run it with the function owner's privileges. Check `(select auth.uid())` inside the function body. Revoke `execute` from `public`, then grant `usage` on the schema and `execute` on the function to the role the policy uses. Policy expressions run as the caller, so that role needs both. Keep the function in an unexposed schema so it is not an RPC. New functions grant `execute` to `public` by default.
+Pin `search_path` on every `security definer` function to a schema its callers can't write to, and schema-qualify the names inside it. `search_path = ''` is the usual choice, and it still resolves `pg_catalog`, which Postgres always searches. Without a pinned `search_path`, a caller can point an unqualified name at their own object and run it with the function owner's privileges. Check `(select auth.uid())` inside the function body. Revoke `execute` from `public`, then grant `usage` on the schema and `execute` on the function to the role the policy uses. Policy expressions run as the caller, so that role needs both. Keep the function in an unexposed schema so it is not an RPC. New functions grant `execute` to `public` by default.
 
 <Admonition type="caution">
 
 A `security definer` function in an exposed schema is callable over the Data API with the creator's privileges. Never create one in a schema listed under "Exposed schemas" in your [API settings](/dashboard/project/_/settings/api).
 
 </Admonition>
+
+### Avoid recursive policies
+
+Two tables whose policies read each other deadlock. Postgres raises `42P17`, `infinite recursion detected in policy for relation`, and the query fails for every role the policies apply to.
+
+Sharing features produce this shape. A policy on `lists` checks `list_members` to find who the list is shared with, and a policy on `list_members` checks `lists` to find who owns it:
+
+```sql
+-- Reject: each policy reads the table the other one protects.
+create policy "members read lists" on lists for select
+to authenticated
+using (
+  exists (
+    select 1 from list_members m
+    where m.list_id = lists.id and m.user_id = (select auth.uid())
+  )
+);
+
+create policy "members read membership" on list_members for select
+to authenticated
+using (
+  exists (
+    select 1 from lists l
+    where l.id = list_members.list_id and l.owner_id = (select auth.uid())
+  )
+);
+```
+
+Break the cycle with a [security definer function](#use-security-definer-functions). It reads the membership table as its owner, so the second policy never runs and there's nothing to recurse into:
+
+```sql
+create function private.user_list_ids()
+returns setof uuid
+language sql
+security definer
+set search_path = ''
+stable
+as $$
+  select list_id from public.list_members
+  where user_id = (select auth.uid())
+$$;
+
+revoke execute on function private.user_list_ids() from public;
+grant usage on schema private to authenticated;
+grant execute on function private.user_list_ids() to authenticated;
+
+create policy "members read lists" on lists for select
+to authenticated
+using ( id in (select private.user_list_ids()) );
+
+create policy "members read membership" on list_members for select
+to authenticated
+using ( list_id in (select private.user_list_ids()) );
+```
+
+The function filters on `(select auth.uid())`, so it returns only the caller's lists. A member who doesn't own the list still reads it, and a non-member reads nothing.
+
+### Debug a policy
+
+A policy that denies too much returns no rows and raises no error, so start by establishing which of the two layers stopped the request.
+
+1. Confirm which role ran the query. `select current_user, (select auth.uid());` inside the same session as the failing statement. The Dashboard SQL Editor runs as `postgres`, which has `bypassrls`, so it can't reproduce a client's result. Switch role first, the way the test files do.
+2. Read the policies on the table. `select * from pg_policies where tablename = 'reports';` shows the command, the roles, the mode, and both expressions for each policy.
+3. Compare a privileged read against the client's read. If a [secret key](/docs/guides/getting-started/api-keys) returns the row and `authenticated` doesn't, the row exists and a policy is hiding it. If neither returns it, the row isn't there and the policy is not your problem.
+4. Check the grants before rewriting anything. A missing grant raises `42501` before any policy runs. See [Grants and policies](#grants-and-policies).
+
+An empty array from the Data API is not proof that no matching row exists. See [Why is my select returning an empty data array?](/docs/guides/troubleshooting/why-is-my-select-returning-an-empty-data-array-and-i-have-data-in-the-table-xvOPgx) for the same problem from the client side.
 
 ### Bypassing Row Level Security
 
@@ -646,4 +727,7 @@ This can be useful for system-level access. **Never** share login credentials fo
 - [Testing your database](/docs/guides/database/testing): the CLI test workflow that `supabase test db` runs.
 - [Securing your API](/docs/guides/api/securing-your-api): grants, dedicated schemas, and pre-request checks around the Data API.
 - [Column Level Security](/docs/guides/database/postgres/column-level-security): restrict access to individual columns.
+- [Custom claims and RBAC](/docs/guides/api/custom-claims-and-role-based-access-control-rbac): model roles and permissions in tables when ownership isn't enough.
+- [Storage access control](/docs/guides/storage/security/access-control): RLS on `storage.objects`, where the policy targets a bucket and a path.
+- [Realtime authorization](/docs/guides/realtime/authorization): RLS on channels, which reads claims differently from a table policy.
 - [`supabase-test-helpers`](https://github.com/usebasejump/supabase-test-helpers/tree/main): a community extension that adds user creation and role impersonation helpers to pgTAP.

--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -7,47 +7,36 @@ subtitle: 'Secure your data using Postgres Row Level Security.'
 
 Postgres [Row Level Security (RLS)](https://www.postgresql.org/docs/current/ddl-rowsecurity.html) gives you granular authorization rules that run inside the database.
 
-## Row Level Security in Supabase
-
 <Admonition type="danger">
 
-A table in an exposed schema without RLS is readable and writable by anyone with your publishable key. RLS must always be enabled on any table stored in an exposed schema. By default, this is the `public` schema.
-
-RLS is enabled by default on tables created with the Table Editor in the dashboard. If you create a table in raw SQL or with the SQL editor, enable RLS yourself and leave each role only the privileges it needs:
-
-```sql
--- Take back the privileges granted automatically to client roles.
-revoke all on table <schema_name>.<table_name> from anon, authenticated;
-
--- Grant back only what each role needs.
-grant select on table <schema_name>.<table_name> to anon, authenticated;
-grant insert, update, delete on table <schema_name>.<table_name> to authenticated;
-
-alter table <schema_name>.<table_name>
-enable row level security;
-```
-
-Policies alone don't do this. See [Grants and policies](#grants-and-policies).
+A table in an exposed schema without RLS is readable and writable by any role with a grant on it. Enable RLS on every table in an exposed schema. On projects that still grant `anon` and `authenticated` by default, revoke those grants. Adding policies doesn't remove them.
 
 </Admonition>
 
-You write RLS rules in SQL, so a rule can express whatever access logic your app needs. Combine RLS with [Supabase Auth](/docs/guides/auth) for end-to-end user security from the browser to the database.
+Use the guide in three parts:
 
-RLS is a Postgres primitive and can provide "[defense in depth](<https://en.wikipedia.org/wiki/Defense_in_depth_(computing)>)" to protect your data from malicious actors even when accessed through third-party tooling.
+- [Understand Row Level Security](#understand-row-level-security) explains how grants and policies combine to control access.
+- [Secure a table with RLS](#secure-a-table-with-rls) is the procedure to follow for every table in an exposed schema.
+- [RLS reference](#rls-reference) documents the helper functions and patterns you use inside a policy expression.
 
-## Policies
+Read the first section when you're deciding how to model access. Go directly to the second section when you're ready to secure a table.
+
+## Understand Row Level Security
+
+### What a policy does
 
 [Policies](https://www.postgresql.org/docs/current/sql-createpolicy.html) are Postgres's rule engine. Each policy is attached to a table, and the policy is executed every time a table is accessed.
 
-Think of a policy as adding a `WHERE` clause to every query. For example, a policy like this:
+Think of a policy as adding a `WHERE` clause to every query. A policy like this:
 
 ```sql
 create policy "Individuals can view their own todos."
 on todos for select
+to authenticated
 using ( (select auth.uid()) = user_id );
 ```
 
-That policy translates to this whenever a user tries to select from the todos table:
+That policy translates to this whenever a user selects from the todos table:
 
 ```sql
 select *
@@ -56,17 +45,9 @@ where auth.uid() = todos.user_id;
 -- Policy is implicitly added.
 ```
 
-## Enabling Row Level Security
+You write RLS rules in SQL, so a rule can express whatever access logic your app needs. Because RLS is a Postgres primitive, it also protects your data when it is reached through third-party tooling, which is what makes it "[defense in depth](<https://en.wikipedia.org/wiki/Defense_in_depth_(computing)>)". Combine RLS with [Supabase Auth](/docs/guides/auth) for end-to-end user security from the browser to the database.
 
-You can enable RLS for any table using the `enable row level security` clause:
-
-```sql
-alter table "table_name" enable row level security;
-```
-
-Once you have enabled RLS, no data will be accessible via the [API](/docs/guides/api) when using a publishable key, until you create policies.
-
-## Grants and policies
+### Grants and policies
 
 Postgres runs two checks before a client touches a table. Grants decide whether a role can run an operation on the table at all. Policies decide which rows that operation applies to. Set both for every table you expose.
 
@@ -80,111 +61,11 @@ On existing projects, a new table in `public` starts with every privilege alread
 
 Adding policies doesn't take those grants back. A table protected only by policies still hands `anon` an insert path if you never revoke the grant.
 
-A missing grant raises a `42501` error before any policy runs. When a request fails that your policy should allow, check the grants before you change the policy.
+Not every project grants these automatically. See [Default privileges](/docs/guides/api/securing-your-api#default-privileges). Grant each role only the operations it needs.
 
-### Set the grants for a table
+A missing grant raises a `42501` error before any policy runs. When a request fails that your policy should allow, check the grants before you change the policy. To set them, see [Lock down the table](#lock-down-the-table).
 
-Run these statements in the [SQL Editor](/dashboard/project/_/sql/new) for a one-off change, or in a [migration](/docs/guides/deployment/database-migrations) to keep the change reproducible across environments. Grants and RLS belong in the same migration.
-
-Set the grants to match what each role does in your app:
-
-1. Revoke the automatic grants from both client roles.
-
-   ```sql
-   revoke all on table public.reports from anon, authenticated;
-   ```
-
-2. Grant back only the privileges the role needs.
-
-   ```sql
-   -- Signed-in users manage reports. Signed-out visitors get nothing.
-   grant select, insert, update, delete on table public.reports to authenticated;
-   ```
-
-3. Enable RLS on the table and write policies that decide which rows each role reaches.
-
-For data that clients read but never write, such as a feed a backend job populates, grant no writes in step 2:
-
-```sql
-revoke all on table public.weather_readings from anon, authenticated;
-grant select on table public.weather_readings to anon, authenticated;
-```
-
-To stop new tables from receiving the automatic grants in the first place, see [Revoke default privileges](/docs/guides/api/securing-your-api#revoke-default-privileges).
-
-Write the tests for this table in the same change. See [Test your policies](#test-your-policies).
-
-## Auto-enable RLS for new tables
-
-If you want RLS enabled automatically for new tables, you can create an event trigger that runs after table creation. This uses a Postgres [event trigger](/docs/guides/database/postgres/event-triggers) to call `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` on each newly created table.
-
-```sql
-CREATE OR REPLACE FUNCTION rls_auto_enable()
-RETURNS EVENT_TRIGGER
-LANGUAGE plpgsql
-SECURITY DEFINER
-SET search_path = pg_catalog
-AS $$
-DECLARE
-  cmd record;
-BEGIN
-  FOR cmd IN
-    SELECT *
-    FROM pg_event_trigger_ddl_commands()
-    WHERE command_tag IN ('CREATE TABLE', 'CREATE TABLE AS', 'SELECT INTO')
-      AND object_type IN ('table','partitioned table')
-  LOOP
-     IF cmd.schema_name IS NOT NULL AND cmd.schema_name IN ('public') AND cmd.schema_name NOT IN ('pg_catalog','information_schema') AND cmd.schema_name NOT LIKE 'pg_toast%' AND cmd.schema_name NOT LIKE 'pg_temp%' THEN
-      BEGIN
-        EXECUTE format('alter table if exists %s enable row level security', cmd.object_identity);
-        RAISE LOG 'rls_auto_enable: enabled RLS on %', cmd.object_identity;
-      EXCEPTION
-        WHEN OTHERS THEN
-          RAISE LOG 'rls_auto_enable: failed to enable RLS on %', cmd.object_identity;
-      END;
-     ELSE
-        RAISE LOG 'rls_auto_enable: skip % (either system schema or not in enforced list: %.)', cmd.object_identity, cmd.schema_name;
-     END IF;
-  END LOOP;
-END;
-$$;
-
-DROP EVENT TRIGGER IF EXISTS ensure_rls;
-CREATE EVENT TRIGGER ensure_rls
-ON ddl_command_end
-WHEN TAG IN ('CREATE TABLE', 'CREATE TABLE AS', 'SELECT INTO')
-EXECUTE FUNCTION rls_auto_enable();
-```
-
-Note that this applies to tables created after the trigger is installed. Existing tables still need RLS enabled manually.
-
-<Admonition type="caution" title="`auth.uid()` Returns `null` When Unauthenticated">
-
-When a request is made without an authenticated user (e.g., no access token is provided or the session has expired), `auth.uid()` returns `null`.
-
-This means that a policy like:
-
-```sql
-USING (auth.uid() = user_id)
-```
-
-will silently fail for unauthenticated users, because:
-
-```sql
-null = user_id
-```
-
-is always false in SQL.
-
-To avoid confusion and make your intention clear, we recommend explicitly checking for authentication:
-
-```sql
-USING (auth.uid() IS NOT NULL AND auth.uid() = user_id)
-```
-
-</Admonition>
-
-## Authenticated and unauthenticated roles
+### Authenticated and unauthenticated roles
 
 Supabase maps every request to one of the roles:
 
@@ -213,99 +94,110 @@ Using the `anon` Postgres role is different from an [anonymous user](/docs/guide
 
 </Admonition>
 
-## Creating policies
+A policy that reads `to anon using ( true )` grants every unauthenticated visitor read access to every row the role can already reach through grants. Use it only for data that is meant to be public.
 
-Policies are SQL logic that you attach to a Postgres table. You can attach as many policies as you want to each table.
+### Views and RLS
 
-Supabase provides some [helpers](#helper-functions) that simplify RLS if you're using Supabase Auth. The examples below use these helpers.
+Views bypass RLS by default because they are usually created with the `postgres` user. This is a feature of Postgres, which automatically creates views with `security definer`. A view over a protected table hands out every row its policies were meant to withhold, so a view needs the same attention as a table. To create one safely, see [Expose a view safely](#expose-a-view-safely).
 
-### SELECT policies
+## Secure a table with RLS
 
-You can specify select policies with the `using` clause.
+Follow these steps for every table in an exposed schema.
 
-Say you have a table called `profiles` in the public schema and you want to enable read access to everyone.
+### Lock down the table
+
+Run these statements in the [SQL Editor](/dashboard/project/_/sql/new) for a one-off change, or in a [migration](/docs/guides/deployment/database-migrations) to keep the change reproducible across environments. Grants and RLS belong in the same migration.
+
+Enable RLS, then set the grants to match what each role does in your app:
+
+1. Enable RLS on the table.
+
+   ```sql
+   alter table public.reports enable row level security;
+   ```
+
+   Once RLS is enabled, no data is accessible through the [API](/docs/guides/api) when using a publishable key, until you create policies.
+
+2. Revoke any existing grants from both client roles.
+
+   ```sql
+   revoke all on table public.reports from anon, authenticated;
+   ```
+
+3. Grant back only the privileges the role needs.
+
+   ```sql
+   -- Signed-in users manage reports. Signed-out visitors get nothing.
+   grant select, insert, update, delete on table public.reports to authenticated;
+   ```
+
+Data that clients read but never write, such as a feed a backend job populates, gets no write grant at all:
 
 ```sql
--- 1. Create table
+revoke all on table public.weather_readings from anon, authenticated;
+grant select on table public.weather_readings to anon, authenticated;
+```
+
+If new tables still receive automatic grants, see [Revoke default privileges](/docs/guides/api/securing-your-api#revoke-default-privileges). To enable RLS automatically on every new table, see [Event triggers](/docs/guides/database/postgres/event-triggers).
+
+Write the tests for this table in the same change. See [Test your policies](#test-your-policies).
+
+### Write a policy for each operation
+
+Write a separate policy for `select`, `insert`, `update`, and `delete`. Postgres does not accept multiple operations in one `for` clause, and a `for all` policy hides which operation each rule was meant to cover.
+
+These examples use a `profiles` table where each user manages only their own row:
+
+```sql
 create table profiles (
   id uuid primary key,
   user_id uuid references auth.users,
   avatar_url text
 );
 
--- 2. Enable RLS
 alter table profiles enable row level security;
 
--- 3. Create Policy
-create policy "Public profiles are visible to everyone."
-on profiles for select
-to anon         -- the Postgres Role (recommended)
-using ( true ); -- the actual Policy
+revoke all on table profiles from anon, authenticated;
+grant select, insert, update, delete on table profiles to authenticated;
 ```
 
-Alternatively, if you only wanted users to be able to see their own profiles:
+Supabase provides [helper functions](#helper-functions) that simplify RLS if you are using Supabase Auth. `auth.uid()` returns the ID of the user making the request.
+
+#### SELECT policies
+
+You can specify select policies with the `using` clause.
 
 ```sql
-create policy "User can see their own profile only."
+create policy "Users can view their own profile."
 on profiles for select
 to authenticated
 using ( (select auth.uid()) = user_id );
 ```
 
-### INSERT policies
+#### INSERT policies
 
-You can specify insert policies with the `with check` clause. The `with check` expression ensures that any new row data adheres to the policy constraints.
-
-Say you have a table called `profiles` in the public schema and you only want users to create a profile for themselves. In that case, check that their user ID matches the value they are trying to insert:
+You can specify insert policies with the `with check` clause. The `with check` expression ensures that any new row adheres to the policy constraints, so a user cannot create a row that belongs to someone else.
 
 ```sql
--- 1. Create table
-create table profiles (
-  id uuid primary key,
-  user_id uuid references auth.users,
-  avatar_url text
-);
-
--- 2. Enable RLS
-alter table profiles enable row level security;
-
--- 3. Create Policy
-create policy "Users can create a profile."
+create policy "Users can create their own profile."
 on profiles for insert
-to authenticated                          -- the Postgres Role (recommended)
-with check ( (select auth.uid()) = user_id );      -- the actual Policy
+to authenticated
+with check ( (select auth.uid()) = user_id );
 ```
 
-### UPDATE policies
+#### UPDATE policies
 
-You can specify update policies by combining both the `using` and `with check` expressions.
-
-The `using` clause represents the condition that must be true for the update to be allowed, and `with check` clause ensures that the updates made adhere to the policy constraints.
-
-Say you have a table called `profiles` in the public schema and you only want users to update their own profile.
-
-You can create a policy where the `using` clause checks if the user owns the profile being updated. And the `with check` clause ensures that, in the resultant row, users do not change the `user_id` to a value that is not equal to their User ID, maintaining that the modified profile still meets the ownership condition.
+You can specify update policies by combining the `using` and `with check` expressions. The `using` clause decides which existing rows can be updated. The `with check` clause decides what the resulting row is allowed to look like, which stops a user from reassigning `user_id` to someone else.
 
 ```sql
--- 1. Create table
-create table profiles (
-  id uuid primary key,
-  user_id uuid references auth.users,
-  avatar_url text
-);
-
--- 2. Enable RLS
-alter table profiles enable row level security;
-
--- 3. Create Policy
 create policy "Users can update their own profile."
 on profiles for update
-to authenticated                    -- the Postgres Role (recommended)
-using ( (select auth.uid()) = user_id )       -- checks if the existing row complies with the policy expression
-with check ( (select auth.uid()) = user_id ); -- checks if the new row complies with the policy expression
+to authenticated
+using ( (select auth.uid()) = user_id )       -- checks the existing row
+with check ( (select auth.uid()) = user_id ); -- checks the resulting row
 ```
 
-If no `with check` expression is defined, then the `using` expression will be used both to determine which rows are visible (normal USING case) and which new rows will be allowed to be added (WITH CHECK case).
+If no `with check` expression is defined, the `using` expression decides both which rows are visible and which new rows are allowed.
 
 <Admonition type="caution">
 
@@ -313,253 +205,37 @@ To perform an `UPDATE` operation, a corresponding [`SELECT` policy](#select-poli
 
 </Admonition>
 
-### DELETE policies
+#### DELETE policies
 
 You can specify delete policies with the `using` clause.
 
-Say you have a table called `profiles` in the public schema and you only want users to be able to delete their own profile:
-
 ```sql
--- 1. Create table
-create table profiles (
-  id uuid primary key,
-  user_id uuid references auth.users,
-  avatar_url text
-);
-
--- 2. Enable RLS
-alter table profiles enable row level security;
-
--- 3. Create Policy
-create policy "Users can delete a profile."
+create policy "Users can delete their own profile."
 on profiles for delete
-to authenticated                     -- the Postgres Role (recommended)
-using ( (select auth.uid()) = user_id );      -- the actual Policy
-```
-
-### Views
-
-Views bypass RLS by default because they are usually created with the `postgres` user. This is a feature of Postgres, which automatically creates views with `security definer`.
-
-In Postgres 15 and above, you can make a view obey the RLS policies of the underlying tables when invoked by `anon` and `authenticated` roles by setting `security_invoker = true`.
-
-```sql
-create view <VIEW_NAME>
-with(security_invoker = true)
-as select <QUERY>
-```
-
-In older versions of Postgres, protect your views by revoking access from the `anon` and `authenticated` roles, or by putting them in an unexposed schema.
-
-## Helper functions
-
-Supabase provides some helper functions that make it easier to write Policies.
-
-### `auth.uid()`
-
-Returns the ID of the user making the request.
-
-### `auth.jwt()`
-
-<Admonition type="caution">
-
-Not all information present in the JWT should be used in RLS policies. For instance, creating an RLS policy that relies on the `user_metadata` claim can create security issues in your application as this information can be modified by authenticated end users.
-
-</Admonition>
-
-Returns the JWT of the user making the request. Anything that you store in the user's `raw_app_meta_data` column or the `raw_user_meta_data` column will be accessible using this function. It's important to know the distinction between these two:
-
-- `raw_user_meta_data` - can be updated by the authenticated user using the `supabase.auth.update()` function. It is not a good place to store authorization data.
-- `raw_app_meta_data` - cannot be updated by the user, so it's a good place to store authorization data.
-
-The `auth.jwt()` function is extremely versatile. For example, if you store some team data inside `app_metadata`, you can use it to determine whether a particular user belongs to a team. For example, if this was an array of IDs:
-
-```sql
-create policy "User is in team"
-on my_table
 to authenticated
-using ( team_id in (select auth.jwt() -> 'app_metadata' -> 'teams'));
+using ( (select auth.uid()) = user_id );
 ```
 
-<Admonition type="caution">
+### Specify roles in your policies
 
-Keep in mind that a JWT is not always "fresh". In the example above, even if you remove a user from a team and update the `app_metadata` field, that will not be reflected using `auth.jwt()` until the user's JWT is refreshed.
-
-Also, if you are using Cookies for Auth, then you must be mindful of the JWT size. Some browsers are limited to 4096 bytes for each cookie, and so the total size of your JWT should be small enough to fit inside this limitation.
-
-</Admonition>
-
-### MFA
-
-The `auth.jwt()` function can be used to check for [Multi-Factor Authentication](/docs/guides/auth/auth-mfa#enforce-rules-for-mfa-logins). For example, you could restrict a user from updating their profile unless they have at least 2 levels of authentication (Assurance Level 2):
+Always name the role a policy applies to, using the `to` clause. Instead of this:
 
 ```sql
-create policy "Restrict updates."
-on profiles
-as restrictive
-for update
-to authenticated using (
-  (select auth.jwt()->>'aal') = 'aal2'
-);
+create policy "rls_test_select" on rls_test
+using ( auth.uid() = user_id );
 ```
 
-## Bypassing Row Level Security
-
-Supabase provides special "Service" keys, which can be used to bypass RLS. These should never be used in the browser or exposed to customers, but they are useful for administrative tasks.
-
-<Admonition type="note">
-
-A Service Key bypasses RLS only when the request carries no user access token. If the request carries one, it runs under the RLS policies of that signed-in user, even when the client library was initialized with a Service Key.
-
-</Admonition>
-
-You can also create new [Postgres Roles](/docs/guides/database/postgres/roles) which can bypass Row Level Security using the "bypass RLS" privilege:
+Use:
 
 ```sql
-alter role "role_name" with bypassrls;
+create policy "rls_test_select" on rls_test
+to authenticated
+using ( (select auth.uid()) = user_id );
 ```
 
-This can be useful for system-level access. **Never** share login credentials for any Postgres Role with this privilege.
+This prevents the policy `( (select auth.uid()) = user_id )` from running for any `anon` users, since the execution stops at the `to authenticated` step.
 
-## Test your policies
-
-We recommend writing tests for every policy, in the same change that sets the grants and creates the policies. Tests are a fundamental part of a secure setup, and they give you a repeatable way to prove a policy behaves the way you intended.
-
-A wrong policy fails quietly. Too permissive, and a query returns rows it shouldn't. Too strict, and it returns nothing and raises no error. Neither case surfaces as an error, so tests are how you find out.
-
-Supabase runs database tests with [pgTAP](/docs/guides/database/extensions/pgtap) through the CLI. Test files are `.sql` files under `supabase/tests/`.
-
-### Anatomy of a policy test
-
-Each case sets an identity, runs one statement as that identity, and asserts the outcome. Three things decide whether the assertion means anything.
-
-**Identity.** Switch role and identity between cases with `set local role` and `set local request.jwt.claim.sub`, so each assertion runs as the user it describes. Without the switch, every case runs as the same role and proves nothing about access.
-
-**Denials.** A denied request doesn't always raise an error, so match the assertion to the way the denial happens:
-
-- A missing grant raises `42501`. Assert it with `throws_ok`.
-- A `with check` violation raises `42501`. Assert it with `throws_ok`.
-- A `using` clause that filters the target row out raises nothing. The update or delete matches zero rows instead. Assert that no row changed.
-
-**Allowed writes.** The absence of an error doesn't prove that anything changed. Add `returning` to the statement so one assertion covers both directions. An allowed write returns the changed row, and a write the policy filters out returns nothing.
-
-### Write and run the tests
-
-1. Create the tests directory and a test file:
-
-   ```bash
-   mkdir -p supabase/tests
-   touch supabase/tests/profiles_rls.test.sql
-   ```
-
-2. Write the tests. Cover `select`, `insert`, `update`, and `delete` twice each, once for a request the policy allows and once for a request it denies. Cover `anon` as well as `authenticated`.
-
-3. Run the suite:
-
-   ```bash
-   supabase test db
-   ```
-
-This example tests a `profiles` table where `authenticated` holds every privilege, `anon` holds none, and each user reads and writes only their own row:
-
-```sql supabase/tests/profiles_rls.test.sql
-begin;
-select plan(11);
-
--- Seed two users. The rows come later, through the policies under test.
-insert into auth.users (id, email)
-values
-  ('11111111-1111-1111-1111-111111111111', 'owner@example.com'),
-  ('22222222-2222-2222-2222-222222222222', 'other@example.com');
-
--- Signed-out visitors hold no grant, so the request stops before any policy runs.
-set local role anon;
-select throws_ok(
-  $$select * from profiles$$,
-  '42501',
-  null,
-  'anon cannot read profiles'
-);
-select throws_ok(
-  $$insert into profiles (id, user_id)
-    values (gen_random_uuid(), '11111111-1111-1111-1111-111111111111')$$,
-  '42501',
-  null,
-  'anon cannot insert a profile'
-);
-
--- The owner reads and writes their own row.
-set local role authenticated;
-set local request.jwt.claim.sub = '11111111-1111-1111-1111-111111111111';
-select results_eq(
-  $$insert into profiles (id, user_id, avatar_url)
-    values (
-      gen_random_uuid(),
-      '11111111-1111-1111-1111-111111111111',
-      'owner.png'
-    )
-    returning avatar_url$$,
-  array['owner.png'],
-  'the owner creates their own profile'
-);
-select results_eq(
-  $$select avatar_url from profiles$$,
-  array['owner.png'],
-  'the owner reads their own profile'
-);
-select results_eq(
-  $$update profiles set avatar_url = 'updated.png' returning avatar_url$$,
-  array['updated.png'],
-  'the owner updates their own profile'
-);
-
--- The with check clause rejects the row, which raises.
-select throws_ok(
-  $$insert into profiles (id, user_id)
-    values (gen_random_uuid(), '22222222-2222-2222-2222-222222222222')$$,
-  '42501',
-  null,
-  'the owner cannot create a profile for someone else'
-);
-
--- A signed-in stranger holds the grant, so the policy is what stops them. The
--- using clause filters the row out, so these match nothing and raise nothing.
-set local request.jwt.claim.sub = '22222222-2222-2222-2222-222222222222';
-select is_empty(
-  $$select * from profiles$$,
-  'another user reads no profiles'
-);
-select is_empty(
-  $$update profiles set avatar_url = 'stolen.png' returning avatar_url$$,
-  'another user updates no profiles'
-);
-select is_empty(
-  $$delete from profiles returning id$$,
-  'another user deletes no profiles'
-);
-
--- The row is still there, still holding the owner's value.
-set local request.jwt.claim.sub = '11111111-1111-1111-1111-111111111111';
-select results_eq(
-  $$select avatar_url from profiles$$,
-  array['updated.png'],
-  'the other user changed nothing'
-);
-select results_eq(
-  $$delete from profiles returning avatar_url$$,
-  array['updated.png'],
-  'the owner deletes their own profile'
-);
-
-select * from finish();
-rollback;
-```
-
-For CLI setup and more pgTAP helpers, see [Testing your database](/docs/guides/database/testing).
-
-## Write policies that scale
-
-Postgres evaluates a policy expression against each candidate row, so the cost scales with the rows a query scans. Three rules keep that cost from growing with your table. Apply all three to every policy you write.
+These three rules keep policies correct as a table grows. For the measured impact and for tuning beyond them, see [Row Level Security performance](/docs/guides/database/postgres/row-level-security-performance).
 
 ### Add indexes
 
@@ -620,26 +296,192 @@ You can only use this technique if the results of the query or function do not c
 
 </Admonition>
 
-### Specify roles in your policies
+### Expose a view safely
 
-Always name the role a policy applies to, using the `to` clause. Instead of this:
+In Postgres 15 and above, make a view obey the RLS policies of its underlying tables when invoked by `anon` and `authenticated` by setting `security_invoker = true`.
 
 ```sql
-create policy "rls_test_select" on rls_test
-using ( auth.uid() = user_id );
+create view <VIEW_NAME>
+with(security_invoker = true)
+as select <QUERY>
 ```
 
-Use:
+In older versions of Postgres, protect your views by revoking access from the `anon` and `authenticated` roles, or by putting them in an unexposed schema.
+
+### Test your policies
+
+We recommend writing tests for every policy, in the same change that sets the grants and creates the policies. Tests are a fundamental part of a secure setup, and they give you a repeatable way to prove a policy behaves the way you intended.
+
+A wrong policy fails quietly. Too permissive, and a query returns rows it shouldn't. Too strict, and it returns nothing and raises no error. Neither case surfaces as an error, so tests are how you find out.
+
+Supabase runs database tests with [pgTAP](/docs/guides/database/extensions/pgtap) through the CLI. Test files are `.sql` files under `supabase/tests/`.
+
+#### Anatomy of a policy test
+
+Each case sets an identity, runs one statement as that identity, and asserts the outcome. Three things decide whether the assertion means anything.
+
+**Identity.** Switch role and identity between cases with `set local role` and `set local request.jwt.claim.sub`, so each assertion runs as the user it describes. Without the switch, every case runs as the same role and proves nothing about access.
+
+**Denials.** A denied request doesn't always raise an error, so match the assertion to the way the denial happens:
+
+- A missing grant raises `42501`. Assert it with `throws_ok`.
+- A `with check` violation raises `42501`. Assert it with `throws_ok`.
+- A `using` clause that filters the target row out raises nothing. The update or delete matches zero rows instead. Assert that no row changed.
+
+**Allowed writes.** The absence of an error doesn't prove that anything changed. Add `returning` to the statement so one assertion covers both directions. An allowed write returns the changed row, and a write the policy filters out returns nothing.
+
+#### Write and run the tests
+
+1. Create a test file:
+
+   ```bash
+   supabase test new profiles_rls
+   ```
+
+2. Write the tests. Cover `select`, `insert`, `update`, and `delete` twice each, once for a request the policy allows and once for a request it denies, for `anon` as well as `authenticated`.
+
+   [`supabase-test-helpers`](https://github.com/usebasejump/supabase-test-helpers/tree/main) removes most of the setup below. It adds `tests.create_supabase_user()`, `tests.authenticate_as()`, and `tests.rls_enabled()`, so you don't hand-roll user seeding or role switching. See [Advanced pgTAP testing](/docs/guides/local-development/testing/pgtap-extended) for schema-wide assertions and a worked multi-tenant example.
+
+3. Run the suite:
+
+   ```bash
+   supabase test db
+   ```
+
+This example shows each of those techniques against a `profiles` table where `authenticated` holds every privilege, `anon` holds none, and each user reads and writes only their own row. Extend it to the remaining operations:
+
+```sql supabase/tests/profiles_rls.test.sql
+begin;
+select plan(4);
+
+insert into auth.users (id, email)
+values
+  ('11111111-1111-1111-1111-111111111111', 'owner@example.com'),
+  ('22222222-2222-2222-2222-222222222222', 'other@example.com');
+
+-- anon holds no grant, so the request stops before any policy runs.
+set local role anon;
+select throws_ok(
+  $$select * from profiles$$,
+  '42501',
+  null,
+  'anon cannot read profiles'
+);
+
+-- The owner writes their own row. returning proves the row changed.
+set local role authenticated;
+set local request.jwt.claim.sub = '11111111-1111-1111-1111-111111111111';
+select results_eq(
+  $$insert into profiles (id, user_id, avatar_url)
+    values (
+      gen_random_uuid(),
+      '11111111-1111-1111-1111-111111111111',
+      'owner.png'
+    )
+    returning avatar_url$$,
+  array['owner.png'],
+  'the owner creates their own profile'
+);
+
+-- A signed-in stranger holds the grant, so the policy is what stops them. The
+-- using clause filters the row out, so these match nothing and raise nothing.
+set local request.jwt.claim.sub = '22222222-2222-2222-2222-222222222222';
+select is_empty(
+  $$select * from profiles$$,
+  'another user reads no profiles'
+);
+select is_empty(
+  $$update profiles set avatar_url = 'stolen.png' returning avatar_url$$,
+  'another user updates no profiles'
+);
+
+select * from finish();
+rollback;
+```
+
+For CLI setup and more pgTAP helpers, see [Testing your database](/docs/guides/database/testing).
+
+## RLS reference
+
+These are the functions and patterns available inside a policy expression.
+
+### Helper functions
+
+Supabase provides some helper functions that make it easier to write policies.
+
+#### `auth.uid()`
+
+Returns the ID of the user making the request.
+
+<Admonition type="caution" title="`auth.uid()` Returns `null` When Unauthenticated">
+
+When a request is made without an authenticated user (e.g., no access token is provided or the session has expired), `auth.uid()` returns `null`.
+
+This means that a policy like:
 
 ```sql
-create policy "rls_test_select" on rls_test
+USING (auth.uid() = user_id)
+```
+
+will silently fail for unauthenticated users, because:
+
+```sql
+null = user_id
+```
+
+is always false in SQL.
+
+To avoid confusion and make your intention clear, we recommend explicitly checking for authentication:
+
+```sql
+USING (auth.uid() IS NOT NULL AND auth.uid() = user_id)
+```
+
+</Admonition>
+
+#### `auth.jwt()`
+
+<Admonition type="caution">
+
+Not all information present in the JWT should be used in RLS policies. For instance, creating an RLS policy that relies on the `user_metadata` claim can create security issues in your application as this information can be modified by authenticated end users.
+
+</Admonition>
+
+Returns the JWT of the user making the request. Anything that you store in the user's `raw_app_meta_data` column or the `raw_user_meta_data` column will be accessible using this function. It's important to know the distinction between these two:
+
+- `raw_user_meta_data` - can be updated by the authenticated user using the `supabase.auth.update()` function. It is not a good place to store authorization data.
+- `raw_app_meta_data` - cannot be updated by the user, so it's a good place to store authorization data.
+
+The `auth.jwt()` function is extremely versatile. For example, if you store some team data inside `app_metadata`, you can use it to determine whether a particular user belongs to a team. For example, if this was an array of IDs:
+
+```sql
+create policy "User is in team"
+on my_table
 to authenticated
-using ( (select auth.uid()) = user_id );
+using ( team_id in (select auth.jwt() -> 'app_metadata' -> 'teams'));
 ```
 
-This prevents the policy `( (select auth.uid()) = user_id )` from running for any `anon` users, since the execution stops at the `to authenticated` step.
+<Admonition type="caution">
 
-These three rules keep policies correct as a table grows. To diagnose whether a policy is still the bottleneck, and to tune beyond these rules, see [Row Level Security performance](/docs/guides/database/postgres/row-level-security-performance).
+Keep in mind that a JWT is not always up-to-date. In the team policy example, even if you remove a user from a team and update the `app_metadata` field, that will not be reflected using `auth.jwt()` until the user's JWT is refreshed.
+
+Also, if you are using Cookies for Auth, then you must be mindful of the JWT size. Some browsers are limited to 4096 bytes for each cookie, and so the total size of your JWT should be small enough to fit inside this limitation.
+
+</Admonition>
+
+#### MFA
+
+The `auth.jwt()` function can be used to check for [Multi-Factor Authentication](/docs/guides/auth/auth-mfa#enforce-rules-for-mfa-logins). For example, you could restrict a user from updating their profile unless they have at least 2 levels of authentication (Assurance Level 2):
+
+```sql
+create policy "Restrict updates."
+on profiles
+as restrictive
+for update
+to authenticated using (
+  (select auth.jwt()->>'aal') = 'aal2'
+);
+```
 
 ### Use security definer functions
 
@@ -687,6 +529,26 @@ Set `search_path = ''` on every `security definer` function and schema-qualify t
 A `security definer` function in an exposed schema is callable over the Data API with the creator's privileges. Never create one in a schema listed under "Exposed schemas" in your [API settings](/dashboard/project/_/settings/api).
 
 </Admonition>
+
+### Bypassing Row Level Security
+
+Use a [secret key](/docs/guides/getting-started/api-keys) for administrative tasks that need to bypass RLS. A secret key authorizes access through the `service_role` Postgres role, which has the `bypassrls` attribute. Never use a secret key in the browser or expose it to customers.
+
+The JWT-based `service_role` key is a legacy alternative. Prefer a secret key where possible.
+
+<Admonition type="note">
+
+A secret key bypasses RLS only when the request carries no user access token. If the request carries one, it runs under the RLS policies of that signed-in user, even when the client library was initialized with a secret key.
+
+</Admonition>
+
+You can also create new [Postgres Roles](/docs/guides/database/postgres/roles) which can bypass Row Level Security using the "bypass RLS" privilege:
+
+```sql
+alter role "role_name" with bypassrls;
+```
+
+This can be useful for system-level access. **Never** share login credentials for any Postgres Role with this privilege.
 
 ## Related content
 

--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -16,7 +16,7 @@ A table in an exposed schema without RLS is readable and writable by any role wi
 Use the guide in three parts:
 
 - [Understand Row Level Security](#understand-row-level-security) explains how grants and policies combine to control access.
-- [Secure a table with RLS](#secure-a-table-with-rls) is the procedure to follow for every table in an exposed schema.
+- [Secure a table with RLS](#secure-a-table-with-rls) is the procedure to follow for every table in an exposed schema: grants, policies, and `supabase test db`.
 - [RLS reference](#rls-reference) documents the helper functions and patterns you use inside a policy expression.
 
 Read the first section when you're deciding how to model access. Go directly to the second section when you're ready to secure a table.
@@ -67,7 +67,7 @@ Not every project grants these automatically. See [Default privileges](/docs/gui
 
 A missing grant raises a `42501` error before any policy runs. When a request fails that your policy should allow, check the grants before you change the policy. To set them, see [Lock down the table](#lock-down-the-table).
 
-Table owners skip RLS unless you force it. Superusers and roles with `bypassrls` always skip RLS; `force row level security` does not apply to them. On Supabase, `postgres` is not a superuser, but it has `bypassrls`, so the Dashboard SQL Editor skips policies even after you force them. That is why [Test your policies](#test-your-policies) switches role. Add `alter table ... force row level security` only when a table owner without `bypassrls` must also obey policies.
+Table owners skip RLS unless you force it. Superusers and roles with `bypassrls` always skip RLS; `force row level security` does not apply to them. On Supabase, `postgres` is not a superuser, but it has `bypassrls`, so the Dashboard SQL Editor skips policies even after you force them. That is why the test files switch role. Add `alter table ... force row level security` only when a table owner without `bypassrls` must also obey policies.
 
 ### Authenticated and unauthenticated roles
 
@@ -106,7 +106,14 @@ Views bypass RLS by default because they are usually created with the `postgres`
 
 ## Secure a table with RLS
 
-Follow these steps for every table in an exposed schema.
+Follow these steps for every table in an exposed schema:
+
+1. Enable RLS and set the grants to match the app.
+2. Write a policy per operation.
+3. Create a `.sql` file under `supabase/tests/` that asserts allow and deny for `select`, `insert`, `update`, and `delete`, for `anon` and `authenticated`.
+4. Run `supabase test db` and stop only when it passes.
+
+A table is not secured until that suite passes.
 
 ### Lock down the table
 
@@ -135,16 +142,78 @@ Enable RLS, then set the grants to match what each role does in your app:
    grant select, insert, update, delete on table public.reports to authenticated;
    ```
 
-Data that clients read but never write, such as a feed a backend job populates, gets no write grant at all:
+Data that clients read but never write, such as a feed a backend job populates, gets select only. The policy and the test file are part of the same change:
 
 ```sql
+alter table public.weather_readings enable row level security;
 revoke all on table public.weather_readings from anon, authenticated;
 grant select on table public.weather_readings to anon, authenticated;
+
+create policy "Anyone can read weather readings"
+on public.weather_readings for select
+to anon, authenticated
+using ( true );
+```
+
+```sql supabase/tests/weather_readings_rls.test.sql
+-- File: supabase/tests/weather_readings_rls.test.sql
+-- Repeat for every public-read table you secured. Do not add a table only the tests use.
+begin;
+select plan(8);
+
+set local role anon;
+select lives_ok(
+  $$select * from weather_readings$$,
+  'anon can read the feed'
+);
+select throws_ok(
+  $$insert into weather_readings select * from weather_readings$$,
+  '42501',
+  null,
+  'anon cannot insert into the feed'
+);
+select throws_ok(
+  $$update weather_readings set id = id$$,
+  '42501',
+  null,
+  'anon cannot update the feed'
+);
+select throws_ok(
+  $$delete from weather_readings$$,
+  '42501',
+  null,
+  'anon cannot delete from the feed'
+);
+
+set local role authenticated;
+select lives_ok(
+  $$select * from weather_readings$$,
+  'authenticated can read the feed'
+);
+select throws_ok(
+  $$insert into weather_readings select * from weather_readings$$,
+  '42501',
+  null,
+  'authenticated cannot insert into the feed'
+);
+select throws_ok(
+  $$update weather_readings set id = id$$,
+  '42501',
+  null,
+  'authenticated cannot update the feed'
+);
+select throws_ok(
+  $$delete from weather_readings$$,
+  '42501',
+  null,
+  'authenticated cannot delete from the feed'
+);
+
+select * from finish();
+rollback;
 ```
 
 If new tables still receive automatic grants, see [Revoke default privileges](/docs/guides/api/securing-your-api#revoke-default-privileges). To enable RLS automatically on every new table, see [Event triggers](/docs/guides/database/postgres/event-triggers).
-
-Write the tests for this table in the same change. See [Test your policies](#test-your-policies).
 
 ### Write a policy for each operation
 
@@ -220,6 +289,117 @@ to authenticated
 using ( (select auth.uid()) = user_id );
 ```
 
+When you adapt those four policies to a table, add this file for that table. The path is `supabase/tests/<table>_rls.test.sql`. For a table users share, also assert that a member who is not the owner can read and write, and that a non-member cannot.
+
+```sql supabase/tests/profiles_rls.test.sql
+-- File: supabase/tests/profiles_rls.test.sql
+-- One file per table you enabled RLS on. Name that table in the assertions.
+-- Do not create a table only the tests use.
+begin;
+select plan(12);
+
+insert into auth.users (id, email)
+values
+  ('11111111-1111-1111-1111-111111111111', 'owner@example.com'),
+  ('22222222-2222-2222-2222-222222222222', 'other@example.com');
+
+-- anon holds no grant, so the request stops before any policy runs.
+set local role anon;
+select throws_ok(
+  $$select * from profiles$$,
+  '42501',
+  null,
+  'anon cannot read profiles'
+);
+select throws_ok(
+  $$insert into profiles (id, user_id, avatar_url)
+    values (
+      gen_random_uuid(),
+      '11111111-1111-1111-1111-111111111111',
+      'anon.png'
+    )$$,
+  '42501',
+  null,
+  'anon cannot create a profile'
+);
+select throws_ok(
+  $$update profiles set avatar_url = 'anon.png'$$,
+  '42501',
+  null,
+  'anon cannot update profiles'
+);
+select throws_ok(
+  $$delete from profiles$$,
+  '42501',
+  null,
+  'anon cannot delete profiles'
+);
+
+-- The owner writes their own row. returning proves the row changed.
+set local role authenticated;
+set local request.jwt.claim.sub = '11111111-1111-1111-1111-111111111111';
+select results_eq(
+  $$insert into profiles (id, user_id, avatar_url)
+    values (
+      gen_random_uuid(),
+      '11111111-1111-1111-1111-111111111111',
+      'owner.png'
+    )
+    returning avatar_url$$,
+  array['owner.png'],
+  'the owner creates their own profile'
+);
+select results_eq(
+  $$select avatar_url from profiles$$,
+  array['owner.png'],
+  'the owner reads their own profile'
+);
+select results_eq(
+  $$update profiles set avatar_url = 'updated.png' returning avatar_url$$,
+  array['updated.png'],
+  'the owner updates their own profile'
+);
+
+-- A signed-in stranger holds the grant, so the policy is what stops them.
+set local request.jwt.claim.sub = '22222222-2222-2222-2222-222222222222';
+select throws_ok(
+  $$insert into profiles (id, user_id, avatar_url)
+    values (
+      gen_random_uuid(),
+      '11111111-1111-1111-1111-111111111111',
+      'stolen.png'
+    )$$,
+  '42501',
+  null,
+  'another user cannot create a profile for the owner'
+);
+select is_empty(
+  $$select * from profiles$$,
+  'another user reads no profiles'
+);
+select is_empty(
+  $$update profiles set avatar_url = 'stolen.png' returning avatar_url$$,
+  'another user updates no profiles'
+);
+select is_empty(
+  $$delete from profiles returning avatar_url$$,
+  'another user deletes no profiles'
+);
+
+-- Owner delete last so earlier cases still have a row to assert against.
+set local request.jwt.claim.sub = '11111111-1111-1111-1111-111111111111';
+select results_eq(
+  $$delete from profiles returning avatar_url$$,
+  array['updated.png'],
+  'the owner deletes their own profile'
+);
+
+select * from finish();
+rollback;
+```
+
+A missing grant or a `with check` violation raises `42501`; assert it with `throws_ok`. A `using` clause that filters the row out raises nothing, so assert that the update or delete changed no rows. An allowed write needs `returning`. Switch role and identity with `set local role` and `set local request.jwt.claim.sub`.
+
 ### Specify roles in your policies
 
 Always name the role a policy applies to, using the `to` clause. Instead of this:
@@ -239,7 +419,13 @@ using ( (select auth.uid()) = user_id );
 
 This prevents the policy `( (select auth.uid()) = user_id )` from running for any `anon` users, since the execution stops at the `to authenticated` step.
 
-These three rules keep policies correct as a table grows. For the measured impact and for tuning beyond them, see [Row Level Security performance](/docs/guides/database/postgres/row-level-security-performance).
+### Test your policies
+
+The files above live under `supabase/tests/` and run through [pgTAP](/docs/guides/database/extensions/pgtap). Create them with `supabase test new <table>_rls.test`. Run the suite with `supabase test db`. Stop only when it reports a passing result.
+
+[`supabase-test-helpers`](https://github.com/usebasejump/supabase-test-helpers/tree/main) adds `tests.create_supabase_user()`, `tests.authenticate_as()`, and `tests.rls_enabled()`. See [Advanced pgTAP testing](/docs/guides/local-development/testing/pgtap-extended) and [Testing your database](/docs/guides/database/testing).
+
+Index the filter columns and wrap helper calls so policies stay fast as a table grows. For the measured impact and for tuning beyond them, see [Row Level Security performance](/docs/guides/database/postgres/row-level-security-performance).
 
 ### Add indexes
 
@@ -311,99 +497,6 @@ as select <QUERY>
 ```
 
 In older versions of Postgres, protect your views by revoking access from the `anon` and `authenticated` roles, or by putting them in an unexposed schema.
-
-### Test your policies
-
-We recommend writing tests for every policy, in the same change that sets the grants and creates the policies. Tests are a fundamental part of a secure setup, and they give you a repeatable way to prove a policy behaves the way you intended.
-
-A wrong policy fails quietly. Too permissive, and a query returns rows it shouldn't. Too strict, and it returns nothing and raises no error. Neither case surfaces as an error, so tests are how you find out.
-
-Supabase runs database tests with [pgTAP](/docs/guides/database/extensions/pgtap) through the CLI. Test files are `.sql` files under `supabase/tests/`.
-
-#### Anatomy of a policy test
-
-Each case sets an identity, runs one statement as that identity, and asserts the outcome. Three things decide whether the assertion means anything.
-
-**Identity.** Switch role and identity between cases with `set local role` and `set local request.jwt.claim.sub`, so each assertion runs as the user it describes. Without the switch, every case runs as the same role and proves nothing about access.
-
-**Denials.** A denied request doesn't always raise an error, so match the assertion to the way the denial happens:
-
-- A missing grant raises `42501`. Assert it with `throws_ok`.
-- A `with check` violation raises `42501`. Assert it with `throws_ok`.
-- A `using` clause that filters the target row out raises nothing. The update or delete matches zero rows instead. Assert that no row changed.
-
-**Allowed writes.** The absence of an error doesn't prove that anything changed. Add `returning` to the statement so one assertion covers both directions. An allowed write returns the changed row, and a write the policy filters out returns nothing.
-
-#### Write and run the tests
-
-1. Create a test file:
-
-   ```bash
-   supabase test new profiles_rls.test
-   ```
-
-2. Write the tests. Cover `select`, `insert`, `update`, and `delete` twice each, once for a request the policy allows and once for a request it denies, for `anon` as well as `authenticated`.
-
-   [`supabase-test-helpers`](https://github.com/usebasejump/supabase-test-helpers/tree/main) removes most of the setup below. It adds `tests.create_supabase_user()`, `tests.authenticate_as()`, and `tests.rls_enabled()`, so you don't hand-roll user seeding or role switching. See [Advanced pgTAP testing](/docs/guides/local-development/testing/pgtap-extended) for schema-wide assertions and a worked multi-tenant example.
-
-3. Run the suite:
-
-   ```bash
-   supabase test db
-   ```
-
-This example shows each of those techniques against a `profiles` table where `authenticated` holds every privilege, `anon` holds none, and each user reads and writes only their own row. Extend it to the remaining operations:
-
-```sql supabase/tests/profiles_rls.test.sql
-begin;
-select plan(4);
-
-insert into auth.users (id, email)
-values
-  ('11111111-1111-1111-1111-111111111111', 'owner@example.com'),
-  ('22222222-2222-2222-2222-222222222222', 'other@example.com');
-
--- anon holds no grant, so the request stops before any policy runs.
-set local role anon;
-select throws_ok(
-  $$select * from profiles$$,
-  '42501',
-  null,
-  'anon cannot read profiles'
-);
-
--- The owner writes their own row. returning proves the row changed.
-set local role authenticated;
-set local request.jwt.claim.sub = '11111111-1111-1111-1111-111111111111';
-select results_eq(
-  $$insert into profiles (id, user_id, avatar_url)
-    values (
-      gen_random_uuid(),
-      '11111111-1111-1111-1111-111111111111',
-      'owner.png'
-    )
-    returning avatar_url$$,
-  array['owner.png'],
-  'the owner creates their own profile'
-);
-
--- A signed-in stranger holds the grant, so the policy is what stops them. The
--- using clause filters the row out, so these match nothing and raise nothing.
-set local request.jwt.claim.sub = '22222222-2222-2222-2222-222222222222';
-select is_empty(
-  $$select * from profiles$$,
-  'another user reads no profiles'
-);
-select is_empty(
-  $$update profiles set avatar_url = 'stolen.png' returning avatar_url$$,
-  'another user updates no profiles'
-);
-
-select * from finish();
-rollback;
-```
-
-For CLI setup and more pgTAP helpers, see [Testing your database](/docs/guides/database/testing).
 
 ## RLS reference
 
@@ -515,6 +608,8 @@ on test_table
 to authenticated
 using ( (select private.has_good_role()) );
 ```
+
+Add member and non-member cases to that table's file under `supabase/tests/`. A member who is not the owner must be allowed; a non-member must not.
 
 Set `search_path = ''` on every `security definer` function and schema-qualify the names inside it. Without a pinned `search_path`, a caller can point an unqualified name at their own object and run it with the function owner's privileges. Check `(select auth.uid())` inside the function body. Revoke `execute` from `public`, then grant `usage` on the schema and `execute` on the function to the role the policy uses. Policy expressions run as the caller, so that role needs both. Keep the function in an unexposed schema so it is not an RPC. New functions grant `execute` to `public` by default.
 

--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -142,44 +142,53 @@ Enable RLS, then set the grants to match what each role does in your app:
    grant select, insert, update, delete on table public.reports to authenticated;
    ```
 
+4. Write the test file for the table, and run the suite.
+
+   ```bash
+   supabase test new reports_rls.test
+   supabase test db
+   ```
+
+   Every table you secure gets one, and the change isn't done until the suite passes. The examples below show what goes in the file.
+
 Data that clients read but never write, such as a feed a backend job populates, gets select only. The policy and the test file are part of the same change:
 
 ```sql
-alter table public.weather_readings enable row level security;
-revoke all on table public.weather_readings from anon, authenticated;
-grant select on table public.weather_readings to anon, authenticated;
+alter table public.announcements enable row level security;
+revoke all on table public.announcements from anon, authenticated;
+grant select on table public.announcements to anon, authenticated;
 
-create policy "Anyone can read weather readings"
-on public.weather_readings for select
+create policy "Anyone can read announcements"
+on public.announcements for select
 to anon, authenticated
 using ( true );
 ```
 
-```sql supabase/tests/weather_readings_rls.test.sql
--- File: supabase/tests/weather_readings_rls.test.sql
+```sql supabase/tests/announcements_rls.test.sql
+-- File: supabase/tests/announcements_rls.test.sql
 -- Repeat for every public-read table you secured. Do not add a table only the tests use.
 begin;
 select plan(8);
 
 set local role anon;
 select lives_ok(
-  $$select * from weather_readings$$,
+  $$select * from announcements$$,
   'anon can read the feed'
 );
 select throws_ok(
-  $$insert into weather_readings select * from weather_readings$$,
+  $$insert into announcements select * from announcements$$,
   '42501',
   null,
   'anon cannot insert into the feed'
 );
 select throws_ok(
-  $$update weather_readings set id = id$$,
+  $$update announcements set id = id$$,
   '42501',
   null,
   'anon cannot update the feed'
 );
 select throws_ok(
-  $$delete from weather_readings$$,
+  $$delete from announcements$$,
   '42501',
   null,
   'anon cannot delete from the feed'
@@ -187,23 +196,23 @@ select throws_ok(
 
 set local role authenticated;
 select lives_ok(
-  $$select * from weather_readings$$,
+  $$select * from announcements$$,
   'authenticated can read the feed'
 );
 select throws_ok(
-  $$insert into weather_readings select * from weather_readings$$,
+  $$insert into announcements select * from announcements$$,
   '42501',
   null,
   'authenticated cannot insert into the feed'
 );
 select throws_ok(
-  $$update weather_readings set id = id$$,
+  $$update announcements set id = id$$,
   '42501',
   null,
   'authenticated cannot update the feed'
 );
 select throws_ok(
-  $$delete from weather_readings$$,
+  $$delete from announcements$$,
   '42501',
   null,
   'authenticated cannot delete from the feed'

--- a/apps/docs/content/troubleshooting/interpreting-supabase-grafana-io-charts-MUynDR.mdx
+++ b/apps/docs/content/troubleshooting/interpreting-supabase-grafana-io-charts-MUynDR.mdx
@@ -42,7 +42,7 @@ Excessive IO usage is highly problematic as it clarifies that your database is e
 
 - **Excessive and needless sequential scans:** poorly indexed tables force requests to scan disk ([guide to resolve](https://github.com/orgs/supabase/discussions/22449))
 - **Too little cache**: There is not enough memory, so instead of reading data from the memory cache, it is accessed from disk ([guide to inspect](https://github.com/orgs/supabase/discussions/22449))
-- **Poorly optimized RLS policies**: RLS that rely heavily on joins are more likely to hit disk. If possible, they should optimized ([RLS performance guide](/docs/guides/database/postgres/row-level-security-performance))
+- **Poorly optimized RLS policies**: RLS that rely heavily on joins are more likely to hit disk. If possible, they should be optimized ([RLS performance guide](/docs/guides/database/postgres/row-level-security-performance))
 - **Excessive bloat**: This is the least likely to cause major issues, but bloat can take up space, preventing data on disk from being placed in the same locality. This can force the database to scan more pages than necessary. ([explainer guide](/blog/postgres-bloat))
 - **Uploading high amounts of data:** temporarily increase compute add-on size for the duration of the uploads
 - **Insufficient memory**: Sometimes an inadequate amount of memory forces queries to hit disk instead of the memory cache. Address memory issues ([guide](https://github.com/orgs/supabase/discussions/27021)) can reduce disk strain.


### PR DESCRIPTION
Stacked on #49017. Review that first.

## Problem

The `build-docs-002-rls-guide` eval points an agent at this guide with a vibe-coder prompt that never says RLS, policy, role, or test. Grants, policies, access probes, indexes, and security-definer placement all pass now. Three checks still fail, and they have failed on every recorded run:

| Check | What it measures | Why it failed |
| --- | --- | --- |
| `pgTAP test file(s) written under supabase/tests/` | Any `.sql` file exists | The agent never wrote one. |
| `supabase test db runs at least 8 assertions and all pass` | The suite runs, ≥8 assertions, none failing | Nothing to run. The guide's only example was `plan(4)`, below the floor even if copied perfectly. |
| `tests assert allow and deny per operation on the seeded tables, for anon and authenticated` | LLM judge on coverage | Never reached the judge: "no test files to review". |

The guide already had a `Test your policies` section, so this isn't a strength problem. It's a placement problem. Agents don't read the page — they fetch it through an LLM extraction guided by their own query, and that query asked for enabling RLS, policy syntax, `auth.uid()`, indexes, and security definer functions. It never mentioned tests. A separate testing section never enters the extract, so more testing prose cannot reach the agent.

Separately, a claim-by-claim check against the [RLS basics](https://github.com/supabase/agent-skills/blob/main/skills/supabase-postgres-best-practices/references/security-rls-basics.md) and [RLS performance](https://github.com/supabase/agent-skills/blob/main/skills/supabase-postgres-best-practices/references/security-rls-performance.md) skill references and the Supacademy RLS course found inaccuracies and three uncovered failure modes.

## Solution

### Testing is now a step of the procedure, not advice at the end

`Secure a table with RLS` already opened by saying a table isn't secured until the suite passes, but the procedure underneath it ended on `grant`. A reader following the numbered steps finished without ever being told to write a test.

- `Lock down the table` gains **step 4**: `supabase test new <table>_rls.test`, then `supabase test db`. The procedure now ends on a passing suite.
- The two worked examples each carry their test file inline, so a test file rides along in the extracts an agent actually pulls — one after the enable/revoke/grant block, one after the four `create policy` examples.
- `Test your policies` shrinks to creating and running the files. It no longer carries content that has to survive extraction.
- Each file leads with its own path as a comment, so it survives if the fence metadata is dropped.

### How that maps to the three checks

| Check | Addressed by |
| --- | --- |
| Test files written | A complete test file now sits inside both of the extracts the agent's own query pulls, and step 4 of the procedure names the command that creates one. |
| ≥8 assertions, all passing | `announcements_rls.test.sql` is `plan(8)` and `profiles_rls.test.sql` is `plan(12)`. Either file alone meets or clears the floor; together they are 20. Both were run — see below. |
| Coverage judge | `profiles` asserts allow **and** deny for all four operations. Allowed writes use `returning` + `results_eq`, so they prove state changed rather than that nothing raised. `using`-filtered denials use `is_empty`, asserting the row is unchanged rather than that an error was raised — the case the rubric explicitly fails suites for getting wrong. Both files switch role with `set local role` and identity with `set local request.jwt.claim.sub`, and cover `anon` as well as `authenticated`. |

**What this does not do:** the judge requires assertions naming every seeded table in its fixture. A guide can't know those. It teaches two shapes — owner-private and public-read — and says to repeat the file for every table you secure, including member and non-member cases for shared tables. The agent still has to generalize.

### Corrections

Permissive vs restrictive combination, `force row level security` and who it doesn't apply to, revoking `execute` on helper functions without breaking the policy that calls them, `null = user_id` being unknown rather than false, updates needing a select policy, `auth.jwt()` returning jsonb, views running with owner rights, composite index leading columns, and `updateUser()`.

The worst one: the team membership policy never ran at all. `team_id in (select auth.jwt() -> 'app_metadata' -> 'teams')` fails at `create policy` with `operator does not exist: uuid = jsonb`.

### New sections

- **`Avoid recursive policies`** — two tables whose policies read each other raise `42P17`. Sharing features produce exactly that shape. Broken with a security definer helper.
- **Materialized views**, in `Expose a view safely` — a materialized view consults no policy, and Postgres rejects both `security_invoker` and `enable row level security` on one.
- **`Debug a policy`** — which role ran the query, `pg_policies`, and separating a hidden row from an absent one.
- `search_path` stated as a principle rather than the literal `''`, which contradicted the event trigger recipe in `event-triggers.mdx`.
- Custom claims and RBAC, Storage access control, and Realtime authorization added to `Related content`.

## Verification

Everything asserted here was executed against a local Postgres 17 before being written down.

| Claim | Result |
| --- | --- |
| Both test files run | `Files=2, Tests=20, Result: PASS` |
| …and aren't vacuous | Sabotaging one expected value produced `Failed test 2` |
| Published team policy is broken | `ERROR: operator does not exist: uuid = jsonb`, at `create policy` |
| Its replacement works | Member of a team sees exactly their row; member of none sees zero |
| Mutually recursive policies fail | `ERROR: 42P17: infinite recursion detected in policy for relation "lists"` |
| The helper breaks the cycle | Member who isn't the owner reads the list; non-member reads nothing |
| `security_invoker` on a matview | `ERROR: unrecognized parameter "security_invoker"` |
| RLS on a matview | `ERROR: ALTER action ENABLE ROW SECURITY cannot be performed` |
| `create policy` on a matview | `ERROR: "mv2" is not a table` |
| A granted matview leaks | Non-owner reads 0 rows from the base table, 1 from the matview |
| `search_path = ''` resolves `pg_catalog` | `format()` and `current_setting()` resolve unqualified |

The SQL was re-extracted from the rendered MDX and run again, so the published blocks are the ones that were tested.

Two hypotheses were **refuted** by running them, and are deliberately not changed: `results_eq` over `INSERT … RETURNING` and `insert into auth.users (id, email)` both work.

The public-read example table is named `announcements`. It was `weather_readings`, which matched a fixture table in the eval and coupled the guide to a harness readers can't see.

## Manual testing

1. Open the [Row Level Security guide](https://docs-git-docs-rls-guide-corrections-supabase.vercel.app/docs/guides/database/postgres/row-level-security) on the preview. `Secure a table with RLS` opens with a four-step definition of done that ends on `supabase test db`.
2. Read `Lock down the table`. The procedure runs 1–4 and ends on writing and running the test, not on the grant.
3. Scroll to `DELETE policies`. The four policies are followed immediately by `profiles_rls.test.sql`, not by a pointer to a later section.
4. Check `Avoid recursive policies` and `Debug a policy` appear in the table of contents under `RLS reference`.
5. Open the [markdown version](https://docs-git-docs-rls-guide-corrections-supabase.vercel.app/docs/guides/database/postgres/row-level-security.md), which is what agents fetch. Both test files are present, each leading with its path.
