### PR TITLE
test(dev-tools): match the capped badge assertion to the implementation

### DIFF
--- a/packages/dev-tools/DevToolbar.test.tsx
+++ b/packages/dev-tools/DevToolbar.test.tsx
@@ -617,7 +617,7 @@ describe('DevToolbar utils', () => {
 
       expect(getEventCountBadge(150)).toEqual({
         label: '99+',
-        sizeClass: 'h-3.5 min-w-3.5 px-1',
+        sizeClass: 'h-4 min-w-4 px-1',
       })
     })
   })


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Test fix. `pnpm --filter dev-tools test` is red on master.

## What is the current behavior?

```
FAIL  DevToolbar.test.tsx > DevToolbar utils > getEventCountBadge > returns a capped pill for large counts
AssertionError: expected { label: '99+', …(1) } to deeply equal { label: '99+', …(1) }
-   "sizeClass": "h-3.5 min-w-3.5 px-1"
+   "sizeClass": "h-4 min-w-4 px-1"
```

`getEventCountBadge` and this assertion both arrived in #49285, and they disagree with each other.

## Which side is wrong

The implementation, and I am fairly confident it is the assertion that is stale rather than the code:

```ts
if (count > 99) return { label: '99+', sizeClass: 'h-4 min-w-4 px-1' }
if (count < 10) return { label: String(count), sizeClass: 'size-3.5' }
return { label: String(count), sizeClass: 'size-4' }
```

The sizes step up with the label: `size-3.5` for one digit, `size-4` for two, then `h-4 min-w-4` plus horizontal padding for the three-character `99+` pill. Height stays consistent with the two-digit badge and the pill only grows sideways, which is what `min-w` and `px-1` are there for.

The assertion asks for `h-3.5 min-w-3.5`, which would render the largest count *shorter* than a two-digit one. That reads like an expectation copied from the single-digit case before the sizes were settled, so I changed the test rather than the component.

If that is backwards and the pill really is meant to be `3.5` high, then the fix belongs in `utils.ts` instead and I am happy to flip it. I did not want to guess silently in either direction, so I am saying which way I went and why.

## Why CI did not catch it

There is no workflow for `packages/dev-tools`. The repo has `studio-unit-tests`, `www-tests`, `ui-tests`, `ui-patterns-tests`, `ai-tests` and `docs-tests`, and none of them cover this package, so the suite only goes red for whoever runs it locally.

I have deliberately not added a workflow here. That is a CI-ownership decision and a separate change from unbreaking the assertion.

## Verification

| | dev-tools suite |
| --- | --- |
| master | 34 passed, **1 failed** |
| this branch | **35 passed, 0 failed** |

Gates: `test:prettier` passes repo wide and `typecheck --filter=dev-tools --force` passes.

Freshman contributor. Found it by running the package suites after a batch of commits landed, and I read the size progression to work out which side was wrong before touching either.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated coverage for large event-count badges to reflect the taller, wider pill styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->