### PR TITLE
fix(www): stop rendering the invisible Clear all filters button

### DIFF
--- a/apps/www/pages/features.tsx
+++ b/apps/www/pages/features.tsx
@@ -253,22 +253,20 @@ function FeaturesPage() {
                   Features selected: {filteredFeatures.length}
                 </div>
               </div>
-              <Button
-                tabIndex={HAS_ACTIVE_FILTERS ? 0 : -1}
-                block
-                variant="dashed"
-                onClick={() => {
-                  setSelectedProducts([])
-                  setSearchTerm('')
-                  setShowSelfHostedOnly(false)
-                }}
-                className={cn(
-                  'opacity-0 transition-opacity hidden md:block',
-                  HAS_ACTIVE_FILTERS && 'block! opacity-100'
-                )}
-              >
-                Clear all filters
-              </Button>
+              {HAS_ACTIVE_FILTERS && (
+                <Button
+                  block
+                  variant="dashed"
+                  onClick={() => {
+                    setSelectedProducts([])
+                    setSearchTerm('')
+                    setShowSelfHostedOnly(false)
+                  }}
+                  className="hidden md:block"
+                >
+                  Clear all filters
+                </Button>
+              )}
             </div>
           </div>
           <div className="md:col-span-3 min-w-0 flex flex-col gap-4 md:gap-6">


### PR DESCRIPTION
Closes FE-4250

<img width="661" height="294" alt="Screenshot 2026-08-21 at 10 44 38 AM" src="https://github.com/user-attachments/assets/db7e09db-845c-43a8-a6ca-5d0c67436355" />



## Problem

With no filters active, `/features` still rendered the "Clear all filters" button and hid it with `opacity-0`. Found with VoiceOver, which announced "You are currently on a button" on an apparently empty control.

Measured on a preview with no filters active:

| Property | Value |
| -- | -- |
| `opacity` | `0` |
| `visibility` | `visible` |
| `display` | `block` |
| `tabIndex` | `-1` |
| `aria-hidden`, `inert`, `disabled` | none |
| `pointer-events` | `auto` |
| Layout | 256 x 26px |

Two assumptions were wrong. `opacity: 0` does not remove an element from the accessibility tree, and `tabIndex="-1"` only removes it from tab order, not the tree. Screen readers walk the tree. It was also a live 256 x 26 mouse target, so a sighted user could click an invisible button.

## Solution

Render it conditionally, matching `IntegrationsContent.tsx` which already does this and was unaffected.

No layout shift. The button is the last child of the sidebar column, so nothing above it moves when it appears.

## Manual testing

1. Open [/features](https://zone-www-dot-com-git-www-features-clear-filters-button-supabase.vercel.app/features) with no filters applied. Confirm no "Clear all filters" button exists anywhere in the DOM.
2. Tick a tag filter in the left sidebar. The button appears.
3. Click it. Every filter clears, the count returns to 79 features, and the button disappears again.

For the before state, open [/features on production](https://supabase.com/features) with no filters, then run this in the console. It reveals the button that is present but invisible:

```js
const b = [...document.querySelectorAll('button')].find(x => /Clear all filters/.test(x.textContent))
Object.assign(b.style, { opacity: '1', outline: '3px solid red' })
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The “Clear all filters” button now appears only when filters are active.
  * Improved keyboard navigation by removing inactive filter controls from the tab order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->