### PR TITLE
fix(docs): correct Performance Advisor link on database advisors page

### DIFF
--- a/apps/docs/content/guides/database/database-advisors.mdx
+++ b/apps/docs/content/guides/database/database-advisors.mdx
@@ -7,7 +7,7 @@ You can use the Database Performance and Security Advisors to check your databas
 
 ## Using the advisors
 
-In the dashboard, navigate to [Security Advisor](/dashboard/project/_/database/security-advisor) and [Performance Advisor](dashboard/project/_/database/performance-advisor) under Database. The advisors run automatically. You can also manually rerun them after you've resolved issues.
+In the dashboard, navigate to [Security Advisor](/dashboard/project/_/database/security-advisor) and [Performance Advisor](/dashboard/project/_/database/performance-advisor) under Database. The advisors run automatically. You can also manually rerun them after you've resolved issues.
 
 ## Available checks
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs bug fix. Fixes #49427.

## What is the current behavior?

On [Performance and Security Advisors](https://supabase.com/docs/guides/database/database-advisors), the **Performance Advisor** link is missing its leading slash:

```md
[Performance Advisor](dashboard/project/_/database/performance-advisor)
```

Because it is not root-relative, it resolves against the current page and 404s at:

`https://supabase.com/docs/guides/database/dashboard/project/_/database/performance-advisor`

The **Security Advisor** link on the same line is already correct, which is why only one of the two breaks.

## What is the new behavior?

The link is root-relative, so it resolves to `/dashboard/project/_/database/performance-advisor` as intended.

## Additional context

- One character, one line.
- This is the only link of this shape in `apps/docs/content` — `grep -rnE '\]\(dashboard/' apps/docs/content` returns no other matches.
- The target path is intentionally left as the legacy form. It is redirected to `/project/:ref/advisors/performance` by [`redirects.shared.ts`](https://github.com/supabase/supabase/blob/master/apps/studio/redirects.shared.ts#L277-L278), and it is the same form already used in `going-into-prod.mdx`, `shared-responsibility-model.mdx`, and the query-performance troubleshooting entry. Keeping it consistent avoids unrelated churn.
- Root-relative is also the form expected by `Rule006NoAbsoluteUrls` in `supa-mdx-lint.config.toml`.
- `prettier --check` passes on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Performance Advisor link so it navigates to the dashboard correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->