### PR TITLE
feat: Show all partner audit logs fields

### DIFF
--- a/apps/studio/components/interfaces/AuditLogs/LogDetailsPanel.tsx
+++ b/apps/studio/components/interfaces/AuditLogs/LogDetailsPanel.tsx
@@ -94,6 +94,30 @@ export const LogDetailsPanel = ({ selectedLog, onClose }: LogDetailsPanelProps) 
               <Input readOnly size="small" value={selectedLog?.actor.app_name ?? ''} />
             </FormItemLayout>
           )}
+          {selectedLog?.actor.partner && (
+            <FormItemLayout label="Partner" isReactForm={false}>
+              <Input readOnly size="small" value={selectedLog?.actor.partner ?? ''} />
+            </FormItemLayout>
+          )}
+          {selectedLog?.actor.partner_installation_id && (
+            <FormItemLayout label="Partner installation ID" isReactForm={false}>
+              <Input
+                readOnly
+                size="small"
+                value={selectedLog?.actor.partner_installation_id ?? ''}
+              />
+            </FormItemLayout>
+          )}
+          {selectedLog?.actor.partner_user_email && (
+            <FormItemLayout label="Partner user email" isReactForm={false}>
+              <Input readOnly size="small" value={selectedLog?.actor.partner_user_email ?? ''} />
+            </FormItemLayout>
+          )}
+          {selectedLog?.actor.partner_user_id && (
+            <FormItemLayout label="Partner user ID" isReactForm={false}>
+              <Input readOnly size="small" value={selectedLog?.actor.partner_user_id ?? ''} />
+            </FormItemLayout>
+          )}
         </FormSectionContent>
       </FormSection>
 

--- a/apps/studio/components/interfaces/Organization/AuditLogs/AuditLogs.tsx
+++ b/apps/studio/components/interfaces/Organization/AuditLogs/AuditLogs.tsx
@@ -9,7 +9,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { Alert, AlertDescription, AlertTitle, Button, WarningIcon } from 'ui'
 import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 
-import { filterByProjects, filterByUsers, sortAuditLogs } from './AuditLogs.utils'
+import { filterByProjects, filterByUsers, formatPartner, sortAuditLogs } from './AuditLogs.utils'
 import { LogDetailsPanel } from '@/components/interfaces/AuditLogs/LogDetailsPanel'
 import { LogsDatePicker } from '@/components/interfaces/Settings/Logs/Logs.DatePickers'
 import { ScaffoldContainer, ScaffoldSection } from '@/components/layouts/Scaffold'
@@ -351,6 +351,13 @@ export const AuditLogs = () => {
                             />
                           )
 
+                        const actorDisplayName =
+                          user?.username ||
+                          log.actor.email ||
+                          (log.actor.partner &&
+                            formatPartner(log.actor.partner, log.actor.partner_user_email)) ||
+                          '-'
+
                         return (
                           <Table.tr
                             key={log.request_id}
@@ -361,9 +368,7 @@ export const AuditLogs = () => {
                               <div className="flex items-center space-x-4">
                                 <div>{userIcon}</div>
                                 <div>
-                                  <p className="text-foreground-light">
-                                    {user?.username ?? log.actor.email ?? '-'}
-                                  </p>
+                                  <p className="text-foreground-light">{actorDisplayName}</p>
                                   {role && (
                                     <p className="mt-0.5 text-xs text-foreground-light">
                                       {role?.name}

--- a/apps/studio/components/interfaces/Organization/AuditLogs/AuditLogs.tsx
+++ b/apps/studio/components/interfaces/Organization/AuditLogs/AuditLogs.tsx
@@ -9,7 +9,12 @@ import { useEffect, useMemo, useState } from 'react'
 import { Alert, AlertDescription, AlertTitle, Button, WarningIcon } from 'ui'
 import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 
-import { filterByProjects, filterByUsers, formatPartner, sortAuditLogs } from './AuditLogs.utils'
+import {
+  filterByProjects,
+  filterByUsers,
+  formatPartnerIfExists,
+  sortAuditLogs,
+} from './AuditLogs.utils'
 import { LogDetailsPanel } from '@/components/interfaces/AuditLogs/LogDetailsPanel'
 import { LogsDatePicker } from '@/components/interfaces/Settings/Logs/Logs.DatePickers'
 import { ScaffoldContainer, ScaffoldSection } from '@/components/layouts/Scaffold'
@@ -354,8 +359,7 @@ export const AuditLogs = () => {
                         const actorDisplayName =
                           user?.username ||
                           log.actor.email ||
-                          (log.actor.partner &&
-                            formatPartner(log.actor.partner, log.actor.partner_user_email)) ||
+                          formatPartnerIfExists(log.actor.partner, log.actor.partner_user_email) ||
                           '-'
 
                         return (

--- a/apps/studio/components/interfaces/Organization/AuditLogs/AuditLogs.utils.ts
+++ b/apps/studio/components/interfaces/Organization/AuditLogs/AuditLogs.utils.ts
@@ -51,10 +51,12 @@ export const formatSelectedDateRange = (value: DatePickerToFrom) => {
   }
 }
 
-export function formatPartner(partner: string, partnerEmail: string | undefined) {
-  let result = `${partner[0].toUpperCase()}${partner.slice(1).toLowerCase()}`
-  if (partnerEmail) {
-    result = `${partnerEmail} (${result})`
-  }
-  return result
+export function formatPartnerIfExists(
+  partner: string | undefined,
+  partnerEmail: string | undefined
+) {
+  if (!partner) return undefined
+
+  const capitalized = `${partner[0].toUpperCase()}${partner.slice(1).toLowerCase()}`
+  return partnerEmail ? `${partnerEmail} (${capitalized})` : capitalized
 }

--- a/apps/studio/components/interfaces/Organization/AuditLogs/AuditLogs.utils.ts
+++ b/apps/studio/components/interfaces/Organization/AuditLogs/AuditLogs.utils.ts
@@ -50,3 +50,11 @@ export const formatSelectedDateRange = (value: DatePickerToFrom) => {
     return { from: from.utc().toISOString(), to: to.utc().toISOString() }
   }
 }
+
+export function formatPartner(partner: string, partnerEmail: string | undefined) {
+  let result = `${partner[0].toUpperCase()}${partner.slice(1).toLowerCase()}`
+  if (partnerEmail) {
+    result = `${partnerEmail} (${result})`
+  }
+  return result
+}

--- a/apps/studio/data/organizations/organization-audit-logs-query.ts
+++ b/apps/studio/data/organizations/organization-audit-logs-query.ts
@@ -29,6 +29,10 @@ export type AuditLog = {
     app_id?: string
     app_name?: string
     ip?: string
+    partner?: string
+    partner_installation_id?: string
+    partner_user_email?: string
+    partner_user_id?: string
   }
   timestamp: number
 }

--- a/apps/studio/tests/components/AuditLogs/OrgAuditLogs.utils.test.ts
+++ b/apps/studio/tests/components/AuditLogs/OrgAuditLogs.utils.test.ts
@@ -2,7 +2,7 @@ import dayjs from 'dayjs'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 
 import {
-  formatPartner,
+  formatPartnerIfExists,
   formatSelectedDateRange,
 } from '@/components/interfaces/Organization/AuditLogs/AuditLogs.utils'
 
@@ -85,16 +85,24 @@ describe('formatSelectedDateRange', () => {
   })
 })
 
-describe('formatPartner', () => {
+describe('formatPartnerIfExists', () => {
   test('capitalizes the partner name', () => {
-    expect(formatPartner('github', undefined)).toBe('Github')
+    expect(formatPartnerIfExists('github', undefined)).toBe('Github')
   })
 
   test('prefixes with the partner email when provided', () => {
-    expect(formatPartner('github', 'a@b.com')).toBe('a@b.com (Github)')
+    expect(formatPartnerIfExists('github', 'a@b.com')).toBe('a@b.com (Github)')
   })
 
   test('normalizes casing regardless of input case', () => {
-    expect(formatPartner('GITHUB', undefined)).toBe('Github')
+    expect(formatPartnerIfExists('GITHUB', undefined)).toBe('Github')
+  })
+
+  test('returns undefined when partner is undefined', () => {
+    expect(formatPartnerIfExists(undefined, 'a@b.com')).toBeUndefined()
+  })
+
+  test('returns undefined when partner is an empty string', () => {
+    expect(formatPartnerIfExists('', 'a@b.com')).toBeUndefined()
   })
 })

--- a/apps/studio/tests/components/AuditLogs/OrgAuditLogs.utils.test.ts
+++ b/apps/studio/tests/components/AuditLogs/OrgAuditLogs.utils.test.ts
@@ -1,7 +1,10 @@
 import dayjs from 'dayjs'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 
-import { formatSelectedDateRange } from '@/components/interfaces/Organization/AuditLogs/AuditLogs.utils'
+import {
+  formatPartner,
+  formatSelectedDateRange,
+} from '@/components/interfaces/Organization/AuditLogs/AuditLogs.utils'
 
 // Pin "now" to a fixed point so date comparisons are deterministic
 const NOW = dayjs('2024-06-15T14:30:00')
@@ -79,5 +82,19 @@ describe('formatSelectedDateRange', () => {
     })
     expect(result.from).toMatch(/Z$/)
     expect(result.to).toMatch(/Z$/)
+  })
+})
+
+describe('formatPartner', () => {
+  test('capitalizes the partner name', () => {
+    expect(formatPartner('github', undefined)).toBe('Github')
+  })
+
+  test('prefixes with the partner email when provided', () => {
+    expect(formatPartner('github', 'a@b.com')).toBe('a@b.com (Github)')
+  })
+
+  test('normalizes casing regardless of input case', () => {
+    expect(formatPartner('GITHUB', undefined)).toBe('Github')
   })
 })


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Changes to the audit logs UI

## What is the current behavior?

Partner related fields in the audit logs are not shown

## What is the new behavior?

- Shows all partner related fields in the audit logs
- Also uses the new fields to compute the user name



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audit log entries now display partner names, installation IDs, user emails, and user IDs when available.
  * Partner identity and email are shown when standard actor details are unavailable.
  * Partner names are consistently formatted for clearer display.
  * Entries without partner information continue to display cleanly without blank or confusing actor details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->