### PR TITLE
fix(studio): stop Authorization header value reverting on edit

### DIFF
--- a/apps/studio/components/interfaces/Database/Hooks/FormContents.tsx
+++ b/apps/studio/components/interfaces/Database/Hooks/FormContents.tsx
@@ -51,8 +51,11 @@ export const FormContents = ({ form, selectedHook }: FormContentsProps) => {
 
   const restUrl = project?.restUrl
 
-  const { can: canReadAPIKeys } = useAsyncCheckPermissions(PermissionAction.SECRETS_READ, '*')
-  const { data: keys = [] } = useAPIKeysQuery(
+  const { can: canReadAPIKeys, isSuccess: isPermissionsSuccess } = useAsyncCheckPermissions(
+    PermissionAction.SECRETS_READ,
+    '*'
+  )
+  const { data: keys = [], isSuccess: isAPIKeysSuccess } = useAPIKeysQuery(
     { projectRef: ref, reveal: true },
     { enabled: canReadAPIKeys }
   )
@@ -61,6 +64,14 @@ export const FormContents = ({ form, selectedHook }: FormContentsProps) => {
   })
 
   const legacyServiceRole = keys.find((x) => x.name === 'service_role')?.api_key ?? '[YOUR API KEY]'
+
+  // The service role key is only "final" once we know we're not still waiting on
+  // it: either the API keys query has completed, or the user doesn't have
+  // permission to read it at all (so it will never resolve to a real value).
+  // Without this, if the edge functions list loads before the API keys do, the
+  // default header below could get written with the `[YOUR API KEY]` placeholder
+  // and then never get corrected once the real key arrives.
+  const isServiceRoleKeyResolved = isPermissionsSuccess && (!canReadAPIKeys || isAPIKeysSuccess)
 
   const httpUrl = useWatch({ control: form.control, name: 'http_url' })
 
@@ -77,17 +88,24 @@ export const FormContents = ({ form, selectedHook }: FormContentsProps) => {
   // updated `httpHeaders`, re-triggered the effect, and got reverted back to the
   // computed service role token. See: header value appears "stuck" and uneditable.
   useEffect(() => {
-    if (!isSuccessEdgeFunctions) return
+    if (!isSuccessEdgeFunctions || !isServiceRoleKeyResolved) return
 
     const isEdgeFunctionSelected = isEdgeFunctionUrl(httpUrl, ref ?? '', restUrl)
     if (!httpUrl || !isEdgeFunctionSelected) return
 
-    const fnSlug = httpUrl.split('/').at(-1)
+    // Drop empty segments so a trailing slash on the URL doesn't turn the slug
+    // into an empty string (which would never match a function).
+    const pathSegments = httpUrl.split('/').filter(Boolean)
+    const fnSlug = pathSegments.at(-1)
     const fn = functions.find((x) => x.slug === fnSlug)
     if (!fn?.verify_jwt) return
 
     const currentHeaders = form.getValues('httpHeaders')
-    const authorizationHeader = currentHeaders.find((x) => x.name === 'Authorization')
+    // Header names are case-insensitive, so an existing lowercase/mixed-case
+    // "authorization" row still counts as already present.
+    const authorizationHeader = currentHeaders.find(
+      (x) => x.name.toLowerCase() === 'authorization'
+    )
     if (authorizationHeader != null) return
 
     const newAuthHeader = {
@@ -96,7 +114,16 @@ export const FormContents = ({ form, selectedHook }: FormContentsProps) => {
       value: `Bearer ${legacyServiceRole}`,
     }
     form.setValue('httpHeaders', [...currentHeaders, newAuthHeader])
-  }, [form, functions, httpUrl, isSuccessEdgeFunctions, legacyServiceRole, ref, restUrl])
+  }, [
+    form,
+    functions,
+    httpUrl,
+    isServiceRoleKeyResolved,
+    isSuccessEdgeFunctions,
+    legacyServiceRole,
+    ref,
+    restUrl,
+  ])
 
   return (
     <div>

--- a/apps/studio/components/interfaces/Database/Hooks/FormContents.tsx
+++ b/apps/studio/components/interfaces/Database/Hooks/FormContents.tsx
@@ -93,9 +93,10 @@ export const FormContents = ({ form, selectedHook }: FormContentsProps) => {
     const isEdgeFunctionSelected = isEdgeFunctionUrl(httpUrl, ref ?? '', restUrl)
     if (!httpUrl || !isEdgeFunctionSelected) return
 
-    // Drop empty segments so a trailing slash on the URL doesn't turn the slug
-    // into an empty string (which would never match a function).
-    const pathSegments = httpUrl.split('/').filter(Boolean)
+    // Parse the pathname (not the raw URL) so a trailing slash or a query
+    // string / fragment doesn't end up folded into the slug — either of
+    // those would fail to match any function and skip adding the header.
+    const pathSegments = new URL(httpUrl).pathname.split('/').filter(Boolean)
     const fnSlug = pathSegments.at(-1)
     const fn = functions.find((x) => x.slug === fnSlug)
     if (!fn?.verify_jwt) return

--- a/apps/studio/components/interfaces/Database/Hooks/FormContents.tsx
+++ b/apps/studio/components/interfaces/Database/Hooks/FormContents.tsx
@@ -63,50 +63,40 @@ export const FormContents = ({ form, selectedHook }: FormContentsProps) => {
   const legacyServiceRole = keys.find((x) => x.name === 'service_role')?.api_key ?? '[YOUR API KEY]'
 
   const httpUrl = useWatch({ control: form.control, name: 'http_url' })
-  const httpHeaders = useWatch({ control: form.control, name: 'httpHeaders' })
 
   const { data: tables = [] } = useTableNamesQuery({
     projectRef: project?.ref,
     connectionString: project?.connectionString,
   })
 
-  // Handle auth header auto-add for edge functions
+  // Auto-add a default Authorization header for edge functions that require JWT
+  // verification, but only when one isn't already present. This must NOT watch
+  // `httpHeaders` (or otherwise re-run on every header edit): doing so previously
+  // caused this effect to immediately overwrite any manual edit to the Authorization
+  // header's value (including trying to clear/remove it), since every keystroke
+  // updated `httpHeaders`, re-triggered the effect, and got reverted back to the
+  // computed service role token. See: header value appears "stuck" and uneditable.
   useEffect(() => {
     if (!isSuccessEdgeFunctions) return
 
     const isEdgeFunctionSelected = isEdgeFunctionUrl(httpUrl, ref ?? '', restUrl)
+    if (!httpUrl || !isEdgeFunctionSelected) return
 
-    if (httpUrl && isEdgeFunctionSelected) {
-      const fnSlug = httpUrl.split('/').at(-1)
-      const fn = functions.find((x) => x.slug === fnSlug)
-      const authorizationHeader = httpHeaders.find((x) => x.name === 'Authorization')
-      const edgeFunctionAuthHeaderVal = `Bearer ${legacyServiceRole}`
+    const fnSlug = httpUrl.split('/').at(-1)
+    const fn = functions.find((x) => x.slug === fnSlug)
+    if (!fn?.verify_jwt) return
 
-      if (fn?.verify_jwt && authorizationHeader == null) {
-        const newAuthHeader = {
-          id: uuidv4(),
-          name: 'Authorization',
-          value: edgeFunctionAuthHeaderVal,
-        }
-        form.setValue('httpHeaders', [...httpHeaders, newAuthHeader])
-      } else if (fn?.verify_jwt && authorizationHeader?.value !== edgeFunctionAuthHeaderVal) {
-        const updatedHttpHeaders = httpHeaders.map((x) => {
-          if (x.name === 'Authorization') return { ...x, value: edgeFunctionAuthHeaderVal }
-          else return x
-        })
-        form.setValue('httpHeaders', updatedHttpHeaders)
-      }
+    const currentHeaders = form.getValues('httpHeaders')
+    const authorizationHeader = currentHeaders.find((x) => x.name === 'Authorization')
+    if (authorizationHeader != null) return
+
+    const newAuthHeader = {
+      id: uuidv4(),
+      name: 'Authorization',
+      value: `Bearer ${legacyServiceRole}`,
     }
-  }, [
-    form,
-    functions,
-    httpHeaders,
-    httpUrl,
-    isSuccessEdgeFunctions,
-    legacyServiceRole,
-    ref,
-    restUrl,
-  ])
+    form.setValue('httpHeaders', [...currentHeaders, newAuthHeader])
+  }, [form, functions, httpUrl, isSuccessEdgeFunctions, legacyServiceRole, ref, restUrl])
 
   return (
     <div>


### PR DESCRIPTION
Closes #49435 

## What
Fixes the Authorization header in the Database Webhooks "HTTP Headers"
section appearing stuck/uneditable when the webhook targets a Supabase
Edge Function that has JWT verification (`verify_jwt`) enabled.

## Why
In `FormContents.tsx`, the effect that auto-populates the Authorization
header watched the entire `httpHeaders` field array via `useWatch` and,
on every change, corrected the header's value back to
`Bearer <service_role_key>` if it didn't match. Since editing the field
itself changes `httpHeaders`, every keystroke re-triggered the effect
and immediately reverted the user's edit — making the field look stuck,
and making it impossible to remove or customize the header.

## Fix
- The effect now only *adds* a default Authorization header when one is
  missing (still a helpful default for `verify_jwt` functions).
- It no longer watches `httpHeaders` as a dependency — it reads the
  current headers via `form.getValues('httpHeaders')` instead, so it
  only re-runs when the relevant selection actually changes (URL,
  function list, project ref, etc.), not on every header edit.
- Once added, the Authorization header behaves like any other header
  row: fully editable and removable.

## Testing
- Manually verified: selecting an edge function with `verify_jwt: true`
  still auto-fills the Authorization header once.
- Manually verified: editing or deleting that header value now sticks
  instead of reverting.
- Manually verified: switching between webhook types / edge functions
  still works as expected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automatic Authorization header handling for edge functions with JWT verification.
  - Waits for required service and permission details to load before applying default headers.
  - Preserves manually edited Authorization values, including differently capitalized header names.
  - Adds a default Authorization header only when none exists.
  - Prevents unnecessary header changes for non-edge-function URLs or functions without JWT verification.
  - Correctly handles trailing slashes, query parameters, and URL fragments in edge-function URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->