### PR TITLE
docs: fix ineffective revoke of function execute from public

### DIFF
--- a/apps/docs/content/guides/api/securing-your-api.mdx
+++ b/apps/docs/content/guides/api/securing-your-api.mdx
@@ -189,7 +189,7 @@ Revoke automatic grants when you want new objects in `public` to remain inaccess
      revoke execute on functions from public;
    ```
 
-The last statement leaves out `in schema public` on purpose. A schema-scoped default privilege is merged with the built-in Postgres default rather than replacing it, so it can't take away the `EXECUTE` privilege that Postgres grants to `PUBLIC` on every new function. Only the schema-less form replaces that default, and it covers functions `postgres` creates in any schema.
+The last statement leaves out `in schema public` on purpose. Postgres merges a schema-scoped default privilege with its built-in default instead of replacing it. Such an entry can only add privileges, so it never reaches the `EXECUTE` that Postgres grants to `PUBLIC`. Only the schema-less form replaces that default. It covers every function `postgres` creates, in any schema, so extensions you enable afterwards need an explicit `grant execute` before `anon` or `authenticated` can call their functions.
 
 New tables, functions, and sequences now require explicit grants before Data API roles can access them.
 

--- a/apps/docs/content/guides/api/securing-your-api.mdx
+++ b/apps/docs/content/guides/api/securing-your-api.mdx
@@ -185,9 +185,11 @@ Revoke automatic grants when you want new objects in `public` to remain inaccess
    alter default privileges for role postgres in schema public
      revoke usage, select on sequences from anon, authenticated, service_role;
 
-   alter default privileges for role postgres in schema public
+   alter default privileges for role postgres
      revoke execute on functions from public;
    ```
+
+The last statement leaves out `in schema public` on purpose. A schema-scoped default privilege is merged with the built-in Postgres default rather than replacing it, so it can't take away the `EXECUTE` privilege that Postgres grants to `PUBLIC` on every new function. Only the schema-less form replaces that default, and it covers functions `postgres` creates in any schema.
 
 New tables, functions, and sequences now require explicit grants before Data API roles can access them.
 

--- a/apps/docs/content/guides/api/securing-your-api.mdx
+++ b/apps/docs/content/guides/api/securing-your-api.mdx
@@ -189,7 +189,7 @@ Revoke automatic grants when you want new objects in `public` to remain inaccess
      revoke execute on functions from public;
    ```
 
-The last statement leaves out `in schema public` on purpose. Postgres merges a schema-scoped default privilege with its built-in default instead of replacing it. Such an entry can only add privileges, so it never reaches the `EXECUTE` that Postgres grants to `PUBLIC`. Only the schema-less form replaces that default. It covers every function `postgres` creates, in any schema, so extensions you enable afterwards need an explicit `grant execute` before `anon` or `authenticated` can call their functions.
+The last statement leaves out `in schema public` on purpose. Postgres merges a schema-scoped default privilege with its built-in default instead of replacing it. Such an entry can undo a matching schema-scoped grant, which is what the first three statements do, but it never reaches the `EXECUTE` that Postgres grants to `PUBLIC`. Only the schema-less form replaces that default. It covers every function `postgres` creates, in any schema, so an extension you enable after this step needs an explicit `grant execute` before `anon` or `authenticated` can call its functions.
 
 New tables, functions, and sequences now require explicit grants before Data API roles can access them.
 

--- a/apps/docs/content/guides/database/functions.mdx
+++ b/apps/docs/content/guides/database/functions.mdx
@@ -468,9 +468,11 @@ By default, database functions can be executed by any role. There are two main w
     To restrict all new functions, change the default privileges for both `public` _and_ the role you want to restrict:
 
     ```sql
-    alter default privileges in schema public revoke execute on functions from public;
+    alter default privileges revoke execute on functions from public;
     alter default privileges in schema public revoke execute on functions from anon, authenticated;
     ```
+
+    The revoke from `public` has to be schema-less. A schema-scoped default privilege can't take away the `EXECUTE` privilege that Postgres grants to `PUBLIC` on every new function.
 
     You can then regrant permissions for a specific function to a specific role:
 

--- a/apps/docs/content/guides/database/functions.mdx
+++ b/apps/docs/content/guides/database/functions.mdx
@@ -472,7 +472,7 @@ By default, database functions can be executed by any role. There are two main w
     alter default privileges in schema public revoke execute on functions from anon, authenticated;
     ```
 
-    The revoke from `public` has to leave out `in schema public`. A schema-scoped default privilege can only add privileges, so it never reaches the `execute` that Postgres grants to `public` on every new function.
+    The revoke from `public` has to leave out `in schema public`. A schema-scoped default privilege can undo a matching schema-scoped grant, but it never reaches the `execute` that Postgres grants to `public` on every new function.
 
     You can then regrant permissions for a specific function to a specific role:
 

--- a/apps/docs/content/guides/database/functions.mdx
+++ b/apps/docs/content/guides/database/functions.mdx
@@ -472,7 +472,7 @@ By default, database functions can be executed by any role. There are two main w
     alter default privileges in schema public revoke execute on functions from anon, authenticated;
     ```
 
-    The revoke from `public` has to be schema-less. A schema-scoped default privilege can't take away the `EXECUTE` privilege that Postgres grants to `PUBLIC` on every new function.
+    The revoke from `public` has to leave out `in schema public`. A schema-scoped default privilege can only add privileges, so it never reaches the `execute` that Postgres grants to `public` on every new function.
 
     You can then regrant permissions for a specific function to a specific role:
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update.

## What is the current behavior?

Fixes #49338.

The hardening steps on [Securing your API](https://supabase.com/docs/guides/api/securing-your-api#revoke-default-privileges) end with:

```sql
alter default privileges for role postgres in schema public
  revoke execute on functions from public;
```

That statement succeeds but changes nothing, so a function created afterwards is still callable with the anon key. A schema-scoped default ACL starts from an empty ACL and only ever adds privileges, so it can cancel a default grant Supabase already created in `public`, but it never reaches the `EXECUTE` that Postgres itself grants to `PUBLIC`. The other three statements work because they do have a Supabase grant to cancel. This one has nothing to cancel, which is why it's easy to miss.

The same statement appears on [Database Functions](https://supabase.com/docs/guides/database/functions#security), under "To restrict all new functions".

## What is the new behavior?

Both statements drop `in schema public`, and each gets a short note on why the schema is left off.

## Additional context

Checked on Postgres 15 with the reporter's script. Before, `has_function_privilege('anon', 'public.f()', 'EXECUTE')` returns true and `proacl` is null; after, it returns false and `proacl` is `{postgres=X/postgres}`. Granting a single function back to a role still works.

The schema-less form applies to every schema, so an extension installed after this step comes out with `proacl = {postgres=X/postgres}` and its functions are no longer callable by `anon` or `authenticated`. The note on the securing-your-api page mentions this.

Left out on purpose: `packages/pg-meta/src/sql/studio/database/privileges.ts` builds the same schema-scoped statement for the Studio default-privileges toggle, so turning the toggle off has the same no effect on functions. That's product behaviour rather than docs, and making it schema-less widens what the toggle does, so it seemed better as a separate change. Happy to open an issue for it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how schema-scoped default privileges interact with matching schema-scoped grants.
  * Explained that schema-scoped defaults cannot revoke PostgreSQL’s automatic `PUBLIC` execute privilege on new functions.
  * Documented that only schema-less defaults replace this privilege.
  * Noted that extensions enabled later require explicit `EXECUTE` grants before `anon` or `authenticated` can call their functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->