### PR TITLE
fix(www): restore pointer cursors on the view-toggle buttons

### DIFF
--- a/apps/www/app/partners/catalog/IntegrationsContent.tsx
+++ b/apps/www/app/partners/catalog/IntegrationsContent.tsx
@@ -314,7 +314,7 @@ export default function IntegrationsContent({
                   title="Grid view"
                   onClick={() => setFilters({ view: 'grid' })}
                   className={cn(
-                    'relative flex items-center justify-center w-8 h-8 rounded-l-lg focus-visible:z-10 focus-ring',
+                    'relative flex items-center justify-center w-8 h-8 cursor-pointer rounded-l-lg focus-visible:z-10 focus-ring',
                     viewMode === 'grid'
                       ? 'bg-surface-300 text-foreground'
                       : 'bg-surface-75 text-foreground-muted hover:text-foreground hover:bg-surface-200'
@@ -327,7 +327,7 @@ export default function IntegrationsContent({
                   title="List view"
                   onClick={() => setFilters({ view: 'list' })}
                   className={cn(
-                    'relative flex items-center justify-center w-8 h-8 border-l border-muted rounded-r-lg focus-visible:z-10 focus-ring',
+                    'relative flex items-center justify-center w-8 h-8 cursor-pointer border-l border-muted rounded-r-lg focus-visible:z-10 focus-ring',
                     viewMode === 'list'
                       ? 'bg-surface-300 text-foreground'
                       : 'bg-surface-75 text-foreground-muted hover:text-foreground hover:bg-surface-200'

--- a/apps/www/pages/features.tsx
+++ b/apps/www/pages/features.tsx
@@ -280,7 +280,7 @@ function FeaturesPage() {
                   title="Grid view"
                   onClick={() => setViewMode('grid')}
                   className={cn(
-                    'relative flex items-center justify-center w-8 h-8 rounded-l-lg focus-visible:z-10 focus-ring',
+                    'relative flex items-center justify-center w-8 h-8 cursor-pointer rounded-l-lg focus-visible:z-10 focus-ring',
                     viewMode === 'grid'
                       ? 'bg-surface-300 text-foreground'
                       : 'bg-surface-75 text-foreground-muted hover:text-foreground hover:bg-surface-200'
@@ -293,7 +293,7 @@ function FeaturesPage() {
                   title="Matrix view"
                   onClick={() => setViewMode('matrix')}
                   className={cn(
-                    'relative flex items-center justify-center w-8 h-8 border-l border-muted rounded-r-lg focus-visible:z-10 focus-ring',
+                    'relative flex items-center justify-center w-8 h-8 cursor-pointer border-l border-muted rounded-r-lg focus-visible:z-10 focus-ring',
                     viewMode === 'matrix'
                       ? 'bg-surface-300 text-foreground'
                       : 'bg-surface-75 text-foreground-muted hover:text-foreground hover:bg-surface-200'


### PR DESCRIPTION
Closes FE-4227

## Problem

Tailwind 4 no longer sets `cursor: pointer` on buttons in Preflight, so the view-toggle buttons render with an arrow cursor. Anchors are unaffected, which is why the problem looks inconsistent rather than total.

Measured against production: 14 of 19 buttons on `/features` compute to `cursor: default`.

## Solution

Add `cursor-pointer` to the four grid, matrix and list toggles on `/features` and `/partners/catalog`.

The `/features` nav controls need the same treatment. That one line ships in the FE-4097 PR so two open PRs are not editing adjacent lines of the same file.

This is a targeted patch. The base-layer fix spanning www, Docs and Studio is FE-4228.

## Manual testing

1. Open `/features` on the deploy preview.
2. Hover the grid and matrix toggles above the feature list. Both show a pointer cursor.
3. Open `/partners/catalog`.
4. Hover the grid and list toggles. Both show a pointer cursor.
