### PR TITLE
Hook up recently updated list

### DIFF
--- a/apps/studio/components/layouts/ExplorerLayout/ExplorerNavHome.tsx
+++ b/apps/studio/components/layouts/ExplorerLayout/ExplorerNavHome.tsx
@@ -68,38 +68,35 @@ export const ExplorerNavHome = ({
         ) : (
           recentItems.map((item) => {
             const Icon = EXPLORER_SECTIONS.find((section) => section.type === item.type)?.icon
+            const content = (
+              <>
+                {Icon && <Icon size={14} className="shrink-0" />}
+                <span className="flex-1 truncate text-left">{item.label}</span>
+                <span className="shrink-0 text-xs text-foreground-lighter">
+                  {formatRelativeTimeShort(item.updatedAt)}
+                </span>
+              </>
+            )
 
-            if (item.type === 'chat') {
-              return (
-                <button
-                  key={item.id}
-                  type="button"
-                  tabIndex={0}
-                  className={rowClassName(false)}
-                  onClick={() => openChat(item.id)}
-                >
-                  {Icon && <Icon size={14} className="shrink-0" />}
-                  <span className="flex-1 truncate text-left">{item.label}</span>
-                  <span className="shrink-0 text-xs text-foreground-lighter">
-                    {formatRelativeTimeShort(item.updatedAt)}
-                  </span>
-                </button>
-              )
-            } else {
-              return (
-                <Link
-                  key={item.id}
-                  href={`/project/${ref}/explorer/notebook/${item.id}`}
-                  className={rowClassName(false)}
-                >
-                  {Icon && <Icon size={14} className="shrink-0" />}
-                  <span className="flex-1 truncate text-left">{item.label}</span>
-                  <span className="shrink-0 text-xs text-foreground-lighter">
-                    {formatRelativeTimeShort(item.updatedAt)}
-                  </span>
-                </Link>
-              )
-            }
+            return item.type === 'chat' ? (
+              <button
+                key={item.id}
+                type="button"
+                tabIndex={0}
+                className={rowClassName(false)}
+                onClick={() => openChat(item.id)}
+              >
+                {content}
+              </button>
+            ) : (
+              <Link
+                key={item.id}
+                href={`/project/${ref}/explorer/notebook/${item.id}`}
+                className={rowClassName(false)}
+              >
+                {content}
+              </Link>
+            )
           })
         )}
       </section>

--- a/apps/studio/components/layouts/ExplorerLayout/ExplorerNavHome.tsx
+++ b/apps/studio/components/layouts/ExplorerLayout/ExplorerNavHome.tsx
@@ -1,7 +1,7 @@
 import { useParams } from 'common'
 import { motion } from 'framer-motion'
 import { ChevronRight } from 'lucide-react'
-import { useRouter } from 'next/router'
+import Link from 'next/link'
 
 import {
   EXPLORER_SECTIONS,
@@ -10,11 +10,7 @@ import {
   LEVEL_TRANSITION,
   rowClassName,
 } from './ExplorerLayout.constants'
-import {
-  formatRelativeTimeShort,
-  getRecentlyUpdatedItems,
-  type RecentlyUpdatedItem,
-} from './ExplorerNavHome.utils'
+import { formatRelativeTimeShort, getRecentlyUpdatedItems } from './ExplorerNavHome.utils'
 import { useCreateChat } from '@/components/interfaces/Explorer/hooks'
 import { useNotebooksInfiniteQuery } from '@/data/content/notebooks/notebooks-infinite-query'
 import { useAiAssistantChatList } from '@/state/ai-assistant-state'
@@ -24,23 +20,14 @@ export const ExplorerNavHome = ({
 }: {
   onSelectSection: (section: ExplorerResourceType) => void
 }) => {
-  const router = useRouter()
   const { ref } = useParams()
   const { openChat } = useCreateChat()
 
-  const { data: notebooksData } = useNotebooksInfiniteQuery({ projectRef: ref, limit: 50 })
+  const { data: notebooksData } = useNotebooksInfiniteQuery({ projectRef: ref, limit: 100 })
   const notebooks = notebooksData?.pages.flatMap((page) => page.content) ?? []
   const chats = useAiAssistantChatList()
 
   const recentItems = getRecentlyUpdatedItems({ notebooks, chats })
-
-  const onSelectRecentItem = (item: RecentlyUpdatedItem) => {
-    if (item.type === 'chat') {
-      openChat(item.id)
-    } else {
-      router.push(`/project/${ref}/explorer/notebook/${item.id}`)
-    }
-  }
 
   return (
     <motion.div
@@ -82,21 +69,37 @@ export const ExplorerNavHome = ({
           recentItems.map((item) => {
             const Icon = EXPLORER_SECTIONS.find((section) => section.type === item.type)?.icon
 
-            return (
-              <button
-                key={item.id}
-                type="button"
-                tabIndex={0}
-                className={rowClassName(false)}
-                onClick={() => onSelectRecentItem(item)}
-              >
-                {Icon && <Icon size={14} className="shrink-0" />}
-                <span className="flex-1 truncate text-left">{item.label}</span>
-                <span className="shrink-0 text-xs text-foreground-lighter">
-                  {formatRelativeTimeShort(item.updatedAt)} ago
-                </span>
-              </button>
-            )
+            if (item.type === 'chat') {
+              return (
+                <button
+                  key={item.id}
+                  type="button"
+                  tabIndex={0}
+                  className={rowClassName(false)}
+                  onClick={() => openChat(item.id)}
+                >
+                  {Icon && <Icon size={14} className="shrink-0" />}
+                  <span className="flex-1 truncate text-left">{item.label}</span>
+                  <span className="shrink-0 text-xs text-foreground-lighter">
+                    {formatRelativeTimeShort(item.updatedAt)}
+                  </span>
+                </button>
+              )
+            } else {
+              return (
+                <Link
+                  key={item.id}
+                  href={`/project/${ref}/explorer/notebook/${item.id}`}
+                  className={rowClassName(false)}
+                >
+                  {Icon && <Icon size={14} className="shrink-0" />}
+                  <span className="flex-1 truncate text-left">{item.label}</span>
+                  <span className="shrink-0 text-xs text-foreground-lighter">
+                    {formatRelativeTimeShort(item.updatedAt)}
+                  </span>
+                </Link>
+              )
+            }
           })
         )}
       </section>

--- a/apps/studio/components/layouts/ExplorerLayout/ExplorerNavHome.tsx
+++ b/apps/studio/components/layouts/ExplorerLayout/ExplorerNavHome.tsx
@@ -70,7 +70,7 @@ export const ExplorerNavHome = ({
             const Icon = EXPLORER_SECTIONS.find((section) => section.type === item.type)?.icon
             const content = (
               <>
-                {Icon && <Icon size={14} className="shrink-0" />}
+                {Icon && <Icon size={14} className="shrink-0" aria-hidden="true" />}
                 <span className="flex-1 truncate text-left">{item.label}</span>
                 <span className="shrink-0 text-xs text-foreground-lighter">
                   {formatRelativeTimeShort(item.updatedAt)}

--- a/apps/studio/components/layouts/ExplorerLayout/ExplorerNavHome.tsx
+++ b/apps/studio/components/layouts/ExplorerLayout/ExplorerNavHome.tsx
@@ -1,5 +1,7 @@
+import { useParams } from 'common'
 import { motion } from 'framer-motion'
 import { ChevronRight } from 'lucide-react'
+import { useRouter } from 'next/router'
 
 import {
   EXPLORER_SECTIONS,
@@ -8,12 +10,38 @@ import {
   LEVEL_TRANSITION,
   rowClassName,
 } from './ExplorerLayout.constants'
+import {
+  formatRelativeTimeShort,
+  getRecentlyUpdatedItems,
+  type RecentlyUpdatedItem,
+} from './ExplorerNavHome.utils'
+import { useCreateChat } from '@/components/interfaces/Explorer/hooks'
+import { useNotebooksInfiniteQuery } from '@/data/content/notebooks/notebooks-infinite-query'
+import { useAiAssistantChatList } from '@/state/ai-assistant-state'
 
 export const ExplorerNavHome = ({
   onSelectSection,
 }: {
   onSelectSection: (section: ExplorerResourceType) => void
 }) => {
+  const router = useRouter()
+  const { ref } = useParams()
+  const { openChat } = useCreateChat()
+
+  const { data: notebooksData } = useNotebooksInfiniteQuery({ projectRef: ref, limit: 50 })
+  const notebooks = notebooksData?.pages.flatMap((page) => page.content) ?? []
+  const chats = useAiAssistantChatList()
+
+  const recentItems = getRecentlyUpdatedItems({ notebooks, chats })
+
+  const onSelectRecentItem = (item: RecentlyUpdatedItem) => {
+    if (item.type === 'chat') {
+      openChat(item.id)
+    } else {
+      router.push(`/project/${ref}/explorer/notebook/${item.id}`)
+    }
+  }
+
   return (
     <motion.div
       key="root"
@@ -48,7 +76,29 @@ export const ExplorerNavHome = ({
         <h3 className="mb-2 px-3 font-mono text-sm font-normal uppercase text-foreground-lighter">
           Recently updated
         </h3>
-        <p className="px-3 text-xs text-foreground-lighter">Nothing edited yet</p>
+        {recentItems.length === 0 ? (
+          <p className="px-3 text-xs text-foreground-lighter">Nothing edited yet</p>
+        ) : (
+          recentItems.map((item) => {
+            const Icon = EXPLORER_SECTIONS.find((section) => section.type === item.type)?.icon
+
+            return (
+              <button
+                key={item.id}
+                type="button"
+                tabIndex={0}
+                className={rowClassName(false)}
+                onClick={() => onSelectRecentItem(item)}
+              >
+                {Icon && <Icon size={14} className="shrink-0" />}
+                <span className="flex-1 truncate text-left">{item.label}</span>
+                <span className="shrink-0 text-xs text-foreground-lighter">
+                  {formatRelativeTimeShort(item.updatedAt)} ago
+                </span>
+              </button>
+            )
+          })
+        )}
       </section>
     </motion.div>
   )

--- a/apps/studio/components/layouts/ExplorerLayout/ExplorerNavHome.utils.test.ts
+++ b/apps/studio/components/layouts/ExplorerLayout/ExplorerNavHome.utils.test.ts
@@ -35,7 +35,10 @@ describe('getRecentlyUpdatedItems', () => {
 
   it('filters out support chats', () => {
     const chats = [
-      chat({ id: 'support', supportMetadata: { isSupportChat: true } as ChatSession['supportMetadata'] }),
+      chat({
+        id: 'support',
+        supportMetadata: { isSupportChat: true } as ChatSession['supportMetadata'],
+      }),
     ]
 
     expect(getRecentlyUpdatedItems({ notebooks: [], chats })).toEqual([])

--- a/apps/studio/components/layouts/ExplorerLayout/ExplorerNavHome.utils.test.ts
+++ b/apps/studio/components/layouts/ExplorerLayout/ExplorerNavHome.utils.test.ts
@@ -81,7 +81,7 @@ describe('formatRelativeTimeShort', () => {
 
   it('shows minutes under an hour', () => {
     const timestamp = now - 12 * 60 * 1000
-    expect(formatRelativeTimeShort(timestamp, now)).toBe('12m')
+    expect(formatRelativeTimeShort(timestamp, now)).toBe('12m ago')
   })
 
   it('shows "just now" for under a minute', () => {
@@ -91,11 +91,11 @@ describe('formatRelativeTimeShort', () => {
 
   it('shows hours under a day', () => {
     const timestamp = now - 21 * 60 * 60 * 1000
-    expect(formatRelativeTimeShort(timestamp, now)).toBe('21h')
+    expect(formatRelativeTimeShort(timestamp, now)).toBe('21h ago')
   })
 
   it('shows days beyond a day', () => {
     const timestamp = now - 2 * 24 * 60 * 60 * 1000
-    expect(formatRelativeTimeShort(timestamp, now)).toBe('2d')
+    expect(formatRelativeTimeShort(timestamp, now)).toBe('2d ago')
   })
 })

--- a/apps/studio/components/layouts/ExplorerLayout/ExplorerNavHome.utils.test.ts
+++ b/apps/studio/components/layouts/ExplorerLayout/ExplorerNavHome.utils.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatRelativeTimeShort, getRecentlyUpdatedItems } from './ExplorerNavHome.utils'
+import type { NotebookRow } from '@/data/content/notebooks/notebooks-infinite-query'
+import type { ChatSession } from '@/state/ai-assistant-state'
+
+const notebook = (overrides: Partial<NotebookRow> = {}): NotebookRow =>
+  ({
+    id: 'notebook-1',
+    name: 'Signup funnel',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  }) as NotebookRow
+
+const chat = (overrides: Partial<ChatSession> = {}): ChatSession =>
+  ({
+    id: 'chat-1',
+    name: 'Investigate errors',
+    messages: [],
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    ...overrides,
+  }) as ChatSession
+
+describe('getRecentlyUpdatedItems', () => {
+  it('merges notebooks and chats sorted by recency, most recent first', () => {
+    const notebooks = [notebook({ id: 'n1', updated_at: '2026-01-01T00:00:00.000Z' })]
+    const chats = [chat({ id: 'c1', updatedAt: new Date('2026-02-01T00:00:00.000Z') })]
+
+    expect(getRecentlyUpdatedItems({ notebooks, chats }).map((item) => item.id)).toEqual([
+      'c1',
+      'n1',
+    ])
+  })
+
+  it('filters out support chats', () => {
+    const chats = [
+      chat({ id: 'support', supportMetadata: { isSupportChat: true } as ChatSession['supportMetadata'] }),
+    ]
+
+    expect(getRecentlyUpdatedItems({ notebooks: [], chats })).toEqual([])
+  })
+
+  it('sorts a chat with no updatedAt yet (not hydrated) after everything else', () => {
+    const chats = [
+      chat({ id: 'rehydrating', updatedAt: undefined as unknown as Date }),
+      chat({ id: 'recent', updatedAt: new Date('2026-01-01T00:00:00.000Z') }),
+    ]
+
+    expect(getRecentlyUpdatedItems({ notebooks: [], chats }).map((item) => item.id)).toEqual([
+      'recent',
+      'rehydrating',
+    ])
+  })
+
+  it('truncates to the given limit', () => {
+    const notebooks = Array.from({ length: 10 }, (_, i) =>
+      notebook({ id: `n${i}`, updated_at: new Date(2026, 0, i + 1).toISOString() })
+    )
+
+    const result = getRecentlyUpdatedItems({ notebooks, chats: [], limit: 3 })
+
+    expect(result).toHaveLength(3)
+    expect(result.map((item) => item.id)).toEqual(['n9', 'n8', 'n7'])
+  })
+
+  it('defaults to a limit of 5', () => {
+    const notebooks = Array.from({ length: 10 }, (_, i) =>
+      notebook({ id: `n${i}`, updated_at: new Date(2026, 0, i + 1).toISOString() })
+    )
+
+    expect(getRecentlyUpdatedItems({ notebooks, chats: [] })).toHaveLength(5)
+  })
+})
+
+describe('formatRelativeTimeShort', () => {
+  const now = new Date('2026-01-01T12:00:00.000Z').getTime()
+
+  it('shows minutes under an hour', () => {
+    const timestamp = now - 12 * 60 * 1000
+    expect(formatRelativeTimeShort(timestamp, now)).toBe('12m')
+  })
+
+  it('shows "just now" for under a minute', () => {
+    const timestamp = now - 30 * 1000
+    expect(formatRelativeTimeShort(timestamp, now)).toBe('just now')
+  })
+
+  it('shows hours under a day', () => {
+    const timestamp = now - 21 * 60 * 60 * 1000
+    expect(formatRelativeTimeShort(timestamp, now)).toBe('21h')
+  })
+
+  it('shows days beyond a day', () => {
+    const timestamp = now - 2 * 24 * 60 * 60 * 1000
+    expect(formatRelativeTimeShort(timestamp, now)).toBe('2d')
+  })
+})

--- a/apps/studio/components/layouts/ExplorerLayout/ExplorerNavHome.utils.ts
+++ b/apps/studio/components/layouts/ExplorerLayout/ExplorerNavHome.utils.ts
@@ -1,0 +1,61 @@
+import dayjs from 'dayjs'
+
+import type { NotebookRow } from '@/data/content/notebooks/notebooks-infinite-query'
+import type { ChatSession } from '@/state/ai-assistant-state'
+
+export const RECENTLY_UPDATED_ITEMS_LIMIT = 5
+
+export interface RecentlyUpdatedItem {
+  id: string
+  type: 'notebook' | 'chat'
+  label: string
+  updatedAt: number
+}
+
+/**
+ * Merges notebooks and chats into one recency-sorted list. Chats can reach here before
+ * their persisted state has hydrated (no `updatedAt` yet), so those sort last rather than
+ * throwing or floating to the top.
+ */
+export function getRecentlyUpdatedItems({
+  notebooks,
+  chats,
+  limit = RECENTLY_UPDATED_ITEMS_LIMIT,
+}: {
+  notebooks: NotebookRow[]
+  chats: ChatSession[]
+  limit?: number
+}): RecentlyUpdatedItem[] {
+  const notebookItems: RecentlyUpdatedItem[] = notebooks.map((notebook) => ({
+    id: notebook.id,
+    type: 'notebook',
+    label: notebook.name,
+    updatedAt: new Date(notebook.updated_at).getTime(),
+  }))
+
+  const chatItems: RecentlyUpdatedItem[] = chats
+    .filter((chat) => !chat.supportMetadata?.isSupportChat)
+    .map((chat) => ({
+      id: chat.id,
+      type: 'chat',
+      label: chat.name,
+      updatedAt: chat.updatedAt?.getTime() ?? 0,
+    }))
+
+  return [...notebookItems, ...chatItems]
+    .sort((a, b) => b.updatedAt - a.updatedAt)
+    .slice(0, limit)
+}
+
+/** Compact relative time (`12m`, `21h`, `2d`) for the narrow recent-items row. */
+export function formatRelativeTimeShort(timestamp: number, now: number = Date.now()): string {
+  const diffMinutes = dayjs(now).diff(timestamp, 'minute')
+  if (diffMinutes < 1) return 'just now'
+  if (diffMinutes < 60) return `${diffMinutes}m`
+
+  const diffHours = dayjs(now).diff(timestamp, 'hour')
+  if (diffHours < 24) return `${diffHours}h`
+
+  const diffDays = dayjs(now).diff(timestamp, 'day')
+  return `${diffDays}d`
+}

--- a/apps/studio/components/layouts/ExplorerLayout/ExplorerNavHome.utils.ts
+++ b/apps/studio/components/layouts/ExplorerLayout/ExplorerNavHome.utils.ts
@@ -46,7 +46,12 @@ export function getRecentlyUpdatedItems({
 }
 
 /** Compact relative time (`12m`, `21h`, `2d`) for the narrow recent-items row. */
-export function formatRelativeTimeShort(timestamp: number, now: number = Date.now()): string {
+export function formatRelativeTimeShort(
+  timestamp: number,
+  now: number = Date.now()
+): string | undefined {
+  if (timestamp === 0) return undefined
+
   const diffMinutes = dayjs(now).diff(timestamp, 'minute')
   if (diffMinutes < 1) return 'just now'
   if (diffMinutes < 60) return `${diffMinutes}m ago`

--- a/apps/studio/components/layouts/ExplorerLayout/ExplorerNavHome.utils.ts
+++ b/apps/studio/components/layouts/ExplorerLayout/ExplorerNavHome.utils.ts
@@ -42,9 +42,7 @@ export function getRecentlyUpdatedItems({
       updatedAt: chat.updatedAt?.getTime() ?? 0,
     }))
 
-  return [...notebookItems, ...chatItems]
-    .sort((a, b) => b.updatedAt - a.updatedAt)
-    .slice(0, limit)
+  return [...notebookItems, ...chatItems].sort((a, b) => b.updatedAt - a.updatedAt).slice(0, limit)
 }
 
 /** Compact relative time (`12m`, `21h`, `2d`) for the narrow recent-items row. */

--- a/apps/studio/components/layouts/ExplorerLayout/ExplorerNavHome.utils.ts
+++ b/apps/studio/components/layouts/ExplorerLayout/ExplorerNavHome.utils.ts
@@ -49,11 +49,11 @@ export function getRecentlyUpdatedItems({
 export function formatRelativeTimeShort(timestamp: number, now: number = Date.now()): string {
   const diffMinutes = dayjs(now).diff(timestamp, 'minute')
   if (diffMinutes < 1) return 'just now'
-  if (diffMinutes < 60) return `${diffMinutes}m`
+  if (diffMinutes < 60) return `${diffMinutes}m ago`
 
   const diffHours = dayjs(now).diff(timestamp, 'hour')
-  if (diffHours < 24) return `${diffHours}h`
+  if (diffHours < 24) return `${diffHours}h ago`
 
   const diffDays = dayjs(now).diff(timestamp, 'day')
-  return `${diffDays}d`
+  return `${diffDays}d ago`
 }


### PR DESCRIPTION
## Context

As per PR title: recently updated list just comprises of notebooks and chats
Note: known API issue that save a notebook doesn't update its `updated_at` value, so you'll notice that if you save a notebook it doesn't move up the recently updated list

<img width="281" height="270" alt="image" src="https://github.com/user-attachments/assets/f637a593-09a7-4df4-85b7-43637f04738d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a home view displaying recently updated notebooks and chats.
  * Recent items are sorted by update time and limited to five entries.
  * Added relative timestamps in minutes, hours, or days.
  * Chat entries open directly, while notebook entries link to their explorer view.
  * Added an empty state when no recent items are available.

* **Bug Fixes**
  * Excluded unsupported chat types from recent-item results.
  * Improved handling of unavailable timestamps.

* **Tests**
  * Added coverage for sorting, filtering, limits, and relative-time formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->