### PR TITLE
refactor(design-system): enforce enum validation for backendProviders in registry schema

### DIFF
--- a/apps/design-system/registry/schema.ts
+++ b/apps/design-system/registry/schema.ts
@@ -13,10 +13,7 @@ export const blockChunkSchema = z.object({
     .optional(),
 })
 
-const backendProviderValues = ['next-auth', 'supabase', 'auth0']
-
-const isBackendProvider = (value: unknown): value is (typeof backendProviderValues)[number] =>
-  backendProviderValues.includes(value as string)
+const backendProviderValues = ['next-auth', 'supabase', 'auth0'] as const
 
 export const registryEntrySchema = z.object({
   name: z.string(),
@@ -35,7 +32,7 @@ export const registryEntrySchema = z.object({
     'docs:example',
   ]),
   category: z.string().optional(),
-  backendProviders: z.array(z.string()).optional(),
+  backendProviders: z.array(z.enum(backendProviderValues)).optional(),
   subcategory: z.string().optional(),
   chunks: z.array(blockChunkSchema).optional(),
   // Optional path of file that is exported from a package


### PR DESCRIPTION
### Summary
- Refactored `backendProviders` in `registryEntrySchema` to strictly validate against `backendProviderValues` using `z.enum()`.
- Added `as const` assertion to `backendProviderValues` to derive exact string literal types for Zod enum validation.
- Removed the unused, non-exported `isBackendProvider` type guard helper to keep the schema definition clean, maintainable, and type-safe.

Fixes #49450

### Testing
- Confirmed schema structure aligns with current design-system registry backend provider requirements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Registry entries now accept only supported backend provider values.
  * Invalid or unsupported provider values are rejected during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->