### PR TITLE
fix(studio): expose notebook diff validation errors for auto-retry

### DIFF
--- a/apps/studio/components/ui/AIAssistantPanel/Confirm.utils.test.ts
+++ b/apps/studio/components/ui/AIAssistantPanel/Confirm.utils.test.ts
@@ -152,6 +152,23 @@ describe('getManualToolApprovalHandlers', () => {
     })
   })
 
+  it('denyWithReason sends the given reason instead of USER_SKIPPED_TOOL_REASON', () => {
+    const addToolApprovalResponse = vi.fn()
+    const { denyWithReason } = getManualToolApprovalHandlers({
+      state: 'approval-requested',
+      approval: { id: 'approval-1' },
+      addToolApprovalResponse,
+    })
+
+    denyWithReason?.('No cell with id "missing" exists in this notebook.')
+
+    expect(addToolApprovalResponse).toHaveBeenCalledWith({
+      id: 'approval-1',
+      approved: false,
+      reason: 'No cell with id "missing" exists in this notebook.',
+    })
+  })
+
   it('does not call addToolApprovalResponse for automatic approvals', () => {
     const addToolApprovalResponse = vi.fn()
     const handlers = getManualToolApprovalHandlers({

--- a/apps/studio/components/ui/AIAssistantPanel/Confirm.utils.ts
+++ b/apps/studio/components/ui/AIAssistantPanel/Confirm.utils.ts
@@ -83,6 +83,9 @@ export function getManualToolApprovalHandlers({
   confirmState?: ConfirmFooterApprovalState
   onApprove?: () => void
   onDeny?: () => void
+  /** Deny with a specific reason instead of USER_SKIPPED_TOOL_REASON, e.g. for an automatic
+   *  denial that should tell the model what went wrong rather than that the user skipped it. */
+  denyWithReason?: (reason: string) => void
 } {
   const confirmState = getManualToolApprovalConfirmState({ state, approval })
   const approvalId = getManualToolApprovalId({ state, approval })
@@ -97,5 +100,7 @@ export function getManualToolApprovalHandlers({
         approved: false,
         reason: USER_SKIPPED_TOOL_REASON,
       }),
+    denyWithReason: (reason: string) =>
+      addToolApprovalResponse?.({ id: approvalId, approved: false, reason }),
   }
 }

--- a/apps/studio/components/ui/AIAssistantPanel/Message.Parts.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/Message.Parts.tsx
@@ -241,7 +241,7 @@ function MessagePartNotebookProposal({
     )
   }
 
-  const { confirmState, onApprove, onDeny } = getManualToolApprovalHandlers({
+  const { confirmState, onApprove, onDeny, denyWithReason } = getManualToolApprovalHandlers({
     state,
     approval: toolPart.approval,
     addToolApprovalResponse,
@@ -256,6 +256,7 @@ function MessagePartNotebookProposal({
       confirmState={confirmState}
       onApprove={onApprove}
       onDeny={onDeny}
+      denyWithReason={denyWithReason}
     />
   )
 }

--- a/apps/studio/components/ui/AIAssistantPanel/NotebookProposalRenderer.test.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/NotebookProposalRenderer.test.tsx
@@ -122,10 +122,10 @@ describe('NotebookProposalRenderer', () => {
     expect(onApprove).not.toHaveBeenCalled()
   })
 
-  it('withholds Apply changes when the update cannot be applied as written', async () => {
-    const user = userEvent.setup()
+  it('withholds Apply changes and auto-denies with the failure reason when the update cannot be applied as written', async () => {
     const onApprove = vi.fn()
     const onDeny = vi.fn()
+    const denyWithReason = vi.fn()
     mockContentItem(mockNotebookRow())
 
     render(
@@ -141,14 +141,69 @@ describe('NotebookProposalRenderer', () => {
         output={undefined}
         onApprove={onApprove}
         onDeny={onDeny}
+        denyWithReason={denyWithReason}
       />
     )
 
     expect(await screen.findByText("This update can't be applied as written")).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Apply changes' })).not.toBeInTheDocument()
-    await user.click(screen.getByRole('button', { name: 'Skip' }))
-    expect(onDeny).toHaveBeenCalledTimes(1)
+    expect(denyWithReason).toHaveBeenCalledWith(
+      'No cell with id "missing" exists in this notebook.'
+    )
+    expect(onDeny).not.toHaveBeenCalled()
     expect(onApprove).not.toHaveBeenCalled()
+  })
+
+  it('falls back to sending the failure reason through Skip if auto-deny did not resolve the approval', async () => {
+    const user = userEvent.setup()
+    const denyWithReason = vi.fn()
+    mockContentItem(mockNotebookRow())
+
+    render(
+      <NotebookProposalRenderer
+        mode="update"
+        state="approval-requested"
+        confirmState="approval-requested"
+        input={{
+          id: NOTEBOOK_ID,
+          expected_updated_at: '2024-01-01T00:00:00.000Z',
+          operations: [{ _tag: 'delete_cell', cell_id: 'missing' }],
+        }}
+        output={undefined}
+        denyWithReason={denyWithReason}
+      />
+    )
+
+    const skipButton = await screen.findByRole('button', { name: 'Skip' })
+    denyWithReason.mockClear()
+    await user.click(skipButton)
+
+    expect(denyWithReason).toHaveBeenCalledWith(
+      'No cell with id "missing" exists in this notebook.'
+    )
+  })
+
+  it('does not auto-deny an unapplyable update once it has already been responded to', async () => {
+    const denyWithReason = vi.fn()
+    mockContentItem(mockNotebookRow())
+
+    render(
+      <NotebookProposalRenderer
+        mode="update"
+        state="approval-responded"
+        confirmState={undefined}
+        input={{
+          id: NOTEBOOK_ID,
+          expected_updated_at: '2024-01-01T00:00:00.000Z',
+          operations: [{ _tag: 'delete_cell', cell_id: 'missing' }],
+        }}
+        output={undefined}
+        denyWithReason={denyWithReason}
+      />
+    )
+
+    await screen.findByText("This update can't be applied as written")
+    expect(denyWithReason).not.toHaveBeenCalled()
   })
 
   it('keeps the create preview and marks it successful once output is available', () => {

--- a/apps/studio/components/ui/AIAssistantPanel/NotebookProposalRenderer.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/NotebookProposalRenderer.tsx
@@ -1,7 +1,7 @@
 import { useParams } from 'common'
 import { Loader2 } from 'lucide-react'
 import Link from 'next/link'
-import { type PropsWithChildren, type ReactNode } from 'react'
+import { useEffect, useEffectEvent, type PropsWithChildren, type ReactNode } from 'react'
 import { Button } from 'ui'
 import { Admonition } from 'ui-patterns/Admonition'
 import { CodeBlock } from 'ui-patterns/CodeBlock'
@@ -42,6 +42,9 @@ export interface NotebookProposalRendererProps {
   confirmState?: ConfirmFooterApprovalState
   onApprove?: () => void
   onDeny?: () => void
+  /** Denies with a specific reason instead of a generic "user skipped" — used to auto-deny
+   *  an update that can't be applied as written so the model sees why and can retry. */
+  denyWithReason?: (reason: string) => void
 }
 
 type NotebookProposalStepProps = Omit<
@@ -74,7 +77,7 @@ const MODE_COPY = {
  */
 export const NotebookProposalRenderer = (props: NotebookProposalRendererProps) => {
   const { ref } = useParams()
-  const { mode, state, input, output, confirmState, onApprove, onDeny } = props
+  const { mode, state, input, output, confirmState, onApprove, onDeny, denyWithReason } = props
   const parsedOutput = notebookToolOutputSchema.safeParse(output)
   const footerAction =
     state === 'output-available' && parsedOutput.success && ref ? (
@@ -101,6 +104,7 @@ export const NotebookProposalRenderer = (props: NotebookProposalRendererProps) =
         footerAction={confirmState === undefined ? undefined : footerAction}
         onApprove={onApprove}
         onDeny={onDeny}
+        denyWithReason={denyWithReason}
       />
     )
 
@@ -230,12 +234,60 @@ function CreateNotebookProposal({
   )
 }
 
+/**
+ * An update whose operations don't apply to the notebook as currently loaded (e.g. an
+ * operation targets a cell id that no longer exists). There's nothing for the user to decide
+ * here, so instead of asking them to Skip, deny automatically with the specific reason —
+ * same text `update_notebook`'s server-side execute() would throw for the same failure — so
+ * the model sees why and can retry (e.g. re-fetch and reissue) without the user's involvement.
+ */
+function UnapplyableNotebookUpdateNotice({
+  notebookName,
+  reason,
+  confirmState,
+  onDeny,
+  denyWithReason,
+}: {
+  notebookName: string
+  reason: string
+  confirmState?: ConfirmFooterApprovalState
+  onDeny?: () => void
+  denyWithReason?: (reason: string) => void
+}) {
+  const onUnapplyable = useEffectEvent(() => {
+    denyWithReason?.(reason)
+  })
+
+  useEffect(() => {
+    if (confirmState === 'approval-requested') onUnapplyable()
+  }, [confirmState])
+
+  return (
+    <NotebookConfirm
+      mode="update"
+      confirmState={confirmState}
+      message={`Assistant wants to update "${notebookName}"`}
+      denyOnly
+      onDeny={() => (denyWithReason ? denyWithReason(reason) : onDeny?.())}
+    >
+      <div className="p-3">
+        <Admonition
+          type="warning"
+          title="This update can't be applied as written"
+          description={reason}
+        />
+      </div>
+    </NotebookConfirm>
+  )
+}
+
 function UpdateNotebookProposal({
   input,
   confirmState,
   footerAction,
   onApprove,
   onDeny,
+  denyWithReason,
 }: NotebookProposalStepProps) {
   const { ref } = useParams()
   const parsedInput = updateNotebookInputSchema.safeParse(input)
@@ -293,21 +345,13 @@ function UpdateNotebookProposal({
 
   if (!diff.success) {
     return (
-      <NotebookConfirm
-        mode="update"
+      <UnapplyableNotebookUpdateNotice
+        notebookName={notebook.name}
+        reason={describeNotebookOperationError(diff.error)}
         confirmState={confirmState}
-        message={`Assistant wants to update "${notebook.name}"`}
-        denyOnly
         onDeny={onDeny}
-      >
-        <div className="p-3">
-          <Admonition
-            type="warning"
-            title="This update can't be applied as written"
-            description={describeNotebookOperationError(diff.error)}
-          />
-        </div>
-      </NotebookConfirm>
+        denyWithReason={denyWithReason}
+      />
     )
   }
 


### PR DESCRIPTION
## Summary

- Automatically deny notebook tool proposals with specific error reasons when client-side diff validation fails (e.g., unknown cell ID)
- Enables the AI Assistant to see the actual failure reason and retry automatically instead of requiring manual user intervention
- Exposes the same `describeNotebookOperationError` helper used server-side for consistent error messaging
- Adds `denyWithReason()` to manual tool approval handlers for flexible denial messaging

## Test plan

- Run `pnpm --filter studio exec vitest run apps/studio/components/ui/AIAssistantPanel/Confirm.utils.test.ts` to verify denyWithReason tests
- Run `pnpm --filter studio exec vitest run apps/studio/components/ui/AIAssistantPanel/NotebookProposalRenderer.test.tsx` to verify auto-deny behavior, Skip fallback, and no re-fire after approval is already handled
- Confirm no regressions in existing notebook tool approval flows

## Manual testing

- Get assistant to create a notebook.
- Open the notebook and manually delete a cell yourself.
- Ask the assistant to delete the cell you just deleted.
- Assistant should automatically recover from the error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Notebook proposals now display clear success, error, and denial outcomes.
  * Tool errors for SQL, Edge Functions, and notebooks now appear in their respective result views.
  * Output links are supported in notebook proposal results.
  * Approval panels remain visible after completed actions with standardized status messages.

* **Bug Fixes**
  * Specific denial reasons are preserved instead of showing a generic skipped message.
  * Unapplyable notebook updates are automatically denied with an explanation.
  * Prevented duplicate denial responses after approval decisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->