### PR TITLE
fix(studio): accept Azure Communication Services SMTP usernames (#34520)

### DIFF
--- a/apps/studio/components/interfaces/Auth/SmtpForm/SmtpForm.schema.test.ts
+++ b/apps/studio/components/interfaces/Auth/SmtpForm/SmtpForm.schema.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+
+import { smtpEnabledSchema, smtpUserSchema } from './SmtpForm.schema'
+
+const validFormValues = {
+  ENABLE_SMTP: true as const,
+  SMTP_ADMIN_EMAIL: 'noreply@yourdomain.com',
+  SMTP_SENDER_NAME: 'Your Name',
+  SMTP_HOST: 'smtp.azure.communication.azure.com',
+  SMTP_PORT: 587,
+  SMTP_MAX_FREQUENCY: 60,
+  SMTP_USER: 'smtp-user',
+  SMTP_PASS: 'password',
+}
+
+describe('smtpUserSchema', () => {
+  it('accepts a standard username', () => {
+    expect(smtpUserSchema.safeParse('smtp-user').success).toBe(true)
+  })
+
+  it('accepts an Azure Communication Services dot-delimited username', () => {
+    expect(
+      smtpUserSchema.safeParse(
+        'my-acs-resource.12345678-90ab-cdef-1234-567890abcdef.87654321-cba0-fedc-4321-fedcba987654'
+      ).success
+    ).toBe(true)
+  })
+
+  it('accepts an Azure Communication Services pipe-delimited username', () => {
+    expect(
+      smtpUserSchema.safeParse(
+        'my-acs-resource|12345678-90ab-cdef-1234-567890abcdef|87654321-cba0-fedc-4321-fedcba987654'
+      ).success
+    ).toBe(true)
+  })
+
+  it('accepts usernames with multiple dots or an email address', () => {
+    expect(smtpUserSchema.safeParse('apikey:user.name').success).toBe(true)
+    expect(smtpUserSchema.safeParse('user@example.com').success).toBe(true)
+  })
+
+  it.each(['', '   '])('rejects an empty username of %s', (value) => {
+    expect(smtpUserSchema.safeParse(value).success).toBe(false)
+  })
+
+  it.each(['my username', 'resource |appId |tenantId'])(
+    'rejects a username containing spaces of %s',
+    (value) => {
+      expect(smtpUserSchema.safeParse(value).success).toBe(false)
+    }
+  )
+})
+
+describe('smtpEnabledSchema', () => {
+  it('accepts a complete form with an Azure Communication Services username', () => {
+    const result = smtpEnabledSchema.safeParse({
+      ...validFormValues,
+      SMTP_USER:
+        'my-acs-resource.12345678-90ab-cdef-1234-567890abcdef.87654321-cba0-fedc-4321-fedcba987654',
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects a missing username', () => {
+    const result = smtpEnabledSchema.safeParse({ ...validFormValues, SMTP_USER: '' })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects a username with embedded whitespace', () => {
+    const result = smtpEnabledSchema.safeParse({
+      ...validFormValues,
+      SMTP_USER: 'my acs resource|app-id|tenant-id',
+    })
+
+    expect(result.success).toBe(false)
+  })
+})

--- a/apps/studio/components/interfaces/Auth/SmtpForm/SmtpForm.schema.ts
+++ b/apps/studio/components/interfaces/Auth/SmtpForm/SmtpForm.schema.ts
@@ -1,0 +1,70 @@
+import * as z from 'zod'
+
+import { urlRegex } from '../Auth.constants'
+
+export const smtpUserSchema = z
+  .string()
+  .trim()
+  .min(1, 'SMTP Username is required')
+  .regex(/^\S+$/, 'SMTP Username must not contain spaces')
+
+export const smtpEnabledSchema = z.object({
+  ENABLE_SMTP: z.literal(true),
+  SMTP_ADMIN_EMAIL: z
+    .string()
+    .trim()
+    .min(1, 'Sender email address is required')
+    .email('Must be a valid email'),
+  SMTP_SENDER_NAME: z.string().trim().min(1, 'Sender name is required'),
+  SMTP_HOST: z
+    .string()
+    .trim()
+    .min(1, 'Host URL is required')
+    .regex(urlRegex({ excludeSimpleDomains: false }), 'Must be a valid URL or IP address'),
+  SMTP_PORT: z.preprocess(
+    (val) => (val === '' || val == null ? undefined : val),
+    z.coerce
+      .number({
+        required_error: 'Port number is required',
+        invalid_type_error: 'Port number is required',
+      })
+      .min(1, 'Must be a valid port number more than 0')
+      .max(65535, 'Must be a valid port number no more than 65535')
+  ),
+  SMTP_MAX_FREQUENCY: z.preprocess(
+    (val) => (val === '' || val == null ? undefined : val),
+    z.coerce
+      .number({
+        required_error: 'Rate limit is required',
+        invalid_type_error: 'Rate limit is required',
+      })
+      .min(1, 'Must be more than 0')
+      .max(32767, 'Must not be more than 32,767 an hour')
+  ),
+  SMTP_USER: smtpUserSchema,
+  SMTP_PASS: z.string().trim().optional(),
+})
+
+export const smtpDisabledSchema = z.object({
+  ENABLE_SMTP: z.literal(false),
+  SMTP_ADMIN_EMAIL: z.string().optional(),
+  SMTP_SENDER_NAME: z.string().optional(),
+  SMTP_HOST: z.string().optional(),
+  SMTP_PORT: z.preprocess(
+    (val) => (val === '' || val == null ? undefined : val),
+    z.coerce.number().optional()
+  ),
+  SMTP_MAX_FREQUENCY: z.preprocess(
+    (val) => (val === '' || val == null ? undefined : val),
+    z.coerce.number().optional()
+  ),
+  SMTP_USER: z.string().optional(),
+  SMTP_PASS: z.string().optional(),
+})
+
+export const smtpSchema = z.discriminatedUnion('ENABLE_SMTP', [
+  smtpEnabledSchema,
+  smtpDisabledSchema,
+])
+
+export type SmtpFormValues = z.infer<typeof smtpSchema>

--- a/apps/studio/components/interfaces/Auth/SmtpForm/SmtpForm.tsx
+++ b/apps/studio/components/interfaces/Auth/SmtpForm/SmtpForm.tsx
@@ -23,13 +23,12 @@ import { Admonition } from 'ui-patterns/Admonition'
 import { Input as PasswordInput } from 'ui-patterns/DataInputs/Input'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { PageSection, PageSectionContent } from 'ui-patterns/PageSection'
-import * as z from 'zod'
 
-import { urlRegex } from '../Auth.constants'
 import { AUTH_TEMPLATE_RESET_TYPES } from '../EmailTemplates/EmailTemplates.constants'
 import { isBeforeFreeTierTemplateBlockCutoff } from '../EmailTemplates/EmailTemplates.utils'
 import { SmtpDisableConfirmationDialog } from './SmtpDisableConfirmationDialog'
 import { defaultDisabledSmtpFormValues } from './SmtpForm.constants'
+import { smtpSchema, type SmtpFormValues } from './SmtpForm.schema'
 import { generateFormValues, isSmtpEnabled } from './SmtpForm.utils'
 import { AlertError } from '@/components/ui/AlertError'
 import { InlineLink } from '@/components/ui/InlineLink'
@@ -39,64 +38,6 @@ import { useAuthConfigUpdateMutation } from '@/data/auth/auth-config-update-muta
 import { useAuthTemplateResetMutation } from '@/data/auth/auth-template-reset-mutation'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
-
-const smtpEnabledSchema = z.object({
-  ENABLE_SMTP: z.literal(true),
-  SMTP_ADMIN_EMAIL: z
-    .string()
-    .trim()
-    .min(1, 'Sender email address is required')
-    .email('Must be a valid email'),
-  SMTP_SENDER_NAME: z.string().trim().min(1, 'Sender name is required'),
-  SMTP_HOST: z
-    .string()
-    .trim()
-    .min(1, 'Host URL is required')
-    .regex(urlRegex({ excludeSimpleDomains: false }), 'Must be a valid URL or IP address'),
-  SMTP_PORT: z.preprocess(
-    (val) => (val === '' || val == null ? undefined : val),
-    z.coerce
-      .number({
-        required_error: 'Port number is required',
-        invalid_type_error: 'Port number is required',
-      })
-      .min(1, 'Must be a valid port number more than 0')
-      .max(65535, 'Must be a valid port number no more than 65535')
-  ),
-  SMTP_MAX_FREQUENCY: z.preprocess(
-    (val) => (val === '' || val == null ? undefined : val),
-    z.coerce
-      .number({
-        required_error: 'Rate limit is required',
-        invalid_type_error: 'Rate limit is required',
-      })
-      .min(1, 'Must be more than 0')
-      .max(32767, 'Must not be more than 32,767 an hour')
-  ),
-  SMTP_USER: z.string().trim().min(1, 'SMTP Username is required'),
-  SMTP_PASS: z.string().trim().optional(),
-})
-
-const smtpDisabledSchema = z.object({
-  ENABLE_SMTP: z.literal(false),
-  SMTP_ADMIN_EMAIL: z.string().optional(),
-  SMTP_SENDER_NAME: z.string().optional(),
-  SMTP_HOST: z.string().optional(),
-  SMTP_PORT: z.preprocess(
-    (val) => (val === '' || val == null ? undefined : val),
-    z.coerce.number().optional()
-  ),
-  SMTP_MAX_FREQUENCY: z.preprocess(
-    (val) => (val === '' || val == null ? undefined : val),
-    z.coerce.number().optional()
-  ),
-  SMTP_USER: z.string().optional(),
-  SMTP_PASS: z.string().optional(),
-})
-
-const smtpSchema = z.discriminatedUnion('ENABLE_SMTP', [smtpEnabledSchema, smtpDisabledSchema])
-
-type SmtpFormValues = z.infer<typeof smtpSchema>
 
 export const SmtpForm = () => {
   const { ref: projectRef } = useParams()
@@ -462,7 +403,18 @@ export const SmtpForm = () => {
                           render={({ field }) => (
                             <FormItemLayout
                               label="Username"
-                              description="Username for your SMTP server."
+                              description={
+                                <>
+                                  <span className="block">
+                                    Username for your SMTP server.
+                                  </span>
+                                  <span className="block text-foreground-lighter">
+                                    Azure Communication Services uses your resource name,
+                                    application ID, and tenant ID joined by dots or pipes (e.g.{' '}
+                                    <code>resource.applicationId.tenantId</code>).
+                                  </span>
+                                </>
+                              }
                             >
                               <FormControl>
                                 <Input


### PR DESCRIPTION
Closes #34520

The custom SMTP form rejected Azure Communication Services usernames, which are resource.appId.tenantId (dot-delimited) or pipe-delimited - not email-shaped.

- Extracted form schemas into SmtpForm.schema.ts (zod) with smtpUserSchema accepting dots/pipes/colons while still rejecting empty input and embedded spaces
- Added a helper hint under the Username field documenting both ACS formats
- New colocated schema tests following the DestinationForm pattern: ACS dot + pipe formats with realistic GUIDs accepted; blank/spaced rejected; full-form integration cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for SMTP settings, including sender details, host, port, frequency, username, and optional password.
  * Added support for standard, email-based, and Azure Communication Services username formats.
  * Added guidance describing accepted Azure Communication Services username formats.

* **Bug Fixes**
  * Improved handling of empty port and frequency fields during validation.
  * Added validation for both enabled and disabled SMTP configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->