### PR TITLE
fix(studio): refresh cron list after toggle regardless of searchTerm

### DIFF
--- a/apps/studio/data/database-cron-jobs/database-cron-jobs-toggle-mutation.ts
+++ b/apps/studio/data/database-cron-jobs/database-cron-jobs-toggle-mutation.ts
@@ -49,10 +49,13 @@ export const useDatabaseCronJobToggleMutation = ({
   return useMutation<DatabaseCronJobToggleData, ResponseError, DatabaseCronJobToggleVariables>({
     mutationFn: (vars) => toggleDatabaseCronJob(vars),
     async onSuccess(data, variables, context) {
-      const { projectRef } = variables
-      await queryClient.invalidateQueries({
-        queryKey: databaseCronJobsKeys.jobs(projectRef),
-      })
+      const { projectRef, searchTerm } = variables
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: databaseCronJobsKeys.jobs(projectRef) }),
+        queryClient.invalidateQueries({
+          queryKey: databaseCronJobsKeys.listInfiniteMinimal(projectRef, searchTerm),
+        }),
+      ])
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/database-cron-jobs/database-cron-jobs-toggle-mutation.ts
+++ b/apps/studio/data/database-cron-jobs/database-cron-jobs-toggle-mutation.ts
@@ -49,9 +49,9 @@ export const useDatabaseCronJobToggleMutation = ({
   return useMutation<DatabaseCronJobToggleData, ResponseError, DatabaseCronJobToggleVariables>({
     mutationFn: (vars) => toggleDatabaseCronJob(vars),
     async onSuccess(data, variables, context) {
-      const { projectRef, searchTerm } = variables
+      const { projectRef } = variables
       await queryClient.invalidateQueries({
-        queryKey: databaseCronJobsKeys.listInfinite(projectRef, searchTerm),
+        queryKey: databaseCronJobsKeys.jobs(projectRef),
       })
       await onSuccess?.(data, variables, context)
     },


### PR DESCRIPTION
Closes #49009

After enable/disable via the switch in the cron jobs table, the
modal showed loading but the row kept its old active state until
the top Refresh was clicked.

Root cause: toggle onSuccess invalidated only
databaseCronJobsKeys.listInfinite(projectRef, searchTerm) with the
exact searchTerm from the mutation ('' when no search), but the
active infinite query can be keyed with undefined. The exact-key
invalidation missed the active query, so it stayed stale.

Fix: invalidate databaseCronJobsKeys.jobs(projectRef) (prefix
['projects', ref, 'cron-jobs']) so any searchTerm variant
refetches. Verified no other narrow invalidation needed; the jobs
prefix covers listInfinite, count, etc.

No behavior change except the grid now reflects the new active
state immediately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed database cron job updates so both standard and infinite job lists refresh correctly after a job is toggled.
  * Ensured updated job statuses appear consistently for projects with or without an active search filter.
  * Improved synchronization between filtered results and the full cron jobs list after status changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->