### PR TITLE
Add isReadOnly flag into QueryEditor component

### DIFF
--- a/apps/studio/components/interfaces/Explorer/QueryEditor/index.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryEditor/index.tsx
@@ -263,7 +263,7 @@ export const QueryEditor = forwardRef<QueryEditorHandle, QueryEditorProps>(funct
   }
 
   const acceptSqlProposal = () => {
-    if (!pendingProposal) return
+    if (isReadOnly || !pendingProposal) return
     if (sql === pendingProposal.original) {
       onSqlChange(pendingProposal.modified)
       onSqlCommit?.(pendingProposal.modified)

--- a/apps/studio/components/interfaces/Explorer/QueryEditor/index.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryEditor/index.tsx
@@ -101,6 +101,7 @@ export type QueryEditorHandle = {
 
 type QueryEditorProps = {
   id: string
+  isReadOnly?: boolean
   variant: 'embedded' | 'viewport'
   title: string
   query: ExplorerQueryModel
@@ -131,6 +132,7 @@ type QueryEditorProps = {
 export const QueryEditor = forwardRef<QueryEditorHandle, QueryEditorProps>(function QueryEditor(
   {
     id,
+    isReadOnly = false,
     variant,
     title,
     query,
@@ -381,6 +383,7 @@ export const QueryEditor = forwardRef<QueryEditorHandle, QueryEditorProps>(funct
             <CodeEditor
               id={`explorer-query-${id}`}
               language="pgsql"
+              isReadOnly={isReadOnly}
               value={sql}
               placeholder={!promptState?.isOpen ? generatePlaceholder(os) : ''}
               placeholderClassName="top-[13px]"

--- a/apps/studio/components/ui/AIAssistantPanel/AssistantQueryCell.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AssistantQueryCell.tsx
@@ -137,6 +137,7 @@ export const AssistantQueryCell = ({
       onConfirm={onApprove}
     >
       <QueryEditor
+        isReadOnly
         id={id}
         variant="viewport"
         title={title}


### PR DESCRIPTION
## Context

`QueryEditor` component is being used in the Assistant Chat currently and needs to be read only in this context specifically
<img width="1251" height="564" alt="image" src="https://github.com/user-attachments/assets/97d7ce9c-59bc-4acb-a105-e70361b6729e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Added read-only support for query editors, allowing query content to be viewed without making changes.
  * Assistant-generated queries are now displayed in a non-editable mode to prevent accidental modifications.
  * Read-only editors also prevent applying suggested SQL changes, helping preserve the original query while it is being reviewed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->