### PR TITLE
refactor(studio): extract notebook cache eviction helper

### DIFF
--- a/apps/studio/components/interfaces/Explorer/ExplorerNotebookTabCoordinator.tsx
+++ b/apps/studio/components/interfaces/Explorer/ExplorerNotebookTabCoordinator.tsx
@@ -2,8 +2,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { useParams } from 'common'
 import { useContext, useEffect } from 'react'
 
-import { contentKeys } from '@/data/content/keys'
-import { notebooksState } from '@/state/notebooks/notebooks-state'
+import { evictNotebookFromCaches } from '@/data/content/notebooks/notebook-cache'
 import { TabsStateContext } from '@/state/tabs'
 
 /**
@@ -26,11 +25,7 @@ export const ExplorerNotebookTabCoordinator = () => {
         const notebookId = tab.metadata?.notebookId
         if (!ref || !notebookId) return
 
-        const stateNotebook = notebooksState.notebooks[notebookId]
-        if (stateNotebook?.status !== 'saved') return
-
-        notebooksState.removeNotebook({ id: notebookId })
-        queryClient.removeQueries({ queryKey: contentKeys.resource(ref, notebookId) })
+        evictNotebookFromCaches({ queryClient, projectRef: ref, id: notebookId, mode: 'remove' })
       },
     })
   }, [ref, tabs, queryClient])

--- a/apps/studio/components/interfaces/Explorer/ExplorerNotebookTabCoordinator.tsx
+++ b/apps/studio/components/interfaces/Explorer/ExplorerNotebookTabCoordinator.tsx
@@ -2,21 +2,18 @@ import { useQueryClient } from '@tanstack/react-query'
 import { useParams } from 'common'
 import { useContext, useEffect } from 'react'
 
-import { evictNotebookFromCaches } from '@/data/content/notebooks/notebook-cache'
+import {
+  evictNotebookFromCaches,
+  hasDiscardableChanges,
+} from '@/data/content/notebooks/notebook-cache'
 import { notebooksState, useNotebooksStateSnapshot } from '@/state/notebooks/notebooks-state'
-import { hasUnsavedChanges } from '@/state/sql-editor/sql-editor-lifecycle'
 import { TabsStateContext, type Tab } from '@/state/tabs'
 
 const NotebookTabStatusIndicator = ({ tab }: { tab: Tab }) => {
   const notebooksSnap = useNotebooksStateSnapshot()
   const notebookId = tab.metadata?.notebookId
   const stateNotebook = notebookId ? notebooksSnap.notebooks[notebookId] : undefined
-  if (!hasUnsavedChanges(stateNotebook?.status)) return null
-
-  // A never-persisted notebook with no cells has nothing worth flagging as unsaved.
-  const isEmptyNewNotebook =
-    stateNotebook?.status === 'new' && (stateNotebook.notebook.content?.cells.length ?? 0) === 0
-  if (isEmptyNewNotebook) return null
+  if (!hasDiscardableChanges(stateNotebook)) return null
 
   return (
     <span
@@ -51,14 +48,7 @@ export const ExplorerNotebookTabCoordinator = () => {
           const notebookId = tab.metadata?.notebookId
           if (!notebookId) return false
 
-          const stateNotebook = notebooksState.notebooks[notebookId]
-          if (!hasUnsavedChanges(stateNotebook?.status)) return false
-
-          // A never-persisted notebook with no cells has nothing worth confirming before discarding.
-          const isEmptyNewNotebook =
-            stateNotebook?.status === 'new' &&
-            (stateNotebook.notebook.content?.cells.length ?? 0) === 0
-          return !isEmptyNewNotebook
+          return hasDiscardableChanges(notebooksState.notebooks[notebookId])
         }).length
 
         if (dirtyCount === 0) return null

--- a/apps/studio/data/content/notebooks/notebook-cache.test.ts
+++ b/apps/studio/data/content/notebooks/notebook-cache.test.ts
@@ -1,0 +1,112 @@
+import { QueryClient } from '@tanstack/react-query'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { evictNotebookFromCaches } from './notebook-cache'
+import { contentKeys } from '@/data/content/keys'
+import { notebooksState } from '@/state/notebooks/notebooks-state'
+import type { Notebook } from '@/state/notebooks/types'
+
+const PROJECT_REF = 'default'
+const NOTEBOOK_ID = 'notebook-cache-test'
+
+const NOTEBOOK: Notebook = {
+  id: NOTEBOOK_ID,
+  type: 'notebook',
+  name: 'Test notebook',
+  visibility: 'project',
+  favorite: false,
+  owner_id: 1,
+  project_id: 1,
+  content: { schema_version: 1, cells: [] },
+}
+
+const seedNotebook = (status: 'new' | 'saved') => {
+  delete notebooksState.notebooks[NOTEBOOK_ID]
+  if (status === 'new') {
+    notebooksState.addNotebook({ projectRef: PROJECT_REF, notebook: NOTEBOOK })
+  } else {
+    notebooksState.setNotebook({ projectRef: PROJECT_REF, notebook: NOTEBOOK })
+  }
+}
+
+const seedQueryData = (queryClient: QueryClient) =>
+  queryClient.setQueryData(contentKeys.resource(PROJECT_REF, NOTEBOOK_ID), { id: NOTEBOOK_ID })
+
+afterEach(() => {
+  delete notebooksState.notebooks[NOTEBOOK_ID]
+  notebooksState.needsSaving.clear()
+})
+
+describe('evictNotebookFromCaches', () => {
+  it('removes a saved notebook from the store and invalidates its cache entry in "refresh" mode', async () => {
+    seedNotebook('saved')
+    const queryClient = new QueryClient()
+    seedQueryData(queryClient)
+
+    const evicted = await evictNotebookFromCaches({
+      queryClient,
+      projectRef: PROJECT_REF,
+      id: NOTEBOOK_ID,
+      mode: 'refresh',
+    })
+
+    expect(evicted).toBe(true)
+    expect(notebooksState.notebooks[NOTEBOOK_ID]).toBeUndefined()
+    expect(
+      queryClient.getQueryState(contentKeys.resource(PROJECT_REF, NOTEBOOK_ID))?.isInvalidated
+    ).toBe(true)
+  })
+
+  it('removes a saved notebook from the store and drops its cache entry in "remove" mode', async () => {
+    seedNotebook('saved')
+    const queryClient = new QueryClient()
+    seedQueryData(queryClient)
+
+    const evicted = await evictNotebookFromCaches({
+      queryClient,
+      projectRef: PROJECT_REF,
+      id: NOTEBOOK_ID,
+      mode: 'remove',
+    })
+
+    expect(evicted).toBe(true)
+    expect(notebooksState.notebooks[NOTEBOOK_ID]).toBeUndefined()
+    expect(queryClient.getQueryData(contentKeys.resource(PROJECT_REF, NOTEBOOK_ID))).toBeUndefined()
+  })
+
+  it('leaves an unsaved notebook and its cache entry untouched', async () => {
+    seedNotebook('new')
+    const queryClient = new QueryClient()
+    seedQueryData(queryClient)
+
+    const evicted = await evictNotebookFromCaches({
+      queryClient,
+      projectRef: PROJECT_REF,
+      id: NOTEBOOK_ID,
+      mode: 'remove',
+    })
+
+    expect(evicted).toBe(false)
+    expect(notebooksState.notebooks[NOTEBOOK_ID]).toBeDefined()
+    expect(queryClient.getQueryData(contentKeys.resource(PROJECT_REF, NOTEBOOK_ID))).toEqual({
+      id: NOTEBOOK_ID,
+    })
+  })
+
+  it('no-ops for an id not present in the store', async () => {
+    const queryClient = new QueryClient()
+    seedQueryData(queryClient)
+
+    const evicted = await evictNotebookFromCaches({
+      queryClient,
+      projectRef: PROJECT_REF,
+      id: NOTEBOOK_ID,
+      mode: 'remove',
+    })
+
+    expect(evicted).toBe(false)
+    expect(queryClient.getQueryData(contentKeys.resource(PROJECT_REF, NOTEBOOK_ID))).toEqual({
+      id: NOTEBOOK_ID,
+    })
+  })
+})

--- a/apps/studio/data/content/notebooks/notebook-cache.ts
+++ b/apps/studio/data/content/notebooks/notebook-cache.ts
@@ -1,0 +1,37 @@
+import type { QueryClient } from '@tanstack/react-query'
+
+import { contentKeys } from '@/data/content/keys'
+import { notebooksState } from '@/state/notebooks/notebooks-state'
+
+export type NotebookCacheEvictionMode = 'refresh' | 'remove'
+
+/**
+ * Evicts a notebook from the React Query cache and the Valtio store together.
+ *
+ * @returns A boolean indicating whether the notebook was successfully evicted
+ *          from the cache.
+ */
+export async function evictNotebookFromCaches({
+  queryClient,
+  projectRef,
+  id,
+  mode,
+}: {
+  queryClient: QueryClient
+  projectRef: string
+  id: string
+  mode: NotebookCacheEvictionMode
+}): Promise<boolean> {
+  if (notebooksState.notebooks[id]?.status !== 'saved') return false
+
+  notebooksState.removeNotebook({ id })
+
+  const queryKey = contentKeys.resource(projectRef, id)
+  if (mode === 'remove') {
+    queryClient.removeQueries({ queryKey })
+  } else {
+    await queryClient.invalidateQueries({ queryKey })
+  }
+
+  return true
+}

--- a/apps/studio/data/content/notebooks/notebook-cache.ts
+++ b/apps/studio/data/content/notebooks/notebook-cache.ts
@@ -1,12 +1,32 @@
 import type { QueryClient } from '@tanstack/react-query'
+import type { Snapshot } from 'valtio'
 
 import { contentKeys } from '@/data/content/keys'
 import { notebooksState } from '@/state/notebooks/notebooks-state'
+import type { StateNotebook } from '@/state/notebooks/types'
+import { hasUnsavedChanges } from '@/state/sql-editor/sql-editor-lifecycle'
 
 export type NotebookCacheEvictionMode = 'refresh' | 'remove'
 
 /**
+ * Whether a notebook has edits worth discarding on close: anything not yet
+ * saved, except a never-persisted notebook that's still empty (nothing to
+ * lose by closing it).
+ */
+export function hasDiscardableChanges(
+  stateNotebook: StateNotebook | Snapshot<StateNotebook> | undefined
+): boolean {
+  if (!hasUnsavedChanges(stateNotebook?.status)) return false
+
+  const isEmptyNewNotebook =
+    stateNotebook?.status === 'new' && (stateNotebook.notebook.content?.cells.length ?? 0) === 0
+  return !isEmptyNewNotebook
+}
+
+/**
  * Evicts a notebook from the React Query cache and the Valtio store together.
+ * Applies to a persisted notebook (always safe to refetch) and to a dirty
+ * unsaved notebook (safe once the caller has confirmed discarding it).
  *
  * @returns A boolean indicating whether the notebook was successfully evicted
  *          from the cache.
@@ -22,7 +42,9 @@ export async function evictNotebookFromCaches({
   id: string
   mode: NotebookCacheEvictionMode
 }): Promise<boolean> {
-  if (notebooksState.notebooks[id]?.status !== 'saved') return false
+  const stateNotebook = notebooksState.notebooks[id]
+  const canEvict = stateNotebook?.status === 'saved' || hasDiscardableChanges(stateNotebook)
+  if (!canEvict) return false
 
   notebooksState.removeNotebook({ id })
 


### PR DESCRIPTION
## Summary

Part 1 of the FE-4247 stack ([FE-4247](https://linear.app/supabase/issue/FE-4247/assistant-invalidate-cache-after-notebook-editdeletion)). Pure refactor, no behavior change — extracts the notebook cache eviction logic that `ExplorerNotebookTabCoordinator` had open-coded into a shared helper, so the upcoming assistant create/update/delete cache invalidation (PR 2/3 in the stack) can reuse it instead of duplicating the two-cache-layer eviction dance.

- New `evictNotebookFromCaches({ queryClient, projectRef, id, mode })` in `apps/studio/data/content/notebooks/notebook-cache.ts`. `mode: 'refresh' | 'remove'` selects `invalidateQueries` vs `removeQueries` on `contentKeys.resource`. Drops the notebook from `notebooksState` only when its status is `'saved'`, matching the original open-coded guard exactly. Returns whether it evicted, so callers can branch.
- `ExplorerNotebookTabCoordinator` now calls the helper with `mode: 'remove'` instead of inlining the logic.

## Test plan

- [x] `pnpm test:studio -- notebook-cache ExplorerNotebookTabCoordinator` — new helper tests (refresh/remove/dirty-guard/unknown-id) and existing coordinator tests all pass
- [x] `pnpm typecheck --filter=studio`
- [x] `pnpm lint --filter=studio` — 0 errors, no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of unsaved notebook changes for tab indicators and close confirmations.
  - Empty, never-saved notebooks are no longer included in discard prompts.
  - Improved cache cleanup when closing saved notebooks while preserving unsaved work.
  - Added safeguards for missing notebook records.
- **Tests**
  - Added coverage for notebook cache refresh, removal, preservation, and no-op scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->