### PR TITLE
docs: add warning for cross-project branching notify URLs

### DIFF
--- a/apps/docs/content/guides/deployment/branching/working-with-branches.mdx
+++ b/apps/docs/content/guides/deployment/branching/working-with-branches.mdx
@@ -177,6 +177,12 @@ Deno.serve(async (request) => {
 
 After completing the steps above, you should receive a Slack message whenever an action run completes on your target branch.
 
+<Admonition type="warning" title="Known limitation: cross-project notify URLs">
+  The `--notify-url` option currently works best when the Edge Function is hosted on the **same** Supabase project as the branch. If you point the notify URL to an Edge Function on a **different** Supabase project, the webhook may fail with a `401 UNAUTHORIZED_INVALID_API_KEY` error because the source project's API key is automatically included in the request.
+
+  As a workaround, deploy your webhook processor Edge Function on the same project as the branch, or use a non-Supabase endpoint (such as a third-party webhook service) that does not require a Supabase API key.
+</Admonition>
+
 ## Migration and seeding behavior
 
 Migrations are run in sequential order. Each migration builds upon the previous one.


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The branching `--notify-url` documentation does not mention that using it with an Edge Function on a different Supabase project may fail with a `401 UNAUTHORIZED_INVALID_API_KEY` error. This is reported in #49310.

## What is the new behavior?

Added a warning admonition explaining:
- The `--notify-url` option works best when the Edge Function is hosted on the same Supabase project as the branch
- Cross-project notify URLs may fail because the source project's API key is automatically included in the request
- Workarounds: deploy the webhook processor on the same project, or use a non-Supabase endpoint

## Additional context

Related issue: #49310

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a warning about potential authorization failures when using cross-project notification URLs.
  * Documented workarounds, including hosting the processor on the branch’s project or using a non-Supabase webhook endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->