### PR TITLE
feat(studio): align assistant message parts

### DIFF
--- a/apps/studio/components/ui/AIAssistantPanel/AssistantChat.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AssistantChat.tsx
@@ -3,7 +3,7 @@ import { useChat } from '@ai-sdk/react'
 import { lastAssistantMessageIsCompleteWithApprovalResponses } from 'ai'
 import { LOCAL_STORAGE_KEYS, useFlag } from 'common'
 import { useParams, useSearchParamsShallow } from 'common/hooks'
-import { AnimatePresence, motion } from 'framer-motion'
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
 import { Eraser, Pencil, X } from 'lucide-react'
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { Button, cn, KeyboardShortcut } from 'ui'
@@ -98,6 +98,7 @@ export const AssistantChat = ({
     useSelectedOrganizationQuery()
 
   const disablePrompts = useFlag('disableAssistantPrompts')
+  const shouldReduceMotion = useReducedMotion()
   const snap = useAiAssistantStateSnapshot()
   const state = useAiAssistantState()
   const currentChat = snap.chats[chatId]
@@ -540,8 +541,12 @@ export const AssistantChat = ({
                 )}
                 {isChatLoading && (
                   <motion.span
-                    animate={{ opacity: [1, 0] }}
-                    transition={{ duration: 1, repeat: Infinity, ease: 'linear' }}
+                    animate={shouldReduceMotion ? { opacity: 1 } : { opacity: [1, 0] }}
+                    transition={
+                      shouldReduceMotion
+                        ? { duration: 0 }
+                        : { duration: 1, repeat: Infinity, ease: 'linear' }
+                    }
                     className="inline-block w-1.5 h-4 bg-foreground-lighter mt-4"
                   />
                 )}

--- a/apps/studio/components/ui/AIAssistantPanel/AssistantChat.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AssistantChat.tsx
@@ -488,10 +488,10 @@ export const AssistantChat = ({
         })}
         {hasMessages ? (
           <Conversation className={cn('flex-1')}>
-            <ConversationContent className="w-full px-7 py-8 mb-10 max-w-3xl mx-auto">
+            <ConversationContent className="w-full px-7 py-8 mb-10">
               {renderedMessages}
-              {error && (
-                <>
+              <div className="w-full max-w-3xl mx-auto">
+                {error && (
                   <AlertError
                     error={
                       isContextExceededError
@@ -537,19 +537,19 @@ export const AssistantChat = ({
                       </div>
                     }
                   />
-                </>
-              )}
-              {isChatLoading && (
-                <motion.span
-                  animate={{ opacity: [1, 0] }}
-                  transition={{ duration: 1, repeat: Infinity, ease: 'linear' }}
-                  className="inline-block w-1.5 h-4 bg-foreground-lighter mt-4"
-                />
-              )}
+                )}
+                {isChatLoading && (
+                  <motion.span
+                    animate={{ opacity: [1, 0] }}
+                    transition={{ duration: 1, repeat: Infinity, ease: 'linear' }}
+                    className="inline-block w-1.5 h-4 bg-foreground-lighter mt-4"
+                  />
+                )}
 
-              <p className="text-center text-xs text-foreground-muted mt-6">
-                The Assistant can make mistakes. Double check responses.
-              </p>
+                <p className="text-center text-xs text-foreground-muted mt-6">
+                  The Assistant can make mistakes. Double check responses.
+                </p>
+              </div>
             </ConversationContent>
             <ConversationScrollButton />
           </Conversation>

--- a/apps/studio/components/ui/AIAssistantPanel/AssistantNotebookPreview.test.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AssistantNotebookPreview.test.tsx
@@ -55,11 +55,12 @@ describe('AssistantNotebookPreview', () => {
       { _tag: 'unchanged', cell: wireMarkdownCell('b', 'two') },
     ]
 
-    render(<AssistantNotebookPreview entries={entries} mode="create" />)
+    const { container } = render(<AssistantNotebookPreview entries={entries} mode="create" />)
 
     expect(screen.getByRole('toolbar', { name: 'Notebook toolbar' })).toBeInTheDocument()
     expect(screen.getByText('2 cells')).toBeInTheDocument()
     expect(screen.getByText('New notebook')).toBeInTheDocument()
+    expect(container.firstElementChild).toHaveClass('max-w-6xl')
   })
 
   it('surfaces a metadata-only change on a replaced cell even when the sql is unchanged', () => {

--- a/apps/studio/components/ui/AIAssistantPanel/AssistantNotebookPreview.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AssistantNotebookPreview.tsx
@@ -54,7 +54,7 @@ export const AssistantNotebookPreview = ({
     expandedOverrides[getEntryKey(entry)] === true
 
   return (
-    <div className={cn('flex min-w-0 flex-col', className)}>
+    <div className={cn('flex w-full min-w-0 max-w-6xl mx-auto flex-col', className)}>
       <ExplorerToolbar aria-label="Notebook toolbar">
         <ExplorerToolbarIcon>
           <NotebookText />

--- a/apps/studio/components/ui/AIAssistantPanel/AssistantQueryCell.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AssistantQueryCell.tsx
@@ -127,7 +127,7 @@ export const AssistantQueryCell = ({
   return (
     <Confirm
       fill
-      className="h-96"
+      className="h-96 w-full max-w-6xl mx-auto"
       state={confirmState}
       message="Assistant wants to run this query"
       cancelLabel="Skip"

--- a/apps/studio/components/ui/AIAssistantPanel/Message.Actions.test.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/Message.Actions.test.tsx
@@ -1,0 +1,18 @@
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { MessageActions } from './Message.Actions'
+
+describe('MessageActions', () => {
+  it('uses the standard centered message width', () => {
+    const { container } = render(
+      <MessageActions>
+        <button type="button" tabIndex={0}>
+          Copy
+        </button>
+      </MessageActions>
+    )
+
+    expect(container.firstChild).toHaveClass('w-full', 'max-w-3xl', 'mx-auto')
+  })
+})

--- a/apps/studio/components/ui/AIAssistantPanel/Message.Actions.test.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/Message.Actions.test.tsx
@@ -1,11 +1,11 @@
-import { render } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 
 import { MessageActions } from './Message.Actions'
+import { customRender } from '@/tests/lib/custom-render'
 
 describe('MessageActions', () => {
   it('uses the standard centered message width', () => {
-    const { container } = render(
+    const { container } = customRender(
       <MessageActions>
         <button type="button" tabIndex={0}>
           Copy

--- a/apps/studio/components/ui/AIAssistantPanel/Message.Actions.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/Message.Actions.tsx
@@ -23,7 +23,7 @@ export function MessageActions({
   alwaysShow = false,
 }: PropsWithChildren<{ alwaysShow?: boolean }>) {
   return (
-    <div className="flex items-center gap-4 mt-2 mb-1">
+    <div className="w-full max-w-3xl mx-auto flex items-center gap-4 mt-2 mb-1">
       <span className="h-0.5 w-5 bg-muted" />
       <div className={cn('group-hover:opacity-100 transition-opacity', !alwaysShow && 'opacity-0')}>
         {children}

--- a/apps/studio/components/ui/AIAssistantPanel/Message.Display.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/Message.Display.tsx
@@ -56,9 +56,11 @@ function MessageDisplayContent({ message }: { message: VercelMessage }) {
             return <MessagePartSwitcher key={idx} part={part} />
           })
         : content && (
-            <MessageDisplayTextMessage id={id} isLoading={isLoading} readOnly={readOnly}>
-              {content}
-            </MessageDisplayTextMessage>
+            <div className="w-full max-w-3xl mx-auto">
+              <MessageDisplayTextMessage id={id} isLoading={isLoading} readOnly={readOnly}>
+                {content}
+              </MessageDisplayTextMessage>
+            </div>
           )}
     </div>
   )

--- a/apps/studio/components/ui/AIAssistantPanel/Message.Parts.test.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/Message.Parts.test.tsx
@@ -1,7 +1,8 @@
-import { render } from '@testing-library/react'
+import type { ToolUIPart } from 'ai'
 import { describe, expect, it } from 'vitest'
 
 import { MessagePartSwitcher } from './Message.Parts'
+import { customRender } from '@/tests/lib/custom-render'
 
 type MessagePart = Parameters<typeof MessagePartSwitcher>[0]['part']
 
@@ -11,16 +12,16 @@ describe('MessagePartSwitcher', () => {
       type: 'reasoning',
       state: 'done',
       text: 'I will look up the project details.',
-    } as unknown as MessagePart
+    } satisfies Extract<MessagePart, { type: 'reasoning' }>
     const toolPart = {
       type: 'tool-load_knowledge',
       toolCallId: 'load-knowledge-1',
       state: 'output-available',
       input: {},
       output: {},
-    } as unknown as MessagePart
+    } satisfies ToolUIPart
 
-    const { container } = render(
+    const { container } = customRender(
       <>
         <MessagePartSwitcher part={reasoningPart} />
         <MessagePartSwitcher part={toolPart} />

--- a/apps/studio/components/ui/AIAssistantPanel/Message.Parts.test.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/Message.Parts.test.tsx
@@ -1,0 +1,35 @@
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { MessagePartSwitcher } from './Message.Parts'
+
+type MessagePart = Parameters<typeof MessagePartSwitcher>[0]['part']
+
+describe('MessagePartSwitcher', () => {
+  it('keeps consecutive generic tool parts as direct siblings', () => {
+    const reasoningPart = {
+      type: 'reasoning',
+      state: 'done',
+      text: 'I will look up the project details.',
+    } as unknown as MessagePart
+    const toolPart = {
+      type: 'tool-load_knowledge',
+      toolCallId: 'load-knowledge-1',
+      state: 'output-available',
+      input: {},
+      output: {},
+    } as unknown as MessagePart
+
+    const { container } = render(
+      <>
+        <MessagePartSwitcher part={reasoningPart} />
+        <MessagePartSwitcher part={toolPart} />
+      </>
+    )
+
+    const toolRows = container.querySelectorAll('.tool-item')
+    expect(toolRows).toHaveLength(2)
+    expect(toolRows[0].nextElementSibling).toBe(toolRows[1])
+    expect(toolRows[0]).toHaveClass('max-w-3xl')
+  })
+})

--- a/apps/studio/components/ui/AIAssistantPanel/Message.Parts.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/Message.Parts.tsx
@@ -1,6 +1,7 @@
 import { UIMessage as VercelMessage } from '@ai-sdk/react'
 import { type DynamicToolUIPart, type ReasoningUIPart, type TextUIPart, type ToolUIPart } from 'ai'
 import { BrainIcon, CheckIcon, Loader2 } from 'lucide-react'
+import { type ReactNode } from 'react'
 import { cn } from 'ui'
 
 import { AssistantQueryCell } from './AssistantQueryCell'
@@ -281,49 +282,78 @@ const MessagePart = {
   NotebookProposal: MessagePartNotebookProposal,
 } as const
 
+function MessagePartContainer({ children, wide = false }: { children: ReactNode; wide?: boolean }) {
+  return <div className={cn('w-full mx-auto', wide ? 'max-w-6xl' : 'max-w-3xl')}>{children}</div>
+}
+
+const isWideMessagePart = (part: NonNullable<VercelMessage['parts']>[number]) =>
+  part.type === 'tool-execute_sql' ||
+  part.type === 'tool-query_logs' ||
+  part.type === 'tool-create_notebook' ||
+  part.type === 'tool-update_notebook' ||
+  (part.type === 'dynamic-tool' && part.toolName === 'query_logs') ||
+  // Unlabelled code fences resolve to SQL in MessageMarkdown, too.
+  (part.type === 'text' && /```(?:sql)?(?:\s|$)/i.test(part.text))
+
+const isCompactToolPart = (part: NonNullable<VercelMessage['parts']>[number]) =>
+  part.type === 'reasoning' ||
+  (part.type === 'dynamic-tool' && part.toolName !== 'query_logs') ||
+  part.type === 'tool-list_policies' ||
+  part.type === 'tool-search_docs' ||
+  part.type === 'tool-get_active_incidents' ||
+  part.type === 'tool-load_knowledge'
+
 export function MessagePartSwitcher({
   part,
 }: {
   part: NonNullable<VercelMessage['parts']>[number]
 }) {
-  switch (part.type) {
-    case 'dynamic-tool': {
-      if (part.toolName === 'query_logs') {
+  const content = (() => {
+    switch (part.type) {
+      case 'dynamic-tool': {
+        if (part.toolName === 'query_logs') {
+          return <MessagePart.QueryLogs toolPart={part} />
+        }
+        return <MessagePart.Dynamic toolPart={part} />
+      }
+      case 'tool-list_policies':
+      case 'tool-search_docs':
+      case 'tool-get_active_incidents':
+      case 'tool-load_knowledge': {
+        return <MessagePart.Tool toolPart={part} />
+      }
+      case 'reasoning':
+        return <MessagePart.Reasoning reasoningPart={part} />
+      case 'text':
+        return <MessagePart.Text textPart={part} />
+
+      case 'tool-execute_sql': {
+        return <MessagePart.ExecuteSql toolPart={part} />
+      }
+      case 'tool-query_logs': {
         return <MessagePart.QueryLogs toolPart={part} />
       }
-      return <MessagePart.Dynamic toolPart={part} />
-    }
-    case 'tool-list_policies':
-    case 'tool-search_docs':
-    case 'tool-get_active_incidents':
-    case 'tool-load_knowledge': {
-      return <MessagePart.Tool toolPart={part} />
-    }
-    case 'reasoning':
-      return <MessagePart.Reasoning reasoningPart={part} />
-    case 'text':
-      return <MessagePart.Text textPart={part} />
+      case 'tool-deploy_edge_function': {
+        return <MessagePart.DeployEdgeFunction toolPart={part} />
+      }
+      case 'tool-create_notebook': {
+        return <MessagePart.NotebookProposal toolPart={part} mode="create" />
+      }
+      case 'tool-update_notebook': {
+        return <MessagePart.NotebookProposal toolPart={part} mode="update" />
+      }
 
-    case 'tool-execute_sql': {
-      return <MessagePart.ExecuteSql toolPart={part} />
+      case 'source-url':
+      case 'source-document':
+      case 'file':
+      default:
+        return null
     }
-    case 'tool-query_logs': {
-      return <MessagePart.QueryLogs toolPart={part} />
-    }
-    case 'tool-deploy_edge_function': {
-      return <MessagePart.DeployEdgeFunction toolPart={part} />
-    }
-    case 'tool-create_notebook': {
-      return <MessagePart.NotebookProposal toolPart={part} mode="create" />
-    }
-    case 'tool-update_notebook': {
-      return <MessagePart.NotebookProposal toolPart={part} mode="update" />
-    }
+  })()
 
-    case 'source-url':
-    case 'source-document':
-    case 'file':
-    default:
-      return null
-  }
+  if (content === null) return null
+  // Tool rows depend on being direct siblings to share their compact spacing and dividers.
+  if (isCompactToolPart(part)) return content
+
+  return <MessagePartContainer wide={isWideMessagePart(part)}>{content}</MessagePartContainer>
 }

--- a/apps/studio/components/ui/AIAssistantPanel/Message.Parts.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/Message.Parts.tsx
@@ -282,8 +282,14 @@ const MessagePart = {
   NotebookProposal: MessagePartNotebookProposal,
 } as const
 
-function MessagePartContainer({ children, wide = false }: { children: ReactNode; wide?: boolean }) {
-  return <div className={cn('w-full mx-auto', wide ? 'max-w-6xl' : 'max-w-3xl')}>{children}</div>
+function MessagePartContainer({
+  children,
+  isWide = false,
+}: {
+  children: ReactNode
+  isWide?: boolean
+}) {
+  return <div className={cn('w-full mx-auto', isWide ? 'max-w-6xl' : 'max-w-3xl')}>{children}</div>
 }
 
 const isWideMessagePart = (part: NonNullable<VercelMessage['parts']>[number]) =>
@@ -355,5 +361,5 @@ export function MessagePartSwitcher({
   // Tool rows depend on being direct siblings to share their compact spacing and dividers.
   if (isCompactToolPart(part)) return content
 
-  return <MessagePartContainer wide={isWideMessagePart(part)}>{content}</MessagePartContainer>
+  return <MessagePartContainer isWide={isWideMessagePart(part)}>{content}</MessagePartContainer>
 }

--- a/apps/studio/components/ui/AIAssistantPanel/Message.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/Message.tsx
@@ -71,7 +71,7 @@ function UserMessage({ message }: { message: VercelMessage }) {
         )}
         onClick={state === 'predecessor-editing' ? onCancelEdit : undefined}
       >
-        <MessageDisplay.MainArea>
+        <MessageDisplay.MainArea className="w-full max-w-3xl mx-auto">
           <MessageDisplay.ProfileImage />
           <MessageDisplay.Content message={message} />
         </MessageDisplay.MainArea>

--- a/apps/studio/components/ui/AIAssistantPanel/elements/Tool.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/elements/Tool.tsx
@@ -13,7 +13,7 @@ export function Tool({ className, label, icon, children }: ToolProps) {
   return (
     <div
       className={cn(
-        'tool-item text-foreground-lighter flex items-center gap-2 py-2',
+        'tool-item w-full max-w-3xl mx-auto text-foreground-lighter flex items-center gap-2 py-2',
         '[&:not(.tool-item+.tool-item)]:mt-4 [&:not(:has(+.tool-item))]:mb-4',
         '[&:has(+.tool-item)]:border-b [&:has(+.tool-item)]:border-b-muted',
         'first:mt-0! last:mb-0',


### PR DESCRIPTION

<img width="2252" height="1228" alt="image" src="https://github.com/user-attachments/assets/5c1165ae-cb65-4495-97dd-427b30ceaefc" />


## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Studio UI improvement.

## Stack context

Builds on #49350.

## What is the current behavior?

The Assistant conversation uses one outer width constraint. This leaves query and notebook previews too narrow, separates consecutive generic tool rows, and leaves message actions aligned to the far left.

## What is the new behavior?

- Gives Assistant query cells and notebook previews a `max-w-6xl` container.
- Keeps text and other regular message parts at their existing `max-w-3xl` width.
- Keeps consecutive generic tool rows such as Reasoned and Ran load_knowledge compact.
- Aligns message action rows with regular message content.

## To test

1. In the Assistant, produce a response containing text plus a SQL query or notebook preview. Confirm the preview is wide while regular text remains at the normal width.
2. Produce a response that reasons and runs consecutive non-preview tools. Confirm those rows remain close together with their separators.
3. Hover an Assistant response and confirm copy, rating, and branch actions align with the regular message content.
4. Hover a user message and confirm edit and delete actions use the same alignment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved AI Assistant message layout with centered, consistent content widths.
  - Expanded notebooks, SQL results, and query-related content where additional space is helpful.
  - Improved alignment and spacing for actions, tool outputs, loading states, errors, and disclaimers.
  - Improved query editor visibility when switching between cells.
  - Loading indicators now respect reduced-motion preferences.

- **Tests**
  - Added coverage for message layouts, tool grouping, and notebook preview sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->