### PR TITLE
Fix code snippets in "Generating Python Types"

### DIFF
--- a/apps/docs/content/guides/api/rest/generating-python-types.mdx
+++ b/apps/docs/content/guides/api/rest/generating-python-types.mdx
@@ -80,17 +80,34 @@ client = create_client("YOUR_SUPABASE_URL", "YOUR_SUPABASE_KEY")
 movies = client.table("movies")
 
 # Select
-selected = [PublicMovies(m) for m in movies.select("*").execute().data]
+selected = [
+    PublicMovies.model_validate(m)
+    for m in movies.select("*").execute().data
+]
 
 # Insert
-inserted = [PublicMovies(m) for m in movies.insert(PublicMoviesInsert(name="foo", data="bar")) \
-                                          .execute().data]
+inserted = [
+    PublicMovies.model_validate(m)
+    for m in (
+        movies.insert(PublicMoviesInsert(name="foo", data="bar"))
+        .select("*")
+        .execute().data
+     )
+]
 
 # Update
-updated  = [PublicMovies(m) for m in movies.update(PublicMoviesUpdate(name="bar")) \
-                                        .eq("id", 5) \
-                                        .execute().data]
+updated  = [
+    PublicMovies.model_validate(m)
+    for m in (
+        movies.update(PublicMoviesUpdate(name="bar"))
+        .select("*")
+        .eq("id", 5)
+        .execute().data
+    )
+]
 ```
+
+Note: using `TypedDict` in insert/update currently doesn't work with tables including non-serializable columns like UUID or timestamp. Manually serialize values before passing to insert/update ([GitHub issue](https://github.com/supabase/supabase-py/issues/1443)).
 
 ## Update types automatically with GitHub Actions
 


### PR DESCRIPTION
The Python snippets under "Generating Python Types" are incorrect:
* `PublicMovies(m)` doesn't work, you need `model_validate`
* insert/update need `.select("*")` to return data

Also added a note about needing to serialize non-JSON serializable data with a link to the github issue

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

## What is the new behavior?

## Additional context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Python API examples to validate query results using Pydantic’s recommended method.
  * Added returned-row selection to insert and update examples.
  * Documented current `TypedDict` limitations for UUID and timestamp fields, including manual serialization guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->