### PR TITLE
fix: AI assistant sidebar doesn't open from org-view support success card

### DIFF
--- a/apps/studio/components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider.tsx
@@ -60,7 +60,7 @@ export const LayoutSidebarProvider = ({ children }: PropsWithChildren) => {
   const sidebarURLParamRef = useLatest(sidebarURLParam)
   const sidebarLocalStorageRef = useLatest(sidebarLocalStorage)
 
-  useRegisterSidebar(SIDEBAR_KEYS.AI_ASSISTANT, () => <AIAssistant />, {}, !!project)
+  useRegisterSidebar(SIDEBAR_KEYS.AI_ASSISTANT, () => <AIAssistant />, {}, true)
   useRegisterSidebar(SIDEBAR_KEYS.EDITOR_PANEL, () => <EditorPanel />, {}, !!project)
   useRegisterSidebar(SIDEBAR_KEYS.ADVISOR_PANEL, () => <AdvisorPanel />, {}, true)
   useRegisterSidebar(

--- a/apps/studio/components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider.tsx
@@ -10,6 +10,7 @@ import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { useTrack } from '@/lib/telemetry/track'
+import { useAiAssistantStateSnapshot } from '@/state/ai-assistant-state'
 import { SHORTCUT_IDS } from '@/state/shortcuts/registry'
 import { useShortcut } from '@/state/shortcuts/useShortcut'
 import {
@@ -46,6 +47,14 @@ export const LayoutSidebarProvider = ({ children }: PropsWithChildren) => {
   const { data: org } = useSelectedOrganizationQuery()
   const track = useTrack()
   const { openSidebar, closeSidebar, activeSidebar } = useSidebarManagerSnapshot()
+  const aiAssistant = useAiAssistantStateSnapshot()
+  // On org-level pages there's no project in the URL, but an org-view support chat
+  // (see SupportAssistantSuccessCardContent) resolves its own project and syncs it into
+  // this context as soon as its chat is created — before the sidebar is ever opened.
+  // Registering on that too (rather than unconditionally) keeps the AI Assistant closed
+  // to the rest of the org UI (header button, shortcut, help panel) until a support chat
+  // actually has a resolved project to show.
+  const hasResolvedAssistantProject = !!project || !!aiAssistant.context.projectRef
 
   const [sidebarURLParam, setSidebarUrlParam] = useQueryState('sidebar', parseAsString)
   const [sidebarLocalStorage, setSidebarLocalStorage, { isSuccess: isLoadedLocalStorage }] =
@@ -60,7 +69,12 @@ export const LayoutSidebarProvider = ({ children }: PropsWithChildren) => {
   const sidebarURLParamRef = useLatest(sidebarURLParam)
   const sidebarLocalStorageRef = useLatest(sidebarLocalStorage)
 
-  useRegisterSidebar(SIDEBAR_KEYS.AI_ASSISTANT, () => <AIAssistant />, {}, true)
+  useRegisterSidebar(
+    SIDEBAR_KEYS.AI_ASSISTANT,
+    () => <AIAssistant />,
+    {},
+    hasResolvedAssistantProject
+  )
   useRegisterSidebar(SIDEBAR_KEYS.EDITOR_PANEL, () => <EditorPanel />, {}, !!project)
   useRegisterSidebar(SIDEBAR_KEYS.ADVISOR_PANEL, () => <AdvisorPanel />, {}, true)
   useRegisterSidebar(

--- a/apps/studio/components/layouts/ProjectLayout/LayoutSidebar/index.test.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutSidebar/index.test.tsx
@@ -148,33 +148,40 @@ describe('LayoutSidebar', () => {
       mockProjectData = mockProject
     })
 
-    it('does not register project-related sidebars when no project is available', async () => {
+    it('registers the AI Assistant sidebar but not other project-related sidebars when no project is available', async () => {
       renderSidebar()
 
       // Wait a bit to ensure sidebars have been registered
       await waitFor(() => {
-        // Project-related sidebars should not be registered
-        expect(sidebarManagerState.sidebars[SIDEBAR_KEYS.AI_ASSISTANT]).toBeUndefined()
+        // The AI Assistant works from org-level pages (e.g. the support ticket flow), so it
+        // should register even without a project
+        expect(sidebarManagerState.sidebars[SIDEBAR_KEYS.AI_ASSISTANT]).toBeDefined()
+        // Other project-related sidebars should still not be registered
         expect(sidebarManagerState.sidebars[SIDEBAR_KEYS.EDITOR_PANEL]).toBeUndefined()
         // Advisor panel should still be available (doesn't require project)
         expect(sidebarManagerState.sidebars[SIDEBAR_KEYS.ADVISOR_PANEL]).toBeDefined()
       })
     })
 
-    it('does not render project-related sidebars even when toggled', async () => {
+    it('renders the AI Assistant sidebar when toggled, but not other project-related sidebars', async () => {
       renderSidebar()
 
       await waitFor(() => {
         expect(sidebarManagerState.sidebars[SIDEBAR_KEYS.ADVISOR_PANEL]).toBeDefined()
       })
 
-      // Try to toggle AI_ASSISTANT - should not work since it's not registered
+      // AI Assistant should render since it's registered even without a project
       act(() => {
         sidebarManagerState.toggleSidebar(SIDEBAR_KEYS.AI_ASSISTANT)
       })
 
-      // Should not render since it's not registered
-      expect(screen.queryByTestId('ai-assistant-sidebar')).toBeNull()
+      expect(await screen.findByTestId('ai-assistant-sidebar')).toBeTruthy()
+
+      // Try to toggle EDITOR_PANEL - should not work since it's not registered
+      act(() => {
+        sidebarManagerState.toggleSidebar(SIDEBAR_KEYS.EDITOR_PANEL)
+      })
+
       expect(screen.queryByTestId('editor-panel-sidebar')).toBeNull()
 
       // Advisor panel should work

--- a/apps/studio/components/layouts/ProjectLayout/LayoutSidebar/index.test.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutSidebar/index.test.tsx
@@ -83,6 +83,12 @@ vi.mock('@/lib/telemetry/track', () => ({
   useTrack: () => vi.fn(),
 }))
 
+let mockAiAssistantContext: { projectRef?: string } = {}
+
+vi.mock('@/state/ai-assistant-state', () => ({
+  useAiAssistantStateSnapshot: () => ({ context: mockAiAssistantContext }),
+}))
+
 const resetSidebarManagerState = () => {
   Object.keys(sidebarManagerState.sidebars).forEach((id) => {
     sidebarManagerState.unregisterSidebar(id)
@@ -99,6 +105,7 @@ describe('LayoutSidebar', () => {
     resetSidebarManagerState()
     localStorage.clear()
     vi.clearAllMocks()
+    mockAiAssistantContext = {}
   })
 
   const renderSidebar = () =>
@@ -148,48 +155,70 @@ describe('LayoutSidebar', () => {
       mockProjectData = mockProject
     })
 
-    it('registers the AI Assistant sidebar but not other project-related sidebars when no project is available', async () => {
-      renderSidebar()
+    describe('without a resolved support chat context', () => {
+      it('does not register the AI Assistant sidebar', async () => {
+        renderSidebar()
 
-      // Wait a bit to ensure sidebars have been registered
-      await waitFor(() => {
-        // The AI Assistant works from org-level pages (e.g. the support ticket flow), so it
-        // should register even without a project
-        expect(sidebarManagerState.sidebars[SIDEBAR_KEYS.AI_ASSISTANT]).toBeDefined()
-        // Other project-related sidebars should still not be registered
+        await waitFor(() => {
+          expect(sidebarManagerState.sidebars[SIDEBAR_KEYS.ADVISOR_PANEL]).toBeDefined()
+        })
+
+        // With no project and no org-view support chat context, the AI Assistant should
+        // stay closed to the rest of the org UI (header button, shortcut, help panel) —
+        // only an org-view support chat with a resolved project should unlock it.
+        expect(sidebarManagerState.sidebars[SIDEBAR_KEYS.AI_ASSISTANT]).toBeUndefined()
         expect(sidebarManagerState.sidebars[SIDEBAR_KEYS.EDITOR_PANEL]).toBeUndefined()
-        // Advisor panel should still be available (doesn't require project)
-        expect(sidebarManagerState.sidebars[SIDEBAR_KEYS.ADVISOR_PANEL]).toBeDefined()
       })
     })
 
-    it('renders the AI Assistant sidebar when toggled, but not other project-related sidebars', async () => {
-      renderSidebar()
-
-      await waitFor(() => {
-        expect(sidebarManagerState.sidebars[SIDEBAR_KEYS.ADVISOR_PANEL]).toBeDefined()
+    describe('with a resolved support chat context', () => {
+      beforeEach(() => {
+        // Simulate an org-view support chat having resolved its own project
+        // (see SupportAssistantSuccessCardContent), before the sidebar is opened.
+        mockAiAssistantContext = { projectRef: 'support-chat-project' }
       })
 
-      // AI Assistant should render since it's registered even without a project
-      act(() => {
-        sidebarManagerState.toggleSidebar(SIDEBAR_KEYS.AI_ASSISTANT)
+      it('registers the AI Assistant sidebar but not other project-related sidebars', async () => {
+        renderSidebar()
+
+        // Wait a bit to ensure sidebars have been registered
+        await waitFor(() => {
+          expect(sidebarManagerState.sidebars[SIDEBAR_KEYS.AI_ASSISTANT]).toBeDefined()
+          // Other project-related sidebars should still not be registered
+          expect(sidebarManagerState.sidebars[SIDEBAR_KEYS.EDITOR_PANEL]).toBeUndefined()
+          // Advisor panel should still be available (doesn't require project)
+          expect(sidebarManagerState.sidebars[SIDEBAR_KEYS.ADVISOR_PANEL]).toBeDefined()
+        })
       })
 
-      expect(await screen.findByTestId('ai-assistant-sidebar')).toBeTruthy()
+      it('renders the AI Assistant sidebar when toggled, but not other project-related sidebars', async () => {
+        renderSidebar()
 
-      // Try to toggle EDITOR_PANEL - should not work since it's not registered
-      act(() => {
-        sidebarManagerState.toggleSidebar(SIDEBAR_KEYS.EDITOR_PANEL)
+        await waitFor(() => {
+          expect(sidebarManagerState.sidebars[SIDEBAR_KEYS.ADVISOR_PANEL]).toBeDefined()
+        })
+
+        // AI Assistant should render since it's registered
+        act(() => {
+          sidebarManagerState.toggleSidebar(SIDEBAR_KEYS.AI_ASSISTANT)
+        })
+
+        expect(await screen.findByTestId('ai-assistant-sidebar')).toBeTruthy()
+
+        // Try to toggle EDITOR_PANEL - should not work since it's not registered
+        act(() => {
+          sidebarManagerState.toggleSidebar(SIDEBAR_KEYS.EDITOR_PANEL)
+        })
+
+        expect(screen.queryByTestId('editor-panel-sidebar')).toBeNull()
+
+        // Advisor panel should work
+        act(() => {
+          sidebarManagerState.toggleSidebar(SIDEBAR_KEYS.ADVISOR_PANEL)
+        })
+
+        expect(await screen.findByTestId('advisor-panel-sidebar')).toBeTruthy()
       })
-
-      expect(screen.queryByTestId('editor-panel-sidebar')).toBeNull()
-
-      // Advisor panel should work
-      act(() => {
-        sidebarManagerState.toggleSidebar(SIDEBAR_KEYS.ADVISOR_PANEL)
-      })
-
-      expect(await screen.findByTestId('advisor-panel-sidebar')).toBeTruthy()
     })
   })
 


### PR DESCRIPTION
Fixes FE-4206.

**Stacked on #49244** — this PR targets that branch and should be merged after it (base will auto-retarget to `master` once #49244 merges).

## What is the current behavior?

After submitting a support ticket from the org-level support form, the "While you wait" assistant card renders correctly, but clicking it does nothing — the AI Assistant panel doesn't open. It only opens later if the user navigates into a project page.

Root cause: `LayoutSidebarProvider` only registered the AI Assistant sidebar when `!!project` was true. On org-level pages there's no project in the URL, so the sidebar was never registered, and `openSidebar('ai-assistant')` silently queued the open request instead of doing anything.

This gate was correct when it was added (the assistant genuinely needed a project to do anything), but no longer holds: general org-view assistant chats already tolerate no project, and support chats resolve their own project context independently via `supportMetadata` (see #49244).

## What is the new behavior?

The AI Assistant sidebar now also registers when an org-view support chat has resolved its own project context (`ai-assistant-state`'s `context.projectRef`, set by `SupportAssistantSuccessCardContent` as soon as it creates the chat — before the sidebar is ever opened).

This is intentionally narrower than "always register regardless of project" — that would have exposed the AI Assistant to every other org-level entry point (the header AI button, the `Cmd/Ctrl+I` shortcut, the Help panel's assistant link), none of which were in scope for this fix. With this change, those entry points still do nothing on an org page *until* a support chat with a resolved project exists — matching the original ticket's scope exactly.

## How to test

1. Go to `/org/<your_org_slug>` (org-level view, not a project page).
2. Submit a support ticket (any category that shows the "While you wait" AI assistant card).
3. Click the card — confirm the AI Assistant sidebar opens.
4. Scope check: on that same org page, *before* submitting a ticket, click the header AI icon button (and/or try `Cmd/Ctrl+I`) — confirm the sidebar does **not** open.
5. Scope check: *after* submitting a ticket (per step 2), try the header AI icon button / shortcut again — confirm it now opens the sidebar, since a resolved support chat context exists.
6. Regression check: open/close the assistant sidebar from a project-level page and confirm it still behaves as before.
7. Regression check: confirm the Editor Panel, Advisor Panel, and Help Panel still behave as before on both org and project pages.
