### PR TITLE
docs(database): correct the RLS guide for failures

### DIFF
--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -41,11 +41,13 @@ That policy translates to this whenever a user selects from the todos table:
 ```sql
 select *
 from todos
-where auth.uid() = todos.user_id;
+where (select auth.uid()) = todos.user_id;
 -- Policy is implicitly added.
 ```
 
 You write RLS rules in SQL, so a rule can express whatever access logic your app needs. Because RLS is a Postgres primitive, it also protects your data when it is reached through third-party tooling, which is what makes it "[defense in depth](<https://en.wikipedia.org/wiki/Defense_in_depth_(computing)>)". Combine RLS with [Supabase Auth](/docs/guides/auth) for end-to-end user security from the browser to the database.
+
+Multiple policies for the same role and operation are permissive by default: if any one of them passes, the row is allowed. A second permissive policy widens access; it does not narrow it. To require two checks at once, mark one `as restrictive`. See [MFA](#mfa). Restrictive policies only reduce access after at least one permissive policy has granted it.
 
 ### Grants and policies
 
@@ -64,6 +66,8 @@ Adding policies doesn't take those grants back. A table protected only by polici
 Not every project grants these automatically. See [Default privileges](/docs/guides/api/securing-your-api#default-privileges). Grant each role only the operations it needs.
 
 A missing grant raises a `42501` error before any policy runs. When a request fails that your policy should allow, check the grants before you change the policy. To set them, see [Enable RLS and set the grants](#enable-rls-and-set-the-grants).
+
+Table owners skip RLS unless you force it. Superusers and roles with `bypassrls` always skip RLS; `force row level security` does not apply to them. On Supabase, `postgres` is not a superuser, but it has `bypassrls`, so the Dashboard SQL Editor skips policies even after you force them. That is why the test files switch role. Add `alter table ... force row level security` only when a table owner without `bypassrls` must also obey policies.
 
 ### Authenticated and unauthenticated roles
 
@@ -98,7 +102,7 @@ A policy that reads `to anon using ( true )` grants every unauthenticated visito
 
 ### Views and RLS
 
-Views bypass RLS by default because they are usually created with the `postgres` user. This is a feature of Postgres, which automatically creates views with `security definer`. A view over a protected table hands out every row its policies were meant to withhold, so a view needs the same attention as a table. To create one safely, see [Expose a view safely](#expose-a-view-safely).
+Views bypass RLS by default because they are usually created with the `postgres` user. Postgres creates views with the owner's rights (`security_invoker` defaults to false), so a view over a protected table hands out every row its policies were meant to withhold. A view needs the same attention as a table. To create one safely, see [Expose a view safely](#expose-a-view-safely).
 
 ## Secure a table with RLS
 
@@ -239,7 +243,7 @@ If new tables still receive automatic grants, see [Revoke default privileges](/d
 
 ### Write a policy for each operation
 
-Write a separate policy for `select`, `insert`, `update`, and `delete`. Postgres does not accept multiple operations in one `for` clause, and a `for all` policy hides which operation each rule was meant to cover.
+Write a separate policy for `select`, `insert`, `update`, and `delete`. Postgres does not accept multiple operations in one `for` clause, and a `for all` policy hides which operation each rule was meant to cover. To deny an operation, grant nothing and write no policy for it.
 
 These examples use a `profiles` table where each user manages only their own row:
 
@@ -296,7 +300,7 @@ If no `with check` expression is defined, the `using` expression decides both wh
 
 <Admonition type="caution">
 
-To perform an `UPDATE` operation, a corresponding [`SELECT` policy](#select-policies) is required. Without a `SELECT` policy, the `UPDATE` operation will not work as expected.
+An `update` that reads the row also needs a matching [`select` policy](#select-policies). That includes a `where` clause, a `returning` clause, and Data API updates, which filter by column and return the updated row. Without a `select` policy, the update matches zero rows rather than raising an error. A SQL `update` that assigns constants and has no `where` or `returning` clause can succeed with only an `update` policy.
 
 </Admonition>
 
@@ -501,7 +505,7 @@ on test_table
 using btree (user_id);
 ```
 
-A column counts as indexed only when it comes first in a `btree` index. Postgres can't use a multi-column index to filter on a column that isn't the leading one, so a composite primary key indexes its first column and no others. A membership table keyed on `(team_id, user_id)` has no index on `user_id`:
+A policy filter uses a `btree` index most efficiently when the filter column leads the index. A composite primary key on `(team_id, user_id)` leads with `team_id`, so a policy that filters on `user_id` still needs its own index:
 
 ```sql
 create table team_members (
@@ -546,7 +550,7 @@ Indexing the filter columns and wrapping helper calls keeps policies fast as a t
 
 ### Expose a view safely
 
-In Postgres 15 and above, make a view obey the RLS policies of its underlying tables when invoked by `anon` and `authenticated` by setting `security_invoker = true`.
+In Postgres 15 or later, make a view obey the RLS policies of its underlying tables when invoked by `anon` and `authenticated` by setting `security_invoker = true`.
 
 ```sql
 create view <VIEW_NAME>
@@ -555,6 +559,20 @@ as select <QUERY>
 ```
 
 In older versions of Postgres, protect your views by revoking access from the `anon` and `authenticated` roles, or by putting them in an unexposed schema.
+
+A materialized view has none of these options. It stores its own copy of the rows, so it doesn't consult the policies on the tables it was built from, and Postgres rejects both `security_invoker` and `enable row level security` on one. Granting `select` on a materialized view hands the client every row it holds:
+
+```sql
+-- Reject: the client reads rows the base table's policies withhold.
+create materialized view reports_summary as select * from public.reports;
+grant select on reports_summary to authenticated;
+```
+
+Keep materialized views out of exposed schemas, or grant no client role access to them:
+
+```sql
+revoke all on reports_summary from anon, authenticated;
+```
 
 ## RLS reference
 
@@ -568,29 +586,11 @@ Supabase provides some helper functions that make it easier to write policies.
 
 Returns the ID of the user making the request.
 
-<Admonition type="caution" title="`auth.uid()` Returns `null` When Unauthenticated">
+<Admonition type="caution" title="`auth.uid()` returns `null` when unauthenticated">
 
-When a request is made without an authenticated user (e.g., no access token is provided or the session has expired), `auth.uid()` returns `null`.
+When a request has no signed-in user, `auth.uid()` returns `null`. `null = user_id` is unknown in SQL, so a policy like `using (auth.uid() = user_id)` filters the row out instead of raising an error.
 
-This means that a policy like:
-
-```sql
-USING (auth.uid() = user_id)
-```
-
-will silently fail for unauthenticated users, because:
-
-```sql
-null = user_id
-```
-
-is always false in SQL.
-
-To avoid confusion and make your intention clear, we recommend explicitly checking for authentication:
-
-```sql
-USING (auth.uid() IS NOT NULL AND auth.uid() = user_id)
-```
+Scope the policy with `to authenticated` so the expression does not run for `anon`. That is both the correct intention and the cheaper plan. See [Specify roles in your policies](#specify-roles-in-your-policies).
 
 </Admonition>
 
@@ -602,18 +602,20 @@ Not all information present in the JWT should be used in RLS policies. For insta
 
 </Admonition>
 
-Returns the JWT of the user making the request. Anything that you store in the user's `raw_app_meta_data` column or the `raw_user_meta_data` column will be accessible using this function. It's important to know the distinction between these two:
+Returns the JWT claims of the user making the request as `jsonb`. Anything that you store in the user's `raw_app_meta_data` column or the `raw_user_meta_data` column is copied into those claims. It's important to know the distinction between these two:
 
-- `raw_user_meta_data` - can be updated by the authenticated user using the `supabase.auth.update()` function. It is not a good place to store authorization data.
+- `raw_user_meta_data` - can be updated by the authenticated user using [`updateUser()`](/docs/reference/javascript/auth-updateuser). It is not a good place to store authorization data.
 - `raw_app_meta_data` - cannot be updated by the user, so it's a good place to store authorization data.
 
-The `auth.jwt()` function is extremely versatile. For example, if you store some team data inside `app_metadata`, you can use it to determine whether a particular user belongs to a team. For example, if this was an array of IDs:
+The `auth.jwt()` function is extremely versatile. For example, if you store some team data inside `app_metadata`, you can use it to determine whether a particular user belongs to a team. If `teams` is a JSON array of IDs:
 
 ```sql
 create policy "User is in team"
 on my_table
 to authenticated
-using ( team_id in (select auth.jwt() -> 'app_metadata' -> 'teams'));
+using (
+  ((select auth.jwt()) -> 'app_metadata' -> 'teams') ? team_id::text
+);
 ```
 
 <Admonition type="caution">
@@ -638,9 +640,11 @@ to authenticated using (
 );
 ```
 
+This restrictive check only applies after a permissive update policy has allowed the row. A table with only restrictive policies denies every row.
+
 ### Use security definer functions
 
-A "security definer" function runs using the same role that _created_ the function. This means that if you create a role with a superuser (like `postgres`), then that function will have `bypassrls` privileges. For example, if you had a policy like this:
+A `security definer` function runs as the role that owns it, not the caller. Functions you create as `postgres` skip RLS because `postgres` has `bypassrls`. That is useful for looking up roles without paying RLS on the lookup table, and dangerous if the function is callable without checking `(select auth.uid())`. For example, if you had a policy like this:
 
 ```sql
 create policy "rls_test_select" on test_table
@@ -653,13 +657,13 @@ using (
 );
 ```
 
-We can instead create a `security definer` function which can scan `roles_table` without any RLS penalties:
+You can instead create a `security definer` function which can scan `roles_table` without any RLS penalties:
 
 ```sql
 create function private.has_good_role()
 returns boolean
 language plpgsql
-security definer -- will run as the creator
+security definer -- runs as the owner
 set search_path = '' -- every name inside must be schema-qualified
 as $$
 begin
@@ -670,6 +674,10 @@ begin
 end;
 $$;
 
+revoke execute on function private.has_good_role() from public;
+grant usage on schema private to authenticated;
+grant execute on function private.has_good_role() to authenticated;
+
 -- Update our policy to use this function:
 create policy "rls_test_select"
 on test_table
@@ -679,7 +687,7 @@ using ( (select private.has_good_role()) );
 
 Add member and non-member cases to that table's file under `supabase/tests/`. A member who is not the owner must be allowed; a non-member must not.
 
-Set `search_path = ''` on every `security definer` function and schema-qualify the names inside it. Without a pinned `search_path`, a caller can point an unqualified name at their own object and run it with the function owner's privileges.
+Pin `search_path` on every `security definer` function to a schema its callers can't write to, and schema-qualify the names inside it. `search_path = ''` is the usual choice, and it still resolves `pg_catalog`, which Postgres always searches. Without a pinned `search_path`, a caller can point an unqualified name at their own object and run it with the function owner's privileges. Check `(select auth.uid())` inside the function body. Revoke `execute` from `public`, then grant `usage` on the schema and `execute` on the function to the role the policy uses. Policy expressions run as the caller, so that role needs both. Keep the function in an unexposed schema so it is not an RPC. New functions grant `execute` to `public` by default.
 
 <Admonition type="caution">
 
@@ -747,6 +755,17 @@ The function filters on `(select auth.uid())`, so it returns only the caller's l
 
 This works because the function runs as its owner, and a `security definer` function only skips RLS when its owner can. On Supabase the owner is `postgres`, which has `bypassrls`. A function owned by a role without `bypassrls`, or reading a table set to `force row level security`, evaluates the membership policy again and stays recursive.
 
+### Debug a policy
+
+A policy that denies too much returns no rows and raises no error, so start by establishing which of the two layers stopped the request.
+
+1. Confirm which role ran the query. `select current_user, (select auth.uid());` inside the same session as the failing statement. The Dashboard SQL Editor runs as `postgres`, which has `bypassrls`, so it can't reproduce a client's result. Switch role first, the way the test files do.
+2. Read the policies on the table. `select * from pg_policies where tablename = 'reports';` shows the command, the roles, the mode, and both expressions for each policy.
+3. Compare a privileged read against the client's read. If a [secret key](/docs/guides/getting-started/api-keys) returns the row and `authenticated` doesn't, the row exists and a policy is hiding it. If neither returns it, the row isn't there and the policy is not your problem.
+4. Check the grants before rewriting anything. A missing grant raises `42501` before any policy runs. See [Grants and policies](#grants-and-policies).
+
+An empty array from the Data API is not proof that no matching row exists. See [Empty select array with rows in the table](/docs/guides/troubleshooting/why-is-my-select-returning-an-empty-data-array-and-i-have-data-in-the-table-xvOPgx) for the same problem from the client side.
+
 ### Bypassing Row Level Security
 
 Use a [secret key](/docs/guides/getting-started/api-keys) for administrative tasks that need to bypass RLS. A secret key authorizes access through the `service_role` Postgres role, which has the `bypassrls` attribute. Never use a secret key in the browser or expose it to customers.
@@ -774,4 +793,7 @@ This can be useful for system-level access. **Never** share login credentials fo
 - [Testing your database](/docs/guides/database/testing): the CLI test workflow that `supabase test db` runs.
 - [Securing your API](/docs/guides/api/securing-your-api): grants, dedicated schemas, and pre-request checks around the Data API.
 - [Column Level Security](/docs/guides/database/postgres/column-level-security): restrict access to individual columns.
+- [Custom claims and RBAC](/docs/guides/api/custom-claims-and-role-based-access-control-rbac): model roles and permissions in tables when ownership isn't enough.
+- [Storage access control](/docs/guides/storage/security/access-control): RLS on `storage.objects`, where the policy targets a bucket and a path.
+- [Realtime authorization](/docs/guides/realtime/authorization): RLS on channels, which reads claims differently from a table policy.
 - [`supabase-test-helpers`](https://github.com/usebasejump/supabase-test-helpers/tree/main): a community extension that adds user creation and role impersonation helpers to pgTAP.


### PR DESCRIPTION
Stacked on #49276. Review that first.

## Problem

A claim-by-claim check of the restructured guide against the [RLS basics](https://github.com/supabase/agent-skills/blob/main/skills/supabase-postgres-best-practices/references/security-rls-basics.md) and [RLS performance](https://github.com/supabase/agent-skills/blob/main/skills/supabase-postgres-best-practices/references/security-rls-performance.md) skill references, the Supacademy RLS course, and Postgres itself.

The worst finding: the team membership policy never ran. `team_id in (select auth.jwt() -> 'app_metadata' -> 'teams')` fails at `create policy` with `operator does not exist: uuid = jsonb`, because `->` returns one jsonb value and `in (select …)` compares `team_id` against it.

Three failure modes were missing entirely — recursive policies, materialized views, and how to debug a policy that denies too much. All three are treated as core by both reference sources.

## Solution

### Corrections

- **Team JWT policy** rewritten with jsonb containment.
- **Permissive vs restrictive** — permissive policies OR together; a restrictive policy ANDs and only narrows what a permissive policy already granted. `as restrictive` appeared once, in the MFA example, unexplained.
- **`force row level security`** — table owners skip RLS unless forced, and forcing still doesn't apply to superusers or `bypassrls` roles. On Supabase `postgres` isn't a superuser but does have `bypassrls`.
- **`revoke execute` on helpers** — revoke from `public`, then grant `usage` and `execute` to the role the policy uses. Policy expressions run as the caller, so revoking from that role breaks the policy that calls the function.
- **`null = user_id`** is unknown, not false.
- **Update needs a select policy** when it reads the row, which is most updates — not only Data API ones.
- **`auth.jwt()`** returns claims as jsonb, not the token string.
- **Views** run with owner rights because `security_invoker` defaults to false, not because Postgres marks them `security definer`.
- **Composite indexes** — a composite primary key leads with its first column, so a filter on a later column needs its own index. Dropped the claim that Postgres can never use a non-leading column.
- **`supabase.auth.update()`** is not a method. It's `updateUser()`.

### New sections

- **`Avoid recursive policies`** — two tables whose policies read each other raise `42P17`. A sharing feature produces exactly that shape. Broken with a security definer helper that reads membership as its owner, so the second policy never runs.
- **Materialized views**, in `Expose a view safely` — a materialized view stores its own rows, consults no policy, and Postgres rejects both `security_invoker` and `enable row level security` on one.
- **`Debug a policy`** — which role ran the query, `pg_policies`, comparing a privileged read against the client's, and grants before rewriting anything.

### Also

`search_path` stated as a principle — pin it to a schema callers can't write to — rather than the literal `''`, which contradicted the event trigger recipe in `event-triggers.mdx`. Custom claims and RBAC, Storage access control, and Realtime authorization added to `Related content`.

## Verification

Every claim was executed against a local Postgres 17 before being written down.

| Claim | Result |
| --- | --- |
| Published team policy is broken | `ERROR: operator does not exist: uuid = jsonb`, at `create policy` |
| Its replacement works | Member of a team sees exactly their row; member of none sees zero |
| Mutually recursive policies fail | `ERROR: 42P17: infinite recursion detected in policy for relation "lists"` |
| The helper breaks the cycle | Member who isn't the owner reads the list; non-member reads nothing |
| `security_invoker` on a matview | `ERROR: unrecognized parameter "security_invoker"` |
| RLS on a matview | `ERROR: ALTER action ENABLE ROW SECURITY cannot be performed` |
| `create policy` on a matview | `ERROR: "mv2" is not a table` |
| A granted matview leaks | Non-owner reads 0 rows from the base table, 1 from the matview |
| `search_path = ''` resolves `pg_catalog` | `format()` and `current_setting()` resolve unqualified |

The SQL in `Avoid recursive policies` was re-extracted from the rendered MDX and run again, so the published blocks are the ones that were tested.

## Manual testing

1. Open the [Row Level Security guide](https://docs-git-docs-rls-guide-accuracy-supabase.vercel.app/docs/guides/database/postgres/row-level-security) on the preview. `Avoid recursive policies` and `Debug a policy` appear in the table of contents under `RLS reference`.
2. Select the [security definer function](https://docs-git-docs-rls-guide-accuracy-supabase.vercel.app/docs/guides/database/postgres/row-level-security#use-security-definer-functions) link inside `Avoid recursive policies`. It jumps to that section.
3. Read `Expose a view safely`. The materialized view guidance follows the Postgres 15 note.
4. Read the `auth.jwt()` team policy. It uses jsonb containment and carries `for select` and `to authenticated`.
