### PR TITLE
docs(platforms): query logs via the ClickHouse endpoint

### DIFF
--- a/apps/docs/content/guides/integrations/supabase-for-platforms.mdx
+++ b/apps/docs/content/guides/integrations/supabase-for-platforms.mdx
@@ -413,21 +413,26 @@ We've created Platform Kit, a collection of UI components that interact with Man
 
 ## Debugging projects
 
-Management API endpoint: [`GET /v1/projects/{ref}/analytics/endpoints/logs.all`](https://api.supabase.com/api/v1#tag/analytics/get/v1/projects/{ref}/analytics/endpoints/logs.all)
+Management API endpoint: [`GET /v1/projects/{ref}/analytics/endpoints/logs`](https://api.supabase.com/api/v1#tag/analytics/get/v1/projects/{ref}/analytics/endpoints/logs)
 
 When you need to debug a project, you can query the project's logs to see if there are any errors and address them accordingly.
 
+Every log line from every service is a row in a single `logs` table, so filter by the `source` column to pick a service. Structured fields live in the `log_attributes` map, and the SQL is the ClickHouse dialect.
+
 ```sh
-curl 'https://api.supabase.com/v1/projects/{ref}/analytics/endpoints/logs.all' \
+curl 'https://api.supabase.com/v1/projects/{ref}/analytics/endpoints/logs' \
   --get \
   --header 'Authorization: Bearer YOUR_SECRET_TOKEN' \
-  --data-urlencode 'sql=SELECT datetime(timestamp), status_code, path, event_message
-    FROM edge_logs
-    CROSS JOIN UNNEST(metadata) AS metadata
-    CROSS JOIN UNNEST(response) AS response
-    WHERE status_code >= 400
-    ORDER BY timestamp DESC
-    LIMIT 100' \
+  --data-urlencode "sql=select
+    timestamp,
+    log_attributes['response.status_code'] as status_code,
+    log_attributes['request.path'] as path,
+    event_message
+  from logs
+  where source = 'edge_logs'
+    and toInt32OrZero(log_attributes['response.status_code']) >= 400
+  order by timestamp desc
+  limit 100" \
   --data-urlencode 'iso_timestamp_start=2025-03-23T00:00:00Z' \
   --data-urlencode 'iso_timestamp_end=2025-03-23T01:00:00Z'
 ```


### PR DESCRIPTION
The `logs.all` Management API endpoint runs BigQuery SQL and is being retired next month. The Platforms guide was the only hand-written doc still pointing at it.

Repoints the debugging example at `GET /v1/projects/{ref}/analytics/endpoints/logs`, which serves the same data as a single `logs` table keyed by `source`, with structured fields in the `log_attributes` map, and converts the query to the ClickHouse dialect.

Verified by running the example's exact SQL and curl shape against a real project on the OTEL logs endpoint: 100 rows, with `status_code` and `path` populated.

The generated API specs still list `logs.all`; those regenerate from the platform side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Supabase for Platforms integration guide’s debugging-projects example.
  - Revised the example to use the analytics logs endpoint and unified logs table.
  - Added ClickHouse SQL filtering for edge logs, structured log attributes, and HTTP errors.
  - Improved the example’s alignment with current log query and analytics capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->