### PR TITLE
feat(studio): warn when auth email templates misuse ConfirmationURL (#36990)

### DIFF
--- a/apps/studio/components/interfaces/Auth/EmailTemplates/AuthTemplatesValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/AuthTemplatesValidation.tsx
@@ -16,7 +16,8 @@ const TemplateVariables: Record<TemplateVariableName, TemplateVariable> = {
   TokenHash: {
     name: 'TokenHash',
     value: '{{ .TokenHash }}',
-    description: 'Hashed token used in the URL, useful for constructing your own email link',
+    description:
+      'Hashed token for building your own link, e.g. {{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=recovery',
   },
   SiteURL: {
     name: 'SiteURL',

--- a/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.utils.test.ts
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   FREE_TIER_TEMPLATE_BLOCK_CUTOFF_DATE,
+  getEmailTemplateIssues,
   hasCustomEmailSender,
   isCustomEmailTemplateEditingRestricted,
   isCustomEmailTemplateRestrictionStatusKnown,
@@ -133,5 +134,71 @@ describe('EmailTemplates.utils', () => {
         projectInsertedAt: POST_CUTOFF,
       })
     ).toBe(false)
+  })
+})
+
+describe('getEmailTemplateIssues', () => {
+  // Template from https://github.com/supabase/supabase/issues/36990
+  const recoveryBody =
+    '<p><a href="{{ .ConfirmationURL }}/?token_hash={{ .TokenHash }}&flow=reset_password&email={{ .Email }}">Reset Password</a></p>'
+
+  it('returns no issues for empty content', () => {
+    expect(getEmailTemplateIssues(undefined)).toEqual([])
+    expect(getEmailTemplateIssues('')).toEqual([])
+  })
+
+  it('returns no issues when ConfirmationURL is the entire value', () => {
+    const body = '<p><a href="{{ .ConfirmationURL }}">Reset Password</a></p>'
+
+    expect(getEmailTemplateIssues(body)).toEqual([])
+  })
+
+  it('flags parameters appended after ConfirmationURL', () => {
+    expect(getEmailTemplateIssues(recoveryBody)).toEqual([
+      {
+        type: 'appended-after-confirmation-url',
+        snippet: '{{ .ConfirmationURL }}/?token_hash=',
+      },
+    ])
+  })
+
+  it('flags query strings and fragments appended after ConfirmationURL', () => {
+    expect(
+      getEmailTemplateIssues('<p>Visit {{ .ConfirmationURL }}?code=1</p>')
+    ).toEqual([
+      { type: 'appended-after-confirmation-url', snippet: '{{ .ConfirmationURL }}?code=1' },
+    ])
+
+    expect(getEmailTemplateIssues('<a href="{{ .ConfirmationURL }}#section">Link</a>')).toEqual([
+      { type: 'appended-after-confirmation-url', snippet: '{{ .ConfirmationURL }}#section' },
+    ])
+  })
+
+  it('does not flag trailing punctuation or a closing tag after ConfirmationURL', () => {
+    expect(getEmailTemplateIssues('<p>Visit {{ .ConfirmationURL }}</p>')).toEqual([])
+    expect(getEmailTemplateIssues('<p>Visit {{ .ConfirmationURL }}.</p>')).toEqual([])
+  })
+
+  it('flags misspelled casing of the ConfirmationURL variable', () => {
+    expect(getEmailTemplateIssues('<a href="{{ .ConfirmationUrl }}">Link</a>')).toEqual([
+      { type: 'case-mismatched-confirmation-url', snippet: '{{ .ConfirmationUrl }}' },
+    ])
+
+    expect(getEmailTemplateIssues('<a href="{{.confirmationurl}}">Link</a>')).toEqual([
+      { type: 'case-mismatched-confirmation-url', snippet: '{{.confirmationurl}}' },
+    ])
+  })
+
+  it('does not flag the documented custom link built from SiteURL and TokenHash', () => {
+    const body =
+      '<a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=recovery">Reset Password</a>'
+
+    expect(getEmailTemplateIssues(body)).toEqual([])
+  })
+
+  it('ignores unrelated template variables', () => {
+    const body = '<p>{{ .Token }} {{ .Email }} {{ .SiteURL }}/reset</p>'
+
+    expect(getEmailTemplateIssues(body)).toEqual([])
   })
 })

--- a/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.utils.ts
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.utils.ts
@@ -73,3 +73,53 @@ export const isCustomEmailTemplateEditingRestricted = ({
   // Temporary Studio-side paygate while Platform/Auth own the exact eligibility cohort.
   return !hasCustomEmailSender(authConfig)
 }
+
+export type EmailTemplateIssueType =
+  | 'appended-after-confirmation-url'
+  | 'case-mismatched-confirmation-url'
+
+export interface EmailTemplateIssue {
+  type: EmailTemplateIssueType
+  /** Offending excerpt from the template body, for display in the editor */
+  snippet?: string
+}
+
+const TEMPLATE_VARIABLE_PATTERN = /\{\{\s*\.([A-Za-z0-9_]+)\s*\}\}/g
+
+// Matches `{{ .ConfirmationURL }}` when non-whitespace text (path, query, or
+// fragment) is written directly after it inside an attribute or link body
+const APPENDED_CONFIRMATION_URL_PATTERN = /(\{\{\s*\.ConfirmationURL\s*\}\})([^\s"'<>{}]{1,40})/
+
+/**
+ * Scans a template body for known-broken usages of email template variables.
+ *
+ * - Text appended directly after `{{ .ConfirmationURL }}` never reaches the
+ *   sent email: the auth server generates that URL itself (including its query
+ *   parameters) and does not merge anything appended by the template, so the
+ *   extra parameters are dropped or produce a malformed link.
+ * - Variable names are case-sensitive; e.g. `{{ .ConfirmationUrl }}` renders
+ *   as empty and the link falls back to the site root without any token.
+ */
+export const getEmailTemplateIssues = (content?: string): EmailTemplateIssue[] => {
+  if (!content) return []
+
+  const issues: EmailTemplateIssue[] = []
+
+  const appended = APPENDED_CONFIRMATION_URL_PATTERN.exec(content)
+  if (appended) {
+    issues.push({
+      type: 'appended-after-confirmation-url',
+      snippet: `${appended[1]}${appended[2]}`,
+    })
+  }
+
+  for (const match of content.matchAll(TEMPLATE_VARIABLE_PATTERN)) {
+    const name = match[1]
+    if (name.toLowerCase() === 'confirmationurl' && name !== 'ConfirmationURL') {
+      issues.push({ type: 'case-mismatched-confirmation-url', snippet: match[0] })
+      break
+    }
+  }
+
+  return issues
+}

--- a/apps/studio/components/interfaces/Auth/EmailTemplates/TemplateEditor.test.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/TemplateEditor.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor, within } from '@testing-library/react'
+import { fireEvent, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { toast } from 'sonner'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -273,5 +273,37 @@ describe('TemplateEditor reset to default', () => {
     expect(within(dialog).getByText('Unable to reset email template')).toBeInTheDocument()
     expect(within(dialog).getByRole('button', { name: 'Reset' })).toBeInTheDocument()
     expect(toast.error).not.toHaveBeenCalled()
+  })
+})
+
+describe('TemplateEditor link validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    validateSpamMock.mockImplementation((_vars, callbacks) => callbacks?.onSuccess?.({ rules: [] }))
+  })
+
+  it('warns when the body appends parameters after ConfirmationURL', async () => {
+    renderTemplateEditor()
+
+    fireEvent.change(screen.getByLabelText('Body source'), {
+      target: {
+        value:
+          '<p><a href="{{ .ConfirmationURL }}/?token_hash={{ .TokenHash }}">Reset password</a></p>',
+      },
+    })
+
+    expect(
+      await screen.findByText('These template variables will not produce the expected link')
+    ).toBeInTheDocument()
+  })
+
+  it('does not warn when the body uses ConfirmationURL on its own', () => {
+    renderTemplateEditor({
+      body: '<p><a href="{{ .ConfirmationURL }}">Confirm email address</a></p>',
+    })
+
+    expect(
+      screen.queryByText('These template variables will not produce the expected link')
+    ).not.toBeInTheDocument()
   })
 })

--- a/apps/studio/components/interfaces/Auth/EmailTemplates/TemplateEditor.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/TemplateEditor.tsx
@@ -28,7 +28,11 @@ import {
   AUTH_EMAIL_TEMPLATES_TERMINOLOGY_ANCHOR,
 } from './EmailTemplates.constants'
 import type { AuthTemplate } from './EmailTemplates.types'
-import { hasCustomEmailSender } from './EmailTemplates.utils'
+import {
+  getEmailTemplateIssues,
+  hasCustomEmailSender,
+  type EmailTemplateIssue,
+} from './EmailTemplates.utils'
 import { ResetTemplateDialog } from './ResetTemplateDialog'
 import { SpamValidation } from './SpamValidation'
 import { DiscardChangesConfirmationDialog } from '@/components/ui-patterns/Dialogs/DiscardChangesConfirmationDialog'
@@ -107,6 +111,10 @@ export const TemplateEditor = ({ template, isReadOnly = false }: TemplateEditorP
   const [isSavingTemplate, setIsSavingTemplate] = useState(false)
   const [activeView, setActiveView] = useState<'source' | 'preview'>('source')
   const previewSrcDoc = useMemo(() => getPreviewSrcDoc(bodyValue), [bodyValue])
+  const templateIssues = useMemo<EmailTemplateIssue[]>(
+    () => getEmailTemplateIssues(bodyValue),
+    [bodyValue]
+  )
 
   const { mutate: validateSpam } = useValidateSpamMutation()
 
@@ -396,8 +404,11 @@ export const TemplateEditor = ({ template, isReadOnly = false }: TemplateEditorP
                             {variable.name === 'Token' &&
                               template.variables.some((x) => x.name === 'ConfirmationURL') && (
                                 <>
-                                  , which can be used instead of{' '}
-                                  <code className="text-code-inline">ConfirmationURL</code>
+                                  , the one-time code users enter manually — it cannot form a
+                                  link on its own. Use{' '}
+                                  <code className="text-code-inline">ConfirmationURL</code> or{' '}
+                                  <code className="text-code-inline">TokenHash</code> to build a
+                                  custom link
                                 </>
                               )}
 
@@ -430,6 +441,42 @@ export const TemplateEditor = ({ template, isReadOnly = false }: TemplateEditorP
                     description="The preview shown here may differ slightly from how your email appears in the recipient’s email client."
                   />
                 </>
+              )}
+              {templateIssues.length > 0 && (
+                <Admonition
+                  type="warning"
+                  title="These template variables will not produce the expected link"
+                  description={
+                    <div className="space-y-2">
+                      {templateIssues.map((issue) => (
+                        <p key={issue.type}>
+                          {issue.type === 'appended-after-confirmation-url' ? (
+                            <>
+                              Auth generates{' '}
+                              <code className="text-code-inline">{'{{ .ConfirmationURL }}'}</code>{' '}
+                              itself at send time, including its query parameters, so anything
+                              written directly after it is ignored or creates a malformed URL.
+                              To add custom parameters, build the link yourself, e.g.{" "}
+                              <code className="text-code-inline">
+                                {
+                                  '{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=recovery'
+                                }
+                              </code>
+                            </>
+                          ) : (
+                            <>
+                              Variable names are case-sensitive:{' '}
+                              <code className="text-code-inline">{issue.snippet}</code> renders as
+                              empty. Use{' '}
+                              <code className="text-code-inline">{'{{ .ConfirmationURL }}'}</code>{' '}
+                              exactly.
+                            </>
+                          )}
+                        </p>
+                      ))}
+                    </div>
+                  }
+                />
               )}
             </CardContent>
 


### PR DESCRIPTION
Context for #36990

Root-cause investigation shows the wrong-URL behavior is server-side (supabase/auth): RecoveryMail builds ConfirmationURL itself and overwrites the query string; anything appended after the variable in a custom template is never merged, and Go template variables are case-sensitive (ConfirmationUrl renders empty). Neither is fixable in dashboard scope.

This PR adds dashboard-side guardrails for the exact trap:
- New getEmailTemplateIssues() detector: flags params/paths appended directly after {{ .ConfirmationURL }} and case-mismatched variables like {{ .ConfirmationUrl }}
- Live warning Admonition in the template editor explaining Auth generates the URL itself, with the supported recipe: {{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=recovery
- Corrected the misleading Token tooltip (manual OTP only) and documented TokenHash custom-link pattern
- 8 unit tests + editor warning tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added validation warnings for email templates that append content to `ConfirmationURL` or use incorrect variable casing.
  - Added guidance for creating custom confirmation and recovery links with `SiteURL` and `TokenHash`.
  - Improved token guidance to clarify when to use `ConfirmationURL` versus `TokenHash`.

- **Bug Fixes**
  - Helps prevent malformed or ineffective authentication links caused by incorrectly formatted template variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->