### PR TITLE
fix(www): point the homepage Vue quickstart links at the page that exists

### DIFF
--- a/apps/www/app/(home)/_components/FrameworksSection.tsx
+++ b/apps/www/app/(home)/_components/FrameworksSection.tsx
@@ -208,7 +208,7 @@ onMounted(async () => {
 })
 </script>`,
     lang: 'vue' as const,
-    docsUrl: '/docs/guides/getting-started/quickstarts/vuejs',
+    docsUrl: '/docs/guides/getting-started/quickstarts/vue',
   },
   {
     name: 'Nuxt',
@@ -307,7 +307,7 @@ const frameworkExamples: Record<
     {
       title: 'Auth with Vue',
       description: 'Email and OAuth authentication.',
-      url: '/docs/guides/getting-started/quickstarts/vuejs',
+      url: '/docs/guides/getting-started/quickstarts/vue',
       icon: 'KeyRound',
     },
   ],


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix. Closes #49142.

## What is the current behavior?

The homepage framework section links Vue at `quickstarts/vuejs`, and the page is `quickstarts/vue`, so both links 404:

| url | live |
| --- | --- |
| `/docs/guides/getting-started/quickstarts/vuejs` | 404 |
| `/docs/guides/getting-started/quickstarts/vue` | 200 |

It is two links rather than the one in the report. `apps/www/app/(home)/_components/FrameworksSection.tsx` has the same typo in the code-window "Read docs" button (line 211) and in the "Auth with Vue" card (line 310).

The repo already spells it correctly in `components/Hero/HeroFrameworks.tsx` and `data/frameworks.ts`, so this is an inconsistency inside www rather than a rename that was missed everywhere.

## What is the new behavior?

Both point at `quickstarts/vue`.

## Additional context

Scope check: I swept every `getting-started/quickstarts/*` link in `apps/www`. 31 resolve, and these 2 are the only dead ones, so this is the whole of it rather than the first of a series.

Verification, since a status code alone would not be enough here. I checked a nonsense slug in the same directory first (`/docs/guides/getting-started/quickstarts/zzz-canary-must-404` returns 404), so 404s in this namespace are meaningful, then confirmed the target's front matter reads `title: 'Use Supabase with Vue'`. There is no redirect covering `vuejs`, so nothing rescues it today.

One judgement call I want to flag rather than bury. The second link sits under "Auth with Vue", and the React equivalent a few entries up points at `auth/quickstarts/react`. There is no `auth/quickstarts/vue` (the auth quickstarts are astrojs, nextjs, react, react-native and with-expo-react-native-social-auth), so I only corrected the slug and kept the entry's original destination. If you would rather that card pointed somewhere else, that is a content decision and I am happy to change it.

Gates: `test:prettier` passes repo wide, `typecheck --filter=www --force` passes, and the www vitest suite passes (6 files, 75 tests).

Freshman contributor. Picked this up from the issue, and I verified the canary, both status codes, the target page's title and the sweep myself before changing anything.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Vue framework documentation links and example URLs to use the correct `/vue` path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->