### PR TITLE
fix(ui-patterns): give the shared InfoTooltip trigger an accessible name

### DIFF
--- a/apps/www/app/pricing/PricingContent.tsx
+++ b/apps/www/app/pricing/PricingContent.tsx
@@ -70,7 +70,7 @@ export default function PricingContent() {
           <div className="flex items-center justify-center gap-1">
             <span className="py-1 px-3 bg-surface-100 flex items-center gap-1 border rounded-full text-xs text-foreground-lighter">
               What is &ldquo;compute&rdquo;?
-              <InfoTooltip side="bottom" className="max-w-[280px]">
+              <InfoTooltip side="bottom" className="max-w-[280px]" label="About compute">
                 Think of compute as the computer your database runs on. As your app grows, you scale
                 CPU and memory to handle more traffic and data.
               </InfoTooltip>

--- a/apps/www/components/Pricing/ComputePricingCalculator.tsx
+++ b/apps/www/components/Pricing/ComputePricingCalculator.tsx
@@ -153,7 +153,7 @@ const ComputePricingCalculator = ({
           <div className="flex items-center gap-1 w-full justify-between">
             <span>Total</span>
             <span className="text-foreground font-mono flex items-center gap-1">
-              <InfoTooltip side="top" className="max-w-[250px]">
+              <InfoTooltip side="top" className="max-w-[250px]" label="About this estimate">
                 This estimate only includes Plan and Compute add-on monthly costs. Other resources
                 might incur additional costs in the final invoice.
               </InfoTooltip>

--- a/apps/www/components/Pricing/PricingTableRow.tsx
+++ b/apps/www/components/Pricing/PricingTableRow.tsx
@@ -193,7 +193,7 @@ export const PricingTableRowDesktop = (props: any) => {
               >
                 <span className="mr-1">{feat.title}</span>
                 {tooltips?.main && (
-                  <InfoTooltip side="top" className="max-w-[250px]">
+                  <InfoTooltip side="top" className="max-w-[250px]" label={`About ${feat.title}`}>
                     {tooltips.main}
                   </InfoTooltip>
                 )}
@@ -221,7 +221,11 @@ export const PricingTableRowDesktop = (props: any) => {
                       <div className="text-foreground text-xs flex flex-col justify-center">
                         <span className="flex items-center gap-2">
                           {tooltips?.[planName] && (
-                            <InfoTooltip side="top" className="max-w-[250px]">
+                            <InfoTooltip
+                              side="top"
+                              className="max-w-[250px]"
+                              label={`About ${feat.title} on the ${planName} plan`}
+                            >
                               {tooltips[planName]}
                             </InfoTooltip>
                           )}

--- a/packages/ui-patterns/src/info-tooltip.tsx
+++ b/packages/ui-patterns/src/info-tooltip.tsx
@@ -22,16 +22,16 @@ const SVG = forwardRef<SVGSVGElement, React.SVGProps<SVGSVGElement>>((props, ref
 
 const InfoTooltip = forwardRef<
   ElementRef<typeof TooltipContent>,
-  React.ComponentPropsWithoutRef<typeof TooltipContent>
->(({ ...props }, _ref) => {
+  React.ComponentPropsWithoutRef<typeof TooltipContent> & { label?: string }
+>(({ label, ...props }, _ref) => {
   return (
     <Tooltip>
       <TooltipTrigger
         type="button"
-        role="button"
         className="flex [&_svg]:data-[state=delayed-open]:fill-foreground-lighter [&_svg]:data-[state=instant-open]:fill-foreground-lighter"
       >
         <SVG strokeWidth={2} className="transition-colors fill-foreground-muted w-4 h-4" />
+        <span className="sr-only">{label ?? 'More information'}</span>
       </TooltipTrigger>
       <TooltipContent {...props} />
     </Tooltip>


### PR DESCRIPTION
Closes FE-4093

## Problem

The shared `InfoTooltip` trigger's only child is an SVG and it has no accessible name, so a screen reader announces an unnamed button and the information the tooltip carries is unreachable. `button-name`, critical.

`/pricing` renders 34 of them.

## Solution

* Add an optional `label` prop rendered as `sr-only` text, with a generic fallback so the 22 call sites that pass nothing still get a name. The prop is optional because 26 files import this component across www, Studio, design-system and ui-patterns.
* Drop the redundant `role="button"` from a native button.
* Label the four www call sites. A shared fallback alone would leave `/pricing` announcing 34 identical names, which passes axe and stays unusable. The labels come from the feature title and plan already in scope, so no pricing data changes.

Docs is unaffected. It has its own `InfoTooltip` at `apps/docs/features/ui/InfoTooltip.tsx` and never imports the shared one.

## Manual testing

1. Open `/pricing` on the deploy preview.
2. Tab through the comparison table. Each info tooltip announces its own feature, for example "About Database size".
3. Tab to a plan-specific tooltip. It announces the feature and the plan, for example "About Automatic backups on the pro plan".
4. Confirm the icons render unchanged and the tooltips still open on hover and on focus.
5. Run axe on the page. `button-name` reports zero elements.
