### PR TITLE
fix(studio): clarify assistant tool terminal states

### DIFF
--- a/apps/studio/components/ui/AIAssistantPanel/MessagePartQueryLogs.test.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/MessagePartQueryLogs.test.tsx
@@ -5,48 +5,84 @@ import { MessageProvider } from './Message.Context'
 import { MessagePartQueryLogs } from './MessagePartQueryLogs'
 import { customRender as render } from '@/tests/lib/custom-render'
 
-vi.mock('./AssistantQueryCell', () => ({
-  AssistantQueryCell: ({
-    sql,
-    initialResult,
+vi.mock('@/components/interfaces/Explorer/QueryEditor', () => ({
+  QueryEditor: ({
+    query,
+    result,
   }: {
-    sql: string
-    initialResult?: { error?: Error }
+    query: { uncheckedSql: string }
+    result?: { error?: { message?: string } }
   }) => (
-    <div>
-      <span>{sql}</span>
-      <span>{initialResult?.error?.message}</span>
+    <div data-testid="query-editor">
+      <span>{query.uncheckedSql}</span>
+      <span>{result?.error?.message}</span>
     </div>
   ),
+}))
+vi.mock('@/lib/telemetry/track', () => ({ useTrack: () => vi.fn() }))
+vi.mock('@/state/role-impersonation-state', () => ({
+  useLocalRoleImpersonationState: () => ({}),
 }))
 
 type QueryLogsToolPart = Parameters<typeof MessagePartQueryLogs>[0]['toolPart']
 
+const messageInfo = {
+  id: 'message-1',
+  isLoading: false,
+  state: 'idle' as const,
+}
+
+const messageActions = {
+  onDelete: vi.fn(),
+  onEdit: vi.fn(),
+  onBranch: vi.fn(),
+  onCancelEdit: vi.fn(),
+}
+
+function renderPart(toolPart: Parameters<typeof MessagePartQueryLogs>[0]['toolPart']) {
+  return render(
+    <MessageProvider messageInfo={messageInfo} messageActions={messageActions}>
+      <MessagePartQueryLogs toolPart={toolPart} />
+    </MessageProvider>
+  )
+}
+
 describe('MessagePartQueryLogs', () => {
   it('renders an output error using raw input when submitted input is unavailable', () => {
-    const toolPart = {
+    renderPart({
       toolCallId: 'query-logs-1',
       state: 'output-error',
       input: undefined,
       rawInput: { sql: 'select count(*) from edge_logs' },
       errorText: 'Log query timed out',
-    } as QueryLogsToolPart
-
-    render(
-      <MessageProvider
-        messageInfo={{ id: 'message-1', isLoading: false, state: 'idle' }}
-        messageActions={{
-          onDelete: vi.fn(),
-          onEdit: vi.fn(),
-          onBranch: vi.fn(),
-          onCancelEdit: vi.fn(),
-        }}
-      >
-        <MessagePartQueryLogs toolPart={toolPart} />
-      </MessageProvider>
-    )
+    } as QueryLogsToolPart)
 
     expect(screen.getByText('select count(*) from edge_logs')).toBeInTheDocument()
     expect(screen.getByText('Log query timed out')).toBeInTheDocument()
+  })
+
+  it('uses logs-specific copy for a rendered tool error', () => {
+    renderPart({
+      toolCallId: 'logs-1',
+      state: 'output-error',
+      input: { sql: 'select event_message from edge_logs' },
+      output: undefined,
+      errorText: 'Analytics request failed',
+    })
+
+    expect(screen.getByText('Failed to query logs')).toBeInTheDocument()
+    expect(screen.queryByText('Failed to execute SQL')).not.toBeInTheDocument()
+  })
+
+  it('shows an explicit failure when errored input cannot be parsed', () => {
+    renderPart({
+      toolCallId: 'logs-2',
+      state: 'output-error',
+      input: { invalid: true },
+      output: undefined,
+      errorText: 'Analytics request failed',
+    })
+
+    expect(screen.getByText('Failed to query logs.')).toBeInTheDocument()
   })
 })

--- a/apps/studio/components/ui/AIAssistantPanel/MessagePartQueryLogs.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/MessagePartQueryLogs.tsx
@@ -15,6 +15,10 @@ type QueryLogsToolPart = Pick<
   'toolCallId' | 'state' | 'input' | 'output' | 'errorText'
 > & { rawInput?: unknown }
 
+function QueryLogsFailure() {
+  return <div className="text-xs text-danger">Failed to query logs.</div>
+}
+
 export function MessagePartQueryLogs({ toolPart }: { toolPart: QueryLogsToolPart }) {
   const { id } = useMessageInfoContext()
   const { toolCallId, state, input: submittedInput, rawInput, output } = toolPart
@@ -31,13 +35,13 @@ export function MessagePartQueryLogs({ toolPart }: { toolPart: QueryLogsToolPart
   if (state !== 'output-available' && state !== 'output-error') return null
 
   const parsedInput = parseQueryLogsInput(submittedInput ?? rawInput)
-  if (!parsedInput.success) return null
+  if (!parsedInput.success) return <QueryLogsFailure />
 
   const result =
     state === 'output-error'
       ? { rows: [], error: { message: toolPart.errorText ?? 'Failed to query logs' } }
       : toQueryLogsResult(output)
-  if (!result) return null
+  if (!result) return <QueryLogsFailure />
 
   return (
     <div className="w-auto overflow-x-hidden my-4 space-y-2">

--- a/apps/studio/components/ui/AIAssistantPanel/NotebookProposalRenderer.test.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/NotebookProposalRenderer.test.tsx
@@ -255,11 +255,12 @@ describe('NotebookProposalRenderer', () => {
     )
   })
 
-  it('shows the notebook action after an automatic update succeeds', () => {
+  it('renders a stable update summary after success instead of diffing against live content', () => {
     render(
       <NotebookProposalRenderer
         mode="update"
         state="output-available"
+        confirmState="success"
         input={{
           id: NOTEBOOK_ID,
           expected_updated_at: '2024-01-01T00:00:00.000Z',
@@ -269,45 +270,16 @@ describe('NotebookProposalRenderer', () => {
       />
     )
 
-    expect(screen.getByRole('link', { name: 'Open notebook' })).toHaveAttribute(
-      'href',
-      `/project/default/explorer/notebook/${NOTEBOOK_ID}`
-    )
-  })
-
-  it('does not show the "can\'t be applied" warning for a completed update whose target cell no longer exists', async () => {
-    mockContentItem(
-      mockNotebookRow({
-        content: {
-          schema_version: 1,
-          cells: [{ _tag: 'markdown_cell', _id: 'cell-2', text: 'world' }],
-        },
-      })
-    )
-
-    render(
-      <NotebookProposalRenderer
-        mode="update"
-        state="output-available"
-        input={{
-          id: NOTEBOOK_ID,
-          expected_updated_at: '2024-01-01T00:00:00.000Z',
-          operations: [{ _tag: 'delete_cell', cell_id: 'cell-1' }],
-        }}
-        output={{ id: NOTEBOOK_ID, name: 'Signup funnel' }}
-      />
-    )
-
-    await waitFor(() => expect(screen.queryByText('Loading notebook...')).not.toBeInTheDocument())
+    expect(screen.getByText('Notebook updated: Signup funnel')).toBeInTheDocument()
     expect(screen.queryByText("This update can't be applied as written")).not.toBeInTheDocument()
-    expect(screen.getByRole('link', { name: 'Open notebook' })).toBeInTheDocument()
+    expect(screen.queryByRole('toolbar', { name: 'Notebook toolbar' })).not.toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'Open notebook' })).toHaveAttribute(
       'href',
       `/project/default/explorer/notebook/${NOTEBOOK_ID}`
     )
   })
 
-  it('shows the notebook action inside the Confirm footer for a manually approved completed update', async () => {
+  it('shows the notebook action after a manually approved completed update', async () => {
     mockContentItem(
       mockNotebookRow({
         content: {
@@ -339,7 +311,7 @@ describe('NotebookProposalRenderer', () => {
     expect(screen.queryByText("This update can't be applied as written")).not.toBeInTheDocument()
   })
 
-  it('renders the snapshot-derived diff for a completed delete_cell update, without fetching the notebook', () => {
+  it('renders the stable summary instead of a snapshot-derived delete diff after completion', () => {
     render(
       <NotebookProposalRenderer
         mode="update"
@@ -363,14 +335,15 @@ describe('NotebookProposalRenderer', () => {
       />
     )
 
-    expect(screen.getByText('−1')).toBeInTheDocument()
+    expect(screen.getByText('Notebook updated: Signup funnel')).toBeInTheDocument()
+    expect(screen.queryByText('−1')).not.toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'Open notebook' })).toHaveAttribute(
       'href',
       `/project/default/explorer/notebook/${NOTEBOOK_ID}`
     )
   })
 
-  it('renders a single added cell for a completed insert_cell update, not a phantom duplicate', () => {
+  it('renders the stable summary instead of a snapshot-derived insert diff after completion', () => {
     render(
       <NotebookProposalRenderer
         mode="update"
@@ -397,8 +370,9 @@ describe('NotebookProposalRenderer', () => {
       />
     )
 
-    expect(screen.getByText('+1')).toBeInTheDocument()
-    expect(screen.getAllByRole('button', { name: 'Added Markdown cell' })).toHaveLength(1)
+    expect(screen.getByText('Notebook updated: Signup funnel')).toBeInTheDocument()
+    expect(screen.queryByText('+1')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Added Markdown cell' })).not.toBeInTheDocument()
   })
 
   it('falls back to the compact completed body when previous_content is absent', () => {
@@ -474,9 +448,7 @@ describe('NotebookProposalRenderer', () => {
     expect(screen.queryByText('−1')).not.toBeInTheDocument()
   })
 
-  it('derives the diff against live content for a denied update', async () => {
-    mockContentItem(mockNotebookRow())
-
+  it('renders a stable summary for a denied update without diffing against live content', () => {
     render(
       <NotebookProposalRenderer
         mode="update"
@@ -491,12 +463,12 @@ describe('NotebookProposalRenderer', () => {
       />
     )
 
-    expect(await screen.findByText('−1')).toBeInTheDocument()
+    expect(screen.getByText('Skipped notebook update')).toBeInTheDocument()
+    expect(screen.queryByText('−1')).not.toBeInTheDocument()
+    expect(screen.queryByRole('toolbar', { name: 'Notebook toolbar' })).not.toBeInTheDocument()
   })
 
-  it('derives the diff against live content for an errored update', async () => {
-    mockContentItem(mockNotebookRow())
-
+  it('renders a stable summary for an errored update without diffing against live content', () => {
     render(
       <NotebookProposalRenderer
         mode="update"
@@ -511,7 +483,9 @@ describe('NotebookProposalRenderer', () => {
       />
     )
 
-    expect(await screen.findByText('−1')).toBeInTheDocument()
+    expect(screen.getByText('Failed to update notebook')).toBeInTheDocument()
+    expect(screen.queryByText('−1')).not.toBeInTheDocument()
+    expect(screen.queryByRole('toolbar', { name: 'Notebook toolbar' })).not.toBeInTheDocument()
   })
 
   it('keeps the create preview and marks it failed when the tool errors', () => {

--- a/apps/studio/components/ui/AIAssistantPanel/NotebookProposalRenderer.test.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/NotebookProposalRenderer.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { HttpResponse } from 'msw'
 import { describe, expect, it, vi } from 'vitest'

--- a/apps/studio/components/ui/AIAssistantPanel/NotebookProposalRenderer.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/NotebookProposalRenderer.tsx
@@ -98,6 +98,14 @@ const NOTEBOOK_ACTION_NOUN: Record<NotebookProposalMode, string> = {
 export const NotebookProposalRenderer = (props: NotebookProposalRendererProps) => {
   const { ref } = useParams()
   const { mode, state, input, output, confirmState, onApprove, onDeny, denyWithReason } = props
+
+  if (
+    mode === 'update' &&
+    (state === 'output-available' || state === 'output-error' || state === 'output-denied')
+  ) {
+    return <UpdateNotebookTerminalSummary state={state} output={output} />
+  }
+
   const parsedOutput = notebookToolOutputSchema.safeParse(output)
   // A deleted notebook no longer exists to open, so this action only applies to create/update.
   const canOpenNotebook = mode !== 'delete' && state === 'output-available'
@@ -146,6 +154,35 @@ export const NotebookProposalRenderer = (props: NotebookProposalRendererProps) =
       {proposal}
       {confirmState === undefined && footerAction}
     </>
+  )
+}
+
+function UpdateNotebookTerminalSummary({
+  state,
+  output,
+}: Pick<NotebookProposalRendererProps, 'state' | 'output'>) {
+  const { ref } = useParams()
+  const parsedOutput = notebookToolOutputSchema.safeParse(output)
+  const label =
+    state === 'output-available'
+      ? parsedOutput.success
+        ? `Notebook updated: ${parsedOutput.data.name}`
+        : 'Notebook updated'
+      : state === 'output-error'
+        ? 'Failed to update notebook'
+        : 'Skipped notebook update'
+
+  return (
+    <div className="flex items-center justify-between gap-2 my-2 mx-4 px-3 py-1.5 text-sm border rounded-md bg-surface-75">
+      <span className="text-foreground-light truncate">{label}</span>
+      {state === 'output-available' && parsedOutput.success && ref && (
+        <Button asChild variant="default" size="tiny">
+          <Link href={`/project/${ref}/explorer/notebook/${parsedOutput.data.id}`}>
+            Open notebook
+          </Link>
+        </Button>
+      )}
+    </div>
   )
 }
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Small Assistant terminal-state fixes.

## Stack context

This stack is based on #49352 (`chore/assistant-tool-outcomes`) and assumes #49350–#49352 merge first.

Review bottom to top:

1. #49361 — assistant notebook run tool
2. #49362 — assistant notebook run UI
3. #49364 — terminal-state polish

## What is the current behavior?

Completed notebook updates can be re-diffed against newer live content, and log-query failures can use SQL-specific or empty fallback UI.

## What is the new behavior?

- Replaces completed notebook update previews with a stable success/error/skipped summary.
- Keeps the Open notebook action on successful updates.
- Uses logs-specific failure copy for Assistant log queries.
- Shows an explicit fallback when a failed log tool input or output cannot be parsed.

## How to test manually

### Notebook update terminal states

1. Ask the AI Assistant to update an existing notebook, then approve the proposal.
2. Confirm the proposal becomes a compact **Notebook updated: [name]** summary instead of re-diffing against the newly saved notebook.
3. Click **Open notebook** and confirm it opens the updated notebook.
4. Request another notebook update and click **Skip**. Confirm the terminal summary says **Skipped notebook update**.
5. Refresh or reopen the conversation and confirm both summaries remain stable.

### Logs failure copy

1. Ask the Assistant to query Logs with an intentionally invalid table or column and approve the query.
2. Confirm the failed result says **Failed to query logs**, not **Failed to execute SQL**.
3. Confirm the failed tool remains visible rather than disappearing when its result cannot be rendered.

## Automated test

The focused top-of-stack suite passes 9 test files and 85 tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer failure messaging when query logs contain invalid input, missing results, or errors.
  - Added compact summaries for completed, failed, and skipped notebook updates.
  - Notebook update summaries include an “Open notebook” link when applicable.

- **Bug Fixes**
  - Improved handling and display of query-log failures instead of showing blank content.
  - Preserved detailed previews for notebook updates that are still in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
