### PR TITLE
fix(www): give the feature and partner card grids list semantics

### DIFF
--- a/apps/www/app/partners/catalog/IntegrationsContent.tsx
+++ b/apps/www/app/partners/catalog/IntegrationsContent.tsx
@@ -266,40 +266,41 @@ export default function IntegrationsContent({
             {showFeatured && (
               <div className="flex flex-col gap-4">
                 <h2 className="text-2xl">Featured</h2>
-                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                <ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
                   {featuredPartners.map((p) => (
-                    <Link
-                      key={p.slug}
-                      href={`/partners/catalog/${p.slug}`}
-                      className="group flex h-full flex-col gap-3 rounded-xl border bg-surface-100 p-5 transition-colors hover:bg-surface-200 overflow-hidden"
-                    >
-                      <div className="flex items-center gap-3">
-                        <div className="relative size-10 shrink-0 rounded-full overflow-hidden bg-muted">
-                          <Image
-                            src={p.logo}
-                            alt={p.title}
-                            fill
-                            className="object-cover bg-white rounded-full overflow-hidden p-1"
-                            sizes="40px"
-                          />
+                    <li key={p.slug} className="flex">
+                      <Link
+                        href={`/partners/catalog/${p.slug}`}
+                        className="group flex h-full flex-col gap-3 rounded-xl border bg-surface-100 p-5 transition-colors hover:bg-surface-200 overflow-hidden w-full"
+                      >
+                        <div className="flex items-center gap-3">
+                          <div className="relative size-10 shrink-0 rounded-full overflow-hidden bg-muted">
+                            <Image
+                              src={p.logo}
+                              alt={p.title}
+                              fill
+                              className="object-cover bg-white rounded-full overflow-hidden p-1"
+                              sizes="40px"
+                            />
+                          </div>
+                          <div className="flex flex-wrap items-center gap-2 min-w-0">
+                            <h3 className="text-foreground text-base font-medium tracking-tight">
+                              {p.title}
+                            </h3>
+                          </div>
                         </div>
-                        <div className="flex flex-wrap items-center gap-2 min-w-0">
-                          <h3 className="text-foreground text-base font-medium tracking-tight">
-                            {p.title}
-                          </h3>
+                        <p className="text-foreground-lighter text-sm line-clamp-3 text-pretty">
+                          {p.description}
+                        </p>
+                        <div className="flex flex-wrap items-center gap-1">
+                          {p.categories.map((c) => (
+                            <Badge key={c.name}>{c.name}</Badge>
+                          ))}
                         </div>
-                      </div>
-                      <p className="text-foreground-lighter text-sm line-clamp-3 text-pretty">
-                        {p.description}
-                      </p>
-                      <div className="flex flex-wrap items-center gap-1">
-                        {p.categories.map((c) => (
-                          <Badge key={c.name}>{c.name}</Badge>
-                        ))}
-                      </div>
-                    </Link>
+                      </Link>
+                    </li>
                   ))}
-                </div>
+                </ul>
               </div>
             )}
 
@@ -341,45 +342,46 @@ export default function IntegrationsContent({
             {/* Grid view */}
             {viewMode === 'grid' &&
               (listPartners.length ? (
-                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 md:gap-4">
+                <ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 md:gap-4">
                   {visiblePartners.map((p) => (
-                    <Link
-                      key={p.slug}
-                      href={`/partners/catalog/${p.slug}`}
-                      className="flex flex-col justify-start items-stretch group cursor-pointer rounded-xl focus-ring"
-                    >
-                      <Panel
-                        hasActiveOnHover
-                        outerClassName="h-full"
-                        innerClassName="flex md:flex-col gap-3 sm:gap-2 h-full items-start p-2"
+                    <li key={p.slug} className="flex">
+                      <Link
+                        href={`/partners/catalog/${p.slug}`}
+                        className="flex flex-col justify-start items-stretch group cursor-pointer rounded-xl focus-ring w-full"
                       >
-                        <div className="relative rounded-lg min-h-[80px] max-h-[80px] md:max-h-[140px] h-full md:h-auto aspect-square md:w-full md:aspect-video! bg-alternative flex items-center justify-center shadow-inner border border-muted overflow-hidden shrink-0 md:shrink">
-                          <Image
-                            src={p.logo}
-                            alt={p.title}
-                            width={60}
-                            height={60}
-                            className="border w-14 h-14 aspect-square p-1 bg-white rounded-full overflow-hidden"
-                            sizes="60px"
-                          />
-                        </div>
-                        <div className="md:p-2 md:pt-1 flex flex-col h-full md:h-auto grow gap-0.5 md:gap-1.5 justify-center md:justify-start min-w-0">
-                          <h3 className="text-sm md:text-base text-foreground leading-5!">
-                            {p.title}
-                          </h3>
-                          <p className="text-foreground-light text-sm line-clamp-2 flex-1">
-                            {p.description}
-                          </p>
-                          <div className="flex flex-wrap items-center gap-1 mt-1">
-                            {p.categories.map((c) => (
-                              <Badge key={c.name}>{c.name}</Badge>
-                            ))}
+                        <Panel
+                          hasActiveOnHover
+                          outerClassName="h-full"
+                          innerClassName="flex md:flex-col gap-3 sm:gap-2 h-full items-start p-2"
+                        >
+                          <div className="relative rounded-lg min-h-[80px] max-h-[80px] md:max-h-[140px] h-full md:h-auto aspect-square md:w-full md:aspect-video! bg-alternative flex items-center justify-center shadow-inner border border-muted overflow-hidden shrink-0 md:shrink">
+                            <Image
+                              src={p.logo}
+                              alt={p.title}
+                              width={60}
+                              height={60}
+                              className="border w-14 h-14 aspect-square p-1 bg-white rounded-full overflow-hidden"
+                              sizes="60px"
+                            />
                           </div>
-                        </div>
-                      </Panel>
-                    </Link>
+                          <div className="md:p-2 md:pt-1 flex flex-col h-full md:h-auto grow gap-0.5 md:gap-1.5 justify-center md:justify-start min-w-0">
+                            <h3 className="text-sm md:text-base text-foreground leading-5!">
+                              {p.title}
+                            </h3>
+                            <p className="text-foreground-light text-sm line-clamp-2 flex-1">
+                              {p.description}
+                            </p>
+                            <div className="flex flex-wrap items-center gap-1 mt-1">
+                              {p.categories.map((c) => (
+                                <Badge key={c.name}>{c.name}</Badge>
+                              ))}
+                            </div>
+                          </div>
+                        </Panel>
+                      </Link>
+                    </li>
                   ))}
-                </div>
+                </ul>
               ) : (
                 <p className="text-foreground-lighter text-sm">
                   No partners found with these filters.
@@ -389,42 +391,45 @@ export default function IntegrationsContent({
             {/* List view */}
             {viewMode === 'list' &&
               (listPartners.length ? (
-                <div className="border bg-background rounded-xl overflow-hidden divide-y">
+                <ul className="border bg-background rounded-xl overflow-hidden divide-y">
                   {visiblePartners.map((p) => (
-                    <Link
-                      key={p.slug}
-                      href={`/partners/catalog/${p.slug}`}
-                      className="group flex items-center gap-4 px-5 py-4 transition-colors hover:bg-surface-100"
-                    >
-                      <div className="relative size-10 shrink-0 rounded-full overflow-hidden bg-muted">
-                        <Image
-                          src={p.logo}
-                          alt={p.title}
-                          fill
-                          className="object-cover bg-white rounded-full overflow-hidden p-1"
-                          sizes="40px"
-                        />
-                      </div>
-                      <div className="flex-1 min-w-0 flex flex-col gap-1">
-                        <div className="flex items-center gap-2 flex-wrap">
-                          <span className="text-foreground text-sm font-medium tracking-tight">
-                            {p.title}
-                          </span>
-                          <div className="flex items-center gap-1">
-                            {p.categories.map((c) => (
-                              <Badge key={c.name}>{c.name}</Badge>
-                            ))}
-                          </div>
+                    <li key={p.slug}>
+                      <Link
+                        href={`/partners/catalog/${p.slug}`}
+                        className="group flex items-center gap-4 px-5 py-4 transition-colors hover:bg-surface-100"
+                      >
+                        <div className="relative size-10 shrink-0 rounded-full overflow-hidden bg-muted">
+                          <Image
+                            src={p.logo}
+                            alt={p.title}
+                            fill
+                            className="object-cover bg-white rounded-full overflow-hidden p-1"
+                            sizes="40px"
+                          />
                         </div>
-                        <p className="text-foreground-lighter text-sm truncate">{p.description}</p>
-                      </div>
-                      <ArrowUpRight
-                        size={16}
-                        className="shrink-0 text-foreground-lighter transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
-                      />
-                    </Link>
+                        <div className="flex-1 min-w-0 flex flex-col gap-1">
+                          <div className="flex items-center gap-2 flex-wrap">
+                            <span className="text-foreground text-sm font-medium tracking-tight">
+                              {p.title}
+                            </span>
+                            <div className="flex items-center gap-1">
+                              {p.categories.map((c) => (
+                                <Badge key={c.name}>{c.name}</Badge>
+                              ))}
+                            </div>
+                          </div>
+                          <p className="text-foreground-lighter text-sm truncate">
+                            {p.description}
+                          </p>
+                        </div>
+                        <ArrowUpRight
+                          size={16}
+                          className="shrink-0 text-foreground-lighter transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
+                        />
+                      </Link>
+                    </li>
                   ))}
-                </div>
+                </ul>
               ) : (
                 <p className="text-foreground-lighter text-sm">
                   No partners found with these filters.

--- a/apps/www/pages/features.tsx
+++ b/apps/www/pages/features.tsx
@@ -311,61 +311,62 @@ function FeaturesPage() {
                 No features found with these filters
               </p>
             ) : (
-              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 md:gap-4">
+              <ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 md:gap-4">
                 {filteredFeatures.map((feature) => (
-                  <Link
-                    key={`feat-${feature.title}`}
-                    href={`/features/${feature.slug}`}
-                    className="flex flex-col justify-start items-stretch group cursor-pointer rounded-xl focus-ring"
-                  >
-                    <Panel
-                      hasActiveOnHover
-                      outerClassName="h-full"
-                      innerClassName="flex md:flex-col gap-3 sm:gap-2 h-full items-start p-2"
+                  <li key={`feat-${feature.title}`} className="flex">
+                    <Link
+                      href={`/features/${feature.slug}`}
+                      className="flex flex-col justify-start items-stretch group cursor-pointer rounded-xl focus-ring w-full"
                     >
-                      <div className="relative rounded-lg min-h-[80px] max-h-[80px] md:max-h-[140px] h-full md:h-auto aspect-square md:w-full md:aspect-video! bg-alternative flex items-center justify-center shadow-inner border border-muted">
-                        <feature.icon className="w-5 h-5 text-foreground-light group-hover:text-foreground transition-colors" />
-                        {feature.status && (
-                          <div className="hidden md:block absolute bottom-1.5 left-1.5">
-                            <Badge
-                              variant={stageBadgeVariant(feature.status.stage)}
-                              className="text-[10px] py-0 px-1.5 h-4 rounded-sm"
-                            >
-                              {stageLabel(feature.status.stage)}
-                            </Badge>
-                          </div>
-                        )}
-                      </div>
-                      <div className="md:p-2 md:pt-1 flex flex-col h-full md:h-auto grow gap-0.5 md:gap-1.5 justify-center md:justify-start">
-                        <h3 className="text-sm md:text-base text-foreground leading-5!">
-                          {feature.title}
-                        </h3>
-                        <p className="text-foreground-light text-sm line-clamp-2">
-                          {feature.subtitle}
-                        </p>
-                        <div className="flex flex-wrap items-center gap-1 mb-0.5">
+                      <Panel
+                        hasActiveOnHover
+                        outerClassName="h-full"
+                        innerClassName="flex md:flex-col gap-3 sm:gap-2 h-full items-start p-2"
+                      >
+                        <div className="relative rounded-lg min-h-[80px] max-h-[80px] md:max-h-[140px] h-full md:h-auto aspect-square md:w-full md:aspect-video! bg-alternative flex items-center justify-center shadow-inner border border-muted">
+                          <feature.icon className="w-5 h-5 text-foreground-light group-hover:text-foreground transition-colors" />
                           {feature.status && (
-                            <Badge
-                              variant={stageBadgeVariant(feature.status.stage)}
-                              className="md:hidden text-[10px] py-0 px-1.5 h-4 rounded-sm"
-                            >
-                              {stageLabel(feature.status.stage)}
-                            </Badge>
+                            <div className="hidden md:block absolute bottom-1.5 left-1.5">
+                              <Badge
+                                variant={stageBadgeVariant(feature.status.stage)}
+                                className="text-[10px] py-0 px-1.5 h-4 rounded-sm"
+                              >
+                                {stageLabel(feature.status.stage)}
+                              </Badge>
+                            </div>
                           )}
-                          {feature.products.map((product) => (
-                            <span
-                              key={product}
-                              className="inline-flex items-center text-[10px] font-medium px-1.5 py-0 h-4 rounded bg-surface-200 text-foreground-light border border-muted capitalize"
-                            >
-                              {productLabel(product)}
-                            </span>
-                          ))}
                         </div>
-                      </div>
-                    </Panel>
-                  </Link>
+                        <div className="md:p-2 md:pt-1 flex flex-col h-full md:h-auto grow gap-0.5 md:gap-1.5 justify-center md:justify-start">
+                          <h3 className="text-sm md:text-base text-foreground leading-5!">
+                            {feature.title}
+                          </h3>
+                          <p className="text-foreground-light text-sm line-clamp-2">
+                            {feature.subtitle}
+                          </p>
+                          <div className="flex flex-wrap items-center gap-1 mb-0.5">
+                            {feature.status && (
+                              <Badge
+                                variant={stageBadgeVariant(feature.status.stage)}
+                                className="md:hidden text-[10px] py-0 px-1.5 h-4 rounded-sm"
+                              >
+                                {stageLabel(feature.status.stage)}
+                              </Badge>
+                            )}
+                            {feature.products.map((product) => (
+                              <span
+                                key={product}
+                                className="inline-flex items-center text-[10px] font-medium px-1.5 py-0 h-4 rounded bg-surface-200 text-foreground-light border border-muted capitalize"
+                              >
+                                {productLabel(product)}
+                              </span>
+                            ))}
+                          </div>
+                        </div>
+                      </Panel>
+                    </Link>
+                  </li>
                 ))}
-              </div>
+              </ul>
             )}
           </div>
         </SectionContainer>


### PR DESCRIPTION
Closes FE-4252

## Problem

`/features` renders 79 feature cards as bare `Link` elements in a grid `div`. Measured on a preview, `main` contains zero `ul`, `ol`, `li`, and zero `role="list"`. `/partners/catalog` is the same.

A screen reader user gets a run of loose links with no "list, 79 items", no set size, and no way to navigate by list. Sighted users see an obvious grid of cards, and the structure conveying that is purely visual.

Same defect class as FE-4101 and DOCS-1279, both already in this milestone.

## Solution

Make each card container a `ul` with one `li` per card. Four containers:

| File | Container |
| -- | -- |
| `apps/www/pages/features.tsx` | feature card grid |
| `apps/www/app/partners/catalog/IntegrationsContent.tsx` | featured partners grid |
| same | grid view |
| same | list view |

This change makes a Screenreader announce the number of items and track them.

Most of this diff is re-indentation from the added wrapper.

## Manual testing

**/features**

1. Open [/features](https://zone-www-dot-com-git-www-card-grid-list-semantics-supabase.vercel.app/features) with Screenreader. Confirm the cards report as a list of 79 items, and that the count tracks the filters.
2. Check the grid at mobile, tablet and desktop widths. Cards stay equal height within a row and the column counts are unchanged.

**/partners/catalog**

3. Open [/partners/catalog](https://zone-www-dot-com-git-www-card-grid-list-semantics-supabase.vercel.app/partners/catalog) in grid view with Screenreader. Confirm both the featured section and the main grid are lists.
4. Switch to [list view](https://zone-www-dot-com-git-www-card-grid-list-semantics-supabase.vercel.app/partners/catalog?view=list). Confirm it is a list and the dividing lines between rows are unchanged.

Compare any of these against [production](https://supabase.com/features). The rendering should be identical; only the markup changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved semantic structure for partner catalog and feature cards using properly organized lists.
  * Expanded card links to make larger portions of featured and grid cards clickable.
  * Preserved existing layouts, content, and filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->