### PR TITLE
docs(database): fix Performance Advisor dashboard link

### DIFF
--- a/apps/docs/content/guides/database/database-advisors.mdx
+++ b/apps/docs/content/guides/database/database-advisors.mdx
@@ -7,7 +7,7 @@ You can use the Database Performance and Security Advisors to check your databas
 
 ## Using the advisors
 
-In the dashboard, navigate to [Security Advisor](/dashboard/project/_/database/security-advisor) and [Performance Advisor](dashboard/project/_/database/performance-advisor) under Database. The advisors run automatically. You can also manually rerun them after you've resolved issues.
+In the dashboard, navigate to [Security Advisor](/dashboard/project/_/database/security-advisor) and [Performance Advisor](/dashboard/project/_/database/performance-advisor) under Database. The advisors run automatically. You can also manually rerun them after you've resolved issues.
 
 ## Available checks
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs fix (broken link).

## What is the current behavior?

On [Performance and Security Advisors](https://supabase.com/docs/guides/database/database-advisors), the Performance Advisor link is written as a relative path, so it resolves to `/docs/guides/database/dashboard/project/_/database/performance-advisor` and 404s. The Security Advisor link next to it already uses a site-root path.

## What is the new behavior?

The link points at `/dashboard/project/_/database/performance-advisor`, which redirects to the Performance Advisor page in the dashboard.

Fixes #49427


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Performance Advisor dashboard link so it navigates to the intended dashboard page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->