### PR TITLE
fix(studio): await identity sequence updates when duplicating a table

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.duplicateTable.test.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.duplicateTable.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { duplicateTable } from './SidePanelEditor.utils'
+import type { RetrieveTableResult } from '@/data/tables/table-retrieve-query'
+
+// Define mock functions at module level
+const mockExecuteSql = vi.fn()
+const mockFetchQuery = vi.fn()
+const mockInvalidateQueries = vi.fn()
+
+// Setup mocks before imports
+vi.mock('@/data/query-client', () => ({
+  getQueryClient: () => ({
+    fetchQuery: mockFetchQuery,
+    invalidateQueries: mockInvalidateQueries,
+  }),
+}))
+
+vi.mock('@/data/sql/execute-sql-mutation', () => ({
+  executeSql: (...args: unknown[]) => mockExecuteSql(...args),
+}))
+
+const sourceTable = {
+  id: 1,
+  name: 'orders',
+  schema: 'public',
+  comment: null,
+  columns: [
+    { name: 'id', identity_generation: 'BY DEFAULT' },
+    { name: 'note', identity_generation: null },
+  ],
+} as unknown as RetrieveTableResult
+
+const duplicatedTable = { id: 2, name: 'orders_duplicate', schema: 'public' }
+
+const isSequenceUpdateSql = (sql: string) => sql.includes('setval')
+
+describe('duplicateTable', () => {
+  const projectRef = 'test-project-ref'
+  const connectionString = 'postgresql://localhost:5432/test'
+
+  const baseMetadata = {
+    duplicateTable: sourceTable,
+    isRLSEnabled: false,
+    isDuplicateRows: true,
+    foreignKeyRelations: [],
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockExecuteSql.mockResolvedValue({ result: [] })
+    mockInvalidateQueries.mockResolvedValue(undefined)
+    mockFetchQuery.mockResolvedValue([duplicatedTable])
+  })
+
+  it('waits for identity sequence updates to finish before resolving', async () => {
+    let isSequenceUpdateDone = false
+    mockExecuteSql.mockImplementation(({ sql }: { sql: string }) => {
+      if (isSequenceUpdateSql(sql)) {
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            isSequenceUpdateDone = true
+            resolve({ result: [] })
+          }, 10)
+        })
+      }
+      return Promise.resolve({ result: [] })
+    })
+
+    const result = await duplicateTable(
+      projectRef,
+      connectionString,
+      { name: 'orders_duplicate' },
+      baseMetadata
+    )
+
+    expect(isSequenceUpdateDone).toBe(true)
+    expect(result).toStrictEqual(duplicatedTable)
+  })
+
+  it('runs one sequence update per identity column', async () => {
+    await duplicateTable(projectRef, connectionString, { name: 'orders_duplicate' }, baseMetadata)
+
+    const sequenceUpdateCalls = mockExecuteSql.mock.calls.filter(([{ sql }]) =>
+      isSequenceUpdateSql(sql)
+    )
+    expect(sequenceUpdateCalls).toHaveLength(1)
+    expect(sequenceUpdateCalls[0][0].sql).toContain('orders_duplicate_id_seq')
+  })
+
+  it('rejects when an identity sequence update fails', async () => {
+    mockExecuteSql.mockImplementation(({ sql }: { sql: string }) => {
+      if (isSequenceUpdateSql(sql)) {
+        return Promise.reject(new Error('sequence update failed'))
+      }
+      return Promise.resolve({ result: [] })
+    })
+
+    await expect(
+      duplicateTable(projectRef, connectionString, { name: 'orders_duplicate' }, baseMetadata)
+    ).rejects.toThrow('sequence update failed')
+  })
+
+  it('skips sequence updates when rows are not duplicated', async () => {
+    await duplicateTable(
+      projectRef,
+      connectionString,
+      { name: 'orders_duplicate' },
+      { ...baseMetadata, isDuplicateRows: false }
+    )
+
+    const sequenceUpdateCalls = mockExecuteSql.mock.calls.filter(([{ sql }]) =>
+      isSequenceUpdateSql(sql)
+    )
+    expect(sequenceUpdateCalls).toHaveLength(0)
+  })
+})

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
@@ -396,18 +396,20 @@ export const duplicateTable = async (
     // Insert into does not copy over auto increment sequences, so we manually do it next if any
     const columns = duplicateTable.columns ?? []
     const identityColumns = columns.filter((column) => column.identity_generation !== null)
-    identityColumns.map(async (column) => {
-      await executeSql({
-        projectRef,
-        connectionString,
-        sql: getDuplicateIdentitySequenceSQL({
-          sourceTableName,
-          sourceTableSchema,
-          duplicatedTableName,
-          columnName: column.name,
-        }),
-      })
-    })
+    await Promise.all(
+      identityColumns.map((column) =>
+        executeSql({
+          projectRef,
+          connectionString,
+          sql: getDuplicateIdentitySequenceSQL({
+            sourceTableName,
+            sourceTableSchema,
+            duplicatedTableName,
+            columnName: column.name,
+          }),
+        })
+      )
+    )
   }
 
   const tables = await queryClient.fetchQuery({


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Related issue: #48977 (this PR fixes the smaller `duplicateTable` problem called out there, not the larger transaction refactor).

When duplicating a table with "duplicate rows" enabled, `duplicateTable` in `SidePanelEditor.utils.tsx` runs one `setval` query per identity column to sync the sequences of the new table. These queries are fired inside `identityColumns.map(async ...)` and the resulting promises are never awaited. Two things go wrong because of that:

1. The duplicate action can report success while the sequence updates are still running in the background.
2. If a sequence update fails, the error becomes an unhandled promise rejection and is silently dropped. The user sees a successful duplicate, but the new table's sequence still starts at 1, so the next insert fails with a duplicate key error.

## What is the new behavior?

The sequence updates are wrapped in `await Promise.all(...)`, so:

1. The duplicate action only resolves after the sequences are synced.
2. A failing sequence update now rejects the whole action and surfaces to the caller, the same way every other step in this flow already does.

Added unit tests for `duplicateTable` covering both behaviors, plus the cases where sequence updates should and should not run. They follow the same mocking setup as the existing `SidePanelEditor.utils.createTable.test.ts`. Before the fix, the new tests fail and vitest also reports the unhandled rejection; after the fix, all 103 tests in the `SidePanelEditor` folder pass.

## Additional context

The larger issue in #48977 (making multi-step Table Editor operations atomic) is left untouched. The issue itself suggests fixing this unawaited map separately, which is what this PR does.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed table duplication so auto-incrementing identity sequences are fully updated before the operation completes.
  - Improved reliability when duplicating tables with multiple identity columns.
  - Errors encountered while updating identity sequences are now properly surfaced.

- **Tests**
  - Added coverage for successful sequence updates, multiple identity columns, error handling, and cases where no rows are duplicated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->