### PR TITLE
fix(www): changelog md negotiation slug-set gate

### DIFF
--- a/apps/www/middleware.test.ts
+++ b/apps/www/middleware.test.ts
@@ -11,7 +11,7 @@ import { middleware } from './middleware'
 vi.mock('./app/api-v2/md/content.generated', () => ({
   MD_CONTENT: new Map<string, string>(),
   MD_PAGES: new Set<string>(['homepage', 'auth', 'pricing']),
-  CHANGELOG_PAGES: new Set<string>(['changelog/100', 'changelog/pipelines']),
+  CHANGELOG_PAGES: new Set<string>(['changelog', 'changelog/100', 'changelog/pipelines']),
 }))
 
 function makeRequest(

--- a/apps/www/middleware.test.ts
+++ b/apps/www/middleware.test.ts
@@ -11,6 +11,7 @@ import { middleware } from './middleware'
 vi.mock('./app/api-v2/md/content.generated', () => ({
   MD_CONTENT: new Map<string, string>(),
   MD_PAGES: new Set<string>(['homepage', 'auth', 'pricing']),
+  CHANGELOG_PAGES: new Set<string>(['changelog/100', 'changelog/pipelines']),
 }))
 
 function makeRequest(
@@ -132,6 +133,18 @@ describe('www middleware', () => {
       expect(res.headers.get('x-middleware-rewrite')).toBe('https://supabase.com/changelog/100.md')
     })
 
+    it('serves markdown for explicit non-legacy changelog .md requests even when Accept excludes it', () => {
+      const req = makeRequest('/changelog/pipelines.md', {
+        accept: 'application/x-content-negotiation-probe',
+      })
+      const res = middleware(req)
+
+      expect(res.status).not.toBe(406)
+      expect(res.headers.get('x-middleware-rewrite')).toBe(
+        'https://supabase.com/changelog/pipelines.md'
+      )
+    })
+
     it('rewrites the changelog index .md request without doubling the suffix', () => {
       const req = makeRequest('/changelog.md', { accept: 'text/markdown' })
       const res = middleware(req)
@@ -183,6 +196,31 @@ describe('www middleware', () => {
       const res = middleware(req)
 
       expect(res.headers.get('x-middleware-rewrite')).toBe('https://supabase.com/changelog/100.md')
+    })
+
+    it('negotiates markdown for non-legacy changelog slugs', () => {
+      const req = makeRequest('/changelog/pipelines', { accept: 'text/markdown' })
+      const res = middleware(req)
+
+      expect(res.headers.get('x-middleware-rewrite')).toBe(
+        'https://supabase.com/changelog/pipelines.md'
+      )
+    })
+
+    it('passes through unpublished numeric-prefix changelog slugs', () => {
+      const req = makeRequest('/changelog/999-not-published', { accept: 'text/markdown' })
+      const res = middleware(req)
+
+      expect(res.headers.get('x-middleware-rewrite')).toBeNull()
+      expect(res.status).not.toBe(406)
+    })
+
+    it('passes through deep paths under a published changelog slug', () => {
+      const req = makeRequest('/changelog/100/bar', { accept: 'text/markdown' })
+      const res = middleware(req)
+
+      expect(res.headers.get('x-middleware-rewrite')).toBeNull()
+      expect(res.status).not.toBe(406)
     })
 
     it('rewrites the bare changelog index to its static .md file', () => {
@@ -284,6 +322,15 @@ describe('www middleware', () => {
 
     it('returns 406 on changelog entries when Accept excludes every type', () => {
       const req = makeRequest('/changelog/100', {
+        accept: 'application/x-content-negotiation-probe',
+      })
+      const res = middleware(req)
+
+      expect(res.status).toBe(406)
+    })
+
+    it('returns 406 for non-legacy changelog entries when Accept matches nothing', () => {
+      const req = makeRequest('/changelog/pipelines', {
         accept: 'application/x-content-negotiation-probe',
       })
       const res = middleware(req)

--- a/apps/www/middleware.ts
+++ b/apps/www/middleware.ts
@@ -14,7 +14,7 @@ export function middleware(request: NextRequest) {
   // entry — NextURL preserves trailing-slash style on rewrite targets.
   const slug = (basePathname === '/' ? 'homepage' : basePathname.slice(1)).replace(/\/$/, '')
   const isMdEligible = MD_PAGES.has(slug)
-  const isChangelogEntry = slug === 'changelog' || CHANGELOG_PAGES.has(slug)
+  const isChangelogEntry = CHANGELOG_PAGES.has(slug)
 
   const decision = negotiateMarkdown(
     { acceptHeader: request.headers.get('accept') ?? '' },

--- a/apps/www/middleware.ts
+++ b/apps/www/middleware.ts
@@ -2,7 +2,7 @@ import { stampFirstReferrerCookie } from 'common/first-referrer-cookie'
 import { negotiateMarkdown } from 'common/markdown-negotiation'
 import { NextResponse, type NextRequest } from 'next/server'
 
-import { MD_PAGES } from './app/api-v2/md/content.generated'
+import { CHANGELOG_PAGES, MD_PAGES } from './app/api-v2/md/content.generated'
 
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl
@@ -14,7 +14,7 @@ export function middleware(request: NextRequest) {
   // entry — NextURL preserves trailing-slash style on rewrite targets.
   const slug = (basePathname === '/' ? 'homepage' : basePathname.slice(1)).replace(/\/$/, '')
   const isMdEligible = MD_PAGES.has(slug)
-  const isChangelogEntry = slug === 'changelog' || /^changelog\/\d+/.test(slug)
+  const isChangelogEntry = slug === 'changelog' || CHANGELOG_PAGES.has(slug)
 
   const decision = negotiateMarkdown(
     { acceptHeader: request.headers.get('accept') ?? '' },

--- a/apps/www/scripts/generateMdContent.mjs
+++ b/apps/www/scripts/generateMdContent.mjs
@@ -237,10 +237,13 @@ if (changelogSlugs.length === 0) {
   )
 }
 
-const changelogIndexExists = await fs.access(path.join(wwwDir, 'public/changelog.md')).then(
-  () => true,
-  () => false
-)
+let changelogIndexExists = false
+try {
+  await fs.access(path.join(wwwDir, 'public/changelog.md'))
+  changelogIndexExists = true
+} catch (err) {
+  if (err.code !== 'ENOENT') throw err
+}
 if (changelogIndexExists) {
   changelogSlugs.unshift('changelog')
 }

--- a/apps/www/scripts/generateMdContent.mjs
+++ b/apps/www/scripts/generateMdContent.mjs
@@ -213,6 +213,33 @@ for (const entry of allEntries) {
   seen.add(entry.slug)
 }
 
+// public/changelog/*.md is written by generateStaticContent.mjs earlier in
+// content:build:core; absent locally when CHANGELOG_SYNC_APP_* secrets are unset.
+const changelogMdDir = path.join(wwwDir, 'public/changelog')
+let changelogFilenames
+try {
+  changelogFilenames = await fs.readdir(changelogMdDir)
+} catch (err) {
+  if (err.code !== 'ENOENT') throw err
+  changelogFilenames = []
+}
+const changelogSlugs = changelogFilenames
+  .filter((f) => f.endsWith('.md'))
+  .map((f) => `changelog/${f.slice(0, -3)}`)
+  .sort()
+
+if (changelogSlugs.length === 0) {
+  if (process.env.VERCEL) {
+    console.error(
+      '❌ No changelog slugs found in public/changelog — changelog generation produced nothing.'
+    )
+    process.exit(1)
+  }
+  console.warn(
+    '⚠️  No changelog slugs found in public/changelog — changelog md negotiation off in this build'
+  )
+}
+
 const contentEntries = liveEntries
   .map((e) => `  [${JSON.stringify(e.slug)}, ${JSON.stringify(e.content)}]`)
   .join(',\n')
@@ -228,9 +255,11 @@ ${contentEntries},
 export const MD_PAGES = new Set<string>([
 ${pageEntries},
 ])
+
+export const CHANGELOG_PAGES = new Set<string>(${JSON.stringify(changelogSlugs, null, 2)})
 `
 
 await fs.writeFile(outputPath, output, 'utf-8')
 console.log(
-  `✅ Generated ${outputPath} (${liveEntries.length} files, ${allPageSlugs.length} pages)`
+  `✅ Generated ${outputPath} (${liveEntries.length} files, ${allPageSlugs.length} pages, ${changelogSlugs.length} changelog)`
 )

--- a/apps/www/scripts/generateMdContent.mjs
+++ b/apps/www/scripts/generateMdContent.mjs
@@ -17,6 +17,7 @@ import { mdxBodyToMarkdown } from './lib/mdxToMarkdown.mjs'
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const wwwDir = path.join(__dirname, '..')
 const contentDir = path.join(wwwDir, 'content/md')
+const changelogMdDir = path.join(wwwDir, 'public/changelog')
 const outputPath = path.join(wwwDir, 'app/api-v2/md/content.generated.ts')
 
 // Matches lib/posts.tsx FILENAME_SUBSTRING — strips YYYY-MM-DD- (11 chars).
@@ -214,19 +215,8 @@ for (const entry of allEntries) {
 }
 
 // public/changelog/*.md is written by generateStaticContent.mjs earlier in
-// content:build:core; absent locally when CHANGELOG_SYNC_APP_* secrets are unset.
-const changelogMdDir = path.join(wwwDir, 'public/changelog')
-let changelogFilenames
-try {
-  changelogFilenames = await fs.readdir(changelogMdDir)
-} catch (err) {
-  if (err.code !== 'ENOENT') throw err
-  changelogFilenames = []
-}
-const changelogSlugs = changelogFilenames
-  .filter((f) => f.endsWith('.md'))
-  .map((f) => `changelog/${f.slice(0, -3)}`)
-  .sort()
+// content:build:core; absent locally e.g. when CHANGELOG_SYNC_APP_* secrets are unset.
+const changelogSlugs = (await collectMdFiles(changelogMdDir, 'changelog')).sort()
 
 if (changelogSlugs.length === 0) {
   if (process.env.VERCEL) {

--- a/apps/www/scripts/generateMdContent.mjs
+++ b/apps/www/scripts/generateMdContent.mjs
@@ -218,6 +218,13 @@ for (const entry of allEntries) {
 // content:build:core; absent locally e.g. when CHANGELOG_SYNC_APP_* secrets are unset.
 const changelogSlugs = (await collectMdFiles(changelogMdDir, 'changelog')).sort()
 
+// The middleware matches request slugs against these keys verbatim, and its
+// tests mock this set — a dropped prefix would ship silently with green tests.
+if (changelogSlugs.some((s) => !s.startsWith('changelog/'))) {
+  console.error('❌ Changelog slugs must carry the changelog/ prefix the middleware matches on.')
+  process.exit(1)
+}
+
 if (changelogSlugs.length === 0) {
   if (process.env.VERCEL) {
     console.error(
@@ -228,6 +235,14 @@ if (changelogSlugs.length === 0) {
   console.warn(
     '⚠️  No changelog slugs found in public/changelog — changelog md negotiation off in this build'
   )
+}
+
+const changelogIndexExists = await fs.access(path.join(wwwDir, 'public/changelog.md')).then(
+  () => true,
+  () => false
+)
+if (changelogIndexExists) {
+  changelogSlugs.unshift('changelog')
 }
 
 const contentEntries = liveEntries


### PR DESCRIPTION
Bare-URL `Accept: text/markdown` negotiation never fires on changelog entries authored after the GitHub-discussions backfill: the middleware gate `/^changelog\/\d+/` only matches legacy numeric slugs (from `legacy_gh_discussion` frontmatter), so agents that signal markdown via Accept get HTML on every new entry. I found this in the independent review round on #48475; pre-existing, not introduced there.

**Changed:**
- **Non-legacy entries negotiate markdown**: `generateMdContent.mjs` now lists `public/changelog/*.md` (written moments earlier by `generateStaticContent.mjs` in the same `content:build:core` chain) and emits a `CHANGELOG_PAGES` set into the generated module; the middleware regex becomes a set lookup, so negotiation coverage derives from the exact static files served and can't drift from what's published.
- **Unknown and deep changelog paths stop negotiating**: the old regex prefix-matched paths like `changelog/100/bar` and nonexistent numeric slugs, rewriting them to missing `.md` files (404 under a markdown Accept); they now pass through to the dynamic route's canonicalizing 308/404.
- **Build guard**: zero collected changelog slugs on Vercel fails the build (today a zero-entry changelog fetch ships empty output with a green build), and a shape assertion fails the build if collected slugs ever lose the `changelog/` prefix the middleware matches on. Locally without `CHANGELOG_SYNC_APP_*` secrets it warns and changelog negotiation is off, matching the absent content.
- **`/changelog` index gated the same way**: the index slug is emitted into the set only when `public/changelog.md` was generated, replacing the hardcoded `slug === 'changelog'` branch; locally without secrets the index no longer rewrites to a nonexistent file.

**Note:** script order in `content:build:core` is load-bearing (static content generation must precede md content generation); the Vercel guard turns a reorder into a loud build failure instead of a silent empty gate.

## To test
Tested on the Vercel preview (`zone-www-dot-com` deployment of head `f451da3`):
- [x] `curl -sI -H "Accept: text/markdown" <preview>/changelog` and `curl -sI <preview>/changelog.md`: got 200 `text/markdown` (index via the generated gate)
- [x] `curl -sI -H "Accept: text/markdown" <preview>/changelog/pipelines`: got 200 `text/markdown` (prod today returns `text/html`)
- [x] Same curl against the legacy numeric slug `48235-migration-of-...`: got 200 `text/markdown` (no regression)
- [x] `curl -sI -H "Accept: application/json" <preview>/changelog/pipelines`: got 406 (prod today returns 200 HTML)
- [x] Explicit `.md` fetches for both slug shapes (`/changelog/pipelines.md`, `/changelog/48235-....md`): got 200 `text/markdown`
- [x] `curl -sI -H "Accept: text/markdown" <preview>/changelog/does-not-exist-xyz`: got a 404 HTML passthrough from the dynamic route, not a 406
- [x] `pnpm test middleware.test.ts` in `apps/www` at head: 41/41 pass (36 pre-existing + 5 new). No CI job runs the www vitest suite, so this local run is the only oracle for the new tests.

## Linear
- fixes GROWTH-1062


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved changelog page handling, including markdown versions of published entries.
  - Added content negotiation for supported changelog formats, with clear responses for unsupported requests.
- **Bug Fixes**
  - Prevented unpublished numeric-prefix pages from being treated as published.
  - Fixed deep links under published changelog entries.
- **Reliability**
  - Changelog availability is now detected automatically, with improved validation during content generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->