### PR TITLE
fix(docs): stop rendering empty troubleshooting error-code pills

### DIFF
--- a/apps/docs/features/docs/Troubleshooting.page.tsx
+++ b/apps/docs/features/docs/Troubleshooting.page.tsx
@@ -12,6 +12,7 @@ export default async function TroubleshootingPage({ entry }: { entry: ITroublesh
   const dateUpdated = entry.data.database_id.startsWith('pseudo-')
     ? new Date()
     : (await getTroubleshootingUpdatedDates()).get(entry.data.database_id)
+  const errorCodes = entry.data.errors?.map(formatError).filter(Boolean) ?? []
 
   return (
     <SidebarSkeleton
@@ -62,17 +63,17 @@ export default async function TroubleshootingPage({ entry }: { entry: ITroublesh
                   <hr className="my-6" aria-hidden />
                 </>
               )}
-              {entry.data.errors?.length && entry.data.errors.length > 0 && (
+              {errorCodes.length > 0 && (
                 <>
                   <h3 className="text-sm text-foreground-lighter mb-3">Related error codes</h3>
                   <div className="flex flex-wrap gap-0.5">
-                    {entry.data.errors.map((error, index) => (
+                    {errorCodes.map((errorCode, index) => (
                       <Link
                         key={index}
-                        href={`/guides/troubleshooting${serializeTroubleshootingSearchParams({ errorCodes: [formatError(error)] })}`}
+                        href={`/guides/troubleshooting${serializeTroubleshootingSearchParams({ errorCodes: [errorCode] })}`}
                       >
                         <PillTag className="hover:bg-200 focus-visible:bg-foreground-muted hover:border-control focus-visible:border-control transition-colors">
-                          {formatError(error)}
+                          {errorCode}
                         </PillTag>
                       </Link>
                     ))}
@@ -80,7 +81,7 @@ export default async function TroubleshootingPage({ entry }: { entry: ITroublesh
                   <hr className="my-6" aria-hidden />
                 </>
               )}
-              {entry.data.keywords?.length && entry.data.keywords.length > 0 && (
+              {!!entry.data.keywords?.length && (
                 <>
                   <h3 className="text-sm text-foreground-lighter mb-3">Keywords</h3>
                   <div className="flex flex-wrap gap-0.5">

--- a/apps/docs/features/docs/Troubleshooting.page.tsx
+++ b/apps/docs/features/docs/Troubleshooting.page.tsx
@@ -12,7 +12,7 @@ export default async function TroubleshootingPage({ entry }: { entry: ITroublesh
   const dateUpdated = entry.data.database_id.startsWith('pseudo-')
     ? new Date()
     : (await getTroubleshootingUpdatedDates()).get(entry.data.database_id)
-  const errorCodes = entry.data.errors?.map(formatError).filter(Boolean) ?? []
+  const errorCodes = [...new Set(entry.data.errors?.map(formatError).filter(Boolean) ?? [])]
 
   return (
     <SidebarSkeleton
@@ -67,9 +67,9 @@ export default async function TroubleshootingPage({ entry }: { entry: ITroublesh
                 <>
                   <h3 className="text-sm text-foreground-lighter mb-3">Related error codes</h3>
                   <div className="flex flex-wrap gap-0.5">
-                    {errorCodes.map((errorCode, index) => (
+                    {errorCodes.map((errorCode) => (
                       <Link
-                        key={index}
+                        key={errorCode}
                         href={`/guides/troubleshooting${serializeTroubleshootingSearchParams({ errorCodes: [errorCode] })}`}
                       >
                         <PillTag className="hover:bg-200 focus-visible:bg-foreground-muted hover:border-control focus-visible:border-control transition-colors">


### PR DESCRIPTION
Closes DOCS-1281

## Problem

Two defects in the "Related error codes" list, both from the page diverging from what `Troubleshooting.utils.ts` already does.

* **Empty pills.** `formatError` returns an empty string when an error has neither an HTTP status code nor a code. The page renders the pill anyway, giving a link with no text whose `href` ends in `errorCodes=` with no value. So it is both an unnamed link and a pill filtering on nothing.
* **Duplicate pills.** The same formatted code renders once per underlying error object, so one entry shows seven identical "500 unexpected_failure" pills.

Measured on production, across the 59 entries that render the section:

| | Count |
| -- | -- |
| Entries with an empty pill | 23 |
| Empty pills | 33 |
| Entries with duplicate pills | 4 |
| Redundant pills | 9 |

The guard also evaluated to `0` rather than `false` for an empty array, which React renders as a literal "0".

## Solution

* Derive the formatted codes once, drop the empties, and dedupe. An entry whose every code formats empty no longer renders a heading and rule with nothing under them.
* Call `formatError` once per code instead of twice per pill, and key on the code now that codes are unique.
* Fix the same `0`-rendering guard on the keywords section.

`Troubleshooting.utils.ts` already filters on `error?.http_status_code || error?.code` at lines 69 and 150, and already dedupes by formatted code at lines 72 to 79. This brings the page in line with the sidebar and filter list rather than introducing a new pattern.

`formatError` itself is unchanged. It also produces grouping and sort keys in `Troubleshooting.utils.ts` and `Troubleshooting.ui.tsx`, so changing its return contract would reach well beyond this fix.

## Manual testing

Compare each page against production, which still shows both defects.

1. Open [dashboard-errors-when-managing-users on production](https://supabase.com/docs/guides/troubleshooting/dashboard-errors-when-managing-users-N1ls4A). It shows 8 pills: seven identical "500 unexpected_failure" and one empty.
2. Open [the same page on the preview](https://docs-git-docs-troubleshooting-empty-error-pills-supabase.vercel.app/docs/guides/troubleshooting/dashboard-errors-when-managing-users-N1ls4A). One "500 unexpected_failure" pill remains.
3. Open [prisma-error-management on production](https://supabase.com/docs/guides/troubleshooting/prisma-error-management-Cm5P_o). It shows 6 empty pills.
4. Open [the same page on the preview](https://docs-git-docs-troubleshooting-empty-error-pills-supabase.vercel.app/docs/guides/troubleshooting/prisma-error-management-Cm5P_o). The section is gone, because every code on that entry formats empty.
5. Run axe on either preview page. `link-name` reports zero elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved troubleshooting displays by formatting and deduplicating error values.
  * Removed empty or invalid error entries from the rendered results.
  * Related error-code links now appear only when valid error codes are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->