### PR TITLE
feat(studio): show read replicas moved notice on Replication

### DIFF
--- a/apps/docs/content/guides/platform/read-replicas/getting-started.mdx
+++ b/apps/docs/content/guides/platform/read-replicas/getting-started.mdx
@@ -26,12 +26,6 @@ Projects must meet these requirements to use Read Replicas:
 
 ## Creating a Read Replica
 
-<Admonition type="note">
-
-Read replica management moved from Database → Replication to [Project Settings → Infrastructure](/dashboard/project/_/settings/infrastructure). Database → Replication is for Pipelines destinations only.
-
-</Admonition>
-
 To add a Read Replica, go to the [Infrastructure](/dashboard/project/_/settings/infrastructure) settings page in your project dashboard.
 
 You can also manage Read Replicas using the Management API (beta functionality):

--- a/apps/docs/content/guides/platform/read-replicas/getting-started.mdx
+++ b/apps/docs/content/guides/platform/read-replicas/getting-started.mdx
@@ -26,6 +26,12 @@ Projects must meet these requirements to use Read Replicas:
 
 ## Creating a Read Replica
 
+<Admonition type="note">
+
+Read replica management moved from Database → Replication to [Project Settings → Infrastructure](/dashboard/project/_/settings/infrastructure). Database → Replication is for Pipelines destinations only.
+
+</Admonition>
+
 To add a Read Replica, go to the [Infrastructure](/dashboard/project/_/settings/infrastructure) settings page in your project dashboard.
 
 You can also manage Read Replicas using the Management API (beta functionality):

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationTypeSelection.test.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationTypeSelection.test.tsx
@@ -60,6 +60,7 @@ const addBackgroundMocks = () => {
 describe('DestinationTypeSelection', () => {
   beforeEach(() => {
     mockInfrastructureReadReplicas.mockReturnValue(true)
+    window.localStorage.clear()
   })
 
   test('shows placeholder when no type is selected', async () => {

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationTypeSelection.test.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationTypeSelection.test.tsx
@@ -171,9 +171,9 @@ describe('DestinationTypeSelection', () => {
     customRender(<DestinationTypeSelection />)
 
     expect(await screen.findByText('Read replicas have moved')).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: 'Add read replica' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Go to Infrastructure' })).toHaveAttribute(
       'href',
-      expect.stringContaining('/settings/infrastructure?addReplica=true')
+      expect.stringContaining('/settings/infrastructure')
     )
   })
 

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationTypeSelection.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationTypeSelection.tsx
@@ -212,11 +212,7 @@ export const DestinationTypeSelection = () => {
           </SelectContent>
         </Select>
       </FormItemLayout>
-      {!editMode && (
-        <div className="px-5 pb-5">
-          <ReadReplicasMovedCallout />
-        </div>
-      )}
+      {!editMode && <ReadReplicasMovedCallout className="px-5 pb-5" />}
     </>
   )
 }

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationTypeSelection.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationTypeSelection.tsx
@@ -22,7 +22,6 @@ import {
 import { DestinationType } from './DestinationPanel.types'
 import { ReadReplicasMovedCallout } from './ReadReplicasMovedCallout'
 import { InlineLink } from '@/components/ui/InlineLink'
-import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
 
 interface DestinationTypeOption {
   value: DestinationType
@@ -47,7 +46,6 @@ export const DestinationTypeSelection = () => {
   const etlEnableDucklake = useIsETLDucklakePrivateAlpha()
   const etlEnableSnowflake = useIsETLSnowflakePrivateAlpha()
   const etlEnableClickHouse = useIsETLClickHousePrivateAlpha()
-  const { infrastructureReadReplicas } = useIsFeatureEnabled(['infrastructure:read_replicas'])
 
   const [urlDestinationType, setDestinationType] = useQueryState(
     'destinationType',
@@ -214,7 +212,7 @@ export const DestinationTypeSelection = () => {
           </SelectContent>
         </Select>
       </FormItemLayout>
-      {!editMode && infrastructureReadReplicas && (
+      {!editMode && (
         <div className="px-5 pb-5">
           <ReadReplicasMovedCallout />
         </div>

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicasMovedCallout.test.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicasMovedCallout.test.tsx
@@ -1,0 +1,66 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { LOCAL_STORAGE_KEYS } from 'common'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { ReadReplicasMovedCallout } from './ReadReplicasMovedCallout'
+import { customRender } from '@/tests/lib/custom-render'
+
+const mockInfrastructureReadReplicas = vi.fn(() => true)
+
+vi.mock('@/hooks/misc/useIsFeatureEnabled', () => ({
+  useIsFeatureEnabled: () => ({
+    infrastructureReadReplicas: mockInfrastructureReadReplicas(),
+  }),
+}))
+
+describe('ReadReplicasMovedCallout', () => {
+  beforeEach(() => {
+    mockInfrastructureReadReplicas.mockReturnValue(true)
+    window.localStorage.clear()
+  })
+
+  test('renders the notice with a link to Infrastructure', async () => {
+    customRender(<ReadReplicasMovedCallout />)
+
+    expect(await screen.findByText('Read replicas have moved')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Go to Infrastructure' })).toHaveAttribute(
+      'href',
+      expect.stringContaining('/settings/infrastructure')
+    )
+  })
+
+  test('hides after dismiss and persists via localStorage', async () => {
+    const user = userEvent.setup()
+    customRender(<ReadReplicasMovedCallout />)
+
+    expect(await screen.findByText('Read replicas have moved')).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'Dismiss read replicas moved notice' }))
+
+    expect(screen.queryByText('Read replicas have moved')).not.toBeInTheDocument()
+    expect(
+      window.localStorage.getItem(
+        LOCAL_STORAGE_KEYS.READ_REPLICAS_MOVED_CALLOUT_DISMISSED('default')
+      )
+    ).toBe('true')
+  })
+
+  test('stays hidden when previously dismissed', async () => {
+    window.localStorage.setItem(
+      LOCAL_STORAGE_KEYS.READ_REPLICAS_MOVED_CALLOUT_DISMISSED('default'),
+      'true'
+    )
+
+    customRender(<ReadReplicasMovedCallout />)
+
+    await expect(screen.findByText('Read replicas have moved')).rejects.toThrow()
+  })
+
+  test('hides when Infrastructure read replicas are disabled', () => {
+    mockInfrastructureReadReplicas.mockReturnValue(false)
+
+    customRender(<ReadReplicasMovedCallout />)
+
+    expect(screen.queryByText('Read replicas have moved')).not.toBeInTheDocument()
+  })
+})

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicasMovedCallout.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicasMovedCallout.tsx
@@ -1,17 +1,24 @@
-import { useParams } from 'common'
+import { LOCAL_STORAGE_KEYS, useParams } from 'common'
+import { X } from 'lucide-react'
 import Link from 'next/link'
 import { Button } from 'ui'
 import { Admonition } from 'ui-patterns/Admonition'
 
 import { getInfrastructurePath } from '@/components/interfaces/Settings/Infrastructure/Infrastructure.utils'
+import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
+import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
 
 /** Shown while muscle-memory still opens Database → Replication for replicas. */
 export const ReadReplicasMovedCallout = () => {
   const { ref: projectRef } = useParams()
   const { infrastructureReadReplicas } = useIsFeatureEnabled(['infrastructure:read_replicas'])
+  const [isDismissed, setIsDismissed, { isSuccess: isDismissalLoaded }] = useLocalStorageQuery(
+    LOCAL_STORAGE_KEYS.READ_REPLICAS_MOVED_CALLOUT_DISMISSED(projectRef ?? 'unknown'),
+    false
+  )
 
-  if (!infrastructureReadReplicas) return null
+  if (!infrastructureReadReplicas || !isDismissalLoaded || isDismissed) return null
 
   return (
     <Admonition
@@ -20,9 +27,19 @@ export const ReadReplicasMovedCallout = () => {
       title="Read replicas have moved"
       description="Manage read replicas on the Infrastructure page, alongside compute and disk."
       actions={
-        <Button asChild variant="default" size="tiny">
-          <Link href={getInfrastructurePath(projectRef)}>Go to Infrastructure</Link>
-        </Button>
+        <>
+          <Button asChild variant="default" size="tiny">
+            <Link href={getInfrastructurePath(projectRef)}>Go to Infrastructure</Link>
+          </Button>
+          <ButtonTooltip
+            icon={<X />}
+            variant="text"
+            className="w-6"
+            tooltip={{ content: { side: 'bottom', text: 'Dismiss' } }}
+            aria-label="Dismiss read replicas moved notice"
+            onClick={() => setIsDismissed(true)}
+          />
+        </>
       }
     />
   )

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicasMovedCallout.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicasMovedCallout.tsx
@@ -10,7 +10,7 @@ import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
 import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
 
 /** Shown while muscle-memory still opens Database → Replication for replicas. */
-export const ReadReplicasMovedCallout = () => {
+export const ReadReplicasMovedCallout = ({ className }: { className?: string }) => {
   const { ref: projectRef } = useParams()
   const { infrastructureReadReplicas } = useIsFeatureEnabled(['infrastructure:read_replicas'])
   const [isDismissed, setIsDismissed, { isSuccess: isDismissalLoaded }] = useLocalStorageQuery(
@@ -18,29 +18,33 @@ export const ReadReplicasMovedCallout = () => {
     false
   )
 
-  if (!infrastructureReadReplicas || !isDismissalLoaded || isDismissed) return null
+  if (!projectRef || !infrastructureReadReplicas || !isDismissalLoaded || isDismissed) {
+    return null
+  }
 
   return (
-    <Admonition
-      type="note"
-      layout="responsive"
-      title="Read replicas have moved"
-      description="Manage read replicas on the Infrastructure page, alongside compute and disk."
-      actions={
-        <>
-          <Button asChild variant="default" size="tiny">
-            <Link href={getInfrastructurePath(projectRef)}>Go to Infrastructure</Link>
-          </Button>
-          <ButtonTooltip
-            icon={<X />}
-            variant="text"
-            className="w-6"
-            tooltip={{ content: { side: 'bottom', text: 'Dismiss' } }}
-            aria-label="Dismiss read replicas moved notice"
-            onClick={() => setIsDismissed(true)}
-          />
-        </>
-      }
-    />
+    <div className={className}>
+      <Admonition
+        type="note"
+        layout="responsive"
+        title="Read replicas have moved"
+        description="Manage read replicas on the Infrastructure page, alongside compute and disk."
+        actions={
+          <>
+            <Button asChild variant="default" size="tiny">
+              <Link href={getInfrastructurePath(projectRef)}>Go to Infrastructure</Link>
+            </Button>
+            <ButtonTooltip
+              icon={<X />}
+              variant="text"
+              className="w-6"
+              tooltip={{ content: { side: 'bottom', text: 'Dismiss' } }}
+              aria-label="Dismiss read replicas moved notice"
+              onClick={() => setIsDismissed(true)}
+            />
+          </>
+        }
+      />
+    </div>
   )
 }

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicasMovedCallout.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicasMovedCallout.tsx
@@ -3,20 +3,25 @@ import Link from 'next/link'
 import { Button } from 'ui'
 import { Admonition } from 'ui-patterns/Admonition'
 
-import { getAddReadReplicaPath } from '@/components/interfaces/Settings/Infrastructure/Infrastructure.utils'
+import { getInfrastructurePath } from '@/components/interfaces/Settings/Infrastructure/Infrastructure.utils'
+import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
 
+/** Shown while muscle-memory still opens Database → Replication for replicas. */
 export const ReadReplicasMovedCallout = () => {
   const { ref: projectRef } = useParams()
+  const { infrastructureReadReplicas } = useIsFeatureEnabled(['infrastructure:read_replicas'])
+
+  if (!infrastructureReadReplicas) return null
 
   return (
     <Admonition
       type="note"
       layout="responsive"
       title="Read replicas have moved"
-      description="Read replicas are now managed on the Infrastructure page, alongside compute and disk."
+      description="Manage read replicas on the Infrastructure page, alongside compute and disk."
       actions={
         <Button asChild variant="default" size="tiny">
-          <Link href={getAddReadReplicaPath(projectRef)}>Add read replica</Link>
+          <Link href={getInfrastructurePath(projectRef)}>Go to Infrastructure</Link>
         </Button>
       }
     />

--- a/apps/studio/pages/project/[ref]/database/replication/index.tsx
+++ b/apps/studio/pages/project/[ref]/database/replication/index.tsx
@@ -9,6 +9,7 @@ import {
 import { PageSection, PageSectionContent } from 'ui-patterns/PageSection'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 
+import { ReadReplicasMovedCallout } from '@/components/interfaces/Database/Replication/DestinationPanel/ReadReplicasMovedCallout'
 import { Destinations } from '@/components/interfaces/Database/Replication/Destinations'
 import { ReplicationDiagram } from '@/components/interfaces/Database/Replication/ReplicationDiagram'
 import DatabaseLayout from '@/components/layouts/DatabaseLayout/DatabaseLayout'
@@ -58,6 +59,7 @@ const DatabaseReplicationPage: NextPageWithLayout = () => {
         ) : (
           <PageSection>
             <PageSectionContent className="flex flex-col gap-12">
+              <ReadReplicasMovedCallout />
               <ReplicationDiagram />
               <Destinations />
             </PageSectionContent>

--- a/packages/common/constants/local-storage.ts
+++ b/packages/common/constants/local-storage.ts
@@ -104,6 +104,10 @@ export const LOCAL_STORAGE_KEYS = {
   // RLS event trigger banner dismissed
   RLS_EVENT_TRIGGER_BANNER_DISMISSED: (ref: string) => `rls-event-trigger-banner-dismissed-${ref}`,
 
+  // Read replicas moved from Replication → Infrastructure
+  READ_REPLICAS_MOVED_CALLOUT_DISMISSED: (ref: string) =>
+    `read-replicas-moved-callout-dismissed-${ref}`,
+
   PROJECT_SECURITY_DISMISSED_AT: (ref: string) => `project-security-dismissed-at-${ref}`,
 
   DATABASE_CONNECTIONS_BANNER_DISMISSED: (ref: string) =>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature / communication. Resolves [PIPE-1008](https://linear.app/supabase/issue/PIPE-1008/communicate-read-replica-move-changelog-leftover-ui-docs).

## What is the current behavior?

Database → Replication is now Pipelines-only. The “Read replicas have moved” callout only appears inside the New destination sheet, so users who land on Replication looking for replicas can miss it. Getting-started already points create at Infrastructure but does not say the management surface moved.

## What is the new behavior?

Replication shows the moved callout at the top of the page (flag-gated), with a _Go to Infrastructure_ CTA. The same callout remains in the destination-type sheet. Getting-started adds a short note that management moved from Replication to Infrastructure.

This Admonition is dismissible, with its state stored in local storage.

| Before | After |
| --- | --- |
| <img width="1024" height="759" alt="64555" src="https://github.com/user-attachments/assets/7084bd51-2f48-4a83-ac2a-89bdd3f23804" /> | <img width="1024" height="759" alt="Replication  Database  Chisel  Toolshed  Supabase" src="https://github.com/user-attachments/assets/9b26c23a-1b44-4711-919b-c7000f155190" /> |



## To test

`infrastructure:read_replicas` on by default.

1. Open [Database → Replication](https://studio-staging-git-danny-pipe-1008-replication-moved-notice-supabase.vercel.app/dashboard/project/_/database/replication) (preview URL once deployed). Confirm the note “Read replicas have moved” and Go to Infrastructure.
2. Click the CTA: lands on Settings → Infrastructure.
3. Open New destination: callout still appears under the type selector.
4. Docs preview: getting-started Creating a Read Replica section shows the move note.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a callout informing users that read replicas are now managed through Infrastructure.
  * Added a direct link to the Infrastructure page from database replication settings.
  * Added the option to dismiss the callout, with dismissal saved per project.
  * Displayed the callout on the replication page and destination selection view.

* **Bug Fixes**
  * Updated callout visibility behavior to respect project settings and prior dismissal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->