### PR TITLE
fix(docs): make hashedNonce reachable in the Google nonce example

### DIFF
--- a/apps/docs/content/guides/auth/social-login/auth-google.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-google.mdx
@@ -352,10 +352,9 @@ Most web apps and websites can use Google's [personalized sign-in buttons](https
    const nonce = btoa(String.fromCharCode(...crypto.getRandomValues(new Uint8Array(32))))
    const encoder = new TextEncoder()
    const encodedNonce = encoder.encode(nonce)
-   crypto.subtle.digest('SHA-256', encodedNonce).then((hashBuffer) => {
-     const hashArray = Array.from(new Uint8Array(hashBuffer))
-     const hashedNonce = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')
-   })
+   const hashBuffer = await crypto.subtle.digest('SHA-256', encodedNonce)
+   const hashArray = Array.from(new Uint8Array(hashBuffer))
+   const hashedNonce = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')
 
    // Use 'hashedNonce' when making the authentication request to Google
    // Use 'nonce' when invoking the supabase.auth.signInWithIdToken() method

--- a/apps/docs/content/guides/auth/social-login/auth-google.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-google.mdx
@@ -349,12 +349,16 @@ Most web apps and websites can use Google's [personalized sign-in buttons](https
    ```js
    // Adapted from https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest#converting_a_digest_to_a_hex_string
 
-   const nonce = btoa(String.fromCharCode(...crypto.getRandomValues(new Uint8Array(32))))
-   const encoder = new TextEncoder()
-   const encodedNonce = encoder.encode(nonce)
-   const hashBuffer = await crypto.subtle.digest('SHA-256', encodedNonce)
-   const hashArray = Array.from(new Uint8Array(hashBuffer))
-   const hashedNonce = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')
+   async function generateNonce() {
+     const nonce = btoa(String.fromCharCode(...crypto.getRandomValues(new Uint8Array(32))))
+     const encoder = new TextEncoder()
+     const encodedNonce = encoder.encode(nonce)
+     const hashBuffer = await crypto.subtle.digest('SHA-256', encodedNonce)
+     const hashArray = Array.from(new Uint8Array(hashBuffer))
+     const hashedNonce = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')
+
+     return [nonce, hashedNonce]
+   }
 
    // Use 'hashedNonce' when making the authentication request to Google
    // Use 'nonce' when invoking the supabase.auth.signInWithIdToken() method


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation fix.

Closes #49406

## What is the current behavior?

In `apps/docs/content/guides/auth/social-login/auth-google.mdx`, the optional nonce step of the "Google pre-built" section declares `hashedNonce` with `const` inside the `.then()` callback:

```js
crypto.subtle.digest('SHA-256', encodedNonce).then((hashBuffer) => {
  const hashArray = Array.from(new Uint8Array(hashBuffer))
  const hashedNonce = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')
})

// Use 'hashedNonce' when making the authentication request to Google
```

`hashedNonce` is scoped to that callback, so the comment directly below points at a value the reader cannot reach. Running the snippet verbatim gives `ReferenceError: hashedNonce is not defined`. Hoisting the declaration alone would not be enough either, since `.then()` is asynchronous and any following code would run before the digest resolves.

## What is the new behavior?

The example is now wrapped in an `async` function that returns both values:

```js
async function generateNonce() {
  const nonce = btoa(String.fromCharCode(...crypto.getRandomValues(new Uint8Array(32))))
  const encoder = new TextEncoder()
  const encodedNonce = encoder.encode(nonce)
  const hashBuffer = await crypto.subtle.digest('SHA-256', encodedNonce)
  const hashArray = Array.from(new Uint8Array(hashBuffer))
  const hashedNonce = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')

  return [nonce, hashedNonce]
}
```

This keeps both values reachable by the caller, and matches the `generateNonce()` helper already used in the "One-tap with Next.js" example further down the same page, so the two examples are now consistent with each other.

An earlier revision of this PR used a bare top-level `await` instead. That was not correct for this section: Google resolves the `data-callback` handler from global scope, so the surrounding context is a classic script, where top-level `await` is a `SyntaxError`. Thanks to @coderabbitai for catching it. The current version is valid in a classic script and in a module, and produces a 64-character lowercase hex digest in both.

## Additional context

Only the one code block changed; no prose or surrounding examples were touched.

The issue also mentions that the HTML example just above shows `data-nonce=""` while the prose says the nonce must be supplied there. I have deliberately left that out to keep this PR to a single change — happy to follow up separately if you would like it fixed.

---

I used an AI assistant (Claude Code) to help locate and verify this issue and prepare the change.
