### PR TITLE
fix(common): enumerate storage with length/key(i) instead of Object.keys

### DIFF
--- a/packages/common/safe-storage.ts
+++ b/packages/common/safe-storage.ts
@@ -61,7 +61,16 @@ function createSafeStorage(kind: StorageKind) {
       const store = getBackingStore(kind)
       if (store === null) return []
       try {
-        return Object.keys(store)
+        // `length` and `key(i)` rather than `Object.keys(store)`: the stored entries are
+        // only own enumerable properties on a plain implementation. jsdom (and this repo's
+        // own test polyfill) expose the methods instead, so `Object.keys` returns
+        // ["getItem", "setItem", ...] and the real entries are invisible.
+        const result: string[] = []
+        for (let i = 0; i < store.length; i++) {
+          const key = store.key(i)
+          if (key !== null) result.push(key)
+        }
+        return result
       } catch (error) {
         reportFailure(kind, 'keys', '*', error)
         return []


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix. `safeLocalStorage.keys()` enumerates with `Object.keys(store)`, which only sees the stored entries when the Storage implementation exposes them as own enumerable properties. Where it does not, it returns the method names instead, so `clearLocalStorage()` iterates `getItem`, `setItem`, ... and removes nothing.

This is what the currently failing `apps/studio/lib/local-storage.test.ts` has been reporting.

## What is the current behavior?

On master, `pnpm test:studio` is red:

```
FAIL  lib/local-storage.test.ts > clearLocalStorage > preserves queue operations
      preferences while removing non-allowlisted keys
AssertionError: expected 'remove-me' to be null
```

The cause, measured rather than guessed. Under jsdom:

```
Object.keys(localStorage)  ->  ["getItem","setItem","removeItem","clear","key","length"]
localStorage.length        ->  2
length + key(i)            ->  ["a","b"]
```

So `clearLocalStorage()` walks the method names, finds none of them in `LOCAL_STORAGE_KEYS_ALLOWLIST`, calls `removeItem("getItem")` and friends, and leaves the real entries untouched.

This is not a jsdom curiosity in isolation. `clearLocalStorage()` is the sign-out purge, called from `packages/common/auth.tsx` and `apps/studio/lib/auth.tsx`, and `Object.keys()` is not the specified way to enumerate a `Storage`. Any implementation that serves entries through a proxy rather than as own properties silently turns that purge into a no-op. This repo already contains one such implementation: the test polyfill at `apps/studio/tests/setup/polyfills.ts`.

To be straight about scope: real browsers do expose stored entries as own enumerable properties, so I am **not** claiming that sign-out fails to clear data for users today. What I can show is a red test on master, a non-spec enumeration on a security-relevant path, and two in-repo Storage implementations where it already returns the wrong thing.

## What is the new behavior?

`keys()` uses `length` and `key(i)`, which is the `Storage` interface's own enumeration API and behaves the same everywhere.

## Why `packages/common/safe-storage.test.ts` never caught this

Its `createMemoryStorage()` mock is a `Proxy` with an explicit `ownKeys` trap, so `Object.keys()` works there by construction. I checked that the change is a no-op for that mock rather than assuming:

| mock | `Object.keys(store)` | `length` + `key(i)` |
| --- | --- | --- |
| `safe-storage.test.ts` proxy mock | `["a","b"]` | `["a","b"]` |
| `apps/studio/tests/setup/polyfills.ts` mock | `["getItem","setItem",...]` | `["a","b"]` |

Worth flagging separately: `packages/common` has no `test` script, so those tests are not run by CI at all. I have deliberately not changed that here, since wiring up a package's test runner is a different PR and may surface unrelated failures.

## Verification

Full `apps/studio` suite, since this touches a shared module:

| | test files | tests |
| --- | --- | --- |
| master | 530 passed, **1 failed** | 5629 passed, **1 failed** |
| this branch | **531 passed, 0 failed** | **5630 passed, 0 failed** |

One caveat I would rather state than hide: my first run on this branch reported 34 failures, including a 5000 ms timeout in `settings/infrastructure.test.tsx`. I stashed the change to get the baseline, then re-ran twice more, and both came back fully green. The first run was load-induced flake on my machine, not this change. I would not have believed a single green run either.

Gates: `test:prettier` passes repo wide, `typecheck --filter=common --filter=studio --force` passes, and `--filter studio run lint:ratchet` reports rules improved.

Freshman contributor. Found this by actually running the suite instead of trusting the "known pre-existing failure" label, and I measured the jsdom enumeration and both mock behaviours myself before touching anything.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved storage key enumeration for broader compatibility with storage implementations.
  * Ensured all stored entries are correctly returned, including when storage methods are enumerable properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->