### PR TITLE
Stop re-deriving notebook update diffs after completion

### DIFF
--- a/apps/studio/components/ui/AIAssistantPanel/NotebookProposalRenderer.test.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/NotebookProposalRenderer.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { HttpResponse } from 'msw'
 import { describe, expect, it, vi } from 'vitest'
@@ -255,8 +255,35 @@ describe('NotebookProposalRenderer', () => {
     )
   })
 
-  it('shows the notebook action after an automatic update succeeds', async () => {
-    mockContentItem(mockNotebookRow())
+  it('shows the notebook action after an automatic update succeeds', () => {
+    render(
+      <NotebookProposalRenderer
+        mode="update"
+        state="output-available"
+        input={{
+          id: NOTEBOOK_ID,
+          expected_updated_at: '2024-01-01T00:00:00.000Z',
+          operations: [{ _tag: 'delete_cell', cell_id: 'cell-1' }],
+        }}
+        output={{ id: NOTEBOOK_ID, name: 'Signup funnel' }}
+      />
+    )
+
+    expect(screen.getByRole('link', { name: 'Open notebook' })).toHaveAttribute(
+      'href',
+      `/project/default/explorer/notebook/${NOTEBOOK_ID}`
+    )
+  })
+
+  it('does not show the "can\'t be applied" warning for a completed update whose target cell no longer exists', async () => {
+    mockContentItem(
+      mockNotebookRow({
+        content: {
+          schema_version: 1,
+          cells: [{ _tag: 'markdown_cell', _id: 'cell-2', text: 'world' }],
+        },
+      })
+    )
 
     render(
       <NotebookProposalRenderer
@@ -271,10 +298,85 @@ describe('NotebookProposalRenderer', () => {
       />
     )
 
-    expect(await screen.findByRole('link', { name: 'Open notebook' })).toHaveAttribute(
+    await waitFor(() => expect(screen.queryByText('Loading notebook...')).not.toBeInTheDocument())
+    expect(screen.queryByText("This update can't be applied as written")).not.toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Open notebook' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Open notebook' })).toHaveAttribute(
       'href',
       `/project/default/explorer/notebook/${NOTEBOOK_ID}`
     )
+  })
+
+  it('shows the notebook action inside the Confirm footer for a manually approved completed update', async () => {
+    mockContentItem(
+      mockNotebookRow({
+        content: {
+          schema_version: 1,
+          cells: [{ _tag: 'markdown_cell', _id: 'cell-2', text: 'world' }],
+        },
+      })
+    )
+
+    render(
+      <NotebookProposalRenderer
+        mode="update"
+        state="output-available"
+        confirmState="success"
+        input={{
+          id: NOTEBOOK_ID,
+          expected_updated_at: '2024-01-01T00:00:00.000Z',
+          operations: [{ _tag: 'delete_cell', cell_id: 'cell-1' }],
+        }}
+        output={{ id: NOTEBOOK_ID, name: 'Signup funnel' }}
+      />
+    )
+
+    const openNotebookLink = await screen.findByRole('link', { name: 'Open notebook' })
+    expect(openNotebookLink).toHaveAttribute(
+      'href',
+      `/project/default/explorer/notebook/${NOTEBOOK_ID}`
+    )
+    expect(screen.queryByText("This update can't be applied as written")).not.toBeInTheDocument()
+  })
+
+  it('derives the diff against live content for a denied update', async () => {
+    mockContentItem(mockNotebookRow())
+
+    render(
+      <NotebookProposalRenderer
+        mode="update"
+        state="output-denied"
+        confirmState="denied"
+        input={{
+          id: NOTEBOOK_ID,
+          expected_updated_at: '2024-01-01T00:00:00.000Z',
+          operations: [{ _tag: 'delete_cell', cell_id: 'cell-1' }],
+        }}
+        output={undefined}
+      />
+    )
+
+    expect(await screen.findByText('−1')).toBeInTheDocument()
+  })
+
+  it('derives the diff against live content for an errored update', async () => {
+    mockContentItem(mockNotebookRow())
+
+    render(
+      <NotebookProposalRenderer
+        mode="update"
+        state="output-error"
+        confirmState="error"
+        input={{
+          id: NOTEBOOK_ID,
+          expected_updated_at: '2024-01-01T00:00:00.000Z',
+          operations: [{ _tag: 'delete_cell', cell_id: 'cell-1' }],
+        }}
+        output={undefined}
+      />
+    )
+
+    expect(await screen.findByText('−1')).toBeInTheDocument()
   })
 
   it('keeps the create preview and marks it failed when the tool errors', () => {

--- a/apps/studio/components/ui/AIAssistantPanel/NotebookProposalRenderer.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/NotebookProposalRenderer.tsx
@@ -100,6 +100,8 @@ export const NotebookProposalRenderer = (props: NotebookProposalRendererProps) =
     ) : (
       <UpdateNotebookProposal
         input={input}
+        state={state}
+        output={output}
         confirmState={confirmState}
         footerAction={confirmState === undefined ? undefined : footerAction}
         onApprove={onApprove}
@@ -234,23 +236,33 @@ function CreateNotebookProposal({
   )
 }
 
+const TERMINAL_CONFIRM_STATES: ConfirmFooterApprovalState[] = ['success', 'error', 'denied']
+
 /**
- * An update whose operations don't apply to the notebook as currently loaded (e.g. an
- * operation targets a cell id that no longer exists). There's nothing for the user to decide
- * here, so instead of asking them to Skip, deny automatically with the specific reason —
- * same text `update_notebook`'s server-side execute() would throw for the same failure — so
- * the model sees why and can retry (e.g. re-fetch and reissue) without the user's involvement.
+ * An update whose operations don't apply to the notebook as currently loaded
+ * (e.g. an operation targets a cell id that no longer exists). There's nothing
+ * for the user to decide here, so instead of asking them to Skip, deny
+ * automatically with the specific reason — same text `update_notebook`'s
+ * server-side execute() would throw for the same failure — so the model sees
+ * why and can retry (e.g. re-fetch and reissue) without the user's involvement.
+ *
+ * For a terminal `confirmState` (the decision already happened), re-deriving
+ * against live content is just for display, and "can't be applied as written"
+ * is inaccurate — nothing is being applied anymore. Instead, state that the
+ * notebook has changed since, so the preview can't be reconstructed.
  */
 function UnapplyableNotebookUpdateNotice({
   notebookName,
   reason,
   confirmState,
+  footerAction,
   onDeny,
   denyWithReason,
 }: {
   notebookName: string
   reason: string
   confirmState?: ConfirmFooterApprovalState
+  footerAction?: ReactNode
   onDeny?: () => void
   denyWithReason?: (reason: string) => void
 }) {
@@ -262,20 +274,31 @@ function UnapplyableNotebookUpdateNotice({
     if (confirmState === 'approval-requested') onUnapplyable()
   }, [confirmState])
 
+  const isTerminal = confirmState !== undefined && TERMINAL_CONFIRM_STATES.includes(confirmState)
+
   return (
     <NotebookConfirm
       mode="update"
       confirmState={confirmState}
+      footerAction={footerAction}
       message={`Assistant wants to update "${notebookName}"`}
       denyOnly
       onDeny={() => (denyWithReason ? denyWithReason(reason) : onDeny?.())}
     >
       <div className="p-3">
-        <Admonition
-          type="warning"
-          title="This update can't be applied as written"
-          description={reason}
-        />
+        {isTerminal ? (
+          <Admonition
+            type="warning"
+            title="Preview unavailable"
+            description="This notebook has changed since, so the preview can't be reconstructed."
+          />
+        ) : (
+          <Admonition
+            type="warning"
+            title="This update can't be applied as written"
+            description={reason}
+          />
+        )}
       </div>
     </NotebookConfirm>
   )
@@ -283,14 +306,17 @@ function UnapplyableNotebookUpdateNotice({
 
 function UpdateNotebookProposal({
   input,
+  state,
+  output,
   confirmState,
   footerAction,
   onApprove,
   onDeny,
   denyWithReason,
-}: NotebookProposalStepProps) {
+}: NotebookProposalStepProps & { state: NotebookProposalState; output: unknown }) {
   const { ref } = useParams()
   const parsedInput = updateNotebookInputSchema.safeParse(input)
+  const isCompleted = state === 'output-available'
 
   const {
     data: notebook,
@@ -299,7 +325,7 @@ function UpdateNotebookProposal({
     error,
   } = useNotebookQuery(
     { projectRef: ref, id: parsedInput.success ? parsedInput.data.id : undefined },
-    { enabled: parsedInput.success }
+    { enabled: parsedInput.success && !isCompleted }
   )
 
   if (!parsedInput.success) {
@@ -310,6 +336,25 @@ function UpdateNotebookProposal({
         input={input}
         onDeny={onDeny}
       />
+    )
+  }
+
+  if (isCompleted) {
+    const parsedOutput = notebookToolOutputSchema.safeParse(output)
+    const notebookName = parsedOutput.success ? parsedOutput.data.name : undefined
+
+    return (
+      <NotebookConfirm
+        mode="update"
+        confirmState={confirmState}
+        footerAction={footerAction}
+        onApprove={onApprove}
+        onDeny={onDeny}
+      >
+        <div className="p-3 text-sm text-foreground-light truncate">
+          {notebookName ? `Notebook updated: ${notebookName}` : MODE_COPY.update.outputLabel}
+        </div>
+      </NotebookConfirm>
     )
   }
 
@@ -349,6 +394,7 @@ function UpdateNotebookProposal({
         notebookName={notebook.name}
         reason={describeNotebookOperationError(diff.error)}
         confirmState={confirmState}
+        footerAction={footerAction}
         onDeny={onDeny}
         denyWithReason={denyWithReason}
       />


### PR DESCRIPTION
## Summary

- Fixes false-negative "This update can't be applied" warning for completed notebook updates (FE-4243)
- When `state='output-available'` (tool completed), skips notebook fetch and diff derivation
- Renders compact "Notebook updated: {name}" instead of a phantom/failed diff
- `UnapplyableNotebookUpdateNotice` now accepts and forwards `footerAction` prop, preserving "Open notebook" link
- Different warning copy for terminal confirm states (success/error/denied): "Preview unavailable / notebook has changed" instead of "can't be applied"
- Preserves diff derivation for non-completed states (output-denied/error)

This is PR 1 of a 3-PR stack; PRs 2-3 restore the full diff preview for completed updates (requires server snapshot).

Towards FE-4243

## Test plan

- [x] All 15 tests in NotebookProposalRenderer.test.tsx pass
- [x] Typecheck clean
- [x] ESLint clean
- [x] Regression tests added: completed updates with missing target cells (auto & manual approval)
- [x] Confirms denied/error states still derive against live content

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer status handling for AI-generated notebook updates.
  - Completed updates now show a confirmation with the notebook name when available.
  - Update actions and footer controls now adapt to the proposal’s current state.

- **Bug Fixes**
  - Improved messaging when notebook changes prevent an update preview from being reconstructed.
  - Preserved accurate previews for denied or failed updates using the notebook’s latest content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->