### PR TITLE
fix(ui-library): make folder structure tree collapsible on mobile

### DIFF
--- a/apps/ui-library/components/block-item-code.tsx
+++ b/apps/ui-library/components/block-item-code.tsx
@@ -1,8 +1,17 @@
 'use client'
 
-import { File } from 'lucide-react'
+import { ChevronDown, File, Folder } from 'lucide-react'
 import { useState } from 'react'
-import { flattenTree, TreeView, TreeViewItem } from 'ui'
+import {
+  cn,
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+  flattenTree,
+  TreeView,
+  TreeViewItem,
+  useIsMobile,
+} from 'ui'
 import { CodeBlock } from 'ui-patterns/CodeBlock'
 
 import { RegistryNode } from '@/lib/process-registry'
@@ -45,6 +54,9 @@ const findFirstFile = (nodes: RegistryNode[]): RegistryNode | null => {
 export function BlockItemCode({ files }: BlockItemCodeProps) {
   // Find the first file to select by default
   const [selectedFile, setSelectedFile] = useState<RegistryNode | null>(findFirstFile(files))
+  // On mobile the tree is collapsed by default so it doesn't take up the full width
+  const [isTreeOpen, setIsTreeOpen] = useState(false)
+  const isMobile = useIsMobile()
   const flattenedData = flattenTree({ name: '', children: flattenChildren(files) })
 
   // Handle file selection from the TreeView
@@ -70,52 +82,73 @@ export function BlockItemCode({ files }: BlockItemCodeProps) {
     if (foundFile?.type === 'directory') return
 
     setSelectedFile(foundFile || null)
+    // Reveal the code straight away instead of leaving the tree covering it
+    if (isMobile) setIsTreeOpen(false)
   }
 
   return (
-    <div className="flex mt-4 border rounded-lg overflow-hidden h-[652px] not-prose">
-      {/* File browser sidebar */}
-      <div className="w-64 py-2 border-r bg-muted/30 overflow-y-auto">
-        <TreeView
-          data={flattenedData}
-          aria-label="file browser"
-          className="w-full"
-          defaultExpandedIds={flattenedData.filter((n) => n.children?.length).map((n) => n.id)}
-          defaultSelectedIds={flattenedData
-            .filter((n) => n.metadata?.path === selectedFile?.path)
-            .map((n) => n.id)}
-          onNodeSelect={({ element }) => handleNodeSelect(element)}
-          nodeRenderer={({ element, isBranch, isExpanded, getNodeProps, level, isSelected }) => (
-            <TreeViewItem
-              {...getNodeProps()}
-              isExpanded={isExpanded}
-              isBranch={isBranch}
-              isSelected={isSelected}
-              level={level}
-              icon={<File strokeWidth={1.5} size={16} className="shrink-0" />}
-              name={element.name}
-              className="gap-1.5"
-            />
-          )}
+    <Collapsible
+      open={!isMobile || isTreeOpen}
+      onOpenChange={setIsTreeOpen}
+      className="flex flex-col md:flex-row mt-4 border rounded-lg overflow-hidden h-[652px] not-prose"
+    >
+      {/* Trigger is mobile-only; from md up the tree is always visible */}
+      <CollapsibleTrigger className="md:hidden flex shrink-0 items-center justify-between gap-2 border-b bg-muted/30 px-3 py-2 text-sm">
+        <span className="flex min-w-0 items-center gap-1.5">
+          <Folder strokeWidth={1.5} size={16} className="shrink-0" />
+          <span className="truncate">{selectedFile?.name ?? 'Folder structure'}</span>
+        </span>
+        <ChevronDown
+          strokeWidth={1.5}
+          size={16}
+          className={cn('shrink-0 transition-transform', isTreeOpen && 'rotate-180')}
         />
-      </div>
+      </CollapsibleTrigger>
+
+      {/* File browser sidebar */}
+      <CollapsibleContent className="shrink-0 md:h-full">
+        <div className="w-full max-h-56 md:w-64 md:max-h-none md:h-full py-2 border-b md:border-b-0 md:border-r bg-muted/30 overflow-y-auto">
+          <TreeView
+            data={flattenedData}
+            aria-label="file browser"
+            className="w-full"
+            defaultExpandedIds={flattenedData.filter((n) => n.children?.length).map((n) => n.id)}
+            defaultSelectedIds={flattenedData
+              .filter((n) => n.metadata?.path === selectedFile?.path)
+              .map((n) => n.id)}
+            onNodeSelect={({ element }) => handleNodeSelect(element)}
+            nodeRenderer={({ element, isBranch, isExpanded, getNodeProps, level, isSelected }) => (
+              <TreeViewItem
+                {...getNodeProps()}
+                isExpanded={isExpanded}
+                isBranch={isBranch}
+                isSelected={isSelected}
+                level={level}
+                icon={<File strokeWidth={1.5} size={16} className="shrink-0" />}
+                name={element.name}
+                className="gap-1.5"
+              />
+            )}
+          />
+        </div>
+      </CollapsibleContent>
 
       {/* Code display area */}
       {selectedFile?.content ? (
         <CodeBlock
-          wrapperClassName="w-full"
+          wrapperClassName="w-full flex-1 min-h-0 min-w-0"
           className="h-full max-w-none w-full! flex-1 font-mono text-xs rounded-none border-none"
           language="ts"
         >
           {selectedFile?.content}
         </CodeBlock>
       ) : (
-        <div className="flex items-center justify-center h-full text-muted-foreground">
+        <div className="flex flex-1 items-center justify-center h-full text-muted-foreground">
           <div className="flex flex-col items-center gap-2">
             <p>No file selected or file content unavailable</p>
           </div>
         </div>
       )}
-    </div>
+    </Collapsible>
   )
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix. Fixes #35563.

## What is the current behavior?

In the **Folder structure** block (`<RegistryBlock />` → `BlockItemCode`), the file browser is a fixed-width column with no responsive or collapse behaviour:

```tsx
<div className="flex ... h-[652px]">
  <div className="w-64 py-2 border-r ...">
```

On a phone that column permanently takes 256px of a ~390px viewport. The file name truncates to `use-infinit…`, every line of code is clipped, and there is no way to dismiss the tree. This affects every `/docs/*` page that renders a registry block.

**Before — 390px viewport:**

<img src="https://raw.githubusercontent.com/kp-krish/supabase/pr-assets/49434/before-mobile.png" width="300" />

## What is the new behavior?

Below `md` the tree collapses behind a trigger showing the selected file, and the code pane gets the full width. Selecting a file closes the tree so the code is visible straight away. From `md` up the layout is unchanged.

**After — 390px, collapsed (default):**

<img src="https://raw.githubusercontent.com/kp-krish/supabase/pr-assets/49434/after-mobile-collapsed.png" width="300" />

**After — 390px, expanded via the trigger:**

<img src="https://raw.githubusercontent.com/kp-krish/supabase/pr-assets/49434/after-mobile-expanded.png" width="300" />

**Desktop (1280px) — before and after are identical:**

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/kp-krish/supabase/pr-assets/49434/before-desktop.png" width="380" /> | <img src="https://raw.githubusercontent.com/kp-krish/supabase/pr-assets/49434/after-desktop.png" width="380" /> |

Measured in Chromium against the dev server:

| Viewport | Tree pane | Trigger |
| --- | --- | --- |
| 390px, default | not rendered (`data-state="closed"`) | visible — `use-infinite-query.ts` |
| 390px, after tap | 324×73, bounded by `max-h-56` | visible, chevron rotated |
| 1280px | **256×650** — unchanged | `md:hidden`, not rendered |

256px is exactly the previous `w-64`, so the desktop layout is untouched.

## Additional context

- Uses `Collapsible` from `ui`, already used in this app in `component-preview.tsx`, and `useIsMobile` from `ui`.
- The tree renders open during SSR, so the file list is still present without JS.
- Verified locally: `tsc --noEmit -p tsconfig.json` exits **0**; `eslint` exits **0** (one pre-existing `no-explicit-any` warning on `handleNodeSelect`, untouched here); `prettier --check` passes.
- The page logs a hydration warning both with and without this change — I A/B'd it against an unmodified tree and the console output is identical, so it is pre-existing and out of scope.
- Screenshots are hosted on a separate `pr-assets` branch of my fork, so they are not part of this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
