### PR TITLE
Flush notebook cache in valtio and react query whenever closing notebook tab

### DIFF
--- a/apps/studio/components/interfaces/Explorer/ExplorerNotebookTabCoordinator.tsx
+++ b/apps/studio/components/interfaces/Explorer/ExplorerNotebookTabCoordinator.tsx
@@ -1,0 +1,39 @@
+import { useQueryClient } from '@tanstack/react-query'
+import { useParams } from 'common'
+import { useContext, useEffect } from 'react'
+
+import { contentKeys } from '@/data/content/keys'
+import { notebooksState } from '@/state/notebooks/notebooks-state'
+import { TabsStateContext } from '@/state/tabs'
+
+/**
+ * Evicts a notebook's content from the valtio store and the React Query cache
+ * when its tab closes, so reopening it always refetches instead of showing
+ * whatever was last loaded. Only applies to notebooks with no unsaved edits —
+ * a dirty notebook is left in the store untouched, same as today, since there's
+ * no autosave or discard-confirmation flow for notebooks yet.
+ *
+ * [Joshen] We'll address discard confirmation separately
+ */
+export const ExplorerNotebookTabCoordinator = () => {
+  const { ref } = useParams()
+  const queryClient = useQueryClient()
+  const tabs = useContext(TabsStateContext)
+
+  useEffect(() => {
+    return tabs.registerTabTypeHandler('notebook', {
+      onClose: (tab) => {
+        const notebookId = tab.metadata?.notebookId
+        if (!ref || !notebookId) return
+
+        const stateNotebook = notebooksState.notebooks[notebookId]
+        if (stateNotebook?.status !== 'saved') return
+
+        notebooksState.removeNotebook({ id: notebookId })
+        queryClient.removeQueries({ queryKey: contentKeys.resource(ref, notebookId) })
+      },
+    })
+  }, [ref, tabs, queryClient])
+
+  return null
+}

--- a/apps/studio/components/interfaces/Explorer/__tests__/ExplorerNotebookTabCoordinator.test.tsx
+++ b/apps/studio/components/interfaces/Explorer/__tests__/ExplorerNotebookTabCoordinator.test.tsx
@@ -1,0 +1,83 @@
+import { QueryClient } from '@tanstack/react-query'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ExplorerNotebookTabCoordinator } from '../ExplorerNotebookTabCoordinator'
+import { contentKeys } from '@/data/content/keys'
+import { notebooksState } from '@/state/notebooks/notebooks-state'
+import type { Notebook } from '@/state/notebooks/types'
+import { createTabId, createTabsState, TabsStateContext } from '@/state/tabs'
+import { customRender } from '@/tests/lib/custom-render'
+
+vi.mock('common', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('common')>()
+  return {
+    ...actual,
+    useParams: () => ({ ref: 'default' }),
+  }
+})
+
+const NOTEBOOK_ID = 'notebook-coordinator-test'
+
+const seedNotebook = (status: 'new' | 'saved') => {
+  delete notebooksState.notebooks[NOTEBOOK_ID]
+  const notebook: Notebook = {
+    id: NOTEBOOK_ID,
+    type: 'notebook',
+    name: 'Test notebook',
+    visibility: 'project',
+    favorite: false,
+    owner_id: 1,
+    project_id: 1,
+    content: { schema_version: 1, cells: [] },
+  }
+  if (status === 'new') notebooksState.addNotebook({ projectRef: 'default', notebook })
+  else notebooksState.setNotebook({ projectRef: 'default', notebook })
+}
+
+const renderCoordinator = (queryClient: QueryClient) => {
+  const tabsState = createTabsState('default')
+  const tabId = createTabId('notebook', { id: NOTEBOOK_ID })
+  tabsState.addTab({ id: tabId, type: 'notebook', metadata: { notebookId: NOTEBOOK_ID } })
+
+  customRender(
+    <TabsStateContext.Provider value={tabsState}>
+      <ExplorerNotebookTabCoordinator />
+    </TabsStateContext.Provider>,
+    { queryClient }
+  )
+
+  return { tabsState, tabId }
+}
+
+afterEach(() => {
+  delete notebooksState.notebooks[NOTEBOOK_ID]
+  notebooksState.needsSaving.clear()
+})
+
+describe('ExplorerNotebookTabCoordinator', () => {
+  it('flushes a saved notebook from the store and evicts its cache entry on close', () => {
+    seedNotebook('saved')
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(contentKeys.resource('default', NOTEBOOK_ID), { id: NOTEBOOK_ID })
+
+    const { tabsState, tabId } = renderCoordinator(queryClient)
+    tabsState.closeTabs([tabId])
+
+    expect(notebooksState.notebooks[NOTEBOOK_ID]).toBeUndefined()
+    expect(queryClient.getQueryData(contentKeys.resource('default', NOTEBOOK_ID))).toBeUndefined()
+  })
+
+  it('leaves an unsaved notebook in the store on close', () => {
+    seedNotebook('new')
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(contentKeys.resource('default', NOTEBOOK_ID), { id: NOTEBOOK_ID })
+
+    const { tabsState, tabId } = renderCoordinator(queryClient)
+    tabsState.closeTabs([tabId])
+
+    expect(notebooksState.notebooks[NOTEBOOK_ID]).toBeDefined()
+    expect(queryClient.getQueryData(contentKeys.resource('default', NOTEBOOK_ID))).toEqual({
+      id: NOTEBOOK_ID,
+    })
+  })
+})

--- a/apps/studio/components/layouts/ExplorerLayout/ExplorerLayout.tsx
+++ b/apps/studio/components/layouts/ExplorerLayout/ExplorerLayout.tsx
@@ -16,6 +16,7 @@ import { type ExplorerResourceType } from './ExplorerLayout.constants'
 import { ExplorerNavChats } from './ExplorerNavChats'
 import { ExplorerNavHome } from './ExplorerNavHome'
 import { ExplorerNavNotebooks } from './ExplorerNavNotebooks'
+import { ExplorerNotebookTabCoordinator } from '@/components/interfaces/Explorer/ExplorerNotebookTabCoordinator'
 import { ExplorerQueryTabCoordinator } from '@/components/interfaces/Explorer/ExplorerQueryTabCoordinator'
 import {
   useCreateChat,
@@ -70,6 +71,9 @@ export const ExplorerLayout = ({ browserTitle, children, title }: ExplorerLayout
       }
     >
       <ExplorerQueryTabCoordinator />
+
+      <ExplorerNotebookTabCoordinator />
+
       <div className="flex flex-col h-full">
         <div className={cn('h-10 md:min-h-(--header-height) flex items-center bg-surface-100')}>
           <EditorTabs

--- a/apps/studio/routeTree.gen.ts
+++ b/apps/studio/routeTree.gen.ts
@@ -106,7 +106,6 @@ import { Route as ProjectRefSqlExamplesRouteImport } from './routes/project/$ref
 import { Route as ProjectRefSqlIdRouteImport } from './routes/project/$ref/sql/$id'
 import { Route as ProjectRefSettingsLogDrainsRouteImport } from './routes/project/$ref/settings/log-drains'
 import { Route as ProjectRefSettingsIntegrationsRouteImport } from './routes/project/$ref/settings/integrations'
-import { Route as ProjectRefSettingsInfrastructureIndexRouteImport } from './routes/project/$ref/settings/infrastructure/index'
 import { Route as ProjectRefSettingsGeneralRouteImport } from './routes/project/$ref/settings/general'
 import { Route as ProjectRefSettingsDashboardRouteImport } from './routes/project/$ref/settings/dashboard'
 import { Route as ProjectRefSettingsApiKeysRouteImport } from './routes/project/$ref/settings/api-keys'
@@ -206,6 +205,7 @@ import { Route as ProjectRefStorageFilesIndexRouteImport } from './routes/projec
 import { Route as ProjectRefStorageAnalyticsIndexRouteImport } from './routes/project/$ref/storage/analytics/index'
 import { Route as ProjectRefSettingsWebhooksIndexRouteImport } from './routes/project/$ref/settings/webhooks/index'
 import { Route as ProjectRefSettingsJwtIndexRouteImport } from './routes/project/$ref/settings/jwt/index'
+import { Route as ProjectRefSettingsInfrastructureIndexRouteImport } from './routes/project/$ref/settings/infrastructure/index'
 import { Route as ProjectRefSettingsApiKeysIndexRouteImport } from './routes/project/$ref/settings/api-keys/index'
 import { Route as ProjectRefLogsExplorerIndexRouteImport } from './routes/project/$ref/logs/explorer/index'
 import { Route as ProjectRefIntegrationsIdIndexRouteImport } from './routes/project/$ref/integrations/$id/index'
@@ -824,12 +824,6 @@ const ProjectRefSettingsIntegrationsRoute =
     path: '/integrations',
     getParentRoute: () => ProjectRefSettingsRoute,
   } as any)
-const ProjectRefSettingsInfrastructureIndexRoute =
-  ProjectRefSettingsInfrastructureIndexRouteImport.update({
-    id: '/infrastructure/',
-    path: '/infrastructure/',
-    getParentRoute: () => ProjectRefSettingsRoute,
-  } as any)
 const ProjectRefSettingsGeneralRoute =
   ProjectRefSettingsGeneralRouteImport.update({
     id: '/general',
@@ -1380,6 +1374,12 @@ const ProjectRefSettingsJwtIndexRoute =
   ProjectRefSettingsJwtIndexRouteImport.update({
     id: '/jwt/',
     path: '/jwt/',
+    getParentRoute: () => ProjectRefSettingsRoute,
+  } as any)
+const ProjectRefSettingsInfrastructureIndexRoute =
+  ProjectRefSettingsInfrastructureIndexRouteImport.update({
+    id: '/infrastructure/',
+    path: '/infrastructure/',
     getParentRoute: () => ProjectRefSettingsRoute,
   } as any)
 const ProjectRefSettingsApiKeysIndexRoute =
@@ -2256,7 +2256,6 @@ export interface FileRoutesByFullPath {
   '/project/$ref/settings/api-keys': typeof ProjectRefSettingsApiKeysRouteWithChildren
   '/project/$ref/settings/dashboard': typeof ProjectRefSettingsDashboardRoute
   '/project/$ref/settings/general': typeof ProjectRefSettingsGeneralRoute
-  '/project/$ref/settings/infrastructure/': typeof ProjectRefSettingsInfrastructureIndexRoute
   '/project/$ref/settings/integrations': typeof ProjectRefSettingsIntegrationsRoute
   '/project/$ref/settings/log-drains': typeof ProjectRefSettingsLogDrainsRoute
   '/project/$ref/sql/$id': typeof ProjectRefSqlIdRoute
@@ -2345,6 +2344,7 @@ export interface FileRoutesByFullPath {
   '/project/$ref/integrations/$id/': typeof ProjectRefIntegrationsIdIndexRoute
   '/project/$ref/logs/explorer/': typeof ProjectRefLogsExplorerIndexRoute
   '/project/$ref/settings/api-keys/': typeof ProjectRefSettingsApiKeysIndexRoute
+  '/project/$ref/settings/infrastructure/': typeof ProjectRefSettingsInfrastructureIndexRoute
   '/project/$ref/settings/jwt/': typeof ProjectRefSettingsJwtIndexRoute
   '/project/$ref/settings/webhooks/': typeof ProjectRefSettingsWebhooksIndexRoute
   '/project/$ref/storage/analytics/': typeof ProjectRefStorageAnalyticsIndexRoute
@@ -2557,7 +2557,6 @@ export interface FileRoutesByTo {
   '/project/$ref/settings/api': typeof ProjectRefSettingsApiRoute
   '/project/$ref/settings/dashboard': typeof ProjectRefSettingsDashboardRoute
   '/project/$ref/settings/general': typeof ProjectRefSettingsGeneralRoute
-  '/project/$ref/settings/infrastructure': typeof ProjectRefSettingsInfrastructureIndexRoute
   '/project/$ref/settings/integrations': typeof ProjectRefSettingsIntegrationsRoute
   '/project/$ref/settings/log-drains': typeof ProjectRefSettingsLogDrainsRoute
   '/project/$ref/sql/$id': typeof ProjectRefSqlIdRoute
@@ -2646,6 +2645,7 @@ export interface FileRoutesByTo {
   '/project/$ref/integrations/$id': typeof ProjectRefIntegrationsIdIndexRoute
   '/project/$ref/logs/explorer': typeof ProjectRefLogsExplorerIndexRoute
   '/project/$ref/settings/api-keys': typeof ProjectRefSettingsApiKeysIndexRoute
+  '/project/$ref/settings/infrastructure': typeof ProjectRefSettingsInfrastructureIndexRoute
   '/project/$ref/settings/jwt': typeof ProjectRefSettingsJwtIndexRoute
   '/project/$ref/settings/webhooks': typeof ProjectRefSettingsWebhooksIndexRoute
   '/project/$ref/storage/analytics': typeof ProjectRefStorageAnalyticsIndexRoute
@@ -2875,7 +2875,6 @@ export interface FileRoutesById {
   '/project/$ref/settings/api-keys': typeof ProjectRefSettingsApiKeysRouteWithChildren
   '/project/$ref/settings/dashboard': typeof ProjectRefSettingsDashboardRoute
   '/project/$ref/settings/general': typeof ProjectRefSettingsGeneralRoute
-  '/project/$ref/settings/infrastructure/': typeof ProjectRefSettingsInfrastructureIndexRoute
   '/project/$ref/settings/integrations': typeof ProjectRefSettingsIntegrationsRoute
   '/project/$ref/settings/log-drains': typeof ProjectRefSettingsLogDrainsRoute
   '/project/$ref/sql/$id': typeof ProjectRefSqlIdRoute
@@ -2964,6 +2963,7 @@ export interface FileRoutesById {
   '/project/$ref/integrations/$id/': typeof ProjectRefIntegrationsIdIndexRoute
   '/project/$ref/logs/explorer/': typeof ProjectRefLogsExplorerIndexRoute
   '/project/$ref/settings/api-keys/': typeof ProjectRefSettingsApiKeysIndexRoute
+  '/project/$ref/settings/infrastructure/': typeof ProjectRefSettingsInfrastructureIndexRoute
   '/project/$ref/settings/jwt/': typeof ProjectRefSettingsJwtIndexRoute
   '/project/$ref/settings/webhooks/': typeof ProjectRefSettingsWebhooksIndexRoute
   '/project/$ref/storage/analytics/': typeof ProjectRefStorageAnalyticsIndexRoute
@@ -3192,7 +3192,6 @@ export interface FileRouteTypes {
     | '/project/$ref/settings/api-keys'
     | '/project/$ref/settings/dashboard'
     | '/project/$ref/settings/general'
-    | '/project/$ref/settings/infrastructure/'
     | '/project/$ref/settings/integrations'
     | '/project/$ref/settings/log-drains'
     | '/project/$ref/sql/$id'
@@ -3281,6 +3280,7 @@ export interface FileRouteTypes {
     | '/project/$ref/integrations/$id/'
     | '/project/$ref/logs/explorer/'
     | '/project/$ref/settings/api-keys/'
+    | '/project/$ref/settings/infrastructure/'
     | '/project/$ref/settings/jwt/'
     | '/project/$ref/settings/webhooks/'
     | '/project/$ref/storage/analytics/'
@@ -3493,7 +3493,6 @@ export interface FileRouteTypes {
     | '/project/$ref/settings/api'
     | '/project/$ref/settings/dashboard'
     | '/project/$ref/settings/general'
-    | '/project/$ref/settings/infrastructure'
     | '/project/$ref/settings/integrations'
     | '/project/$ref/settings/log-drains'
     | '/project/$ref/sql/$id'
@@ -3582,6 +3581,7 @@ export interface FileRouteTypes {
     | '/project/$ref/integrations/$id'
     | '/project/$ref/logs/explorer'
     | '/project/$ref/settings/api-keys'
+    | '/project/$ref/settings/infrastructure'
     | '/project/$ref/settings/jwt'
     | '/project/$ref/settings/webhooks'
     | '/project/$ref/storage/analytics'
@@ -3810,7 +3810,6 @@ export interface FileRouteTypes {
     | '/project/$ref/settings/api-keys'
     | '/project/$ref/settings/dashboard'
     | '/project/$ref/settings/general'
-    | '/project/$ref/settings/infrastructure/'
     | '/project/$ref/settings/integrations'
     | '/project/$ref/settings/log-drains'
     | '/project/$ref/sql/$id'
@@ -3899,6 +3898,7 @@ export interface FileRouteTypes {
     | '/project/$ref/integrations/$id/'
     | '/project/$ref/logs/explorer/'
     | '/project/$ref/settings/api-keys/'
+    | '/project/$ref/settings/infrastructure/'
     | '/project/$ref/settings/jwt/'
     | '/project/$ref/settings/webhooks/'
     | '/project/$ref/storage/analytics/'
@@ -4761,13 +4761,6 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProjectRefSettingsIntegrationsRouteImport
       parentRoute: typeof ProjectRefSettingsRoute
     }
-    '/project/$ref/settings/infrastructure/': {
-      id: '/project/$ref/settings/infrastructure/'
-      path: '/infrastructure'
-      fullPath: '/project/$ref/settings/infrastructure/'
-      preLoaderRoute: typeof ProjectRefSettingsInfrastructureIndexRouteImport
-      parentRoute: typeof ProjectRefSettingsRoute
-    }
     '/project/$ref/settings/general': {
       id: '/project/$ref/settings/general'
       path: '/general'
@@ -5459,6 +5452,13 @@ declare module '@tanstack/react-router' {
       path: '/jwt'
       fullPath: '/project/$ref/settings/jwt/'
       preLoaderRoute: typeof ProjectRefSettingsJwtIndexRouteImport
+      parentRoute: typeof ProjectRefSettingsRoute
+    }
+    '/project/$ref/settings/infrastructure/': {
+      id: '/project/$ref/settings/infrastructure/'
+      path: '/infrastructure'
+      fullPath: '/project/$ref/settings/infrastructure/'
+      preLoaderRoute: typeof ProjectRefSettingsInfrastructureIndexRouteImport
       parentRoute: typeof ProjectRefSettingsRoute
     }
     '/project/$ref/settings/api-keys/': {
@@ -6822,15 +6822,15 @@ interface ProjectRefSettingsRouteChildren {
   ProjectRefSettingsApiKeysRoute: typeof ProjectRefSettingsApiKeysRouteWithChildren
   ProjectRefSettingsDashboardRoute: typeof ProjectRefSettingsDashboardRoute
   ProjectRefSettingsGeneralRoute: typeof ProjectRefSettingsGeneralRoute
-  ProjectRefSettingsInfrastructureIndexRoute: typeof ProjectRefSettingsInfrastructureIndexRoute
-  ProjectRefSettingsInfrastructureReplicaReplicaIdRoute: typeof ProjectRefSettingsInfrastructureReplicaReplicaIdRoute
   ProjectRefSettingsIntegrationsRoute: typeof ProjectRefSettingsIntegrationsRoute
   ProjectRefSettingsLogDrainsRoute: typeof ProjectRefSettingsLogDrainsRoute
   ProjectRefSettingsBillingUsageRoute: typeof ProjectRefSettingsBillingUsageRoute
   ProjectRefSettingsJwtLegacyRoute: typeof ProjectRefSettingsJwtLegacyRoute
   ProjectRefSettingsWebhooksEndpointIdRoute: typeof ProjectRefSettingsWebhooksEndpointIdRoute
+  ProjectRefSettingsInfrastructureIndexRoute: typeof ProjectRefSettingsInfrastructureIndexRoute
   ProjectRefSettingsJwtIndexRoute: typeof ProjectRefSettingsJwtIndexRoute
   ProjectRefSettingsWebhooksIndexRoute: typeof ProjectRefSettingsWebhooksIndexRoute
+  ProjectRefSettingsInfrastructureReplicaReplicaIdRoute: typeof ProjectRefSettingsInfrastructureReplicaReplicaIdRoute
 }
 
 const ProjectRefSettingsRouteChildren: ProjectRefSettingsRouteChildren = {
@@ -6839,18 +6839,18 @@ const ProjectRefSettingsRouteChildren: ProjectRefSettingsRouteChildren = {
   ProjectRefSettingsApiKeysRoute: ProjectRefSettingsApiKeysRouteWithChildren,
   ProjectRefSettingsDashboardRoute: ProjectRefSettingsDashboardRoute,
   ProjectRefSettingsGeneralRoute: ProjectRefSettingsGeneralRoute,
-  ProjectRefSettingsInfrastructureIndexRoute:
-    ProjectRefSettingsInfrastructureIndexRoute,
-  ProjectRefSettingsInfrastructureReplicaReplicaIdRoute:
-    ProjectRefSettingsInfrastructureReplicaReplicaIdRoute,
   ProjectRefSettingsIntegrationsRoute: ProjectRefSettingsIntegrationsRoute,
   ProjectRefSettingsLogDrainsRoute: ProjectRefSettingsLogDrainsRoute,
   ProjectRefSettingsBillingUsageRoute: ProjectRefSettingsBillingUsageRoute,
   ProjectRefSettingsJwtLegacyRoute: ProjectRefSettingsJwtLegacyRoute,
   ProjectRefSettingsWebhooksEndpointIdRoute:
     ProjectRefSettingsWebhooksEndpointIdRoute,
+  ProjectRefSettingsInfrastructureIndexRoute:
+    ProjectRefSettingsInfrastructureIndexRoute,
   ProjectRefSettingsJwtIndexRoute: ProjectRefSettingsJwtIndexRoute,
   ProjectRefSettingsWebhooksIndexRoute: ProjectRefSettingsWebhooksIndexRoute,
+  ProjectRefSettingsInfrastructureReplicaReplicaIdRoute:
+    ProjectRefSettingsInfrastructureReplicaReplicaIdRoute,
 }
 
 const ProjectRefSettingsRouteWithChildren =

--- a/apps/studio/state/notebooks/notebook-session-state.ts
+++ b/apps/studio/state/notebooks/notebook-session-state.ts
@@ -1,9 +1,0 @@
-/**
- * Ephemeral, per-session notebook state that is NOT persisted: query cell
- * results and the row limit. Kept separate from the notebook content store
- * (which deals with persistence) because none of this is saved — it lives
- * only for the current editing session, keyed by cell id rather than
- * notebook id since a single notebook can have many independent query cells.
- *
- * [Joshen] Will be fleshed out in subsequent PRs
- */


### PR DESCRIPTION
## Context

Opting to flush the notebook cache within the Valtio store (nootebook-store) and react query whenever we close the notebook tab in the explorer.

Mainly to ensure that whenever we re-open the notebook again, the notebook content isn't stale and we refetch the notebook content from the API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Closing a saved notebook tab now removes it from the session and clears its cached content.
  - Notebooks with unsaved changes are preserved when their tabs close.

- **Tests**
  - Added coverage for saved and unsaved notebook tab cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->