### PR TITLE
fix(docs): replace the generated examples copy instead of merging into it

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -14,7 +14,7 @@
     "build:gz-archive": "tsx ./internals/generate-gz-archive.ts",
     "build:sitemap": "tsx ./internals/generate-sitemap.ts",
     "clean": "rimraf .next .turbo features/docs/generated examples __generated__ tsconfig.tsbuildinfo",
-    "codegen:examples": "shx cp -r ../../examples ./examples",
+    "codegen:examples": "shx rm -rf ./examples && shx cp -r ../../examples ./examples",
     "codegen:graphql": "tsx --conditions=react-server ./scripts/graphqlSchema.ts && graphql-codegen --config codegen.ts",
     "codegen:references:new:ensure": "(test -f spec/reference/javascript/v2/supabase.json || (cd spec && make download.tsdoc.v2)) && (test -f spec/reference/server/v1/server.json || (cd spec && make download.server.v1))",
     "codegen:references:dart": "tsx scripts/generate-dart-reference.ts",

--- a/apps/docs/vitest.globalSetup.ts
+++ b/apps/docs/vitest.globalSetup.ts
@@ -1,4 +1,4 @@
-import { cpSync, existsSync } from 'node:fs'
+import { cpSync, existsSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 
 // Mirrors `pnpm run codegen:examples` so the test suite is self-contained.
@@ -12,5 +12,9 @@ export default function setup() {
   if (!existsSync(source)) {
     throw new Error(`Expected repo-root examples directory at ${source}`)
   }
+  // Replace rather than merge, matching `codegen:examples`. cpSync copies over
+  // what is already there but never deletes, so a renamed or removed example
+  // would linger here and only here, since the npm path now clears first.
+  rmSync(dest, { recursive: true, force: true })
   cpSync(source, dest, { recursive: true })
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix. The generated `apps/docs/examples` copy is merged into rather than replaced, on both paths that produce it. `codegen:examples` nests a second copy of the whole tree on the second run, and `vitest.globalSetup.ts` silently keeps files that no longer exist upstream.

## What is the current behavior?

```json
"codegen:examples": "shx cp -r ../../examples ./examples"
```

`cp -r src dest` copies *into* `dest` when `dest` already exists, so the second run produces `apps/docs/examples/examples/`. Measured in this repo:

| | directories under `apps/docs/examples` | nested copy |
| --- | --- | --- |
| run 1 | 18 | no |
| run 2 | 19 | **yes, 1482 duplicated files** |

This is easy to hit without noticing, because `codegen:examples` is wired into `predev`, `prebuild` and `pretest`. Any second `pnpm dev` without an intervening `pnpm clean` leaves the duplicate behind.

The reason it is worth fixing rather than shrugging at: the duplicate is gitignored, so it never shows up in `git status`, but every subsequent lint, typecheck and test run walks those 1482 extra files. It also reports each finding twice, once under `examples/...` and once under `examples/examples/...`, which is how I ran into it. I spent a while treating duplicated lint output as a real problem in the repo before realising it was my own second `pnpm dev`.

## What is the new behavior?

The destination is cleared first, so the script is idempotent:

| | run 1 | run 2 | run 3 |
| --- | --- | --- | --- |
| directories | 18 | 18 | 18 |
| nested copy | no | no | no |

## Second commit: the same problem on the direct vitest path

@coderabbitai flagged, and @Hardanish-Singh agreed, that `apps/docs/vitest.globalSetup.ts` copies the same examples without replacing. That is right, and it matters more now than before, because the npm path clears first after the first commit and this one did not, so the two diverged.

One correction to the framing though, since it changes what the fix is for. Node's `cpSync(src, dest, { recursive: true })` copies the *contents* of `src` into `dest`, so unlike shell `cp -r` it never produces the nested `examples/examples`. I checked rather than assumed:

```
cpSync run 1 -> dest/a/f.txt, dest/stale.txt
cpSync run 2 -> dest/a/f.txt, dest/stale.txt     (no dest/src, but stale.txt survives)
```

So the defect here is not nesting, it is staleness: a renamed or deleted example lingers forever, and only on the path that `npx vitest`, `pnpm test:local` and IDE runs actually use.

Verified both directions by planting a marker in `apps/docs/examples`:

| | marker after a vitest run |
| --- | --- |
| master | survives |
| this branch | removed |

`vitest run CodeSample` passes 15/15 from a deleted `examples/` directory, so the setup still does its job.

## Additional context

This is the only `shx cp -r` into a fixed destination in the repo, and the only codegen step in `apps/docs` that is not safe to re-run. The neighbouring one already guards itself:

```
"codegen:references:new:ensure": "(test -f spec/reference/javascript/v2/supabase.json || ...)"
```

`clean` already lists `examples` as generated output, so removing it before the copy matches how the directory is treated elsewhere.

I used `shx rm -rf` rather than plain `rm -rf` to stay consistent with the existing `shx cp` and keep the script working on Windows. `shx` is already a dependency here.

Scope I deliberately left alone: CI does a fresh checkout, so it only ever runs this once and is unaffected. This is a local developer fix, not a build correctness fix, and I would rather say that than oversell it.

Gates: `test:prettier` passes repo wide and `typecheck --filter=docs --force` passes. I verified the before and after by deleting `apps/docs/examples` and running `codegen:examples` twice on master (nested, 1482 duplicate files) and twice on this branch (stable at 18 directories).

Freshman contributor. Found this by accident when repo-wide lint reported every docs example error twice, and I traced it back to the copy step and reproduced both sides myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated example generation and test setup to replace existing examples with fresh repository copies, preventing stale files from remaining.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->