### PR TITLE
fix(docs): stop rendering empty troubleshooting error-code pills

### DIFF
--- a/apps/docs/features/docs/Troubleshooting.page.tsx
+++ b/apps/docs/features/docs/Troubleshooting.page.tsx
@@ -12,6 +12,7 @@ export default async function TroubleshootingPage({ entry }: { entry: ITroublesh
   const dateUpdated = entry.data.database_id.startsWith('pseudo-')
     ? new Date()
     : (await getTroubleshootingUpdatedDates()).get(entry.data.database_id)
+  const errorCodes = entry.data.errors?.map(formatError).filter(Boolean) ?? []
 
   return (
     <SidebarSkeleton
@@ -62,17 +63,17 @@ export default async function TroubleshootingPage({ entry }: { entry: ITroublesh
                   <hr className="my-6" aria-hidden />
                 </>
               )}
-              {entry.data.errors?.length && entry.data.errors.length > 0 && (
+              {errorCodes.length > 0 && (
                 <>
                   <h3 className="text-sm text-foreground-lighter mb-3">Related error codes</h3>
                   <div className="flex flex-wrap gap-0.5">
-                    {entry.data.errors.map((error, index) => (
+                    {errorCodes.map((errorCode, index) => (
                       <Link
                         key={index}
-                        href={`/guides/troubleshooting${serializeTroubleshootingSearchParams({ errorCodes: [formatError(error)] })}`}
+                        href={`/guides/troubleshooting${serializeTroubleshootingSearchParams({ errorCodes: [errorCode] })}`}
                       >
                         <PillTag className="hover:bg-200 focus-visible:bg-foreground-muted hover:border-control focus-visible:border-control transition-colors">
-                          {formatError(error)}
+                          {errorCode}
                         </PillTag>
                       </Link>
                     ))}
@@ -80,7 +81,7 @@ export default async function TroubleshootingPage({ entry }: { entry: ITroublesh
                   <hr className="my-6" aria-hidden />
                 </>
               )}
-              {entry.data.keywords?.length && entry.data.keywords.length > 0 && (
+              {!!entry.data.keywords?.length && (
                 <>
                   <h3 className="text-sm text-foreground-lighter mb-3">Keywords</h3>
                   <div className="flex flex-wrap gap-0.5">


### PR DESCRIPTION
Closes DOCS-1281

## Problem

`formatError` returns an empty string when an error entry has neither an HTTP status code nor a code. The troubleshooting page renders the pill anyway, producing a link with no text content whose `href` ends in `?errorCodes=` with no value.

Two bugs from one cause: an unnamed link, and a pill linking to a filter for no error code.

The guard also evaluated to `0` rather than `false` for an empty array, and React renders that as a literal "0" on the page.

## Solution

* Derive the formatted codes once, drop the empties, and gate the section on the filtered list. An entry whose every code formats empty no longer renders a heading and rule with nothing under them.
* Call `formatError` once per code instead of twice per pill.
* Fix the same `0`-rendering guard on the keywords section.

`formatError` itself is unchanged. It also produces grouping and sort keys in `Troubleshooting.utils.ts` and `Troubleshooting.ui.tsx`, so changing its return contract would reach well beyond this fix.

## Manual testing

1. Open a troubleshooting entry on the deploy preview, for example `/guides/troubleshooting`.
2. Open an entry that lists related error codes. Every pill shows a code.
3. Inspect each pill's `href`. None ends in `?errorCodes=` with no value.
4. Confirm no stray "0" renders where an error or keyword list is empty.
5. Run axe on the page. `link-name` reports zero elements.
