### PR TITLE
docs: add the missing leading slash to the Performance Advisor link

### DIFF
--- a/apps/docs/content/guides/database/database-advisors.mdx
+++ b/apps/docs/content/guides/database/database-advisors.mdx
@@ -7,7 +7,7 @@ You can use the Database Performance and Security Advisors to check your databas
 
 ## Using the advisors
 
-In the dashboard, navigate to [Security Advisor](/dashboard/project/_/database/security-advisor) and [Performance Advisor](dashboard/project/_/database/performance-advisor) under Database. The advisors run automatically. You can also manually rerun them after you've resolved issues.
+In the dashboard, navigate to [Security Advisor](/dashboard/project/_/database/security-advisor) and [Performance Advisor](/dashboard/project/_/database/performance-advisor) under Database. The advisors run automatically. You can also manually rerun them after you've resolved issues.
 
 ## Available checks
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs fix. Closes #49427.

## What is the current behavior?

The two advisor links sit on the same line of `guides/database/database-advisors.mdx`, and only one of them has a leading slash:

```
[Security Advisor](/dashboard/project/_/database/security-advisor)
[Performance Advisor](dashboard/project/_/database/performance-advisor)
```

Without the `/` the second target is relative to the current page, so from `/docs/guides/database/database-advisors` it resolves to `/docs/guides/database/dashboard/project/_/database/performance-advisor` and 404s. The Security Advisor link right beside it works precisely because it has the slash.

| url | live |
| --- | --- |
| `/docs/guides/database/dashboard/project/_/database/performance-advisor` | 404 |
| `/docs/guides/database/database-advisors` | 200 |

## What is the new behavior?

The Performance Advisor link gets its leading slash, so both point at the dashboard.

## Additional context

Scope: I swept `apps/docs/content`, `apps/www/_blog`, `apps/www/_customers` and `examples` for any markdown link whose target starts with `dashboard/` rather than `/dashboard/`. This line is the only one, so the fix is contained rather than the first of a series. I also checked for the same shape with `docs/` and `guides/` targets and found none.

Verification: I checked a deliberate nonsense path in the same namespace first (`/docs/guides/zzz-canary-must-404` returns 404) so the 404 above is meaningful rather than a coincidence of the docs router.

Gates: `test:prettier` passes repo wide and `typecheck --filter=docs --force` passes. No test to add or update, since this is a link target in MDX content.

Freshman contributor. Picked this up from the issue, and I reproduced the 404, confirmed the relative-resolution cause and ran the sweep myself before changing anything.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Performance Advisor link so it navigates correctly from all documentation pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->