### PR TITLE
fix(studio): thread auth headers through getReadReplicas

### DIFF
--- a/apps/studio/data/read-replicas/replicas-query.test.ts
+++ b/apps/studio/data/read-replicas/replicas-query.test.ts
@@ -1,10 +1,13 @@
+import { HttpResponse } from 'msw'
 import { describe, expect, it } from 'vitest'
 
 import {
   getMaxReplicas,
+  getReadReplicas,
   READ_REPLICA_COMPUTE_CAPS,
   READ_REPLICAS_MAX_COUNT,
 } from './replicas-query'
+import { addAPIMock } from '@/tests/lib/msw'
 
 describe('getMaxReplicas', () => {
   it('returns 0 for ineligible compute sizes (pico, nano, micro)', () => {
@@ -44,5 +47,26 @@ describe('getMaxReplicas', () => {
         expect(cap).toBeLessThanOrEqual(READ_REPLICAS_MAX_COUNT)
       }
     }
+  })
+})
+
+describe('getReadReplicas', () => {
+  it('forwards the given headers on the request', async () => {
+    let receivedAuthHeader: string | null = null
+
+    addAPIMock({
+      method: 'get',
+      path: '/platform/projects/:ref/databases',
+      response: ({ request }) => {
+        receivedAuthHeader = request.headers.get('Authorization')
+        return HttpResponse.json([])
+      },
+    })
+
+    await getReadReplicas({ projectRef: 'default' }, undefined, {
+      Authorization: 'Bearer test-token',
+    })
+
+    expect(receivedAuthHeader).toBe('Bearer test-token')
   })
 })

--- a/apps/studio/data/read-replicas/replicas-query.ts
+++ b/apps/studio/data/read-replicas/replicas-query.ts
@@ -33,11 +33,16 @@ export type ReadReplicasVariables = {
 
 export type Database = components['schemas']['DatabaseDetailResponse']
 
-export async function getReadReplicas({ projectRef }: ReadReplicasVariables, signal?: AbortSignal) {
+export async function getReadReplicas(
+  { projectRef }: ReadReplicasVariables,
+  signal?: AbortSignal,
+  headers?: HeadersInit
+) {
   if (!projectRef) throw new Error('Project ref is required')
 
   const { data, error } = await get(`/platform/projects/{ref}/databases`, {
     params: { path: { ref: projectRef } },
+    headers,
     signal,
   })
 


### PR DESCRIPTION
## Summary
- `getReadReplicas` now accepts an optional `headers?: HeadersInit` param, forwarded to the underlying `get()` call — mirrors `getContentById`/`getNotebook`.
- Pure plumbing: no behavior change for existing (browser/cookie-auth) callers.

Part 1/6 of the stack for FE-4225 (expose valid database identifiers to the notebook AI agent). This PR lets a server-side AI tool call `getReadReplicas` with the request's bearer token in a later PR in the stack.

## Test plan
- [x] `getReadReplicas` unit test verifying the header is forwarded on the outgoing request
- [x] `pnpm --filter studio exec tsc --noEmit` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved read-replica data requests by forwarding authorization headers correctly.
  * Maintained existing request cancellation and error-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->