### PR TITLE
fix(studio): AI assistant notebooks no longer set an invalid database_identifier

### DIFF
--- a/apps/studio/components/ui/AIAssistantPanel/AssistantNotebookPreview.test.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AssistantNotebookPreview.test.tsx
@@ -23,11 +23,10 @@ const wireDatabaseCell = (id: string, database_identifier?: string): CellWire =>
   database_identifier,
 })
 
-const agentDatabaseCell = (database_identifier?: string): AgentCell => ({
+const agentDatabaseCell = (): AgentCell => ({
   _tag: 'database_cell',
   sql: 'select 1',
   row_limit: 100,
-  database_identifier,
 })
 
 describe('AssistantNotebookPreview', () => {
@@ -68,17 +67,17 @@ describe('AssistantNotebookPreview', () => {
       {
         _tag: 'replaced',
         before: wireDatabaseCell('cell-1', 'primary'),
-        after: agentDatabaseCell('replica-3'),
+        after: agentDatabaseCell(),
         operationIndex: 0,
       },
     ]
 
     render(<AssistantNotebookPreview entries={entries} mode="update" />)
 
-    expect(screen.getByText('Database: primary → Database: replica-3')).toBeInTheDocument()
+    expect(screen.getByText('Database: primary → No metadata')).toBeInTheDocument()
     expect(
       screen.getByRole('button', { name: 'Replaced Query: Untitled query' })
-    ).toHaveTextContent('Database: primary → Database: replica-3')
+    ).toHaveTextContent('Database: primary → No metadata')
   })
 
   it('hides entries past the limit behind a "Show N more" button', async () => {

--- a/apps/studio/components/ui/AIAssistantPanel/AssistantNotebookPreview.utils.test.ts
+++ b/apps/studio/components/ui/AIAssistantPanel/AssistantNotebookPreview.utils.test.ts
@@ -38,11 +38,10 @@ const wireLogCell = (id: string): CellWire => ({
   time_range: { _tag: 'relative_time_range', unit: 'day', amount: 7 },
 })
 
-const agentDatabaseCell = (database_identifier?: string): AgentCell => ({
+const agentDatabaseCell = (): AgentCell => ({
   _tag: 'database_cell',
   sql: 'select 1',
   row_limit: 100,
-  database_identifier,
 })
 
 describe('getEntryKey', () => {
@@ -146,26 +145,26 @@ describe('getEntryMetadataLine', () => {
     ).toBe('Database: replica-3')
   })
 
-  it('returns a before → after pair when a replacement changes only metadata', () => {
+  it('returns a before → after pair when a replacement drops the database metadata', () => {
     expect(
       getEntryMetadataLine({
         _tag: 'replaced',
         before: wireDatabaseCell('cell-1', 'Signups', 'primary'),
-        after: agentDatabaseCell('replica-3'),
+        after: agentDatabaseCell(),
         operationIndex: 0,
       })
-    ).toBe('Database: primary → Database: replica-3')
+    ).toBe('Database: primary → No metadata')
   })
 
   it('returns a single line when replacement metadata is unchanged', () => {
     expect(
       getEntryMetadataLine({
         _tag: 'replaced',
-        before: wireDatabaseCell('cell-1', 'Signups', 'primary'),
-        after: agentDatabaseCell('primary'),
+        before: wireDatabaseCell('cell-1', undefined, undefined),
+        after: agentDatabaseCell(),
         operationIndex: 0,
       })
-    ).toBe('Database: primary')
+    ).toBe(null)
   })
 })
 

--- a/apps/studio/components/ui/AIAssistantPanel/AssistantNotebookPreview.utils.ts
+++ b/apps/studio/components/ui/AIAssistantPanel/AssistantNotebookPreview.utils.ts
@@ -83,8 +83,11 @@ export function getCellMetadataLine(cell: OperationResultCell): string | null {
   switch (cell._tag) {
     case 'markdown_cell':
       return null
-    case 'database_cell':
-      return cell.database_identifier ? `Database: ${cell.database_identifier}` : null
+    case 'database_cell': {
+      const databaseIdentifier =
+        'database_identifier' in cell ? cell.database_identifier : undefined
+      return databaseIdentifier ? `Database: ${databaseIdentifier}` : null
+    }
     case 'log_cell':
       return `Time range: ${formatTimeRange(cell.time_range)}`
   }

--- a/apps/studio/data/content/notebooks/notebook-schema.test.ts
+++ b/apps/studio/data/content/notebooks/notebook-schema.test.ts
@@ -260,6 +260,26 @@ describe('agentNotebookSchema', () => {
 
     expect(result.success).toBe(false)
   })
+
+  it('rejects a database_cell that carries a database_identifier', () => {
+    // Agents have no way to discover a project's real read-replica identifiers, so an
+    // invented one silently breaks the cell (its connection string never resolves) — the
+    // field is stripped from the agent-facing schema entirely rather than left for a model
+    // to guess at.
+    const result = agentNotebookSchema.safeParse({
+      schema_version: 1,
+      cells: [
+        {
+          _tag: 'database_cell',
+          sql: 'select 1',
+          row_limit: 100,
+          database_identifier: 'replica-1',
+        },
+      ],
+    })
+
+    expect(result.success).toBe(false)
+  })
 })
 
 describe('writableNotebookSchema', () => {

--- a/apps/studio/data/content/notebooks/notebook-schema.ts
+++ b/apps/studio/data/content/notebooks/notebook-schema.ts
@@ -154,11 +154,18 @@ export type WritableNotebook = Omit<z.infer<typeof writableNotebookSchema>, 'cel
 type WritableCellWire = z.infer<typeof writableCellSchema>
 type WritableNotebookWire = z.infer<typeof writableNotebookSchema>
 
+// Agents cannot yet target a specific read replica: there's no tool exposing a project's
+// real replica identifiers, so a model asked to fill this field has no legitimate value to
+// put there — and an invented one silently breaks the cell, since its connection string can
+// never resolve (see QueryEditor's run handler). Omit the field entirely until replica
+// selection is actually wired up for agents, rather than leave it for a model to guess at.
+const agentDatabaseFieldsSchema = databaseFieldsSchema.omit({ database_identifier: true })
+
 // Agents have restrictions on writing IDs to preserve guarantees about ID
 // uniqueness
 export const agentCellSchema = z.discriminatedUnion('_tag', [
   markdownFieldsSchema.extend({ _tag: z.literal('markdown_cell') }).strict(),
-  databaseFieldsSchema.extend({ _tag: z.literal('database_cell') }).strict(),
+  agentDatabaseFieldsSchema.extend({ _tag: z.literal('database_cell') }).strict(),
   logFieldsSchema.extend({ _tag: z.literal('log_cell') }).strict(),
 ])
 


### PR DESCRIPTION
## Summary

- The AI assistant's `create_notebook`/`update_notebook` tools could set a `database_cell`'s `database_identifier` to a value that doesn't correspond to any real database, because no tool exposes a project's actual read-replica identifiers to the model.
- An unresolvable `database_identifier` silently breaks the cell: `QueryEditor`'s connection-string lookup fails to find a match, and running the cell fails with `Unable to run query: Connection string is missing` — even though the exact same SQL runs fine when pasted into a manually-created cell (which never sets this field).
- Fix: strip `database_identifier` from the agent-facing schema (`agentCellSchema` in `notebook-schema.ts`) entirely, so the model can no longer emit it at all. **This is a temporary fix** until we wire in real read-replica support for the AI assistant (e.g. a tool exposing a project's valid replica identifiers) — the field can be reintroduced once the model has a legitimate source of truth to pull a valid identifier from.
- Updated tests that relied on agent cells carrying `database_identifier` to reflect the new behavior, and added a regression test asserting `agentNotebookSchema` rejects a `database_cell` with that field set.

Resolves FE-4224

## Test plan

- [x] `notebook-schema.test.ts`, `notebook-operations.test.ts`, `notebook-tools.test.ts`, `AssistantNotebookPreview.test.tsx`, `AssistantNotebookPreview.utils.test.ts` all pass
- [x] `tsc --noEmit` clean
- [x] Prettier clean on touched files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of database notebook cells when database metadata is unavailable.
  * Cells without database identifiers now display “No metadata” instead of an incorrect replica identifier.
  * Prevented invalid database identifiers from being accepted in agent-generated notebook content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->