### PR TITLE
fix(studio): do not treat a truncated project list as complete

### DIFF
--- a/apps/studio/components/interfaces/Account/AccessTokens/hooks/useOrgAndProjectData.ts
+++ b/apps/studio/components/interfaces/Account/AccessTokens/hooks/useOrgAndProjectData.ts
@@ -12,7 +12,11 @@ export const useOrgAndProjectData = (options: UseOrgAndProjectDataOptions = {}) 
 
   const { data: organizations = [], isLoading: isLoadingOrgs } = useOrganizationsQuery({ enabled })
 
-  const { data: projectsData, isLoading: isLoadingProjects } = useProjectsInfiniteQuery({
+  const {
+    data: projectsData,
+    isLoading: isLoadingProjects,
+    hasNextPage: hasMoreProjects = false,
+  } = useProjectsInfiniteQuery({
     limit: 100,
   })
 
@@ -26,5 +30,9 @@ export const useOrgAndProjectData = (options: UseOrgAndProjectDataOptions = {}) 
     projects,
     isLoadingOrgs,
     isLoadingProjects,
+    // Only the first page is ever fetched, so `projects` is a prefix of the real list for
+    // anyone with more than `limit`. Callers that ask "is this ref mine?" must not read a
+    // miss as a no.
+    hasMoreProjects,
   }
 }

--- a/apps/studio/components/interfaces/Account/AccessTokens/hooks/useTokenAccessEvaluation.ts
+++ b/apps/studio/components/interfaces/Account/AccessTokens/hooks/useTokenAccessEvaluation.ts
@@ -34,13 +34,15 @@ export const useTokenAccessEvaluation = ({
   enabled = true,
 }: UseTokenAccessEvaluationArgs): TokenAccessEvaluation => {
   const { data: permissions } = usePermissionsQuery({ enabled })
-  const { organizations, projects, isLoadingOrgs, isLoadingProjects } = useOrgAndProjectData({
-    enabled,
-  })
+  const { organizations, projects, isLoadingOrgs, isLoadingProjects, hasMoreProjects } =
+    useOrgAndProjectData({
+      enabled,
+    })
 
-  // Org/project lists still loading: resources the user *does* have access to would read as
-  // inaccessible, so report unknown instead.
-  const hasCompleteResourceLists = !isLoadingOrgs && !isLoadingProjects
+  // Org/project lists still loading, or the project list truncated at the first page: either way
+  // resources the user *does* have access to would read as inaccessible, so report unknown
+  // instead.
+  const hasCompleteResourceLists = !isLoadingOrgs && !isLoadingProjects && !hasMoreProjects
 
   const context = useMemo(
     () =>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix. The scoped-token access evaluation treats a truncated project list as a complete one, so a user with more than 100 projects can be told they have no access to a project they own.

## What is the current behavior?

`useOrgAndProjectData` fetches one page and never asks for another:

```ts
const { data: projectsData, isLoading: isLoadingProjects } = useProjectsInfiniteQuery({
  limit: 100,
})
const projects = useMemo(() => projectsData?.pages.flatMap((page) => page.projects) ?? [], [projectsData])
```

There is no `fetchNextPage`, so `projects` is the first 100 and nothing more.

`useTokenAccessEvaluation` then gates on loading only:

```ts
// Org/project lists still loading: resources the user *does* have access to would read as
// inaccessible, so report unknown instead.
const hasCompleteResourceLists = !isLoadingOrgs && !isLoadingProjects
```

`isLoadingProjects` goes false once page one arrives, so `hasCompleteResourceLists` claims complete while the list is a prefix. The evaluation then does an exact membership test:

```ts
const projectsByRef = new Map(projects.map((project) => [project.ref, project]))
const inaccessibleProjectRefs =
  resourceAccess === 'project' ? projectRefs.filter((ref) => !projectsByRef.has(ref)) : []
```

So for a user with more than 100 projects, a token bound to a project outside the first page is reported inaccessible and the review screen shows an access warning for a project they own. That is precisely the failure the comment above says the `unknown` state exists to prevent; it just does not fire, because a truncated list is not the same as a loading one.

Found while looking for siblings of #49393, which fixed this same 100-project cap in the review and pills components. That PR dropped `useOrgAndProjectData` from its consumers, and `useTokenAccessEvaluation` is the one that still uses it.

## What is the new behavior?

`useOrgAndProjectData` surfaces `hasMoreProjects` from the query's `hasNextPage`, and the evaluation folds it into the existing completeness gate. When the list is truncated the evaluation reports `unknown`, which callers already handle by showing no warning.

## The tradeoff, stated plainly

This makes the evaluation stop giving a wrong answer; it does not make it give a complete one. A user with more than 100 projects now gets no advisory warnings on that screen instead of a false one. That matches the hook's documented contract ("callers must show no warnings rather than flash false ones") and it is a two-line change with no extra requests.

The fuller alternative is to page through everything, or to follow #49393 and look each bound ref up individually rather than materialising the list. Both are bigger and involve a request-count decision that is yours, not mine, so I went with the smallest change that removes the incorrect claim. Happy to do it the other way if you would rather have real answers than an honest `unknown`.

## Verification

`components/interfaces/Account/AccessTokens` suite: **147 passed, 0 failed**, run three times.

I also ran the whole studio suite and I want to be upfront that it is not usable as evidence right now. On my machine it reported 13 failures on this branch and **22 on clean master** in back-to-back runs, with durations of 359 s and 253 s against 127 s for a quiet run this morning that showed a single failure. Those are load-induced timeouts on my end, not this change, and the direction (master worse than the branch) rules the change out as the cause.

Gates: `test:prettier` passes repo wide, `typecheck --filter=studio --force` passes, `--filter studio run lint:ratchet` reports rules improved.

No test added. These hooks have no test harness in that directory, which only has pure-utility tests, and standing up React Query mocks for a two-line gate change felt like more than it warrants. The behaviour is a straight-line read of the two snippets above. Say the word if you want a hook test and I will add one.

Freshman contributor. Found it by chasing what #49393 left behind, and I traced the path from the query limit to `inaccessibleProjectRefs` myself before changing anything.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved access-token permission checks when project results are incomplete.
  * Prevented permission decisions from being finalized until all available project data has loaded.
  * Added clearer handling for paginated project results to avoid inaccurate access evaluations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->