### PR TITLE
chore(common): remove four telemetry events whose features were deleted

### DIFF
--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -1408,18 +1408,6 @@ export interface StudioPricingSidePanelOpenedEvent {
 }
 
 /**
- * User clicks on grafana banner in studio Reports page.
- *
- * @group Events
- * @source studio
- * @page /reports/database
- */
-export interface ReportsDatabaseGrafanaBannerClickedEvent {
-  action: 'reports_database_grafana_banner_clicked'
-  groups: TelemetryGroups
-}
-
-/**
  * The logs.all deprecation banner was rendered, fired once per mount. Acts as the
  * denominator for the dismiss rate. Migration outcome itself is measured via decay in
  * `/v1/projects/:ref/analytics/endpoints/logs.all` traffic in the warehouse, not from this event.
@@ -2453,42 +2441,6 @@ export interface TableRlsEnabledEvent {
     table_name?: string
   }
   groups: Partial<TelemetryGroups>
-}
-
-/**
- * User clicked the generate policies button in the table editor.
- *
- * @group Events
- * @source studio
- * @page /dashboard/project/{ref}/editor
- */
-export interface RlsGeneratePoliciesClickedEvent {
-  action: 'rls_generate_policies_clicked'
-  groups: TelemetryGroups
-}
-
-/**
- * User removed a generated policy from the table editor.
- *
- * @group Events
- * @source studio
- * @page /dashboard/project/{ref}/editor
- */
-export interface RlsGeneratedPolicyRemovedEvent {
-  action: 'rls_generated_policy_removed'
-  groups: TelemetryGroups
-}
-
-/**
- * User successfully created generated RLS policies for a table.
- *
- * @group Events
- * @source studio
- * @page /dashboard/project/{ref}/editor
- */
-export interface RlsGeneratedPoliciesCreatedEvent {
-  action: 'rls_generated_policies_created'
-  groups: TelemetryGroups
 }
 
 /**
@@ -3798,7 +3750,6 @@ export type TelemetryEvent =
   | StudioPricingPlanCtaClickedEvent
   | StudioBillingCancelSubscriptionClickedEvent
   | StudioPricingSidePanelOpenedEvent
-  | ReportsDatabaseGrafanaBannerClickedEvent
   | LogsAllDeprecationBannerExposedEvent
   | LogsAllDeprecationBannerDismissButtonClickedEvent
   | IndexAdvisorEnableButtonClickedEvent
@@ -3856,9 +3807,6 @@ export type TelemetryEvent =
   | TableCreatedEvent
   | TableDataAddedEvent
   | TableRlsEnabledEvent
-  | RlsGeneratePoliciesClickedEvent
-  | RlsGeneratedPolicyRemovedEvent
-  | RlsGeneratedPoliciesCreatedEvent
   | AuthUsersSearchSubmittedEvent
   | CommandMenuOpenedEvent
   | CommandMenuClosedEvent


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Cleanup, following #49454. That PR removed two Unified Logs banner events that nothing fired any more. Four more in the same file have the same profile, from two features that have since been deleted.

## What is the current behavior?

`TelemetryEvent` is a union of 205 actions. These four are declared, exported and in the union, and nothing in the monorepo references either the interface or the action string:

| event | came from | feature today |
| --- | --- | --- |
| `reports_database_grafana_banner_clicked` | #33657 "promote grafana in reports" | no `grafana` reference left under `Reports` |
| `rls_generate_policies_clicked` | #40881 "Generate policies experiment" | no `generatePolicies` reference left in studio |
| `rls_generated_policies_created` | #40881 | as above |
| `rls_generated_policy_removed` | #40881 | as above |

Both features were removed and left their events behind. The grafana one had 4 commits referencing it in `apps/` historically and the RLS trio 2, so these were genuinely wired up once rather than declared and forgotten.

One more angle, from `.claude/skills/telemetry-standards`: its review rules flag "`@page`/`@source` descriptions that don't match the actual implementation" as a required change. All four of these carry a `@page` pointing at UI that no longer exists, so by that rule they are already non-compliant, and deleting them is the honest fix rather than rewriting docs for an event nobody sends.

## What is the new behavior?

The four interfaces and their union members are gone. `typecheck` across `common`, `studio`, `www` and `docs` passes, which is the real proof nothing referenced them.

## Two I deliberately left

`integration_install_completed` and `integration_uninstall_completed` are also unreferenced, but I did not touch them and I would rather say why than quietly include them. They were added by #41786, a naming-convention chore, and `git log -S` shows they have **never** been referenced in `apps/` in any commit. That reads less like an abandoned feature and more like a definition that may exist for an event emitted outside this repo. I cannot check what the platform emits, so removing them is your call rather than mine.

## Scope note

I looked for dynamically built action strings before trusting a literal grep, since a template literal would make this analysis worthless. Every `action:` value in the codebase is a literal; the only `action:` matches that are not are command-menu `action: () => ...` callbacks, which are unrelated.

Gates: `test:prettier` passes repo wide, `typecheck --filter=common --filter=studio --filter=www --filter=docs --force` passes 11/11, and `--filter studio run lint:ratchet` reports rules improved.

Happy to close this if you would rather keep the definitions as a historical catalog. I opened it because #49454 removed exactly this shape a few hours ago, so it looked like a cleanup you wanted rather than one I invented.

Freshman contributor. Found it by asking what #49454 left behind, and I checked each event's history and its feature's current state myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed telemetry tracking for the Grafana banner interaction and RLS policy generation actions.
  * These events will no longer be included in telemetry data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->