### PR TITLE
revert(studio): reinstate database_identifier on the agent notebook schema

### DIFF
--- a/apps/studio/components/ui/AIAssistantPanel/AssistantNotebookPreview.test.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AssistantNotebookPreview.test.tsx
@@ -23,10 +23,11 @@ const wireDatabaseCell = (id: string, database_identifier?: string): CellWire =>
   database_identifier,
 })
 
-const agentDatabaseCell = (): AgentCell => ({
+const agentDatabaseCell = (database_identifier?: string): AgentCell => ({
   _tag: 'database_cell',
   sql: 'select 1',
   row_limit: 100,
+  database_identifier,
 })
 
 describe('AssistantNotebookPreview', () => {
@@ -68,17 +69,17 @@ describe('AssistantNotebookPreview', () => {
       {
         _tag: 'replaced',
         before: wireDatabaseCell('cell-1', 'primary'),
-        after: agentDatabaseCell(),
+        after: agentDatabaseCell('replica-3'),
         operationIndex: 0,
       },
     ]
 
     render(<AssistantNotebookPreview entries={entries} mode="update" />)
 
-    expect(screen.getByText('Database: primary → No metadata')).toBeInTheDocument()
+    expect(screen.getByText('Database: primary → Database: replica-3')).toBeInTheDocument()
     expect(
       screen.getByRole('button', { name: 'Replaced Query: Untitled query' })
-    ).toHaveTextContent('Database: primary → No metadata')
+    ).toHaveTextContent('Database: primary → Database: replica-3')
   })
 
   it('hides entries past the limit behind a "Show N more" button', async () => {

--- a/apps/studio/components/ui/AIAssistantPanel/AssistantNotebookPreview.utils.test.ts
+++ b/apps/studio/components/ui/AIAssistantPanel/AssistantNotebookPreview.utils.test.ts
@@ -38,10 +38,11 @@ const wireLogCell = (id: string): CellWire => ({
   time_range: { _tag: 'relative_time_range', unit: 'day', amount: 7 },
 })
 
-const agentDatabaseCell = (): AgentCell => ({
+const agentDatabaseCell = (database_identifier?: string): AgentCell => ({
   _tag: 'database_cell',
   sql: 'select 1',
   row_limit: 100,
+  database_identifier,
 })
 
 describe('getEntryKey', () => {
@@ -145,26 +146,26 @@ describe('getEntryMetadataLine', () => {
     ).toBe('Database: replica-3')
   })
 
-  it('returns a before → after pair when a replacement drops the database metadata', () => {
+  it('returns a before → after pair when a replacement changes only metadata', () => {
     expect(
       getEntryMetadataLine({
         _tag: 'replaced',
         before: wireDatabaseCell('cell-1', 'Signups', 'primary'),
-        after: agentDatabaseCell(),
+        after: agentDatabaseCell('replica-3'),
         operationIndex: 0,
       })
-    ).toBe('Database: primary → No metadata')
+    ).toBe('Database: primary → Database: replica-3')
   })
 
   it('returns a single line when replacement metadata is unchanged', () => {
     expect(
       getEntryMetadataLine({
         _tag: 'replaced',
-        before: wireDatabaseCell('cell-1', undefined, undefined),
-        after: agentDatabaseCell(),
+        before: wireDatabaseCell('cell-1', 'Signups', 'primary'),
+        after: agentDatabaseCell('primary'),
         operationIndex: 0,
       })
-    ).toBe(null)
+    ).toBe('Database: primary')
   })
 })
 

--- a/apps/studio/components/ui/AIAssistantPanel/AssistantNotebookPreview.utils.ts
+++ b/apps/studio/components/ui/AIAssistantPanel/AssistantNotebookPreview.utils.ts
@@ -83,11 +83,8 @@ export function getCellMetadataLine(cell: OperationResultCell): string | null {
   switch (cell._tag) {
     case 'markdown_cell':
       return null
-    case 'database_cell': {
-      const databaseIdentifier =
-        'database_identifier' in cell ? cell.database_identifier : undefined
-      return databaseIdentifier ? `Database: ${databaseIdentifier}` : null
-    }
+    case 'database_cell':
+      return cell.database_identifier ? `Database: ${cell.database_identifier}` : null
     case 'log_cell':
       return `Time range: ${formatTimeRange(cell.time_range)}`
   }

--- a/apps/studio/data/content/notebooks/notebook-schema.test.ts
+++ b/apps/studio/data/content/notebooks/notebook-schema.test.ts
@@ -260,26 +260,6 @@ describe('agentNotebookSchema', () => {
 
     expect(result.success).toBe(false)
   })
-
-  it('rejects a database_cell that carries a database_identifier', () => {
-    // Agents have no way to discover a project's real read-replica identifiers, so an
-    // invented one silently breaks the cell (its connection string never resolves) — the
-    // field is stripped from the agent-facing schema entirely rather than left for a model
-    // to guess at.
-    const result = agentNotebookSchema.safeParse({
-      schema_version: 1,
-      cells: [
-        {
-          _tag: 'database_cell',
-          sql: 'select 1',
-          row_limit: 100,
-          database_identifier: 'replica-1',
-        },
-      ],
-    })
-
-    expect(result.success).toBe(false)
-  })
 })
 
 describe('writableNotebookSchema', () => {

--- a/apps/studio/data/content/notebooks/notebook-schema.ts
+++ b/apps/studio/data/content/notebooks/notebook-schema.ts
@@ -154,18 +154,11 @@ export type WritableNotebook = Omit<z.infer<typeof writableNotebookSchema>, 'cel
 type WritableCellWire = z.infer<typeof writableCellSchema>
 type WritableNotebookWire = z.infer<typeof writableNotebookSchema>
 
-// Agents cannot yet target a specific read replica: there's no tool exposing a project's
-// real replica identifiers, so a model asked to fill this field has no legitimate value to
-// put there — and an invented one silently breaks the cell, since its connection string can
-// never resolve (see QueryEditor's run handler). Omit the field entirely until replica
-// selection is actually wired up for agents, rather than leave it for a model to guess at.
-const agentDatabaseFieldsSchema = databaseFieldsSchema.omit({ database_identifier: true })
-
 // Agents have restrictions on writing IDs to preserve guarantees about ID
 // uniqueness
 export const agentCellSchema = z.discriminatedUnion('_tag', [
   markdownFieldsSchema.extend({ _tag: z.literal('markdown_cell') }).strict(),
-  agentDatabaseFieldsSchema.extend({ _tag: z.literal('database_cell') }).strict(),
+  databaseFieldsSchema.extend({ _tag: z.literal('database_cell') }).strict(),
   logFieldsSchema.extend({ _tag: z.literal('log_cell') }).strict(),
 ])
 


### PR DESCRIPTION
## Summary
- Reverts #49326's temporary mitigation, which stripped `database_identifier` from the agent-facing notebook cell schema (`agentCellSchema`) because the assistant had no legitimate source of truth for valid read-replica identifiers.
- The previous PR in this stack (#49328) added the `list_databases` tool, so that source of truth now exists — `database_cell`s can carry `database_identifier` again.

Part 3/6 of the stack for FE-4225 (expose valid database identifiers to the notebook AI agent). Stacked on #49328.

## Test plan
- [x] Existing schema/preview tests (reverted alongside the mitigation) pass
- [x] `pnpm --filter studio exec tsc --noEmit` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI-generated notebook database cells now support database identifiers.
  * Notebook previews display the associated database source, including transitions between primary and replica databases.

* **Bug Fixes**
  * Improved database metadata handling to preserve identifiers when updating notebook cells.
  * Database information is now shown only when available, preventing inaccurate or missing metadata displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->