### PR TITLE
docs(studio): instruct the notebook agent to use list_databases

### DIFF
--- a/apps/studio/lib/ai/prompts.ts
+++ b/apps/studio/lib/ai/prompts.ts
@@ -814,6 +814,7 @@ export const NOTEBOOKS_PROMPT = `
 - When describing an existing notebook, report each query cell's configuration that changes what it returns — a log cell's time range, a database cell's row limit — and don't count markdown cells as queries.
 - Before writing a \`database_cell\`'s SQL, call \`list_tables\` to confirm the referenced tables and columns actually exist. Never assume a table or column exists from the user's wording alone — if it isn't in the schema you fetched, say so instead of fabricating a query against it.
 - A \`database_cell\` or \`log_cell\` whose SQL performs an irreversible operation (DROP, TRUNCATE, DELETE without a WHERE clause, etc.) is still subject to the Destructive Operations rule below — warn explicitly before creating or updating a cell with such a query. Saving it for repeated future use does not make it safer.
+- Before setting a \`database_cell\`'s \`database_identifier\` (e.g. to target a read replica the user names or describes), call \`list_databases\` and use one of the identifiers it returns. Never invent one — an unrecognized identifier is rejected. Omit the field entirely to target the project's primary database.
 - A cell that queries logs (edge_logs, postgres_logs, auth_logs, function_edge_logs, function_logs, storage_logs, realtime_logs, postgrest_logs, supavisor_logs, or pgbouncer_logs) must be a \`log_cell\`, never a \`database_cell\` — these are not Postgres tables, and a \`log_cell\`'s SQL runs on ClickHouse, not Postgres.
 ${CLICKHOUSE_LOGS_COMPLETION_INSTRUCTIONS}
 ${buildClickhouseLogsSchemaSection()}


### PR DESCRIPTION
## Summary
- Adds a bullet to `NOTEBOOKS_PROMPT` instructing the assistant to call `list_databases` before setting a `database_cell`'s `database_identifier`, mirroring the existing `list_tables` schema-validation instruction immediately above it.

Part 5/6 of the stack for FE-4225 (expose valid database identifiers to the notebook AI agent). Stacked on #49333. This is the last piece that makes the assistant actually *use* the tool and schema field wired up earlier in the stack, rather than just having them available.

## Test plan
- [x] `pnpm --filter studio exec tsc --noEmit` passes
- [x] `prettier --check` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notebook database configuration by ensuring database identifiers are selected from available databases.
  * Prevented unnecessary identifiers from being assigned to cells using the primary database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->