### PR TITLE
fix(docker): correct 'placehoder' typo in docker/.env.example

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -385,5 +385,5 @@ IMGPROXY_AUTO_WEBP=true
 PROXY_DOMAIN=your-domain.example.com
 
 # Email for Let's Encrypt certificate notifications (nginx only, Caddy uses PROXY_DOMAIN).
-# This should be a valid email, not a placehoder (otherwise Certbot may fail to start).
+# This should be a valid email, not a placeholder (otherwise Certbot may fail to start).
 CERTBOT_EMAIL=admin@example.com


### PR DESCRIPTION
## Summary
Fixes the typo `placehoder` → `placeholder` in `docker/.env.example` (line 388).

Closes #49330

## What changed
- `docker/.env.example`: corrected spelling in the CERTBOT_EMAIL comment

Refs the prior PR #43451 (closed without an accompanying issue).

## Test plan
- [x] Verified the typo appears exactly once in the file
- [x] No other occurrences elsewhere in the repo (`git grep` clean)
- [x] Comment now reads correctly

Release notes: documentation-only change, no runtime impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the spelling of “placeholder” in the Certbot email configuration comment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->