### PR TITLE
fix(www): point three broken references at what actually exists

### DIFF
--- a/apps/www/_blog/2023-08-11-supavisor-1-million.mdx
+++ b/apps/www/_blog/2023-08-11-supavisor-1-million.mdx
@@ -110,7 +110,7 @@ We also monitored how the load was distributed over Supavisor instance's cores:
   <Img
     alt="cpu load vertical scaling light"
     src={{
-      light: '/images/blog/2023-08-11-supavisor-1-million/cpu-vertical-light.png',
+      light: '/images/blog/2023-08-11-supavisor-1-million/cpu-vertical-light.jpg',
       dark: '/images/blog/2023-08-11-supavisor-1-million/cpu-vertical-dark.png',
     }}
   />
@@ -153,7 +153,7 @@ Within the cluster:
   <Img
     alt="cpu load 1 million light"
     src={{
-      light: '/images/blog/2023-08-11-supavisor-1-million/cpu-1m-light.png',
+      light: '/images/blog/2023-08-11-supavisor-1-million/cpu-1m-light.jpg',
       dark: '/images/blog/2023-08-11-supavisor-1-million/cpu-1m-dark.png',
     }}
   />

--- a/apps/www/app/(home)/_components/FrameworksSection.tsx
+++ b/apps/www/app/(home)/_components/FrameworksSection.tsx
@@ -208,7 +208,7 @@ onMounted(async () => {
 })
 </script>`,
     lang: 'vue' as const,
-    docsUrl: '/docs/guides/getting-started/quickstarts/vuejs',
+    docsUrl: '/docs/guides/getting-started/quickstarts/vue',
   },
   {
     name: 'Nuxt',
@@ -307,7 +307,7 @@ const frameworkExamples: Record<
     {
       title: 'Auth with Vue',
       description: 'Email and OAuth authentication.',
-      url: '/docs/guides/getting-started/quickstarts/vuejs',
+      url: '/docs/guides/getting-started/quickstarts/vue',
       icon: 'KeyRound',
     },
   ],

--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -10,6 +10,18 @@ module.exports = [
     source: '/images/customers/logos/:slug((?!dreambase-mark\\.png)[^/.]+).png',
     destination: '/images/customers/logos/on-light/:slug.png',
   },
+  // The two svg wordmarks that moved with them. Listed individually so the
+  // `{slug}-icon.svg` chips, which stayed at the logos/ root, keep resolving.
+  {
+    permanent: true,
+    source: '/images/customers/logos/accenture.svg',
+    destination: '/images/customers/logos/on-light/accenture.svg',
+  },
+  {
+    permanent: true,
+    source: '/images/customers/logos/stigg.svg',
+    destination: '/images/customers/logos/on-light/stigg.svg',
+  },
   {
     permanent: true,
     source: '/blog/pricing',

--- a/apps/www/next.config.test.ts
+++ b/apps/www/next.config.test.ts
@@ -90,4 +90,25 @@ describe('next.config.mjs', () => {
       slug: 'dreambase-marketing',
     })
   })
+
+  it('redirects legacy svg wordmarks while leaving icon chips at the logos root', async () => {
+    const { default: config } = (await import('./next.config.mjs')) as { default: NextConfig }
+    const redirects = (await config.redirects?.()) || []
+
+    const logoRedirects = redirects.filter((redirect) =>
+      redirect.source.startsWith('/images/customers/logos')
+    )
+    const isRedirected = (url: string) =>
+      logoRedirects.some((redirect) => getPathMatch(redirect.source)(url) !== false)
+
+    // Wordmarks that moved from logos/ to logos/on-light/ have to keep resolving.
+    expect(isRedirected('/images/customers/logos/accenture.svg')).toBe(true)
+    expect(isRedirected('/images/customers/logos/stigg.svg')).toBe(true)
+    // hyper.svg moved out of logos/light/, which the :path* rule already covers.
+    expect(isRedirected('/images/customers/logos/light/hyper.svg')).toBe(true)
+
+    // Icon chips and dreambase-mark.png deliberately stayed put, so they must not redirect.
+    expect(isRedirected('/images/customers/logos/chatbase-icon.svg')).toBe(false)
+    expect(isRedirected('/images/customers/logos/dreambase-mark.png')).toBe(false)
+  })
 })

--- a/apps/www/next.config.test.ts
+++ b/apps/www/next.config.test.ts
@@ -98,17 +98,27 @@ describe('next.config.mjs', () => {
     const logoRedirects = redirects.filter((redirect) =>
       redirect.source.startsWith('/images/customers/logos')
     )
-    const isRedirected = (url: string) =>
-      logoRedirects.some((redirect) => getPathMatch(redirect.source)(url) !== false)
+    const redirectFor = (url: string) =>
+      logoRedirects.find((redirect) => getPathMatch(redirect.source)(url) !== false)
 
-    // Wordmarks that moved from logos/ to logos/on-light/ have to keep resolving.
-    expect(isRedirected('/images/customers/logos/accenture.svg')).toBe(true)
-    expect(isRedirected('/images/customers/logos/stigg.svg')).toBe(true)
+    // Wordmarks that moved from logos/ to logos/on-light/ have to keep resolving, and
+    // land on the file's new home rather than merely matching some rule.
+    expect(redirectFor('/images/customers/logos/accenture.svg')).toMatchObject({
+      destination: '/images/customers/logos/on-light/accenture.svg',
+      permanent: true,
+    })
+    expect(redirectFor('/images/customers/logos/stigg.svg')).toMatchObject({
+      destination: '/images/customers/logos/on-light/stigg.svg',
+      permanent: true,
+    })
     // hyper.svg moved out of logos/light/, which the :path* rule already covers.
-    expect(isRedirected('/images/customers/logos/light/hyper.svg')).toBe(true)
+    expect(redirectFor('/images/customers/logos/light/hyper.svg')).toMatchObject({
+      destination: '/images/customers/logos/on-dark/:path*',
+      permanent: true,
+    })
 
     // Icon chips and dreambase-mark.png deliberately stayed put, so they must not redirect.
-    expect(isRedirected('/images/customers/logos/chatbase-icon.svg')).toBe(false)
-    expect(isRedirected('/images/customers/logos/dreambase-mark.png')).toBe(false)
+    expect(redirectFor('/images/customers/logos/chatbase-icon.svg')).toBeUndefined()
+    expect(redirectFor('/images/customers/logos/dreambase-mark.png')).toBeUndefined()
   })
 })


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix, and a consolidation. Three references in `apps/www` point at something that is not there. This replaces #49282, #49001 and #48806, which were the same class of fix sitting in your queue as three separate reviews. Same commits, one review.

## What is the current behavior?

**1. The homepage Vue links 404** (2 links). `FrameworksSection.tsx` uses `quickstarts/vuejs` in the code-window "Read docs" button and in the "Auth with Vue" card. The page is `quickstarts/vue`:

| url | live |
| --- | --- |
| `/docs/guides/getting-started/quickstarts/vuejs` | 404 |
| `/docs/guides/getting-started/quickstarts/vue` | 200 |

Reported by a user in #49142. The correct spelling already exists in `components/Hero/HeroFrameworks.tsx` and `data/frameworks.ts`, so this is an inconsistency inside www rather than a rename that was missed everywhere.

**2. Two customer wordmarks 404** (2 redirects). `accenture.svg` and `stigg.svg` moved to `logos/on-light/` and only the `.png` rule was updated, so the `.svg` originals resolve to nothing:

| url | live |
| --- | --- |
| `/images/customers/logos/accenture.svg` | 404 |
| `/images/customers/logos/stigg.svg` | 404 |
| `/images/customers/logos/on-light/accenture.svg` | 200 |

**3. Two light-mode chart images are broken** in the 2023 supavisor post. The post asks for `.png`; the files on disk are `.jpg`:

```
apps/www/public/images/blog/2023-08-11-supavisor-1-million/
  cpu-1m-light.jpg        <- post requests cpu-1m-light.png
  cpu-vertical-light.jpg  <- post requests cpu-vertical-light.png
  cpu-1m-dark.png         (dark variants really are .png, untouched)
  cpu-vertical-dark.png
```

## Why one PR

These went out as three because I filed them as I found them, over two weeks. That was the wrong call: they are one class of defect in one app under one owner, and three separate reviews is three times the overhead for the same amount of reading. Grouping them is the same thing that made #49215 reviewable.

Every commit is cherry-picked unchanged, so the per-fix reasoning and verification is still in the history rather than flattened.

## Verification

For the URL cases I checked a deliberate nonsense path in the same directory first, so the 404s mean something: `/docs/guides/getting-started/quickstarts/zzz-canary-must-404` and `/images/customers/logos/zzz-canary-must-404.svg` both return 404. For the images I listed the directory rather than trusting the post.

Scope check on the Vue one: I swept every `getting-started/quickstarts/*` link in `apps/www`. 31 resolve and these 2 are the only dead ones.

One judgement call I would rather flag than bury. The second Vue link sits under "Auth with Vue", and the React equivalent points at `auth/quickstarts/react`. There is no `auth/quickstarts/vue`, so I only corrected the slug and kept the card's original destination.

Gates: `test:prettier` passes repo wide, `typecheck --filter=www --force` passes, and the www suite passes 6 files / 81 tests, including the redirect assertions in `next.config.test.ts` that CodeRabbit asked to be strengthened on #49001.

Freshman contributor, with Claude Code's help. I verified every status code, every canary and the on-disk filenames myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Vue quickstart links to use the current route.
  * Corrected CPU load chart image links in the Supavisor blog post.
  * Added permanent redirects for legacy customer logo wordmark URLs while preserving icon links.

* **Tests**
  * Added coverage to verify logo redirects and ensure unrelated image paths remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->