### PR TITLE
feat(studio): lighten logs.all deprecation banner

### DIFF
--- a/apps/studio/components/interfaces/App/AppBannerWrapper.tsx
+++ b/apps/studio/components/interfaces/App/AppBannerWrapper.tsx
@@ -3,6 +3,7 @@ import { usePathname } from 'next/navigation'
 import { PropsWithChildren, useEffect, useRef } from 'react'
 
 import { OrganizationResourceBanner } from '../Organization/HeaderBanner'
+import { isLogsOrObservabilityPath } from './AppBannerWrapper.utils'
 import { ClockSkewBanner } from '@/components/layouts/AppLayout/ClockSkewBanner'
 import { NoticeBanner } from '@/components/layouts/AppLayout/NoticeBanner'
 import { StatusPageBanner } from '@/components/layouts/AppLayout/StatusPageBanner'
@@ -17,9 +18,6 @@ const TOSUpdateExpiry = new Date('2026-08-29T00:00:00Z')
 // Update this whenever the banner content changes so old client bundles stop
 // displaying the notice after the removal date passes.
 const LogsAllDeprecationExpiry = new Date('2026-09-24T00:00:00Z')
-// Anchored to the section root so per-resource log pages (e.g. a single edge
-// function's logs) don't pull the banner outside Logs/Observability.
-const LOGS_SECTION_PATH = /^\/project\/[^/]+\/(logs|observability)(\/|$)/
 
 export const AppBannerWrapper = ({ children }: PropsWithChildren<{}>) => {
   const showNoticeBanner = useFlag('showNoticeBanner')
@@ -52,17 +50,17 @@ export const AppBannerWrapper = ({ children }: PropsWithChildren<{}>) => {
   const [isLogsAllDeprecationDismissed, , { isSuccess: isLogsAllDeprecationLoaded }] =
     useLocalStorageQuery(LOCAL_STORAGE_KEYS.LOGS_ALL_DEPRECATION_2026_09_23, false)
 
-  const shouldShowLogsAllDeprecation =
-    IS_PLATFORM &&
-    Date.now() < LogsAllDeprecationExpiry.getTime() &&
-    !!pathname &&
-    LOGS_SECTION_PATH.test(pathname) &&
-    isLogsAllDeprecationLoaded &&
-    !isLogsAllDeprecationDismissed
-
   const hasTrackedLogsAllExposure = useRef(false)
   useEffect(() => {
-    if (!shouldShowLogsAllDeprecation) {
+    if (!isLogsAllDeprecationLoaded || pathname == null) return
+
+    const shouldShow =
+      IS_PLATFORM &&
+      Date.now() < LogsAllDeprecationExpiry.getTime() &&
+      isLogsOrObservabilityPath(pathname) &&
+      !isLogsAllDeprecationDismissed
+
+    if (!shouldShow) {
       dismissBanner(BANNER_ID.LOGS_ALL_DEPRECATION)
       return
     }
@@ -78,7 +76,14 @@ export const AppBannerWrapper = ({ children }: PropsWithChildren<{}>) => {
       hasTrackedLogsAllExposure.current = true
       track('logs_all_deprecation_banner_exposed')
     }
-  }, [shouldShowLogsAllDeprecation, addBanner, dismissBanner, track])
+  }, [
+    pathname,
+    isLogsAllDeprecationLoaded,
+    isLogsAllDeprecationDismissed,
+    addBanner,
+    dismissBanner,
+    track,
+  ])
 
   return (
     <div className="flex flex-col">

--- a/apps/studio/components/interfaces/App/AppBannerWrapper.utils.ts
+++ b/apps/studio/components/interfaces/App/AppBannerWrapper.utils.ts
@@ -1,0 +1,8 @@
+// Anchored to the section root so per-resource log pages (e.g. a single edge
+// function's logs) don't pull the banner outside Logs/Observability.
+const LOGS_SECTION_PATH = /^\/project\/[^/]+\/(logs|observability)(\/|$)/
+
+export function isLogsOrObservabilityPath(pathname: string | null | undefined): boolean {
+  if (!pathname) return false
+  return LOGS_SECTION_PATH.test(pathname)
+}

--- a/apps/studio/components/ui/BannerStack/BannerStackProvider.test.tsx
+++ b/apps/studio/components/ui/BannerStack/BannerStackProvider.test.tsx
@@ -1,0 +1,70 @@
+import { act, renderHook } from '@testing-library/react'
+import { type PropsWithChildren } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { BANNER_ID, BannerStackProvider, useBannerStack } from './BannerStackProvider'
+
+const wrapper = ({ children }: PropsWithChildren) => (
+  <BannerStackProvider>{children}</BannerStackProvider>
+)
+
+describe('BannerStackProvider', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('keeps a banner that is revived before the dismiss animation finishes', () => {
+    const { result } = renderHook(() => useBannerStack(), { wrapper })
+
+    act(() => {
+      result.current.dismissBanner(BANNER_ID.LOGS_ALL_DEPRECATION)
+    })
+
+    act(() => {
+      result.current.addBanner({
+        id: BANNER_ID.LOGS_ALL_DEPRECATION,
+        isDismissed: false,
+        content: null,
+      })
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(300)
+    })
+
+    expect(result.current.banners).toEqual([
+      expect.objectContaining({
+        id: BANNER_ID.LOGS_ALL_DEPRECATION,
+        isDismissed: false,
+      }),
+    ])
+  })
+
+  it('removes a banner after the dismiss animation when it stays dismissed', () => {
+    const { result } = renderHook(() => useBannerStack(), { wrapper })
+
+    act(() => {
+      result.current.addBanner({
+        id: BANNER_ID.LOGS_ALL_DEPRECATION,
+        isDismissed: false,
+        content: null,
+      })
+    })
+
+    act(() => {
+      result.current.dismissBanner(BANNER_ID.LOGS_ALL_DEPRECATION)
+    })
+
+    expect(result.current.banners[0]?.isDismissed).toBe(true)
+
+    act(() => {
+      vi.advanceTimersByTime(300)
+    })
+
+    expect(result.current.banners).toEqual([])
+  })
+})

--- a/apps/studio/components/ui/BannerStack/BannerStackProvider.tsx
+++ b/apps/studio/components/ui/BannerStack/BannerStackProvider.tsx
@@ -48,7 +48,9 @@ export const BannerStackProvider = ({ children }: { children: React.ReactNode })
   const dismissBanner = useCallback((id: string) => {
     setBanners((prev) => prev.map((b) => (b.id === id ? { ...b, isDismissed: true } : b)))
     setTimeout(() => {
-      setBanners((prev) => prev.filter((b) => b.id !== id))
+      // A later addBanner can revive this id before the exit animation
+      // finishes. Drop it only if it is still dismissed.
+      setBanners((prev) => prev.filter((b) => b.id !== id || !b.isDismissed))
     }, 300)
   }, [])
 

--- a/apps/studio/components/ui/BannerStack/Banners/BannerLogsAllDeprecation.tsx
+++ b/apps/studio/components/ui/BannerStack/Banners/BannerLogsAllDeprecation.tsx
@@ -1,5 +1,6 @@
 import { LOCAL_STORAGE_KEYS } from 'common'
-import { Button } from 'ui'
+import { ExternalLink } from 'lucide-react'
+import { Badge, Button } from 'ui'
 
 import { BannerCard } from '../BannerCard'
 import { BANNER_ID, useBannerStack } from '../BannerStackProvider'
@@ -26,22 +27,29 @@ export const BannerLogsAllDeprecation = () => {
         track('logs_all_deprecation_banner_dismissed')
       }}
     >
-      <div className="flex flex-col gap-y-4">
+      <div className="flex flex-col gap-y-2">
+        <Badge variant="default" className="w-min -ml-0.5 uppercase inline-flex items-center mb-2">
+          Notice
+        </Badge>
+
         <div className="flex flex-col gap-y-1 mb-2">
-          <p className="text-sm font-medium">logs.all endpoint is removed on September 23</p>
+          <p className="text-sm font-medium">Logs endpoint retires September 23</p>
           <p className="text-xs text-foreground-lighter text-balance">
-            If you query project logs through the <code>analytics/endpoints/logs.all</code>{' '}
-            Management API endpoint, migrate to <code>analytics/endpoints/logs</code> before then.
-            The new endpoint uses ClickHouse SQL, so queries need rewriting.
+            Scripts that call the <code className="text-code-inline break-keep!">logs.all</code>{' '}
+            Management API endpoint need to migrate. Dashboard logs are unchanged.
           </p>
         </div>
-        <div className="flex gap-2">
-          <Button variant="default" size="tiny" asChild>
-            <a href={MIGRATION_GUIDE_URL} target="_blank" rel="noreferrer noopener">
-              View migration guide
-            </a>
-          </Button>
-        </div>
+        <Button
+          variant="default"
+          size="tiny"
+          className="w-min"
+          asChild
+          iconRight={<ExternalLink size={14} />}
+        >
+          <a href={MIGRATION_GUIDE_URL} target="_blank" rel="noreferrer noopener">
+            View changelog
+          </a>
+        </Button>
       </div>
     </BannerCard>
   )

--- a/apps/studio/components/ui/BannerStack/Banners/BannerLogsAllDeprecation.tsx
+++ b/apps/studio/components/ui/BannerStack/Banners/BannerLogsAllDeprecation.tsx
@@ -1,5 +1,4 @@
 import { LOCAL_STORAGE_KEYS } from 'common'
-import { ExternalLink } from 'lucide-react'
 import { Badge, Button } from 'ui'
 
 import { BannerCard } from '../BannerCard'
@@ -39,15 +38,9 @@ export const BannerLogsAllDeprecation = () => {
             Management API endpoint need to migrate. Dashboard logs are unchanged.
           </p>
         </div>
-        <Button
-          variant="default"
-          size="tiny"
-          className="w-min"
-          asChild
-          iconRight={<ExternalLink size={14} />}
-        >
+        <Button variant="default" size="tiny" className="w-min" asChild>
           <a href={MIGRATION_GUIDE_URL} target="_blank" rel="noreferrer noopener">
-            View changelog
+            Learn more
           </a>
         </Button>
       </div>

--- a/apps/studio/tests/components/interfaces/App/AppBannerWrapper.utils.test.ts
+++ b/apps/studio/tests/components/interfaces/App/AppBannerWrapper.utils.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'vitest'
+
+import { isLogsOrObservabilityPath } from '@/components/interfaces/App/AppBannerWrapper.utils'
+
+describe('isLogsOrObservabilityPath', () => {
+  test.each([
+    '/project/abc/logs',
+    '/project/abc/logs/',
+    '/project/abc/logs/explorer',
+    '/project/abc/observability',
+    '/project/abc/observability/query-performance',
+  ])('matches %s', (pathname) => {
+    expect(isLogsOrObservabilityPath(pathname)).toBe(true)
+  })
+
+  test.each([
+    undefined,
+    null,
+    '',
+    '/project/abc',
+    '/project/abc/editor',
+    '/project/abc/logs-explorer',
+    '/project/abc/functions/my-fn/logs',
+    '/org/abc/logs',
+  ])('does not match %s', (pathname) => {
+    expect(isLogsOrObservabilityPath(pathname)).toBe(false)
+  })
+})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Polish on top of #49059.

## What is the current behavior?

The logs.all deprecation banner repeats migration detail in a narrow card, and it can flash then disappear on refresh because a pending dismiss timer removes the banner after localStorage finishes loading.

## What is the new behavior?

- Shortens the banner to a Notice badge, title, one line of copy, and a changelog link with an external-link icon
- Waits for localStorage before deciding whether to show the banner
- Fixes the BannerStack dismiss race so a revived banner is not removed by a stale timer

Stacked on #49059.

| Before | After |
| --- | --- |
| <img width="626" height="528" alt="CleanShot 2026-08-20 at 12 29 49@2x" src="https://github.com/user-attachments/assets/2044966d-bc83-4f88-ac75-1b8ff80be08d" /> | <img width="622" height="440" alt="CleanShot 2026-08-20 at 12 28 33@2x" src="https://github.com/user-attachments/assets/1dc768cd-837c-4a5a-a3fa-7b6986fe5876" /> |

## To test

1. Open `/project/_/logs` or `/project/_/observability` on platform staging
2. Confirm the bottom-right card shows **Logs endpoint retires September 23**, one line of body copy with `logs.all` inline, and a **Learn more** button that opens the changelog in a new tab
3. Refresh the page a few times: the banner should stay visible (unless you previously dismissed it)
4. Dismiss with the X, refresh again, and confirm it stays hidden