### PR TITLE
fix(www): make the view toggles a radio group and fix the filter rows

### DIFF
--- a/apps/www/app/partners/catalog/IntegrationsContent.tsx
+++ b/apps/www/app/partners/catalog/IntegrationsContent.tsx
@@ -314,7 +314,7 @@ export default function IntegrationsContent({
                   title="Grid view"
                   onClick={() => setFilters({ view: 'grid' })}
                   className={cn(
-                    'relative flex items-center justify-center w-8 h-8 rounded-l-lg focus-visible:z-10 focus-ring',
+                    'relative flex items-center justify-center w-8 h-8 cursor-pointer rounded-l-lg focus-visible:z-10 focus-ring',
                     viewMode === 'grid'
                       ? 'bg-surface-300 text-foreground'
                       : 'bg-surface-75 text-foreground-muted hover:text-foreground hover:bg-surface-200'
@@ -327,7 +327,7 @@ export default function IntegrationsContent({
                   title="List view"
                   onClick={() => setFilters({ view: 'list' })}
                   className={cn(
-                    'relative flex items-center justify-center w-8 h-8 border-l border-muted rounded-r-lg focus-visible:z-10 focus-ring',
+                    'relative flex items-center justify-center w-8 h-8 cursor-pointer border-l border-muted rounded-r-lg focus-visible:z-10 focus-ring',
                     viewMode === 'list'
                       ? 'bg-surface-300 text-foreground'
                       : 'bg-surface-75 text-foreground-muted hover:text-foreground hover:bg-surface-200'

--- a/apps/www/app/partners/catalog/IntegrationsContent.tsx
+++ b/apps/www/app/partners/catalog/IntegrationsContent.tsx
@@ -312,12 +312,13 @@ export default function IntegrationsContent({
                 <button
                   tabIndex={0}
                   title="Grid view"
+                  aria-pressed={viewMode === 'grid'}
                   onClick={() => setFilters({ view: 'grid' })}
                   className={cn(
-                    'relative flex items-center justify-center w-8 h-8 cursor-pointer rounded-l-lg focus-visible:z-10 focus-ring',
+                    'relative flex items-center justify-center w-8 h-8 rounded-l-lg focus-visible:z-10 focus-ring',
                     viewMode === 'grid'
-                      ? 'bg-surface-300 text-foreground'
-                      : 'bg-surface-75 text-foreground-muted hover:text-foreground hover:bg-surface-200'
+                      ? 'cursor-default bg-surface-400 text-foreground'
+                      : 'cursor-pointer bg-surface-75 text-foreground-muted hover:text-foreground hover:bg-surface-200'
                   )}
                 >
                   <LayoutGrid size={14} />
@@ -325,12 +326,13 @@ export default function IntegrationsContent({
                 <button
                   tabIndex={0}
                   title="List view"
+                  aria-pressed={viewMode === 'list'}
                   onClick={() => setFilters({ view: 'list' })}
                   className={cn(
-                    'relative flex items-center justify-center w-8 h-8 cursor-pointer border-l border-muted rounded-r-lg focus-visible:z-10 focus-ring',
+                    'relative flex items-center justify-center w-8 h-8 border-l border-muted rounded-r-lg focus-visible:z-10 focus-ring',
                     viewMode === 'list'
-                      ? 'bg-surface-300 text-foreground'
-                      : 'bg-surface-75 text-foreground-muted hover:text-foreground hover:bg-surface-200'
+                      ? 'cursor-default bg-surface-400 text-foreground'
+                      : 'cursor-pointer bg-surface-75 text-foreground-muted hover:text-foreground hover:bg-surface-200'
                   )}
                 >
                   <List size={14} />

--- a/apps/www/app/partners/catalog/IntegrationsContent.tsx
+++ b/apps/www/app/partners/catalog/IntegrationsContent.tsx
@@ -31,6 +31,8 @@ import {
   SheetHeader,
   SheetTitle,
   SheetTrigger,
+  ToggleGroup,
+  ToggleGroupItem,
 } from 'ui'
 import { useDebounce } from 'use-debounce'
 
@@ -308,36 +310,38 @@ export default function IntegrationsContent({
               <span className="text-foreground-muted text-xs">
                 {listPartners.length} partner{listPartners.length !== 1 ? 's' : ''}
               </span>
-              <div className="flex items-center rounded-lg border border-muted">
-                <button
-                  tabIndex={0}
+              <ToggleGroup
+                type="single"
+                value={viewMode}
+                onValueChange={(value) => value && setFilters({ view: value as ViewMode })}
+                aria-label="Partner layout"
+                className="flex items-center gap-0 rounded-lg border border-muted"
+              >
+                <ToggleGroupItem
+                  value="grid"
                   title="Grid view"
-                  aria-pressed={viewMode === 'grid'}
-                  onClick={() => setFilters({ view: 'grid' })}
                   className={cn(
-                    'relative flex items-center justify-center w-8 h-8 rounded-l-lg focus-visible:z-10 focus-ring',
-                    viewMode === 'grid'
-                      ? 'cursor-default bg-surface-400 text-foreground'
-                      : 'cursor-pointer bg-surface-75 text-foreground-muted hover:text-foreground hover:bg-surface-200'
+                    'relative flex items-center justify-center w-8 h-8 p-0 rounded-none rounded-l-lg focus-visible:z-10 focus-ring',
+                    'cursor-pointer bg-surface-75 text-foreground-muted hover:text-foreground hover:bg-surface-200',
+                    'data-[state=on]:cursor-default data-[state=on]:bg-surface-400 data-[state=on]:text-foreground',
+                    'aria-checked:bg-surface-400 aria-checked:text-foreground'
                   )}
                 >
                   <LayoutGrid size={14} />
-                </button>
-                <button
-                  tabIndex={0}
+                </ToggleGroupItem>
+                <ToggleGroupItem
+                  value="list"
                   title="List view"
-                  aria-pressed={viewMode === 'list'}
-                  onClick={() => setFilters({ view: 'list' })}
                   className={cn(
-                    'relative flex items-center justify-center w-8 h-8 border-l border-muted rounded-r-lg focus-visible:z-10 focus-ring',
-                    viewMode === 'list'
-                      ? 'cursor-default bg-surface-400 text-foreground'
-                      : 'cursor-pointer bg-surface-75 text-foreground-muted hover:text-foreground hover:bg-surface-200'
+                    'relative flex items-center justify-center w-8 h-8 p-0 rounded-none rounded-r-lg border-l border-muted focus-visible:z-10 focus-ring',
+                    'cursor-pointer bg-surface-75 text-foreground-muted hover:text-foreground hover:bg-surface-200',
+                    'data-[state=on]:cursor-default data-[state=on]:bg-surface-400 data-[state=on]:text-foreground',
+                    'aria-checked:bg-surface-400 aria-checked:text-foreground'
                   )}
                 >
                   <List size={14} />
-                </button>
-              </div>
+                </ToggleGroupItem>
+              </ToggleGroup>
             </div>
 
             {/* Grid view */}

--- a/apps/www/pages/features.tsx
+++ b/apps/www/pages/features.tsx
@@ -207,20 +207,16 @@ function FeaturesPage() {
                 />
               </InputGroup>
               <div className="hidden md:flex flex-col gap-2.5">
-                <div className="flex items-center gap-2 text-foreground-light hover:text-foreground cursor-pointer! hover:cursor-pointer! transition-colors">
+                <label className="flex cursor-pointer items-center gap-2 text-foreground-light hover:text-foreground transition-colors">
                   <Checkbox
-                    id="self-hosted-filter"
                     checked={showSelfHostedOnly}
                     onCheckedChange={() => setShowSelfHostedOnly(!showSelfHostedOnly)}
                     className="[&_input]:m-0"
                   />
-                  <label
-                    htmlFor="self-hosted-filter"
-                    className="text-sm leading-none! flex-1 text-left"
-                  >
+                  <span className="text-sm leading-none! flex-1 text-left">
                     Show only self-hosted features
-                  </label>
-                </div>
+                  </span>
+                </label>
               </div>
               <div className="hidden md:flex flex-col gap-4">
                 <h2 className="text-sm text-foreground-lighter">Filter by tags:</h2>
@@ -228,23 +224,19 @@ function FeaturesPage() {
                   {products
                     .sort((a, b) => (a.toLowerCase() > b.toLowerCase() ? 1 : -1))
                     .map((product) => (
-                      <div
+                      <label
                         key={product}
-                        className="flex items-center gap-2 text-foreground-light hover:text-foreground cursor-pointer! hover:cursor-pointer! transition-colors"
+                        className="flex cursor-pointer items-center gap-2 text-foreground-light hover:text-foreground transition-colors"
                       >
                         <Checkbox
-                          id={product}
                           checked={selectedProducts.includes(product)}
                           onCheckedChange={() => handleProductChange(product)}
                           className="[&_input]:m-0"
                         />
-                        <label
-                          htmlFor={product}
-                          className="text-sm leading-none! capitalize flex-1 text-left"
-                        >
+                        <span className="text-sm leading-none! capitalize flex-1 text-left">
                           {product}
-                        </label>
-                      </div>
+                        </span>
+                      </label>
                     ))}
                 </div>
                 <div className="text-foreground-muted text-xs">
@@ -278,12 +270,13 @@ function FeaturesPage() {
                 <button
                   tabIndex={0}
                   title="Grid view"
+                  aria-pressed={viewMode === 'grid'}
                   onClick={() => setViewMode('grid')}
                   className={cn(
-                    'relative flex items-center justify-center w-8 h-8 cursor-pointer rounded-l-lg focus-visible:z-10 focus-ring',
+                    'relative flex items-center justify-center w-8 h-8 rounded-l-lg focus-visible:z-10 focus-ring',
                     viewMode === 'grid'
-                      ? 'bg-surface-300 text-foreground'
-                      : 'bg-surface-75 text-foreground-muted hover:text-foreground hover:bg-surface-200'
+                      ? 'cursor-default bg-surface-400 text-foreground'
+                      : 'cursor-pointer bg-surface-75 text-foreground-muted hover:text-foreground hover:bg-surface-200'
                   )}
                 >
                   <LayoutGrid size={14} />
@@ -291,12 +284,13 @@ function FeaturesPage() {
                 <button
                   tabIndex={0}
                   title="Matrix view"
+                  aria-pressed={viewMode === 'matrix'}
                   onClick={() => setViewMode('matrix')}
                   className={cn(
-                    'relative flex items-center justify-center w-8 h-8 cursor-pointer border-l border-muted rounded-r-lg focus-visible:z-10 focus-ring',
+                    'relative flex items-center justify-center w-8 h-8 border-l border-muted rounded-r-lg focus-visible:z-10 focus-ring',
                     viewMode === 'matrix'
-                      ? 'bg-surface-300 text-foreground'
-                      : 'bg-surface-75 text-foreground-muted hover:text-foreground hover:bg-surface-200'
+                      ? 'cursor-default bg-surface-400 text-foreground'
+                      : 'cursor-pointer bg-surface-75 text-foreground-muted hover:text-foreground hover:bg-surface-200'
                   )}
                 >
                   <Table2 size={14} />

--- a/apps/www/pages/features.tsx
+++ b/apps/www/pages/features.tsx
@@ -6,7 +6,17 @@ import { useRouter } from 'next/compat/router'
 import Head from 'next/head'
 import Link from 'next/link'
 import { useCallback, useEffect, useState, type ChangeEvent } from 'react'
-import { Badge, Button, Checkbox, cn, InputGroup, InputGroupAddon, InputGroupInput } from 'ui'
+import {
+  Badge,
+  Button,
+  Checkbox,
+  cn,
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+  ToggleGroup,
+  ToggleGroupItem,
+} from 'ui'
 
 import {
   FeaturesMatrix,
@@ -266,36 +276,38 @@ function FeaturesPage() {
               <span className="text-foreground-muted text-xs">
                 {filteredFeatures.length} feature{filteredFeatures.length !== 1 ? 's' : ''}
               </span>
-              <div className="flex items-center rounded-lg border border-muted">
-                <button
-                  tabIndex={0}
+              <ToggleGroup
+                type="single"
+                value={viewMode}
+                onValueChange={(value) => value && setViewMode(value as ViewMode)}
+                aria-label="Feature layout"
+                className="flex items-center gap-0 rounded-lg border border-muted"
+              >
+                <ToggleGroupItem
+                  value="grid"
                   title="Grid view"
-                  aria-pressed={viewMode === 'grid'}
-                  onClick={() => setViewMode('grid')}
                   className={cn(
-                    'relative flex items-center justify-center w-8 h-8 rounded-l-lg focus-visible:z-10 focus-ring',
-                    viewMode === 'grid'
-                      ? 'cursor-default bg-surface-400 text-foreground'
-                      : 'cursor-pointer bg-surface-75 text-foreground-muted hover:text-foreground hover:bg-surface-200'
+                    'relative flex items-center justify-center w-8 h-8 p-0 rounded-none rounded-l-lg focus-visible:z-10 focus-ring',
+                    'cursor-pointer bg-surface-75 text-foreground-muted hover:text-foreground hover:bg-surface-200',
+                    'data-[state=on]:cursor-default data-[state=on]:bg-surface-400 data-[state=on]:text-foreground',
+                    'aria-checked:bg-surface-400 aria-checked:text-foreground'
                   )}
                 >
                   <LayoutGrid size={14} />
-                </button>
-                <button
-                  tabIndex={0}
+                </ToggleGroupItem>
+                <ToggleGroupItem
+                  value="matrix"
                   title="Matrix view"
-                  aria-pressed={viewMode === 'matrix'}
-                  onClick={() => setViewMode('matrix')}
                   className={cn(
-                    'relative flex items-center justify-center w-8 h-8 border-l border-muted rounded-r-lg focus-visible:z-10 focus-ring',
-                    viewMode === 'matrix'
-                      ? 'cursor-default bg-surface-400 text-foreground'
-                      : 'cursor-pointer bg-surface-75 text-foreground-muted hover:text-foreground hover:bg-surface-200'
+                    'relative flex items-center justify-center w-8 h-8 p-0 rounded-none rounded-r-lg border-l border-muted focus-visible:z-10 focus-ring',
+                    'cursor-pointer bg-surface-75 text-foreground-muted hover:text-foreground hover:bg-surface-200',
+                    'data-[state=on]:cursor-default data-[state=on]:bg-surface-400 data-[state=on]:text-foreground',
+                    'aria-checked:bg-surface-400 aria-checked:text-foreground'
                   )}
                 >
                   <Table2 size={14} />
-                </button>
-              </div>
+                </ToggleGroupItem>
+              </ToggleGroup>
             </div>
 
             {viewMode === 'matrix' ? (

--- a/apps/www/pages/features.tsx
+++ b/apps/www/pages/features.tsx
@@ -280,7 +280,7 @@ function FeaturesPage() {
                   title="Grid view"
                   onClick={() => setViewMode('grid')}
                   className={cn(
-                    'relative flex items-center justify-center w-8 h-8 rounded-l-lg focus-visible:z-10 focus-ring',
+                    'relative flex items-center justify-center w-8 h-8 cursor-pointer rounded-l-lg focus-visible:z-10 focus-ring',
                     viewMode === 'grid'
                       ? 'bg-surface-300 text-foreground'
                       : 'bg-surface-75 text-foreground-muted hover:text-foreground hover:bg-surface-200'
@@ -293,7 +293,7 @@ function FeaturesPage() {
                   title="Matrix view"
                   onClick={() => setViewMode('matrix')}
                   className={cn(
-                    'relative flex items-center justify-center w-8 h-8 border-l border-muted rounded-r-lg focus-visible:z-10 focus-ring',
+                    'relative flex items-center justify-center w-8 h-8 cursor-pointer border-l border-muted rounded-r-lg focus-visible:z-10 focus-ring',
                     viewMode === 'matrix'
                       ? 'bg-surface-300 text-foreground'
                       : 'bg-surface-75 text-foreground-muted hover:text-foreground hover:bg-surface-200'

--- a/packages/ui/src/components/shadcn/ui/checkbox.tsx
+++ b/packages/ui/src/components/shadcn/ui/checkbox.tsx
@@ -17,7 +17,7 @@ const Checkbox = React.forwardRef<
     <CheckboxPrimitive.Root
       ref={ref}
       className={cn(
-        'peer flex cursor-pointer items-center justify-center h-4 w-4 shrink-0 rounded-sm border border-control bg-control/25 ring-offset-background',
+        'peer flex items-center justify-center h-4 w-4 shrink-0 rounded-sm border border-control bg-control/25 ring-offset-background',
         'transition-colors duration-150 ease-in-out',
         'hover:border-strong',
         'focus-ring',

--- a/packages/ui/src/components/shadcn/ui/checkbox.tsx
+++ b/packages/ui/src/components/shadcn/ui/checkbox.tsx
@@ -17,7 +17,7 @@ const Checkbox = React.forwardRef<
     <CheckboxPrimitive.Root
       ref={ref}
       className={cn(
-        'peer flex items-center justify-center h-4 w-4 shrink-0 rounded-sm border border-control bg-control/25 ring-offset-background',
+        'peer flex cursor-pointer items-center justify-center h-4 w-4 shrink-0 rounded-sm border border-control bg-control/25 ring-offset-background',
         'transition-colors duration-150 ease-in-out',
         'hover:border-strong',
         'focus-ring',


### PR DESCRIPTION
Closes FE-4227

> [!NOTE]
> Bottom of a stack. #49409 and #49410 sit on top of this one, so merge this first.

## Problem

Five defects in the view toggles on `/features` and `/partners/catalog`, plus one in the `/features` filter rows. All measured on a preview.

**Toggles**

| Defect | Evidence |
| -- | -- |
| No pointer cursor | Tailwind 4 Preflight no longer sets `cursor: pointer` on buttons. 14 of 19 buttons on `/features` computed to `default`. Anchors were unaffected, which is why it looked inconsistent rather than total. |
| The selected toggle offered a pointer | It is a no-op, so the cursor promised an action that does nothing. |
| The selected state was invisible in light mode | `bg-surface-300` and `bg-surface-75` both resolve to pure white. Contrast ratio exactly 1.000. The light theme base lightness is `.995` and each surface step adds `.024`, so every lighter step clamps at white. The only cue left was icon colour. |
| Hover inverted the selection | Unselected hover is `bg-surface-200`, a 2.7% black overlay, while the selected state was white. Hovering the wrong button made it look selected. |
| No grouping | Two unrelated buttons. Nothing conveyed one choice with two options, and the selected view was not programmatically determinable at all. |

**Filter rows on /features**

A pointer appeared only on the narrow gap between each checkbox and its label:

| Element | Computed cursor |
| -- | -- |
| wrapper `div` | `pointer` |
| `label` | `default` |
| checkbox | `default` |

`cursor-pointer!` sat on the wrapper. A declaration targeting an element always beats an inherited value, so `!important` on the parent changed nothing and both children overrode it.

## Solution

**Toggles become a `ToggleGroup`** on both pages, replacing the raw button pairs.

* `type="single"` renders `role="group"` with `role="radio"` and `aria-checked` per item. That describes one choice with two options rather than two independent toggles, so a screen reader announces the selection and its position in the set.
* Each group gets an `aria-label`, which the existing `ToggleGroup` usage on `/pricing` lacks.
* Selected item gets `cursor-default`, unselected gets `cursor-pointer`.
* Selected background becomes `bg-surface-400`, a 5.4% overlay that clears the 2.7% unselected hover and removes the inversion.

**Filter rows** become wrapping `label` elements with `cursor-pointer` directly on the label, matching `IntegrationsContent.tsx`. The whole row becomes a click target, and `id` values derived from raw product names go away.

`toggleVariants` sets the selected background to `bg-surface-300` under both `data-[state=on]:` and `aria-checked:`, and twMerge only dedupes matching prefixes. Both are overridden here so adopting the primitive does not reintroduce the invisible state this PR fixes. The primitive defect is FE-4245.

### Behaviour change

The toggle pair is now a single tab stop navigated with arrow keys, rather than two separate tab stops. That is correct for a mutually exclusive group, but it is a change from current behaviour.

### Related, deliberately not here

| Work | Where |
| -- | -- |
| Checkbox primitive pointer cursor | #49408, so the shared-package change is reviewed separately. The checkbox itself still shows an arrow on this branch. |
| Naming these toggles, which rely on `title` | FE-4229 |
| Base-layer cursor fix across www, Docs and Studio | FE-4228 |
| Sharing one component between the two pages | FE-4244 |

## Manual testing

1. Open [/features](https://zone-www-dot-com-git-www-view-toggle-pointer-cursor-supabase.vercel.app/features) in light mode. The selected toggle is visibly darker than the unselected one.
2. Hover the selected toggle. The cursor is an arrow. Hover the unselected one. It is a pointer, and it does not become darker than the selected one.
3. Tab to the toggle pair. It takes one tab stop. Move between options with the arrow keys.
4. Inspect either toggle. It has `role="radio"` with `aria-checked` tracking the selection, and the wrapping group has an `aria-label`.
5. Hover a tag filter row over the label text and over the gap between the checkbox and the text. Both show a pointer. The checkbox itself still shows an arrow here; that is #49408.
6. Click a filter row well away from the checkbox. The filter toggles.
7. Repeat steps 1 to 4 on [/partners/catalog](https://zone-www-dot-com-git-www-view-toggle-pointer-cursor-supabase.vercel.app/partners/catalog).
