### PR TITLE
fix(studio): drop duplicate region lookup in generateNodes

### DIFF
--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.constants.test.ts
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.constants.test.ts
@@ -1,0 +1,22 @@
+import { AWS_REGIONS } from 'shared-data'
+import { describe, expect, it } from 'vitest'
+
+import {
+  AVAILABLE_REPLICA_REGIONS,
+  AWS_REGIONS_COORDINATES,
+} from './InstanceConfiguration.constants'
+
+describe('AVAILABLE_REPLICA_REGIONS', () => {
+  it('covers every AWS region', () => {
+    expect(AVAILABLE_REPLICA_REGIONS.map((region) => region.key).sort()).toEqual(
+      Object.keys(AWS_REGIONS).sort()
+    )
+  })
+
+  it('has coordinates for every AWS region', () => {
+    expect(Object.keys(AWS_REGIONS_COORDINATES).sort()).toEqual(Object.keys(AWS_REGIONS).sort())
+    AVAILABLE_REPLICA_REGIONS.forEach((region) => {
+      expect(region.coordinates).toHaveLength(2)
+    })
+  })
+})

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.constants.ts
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.constants.ts
@@ -58,7 +58,7 @@ export const NODE_HEIGHT_FALLBACKS: Record<string, number> = {
 
 // [Joshen] Coordinates from https://github.com/tobilg/aws-edge-locations/blob/main/data/aws-edge-locations.json
 // In the format of [lon, lat]
-export const AWS_REGIONS_COORDINATES: { [key: string]: [number, number] } = {
+export const AWS_REGIONS_COORDINATES: Record<AWS_REGIONS_KEYS, [number, number]> = {
   SOUTHEAST_ASIA: [103.8, 1.37],
   NORTHEAST_ASIA: [139.42, 35.41],
   NORTHEAST_ASIA_2: [126.98, 37.56],
@@ -79,16 +79,14 @@ export const AWS_REGIONS_COORDINATES: { [key: string]: [number, number] } = {
 }
 
 // [Joshen] Just to make sure that we just depend on AWS_REGIONS to determine available
-export const AVAILABLE_REPLICA_REGIONS: Region[] = Object.keys(AWS_REGIONS)
-  .map((key) => {
-    return {
-      key: key as AWS_REGIONS_KEYS,
-      name: AWS_REGIONS?.[key as AWS_REGIONS_KEYS].displayName,
-      region: AWS_REGIONS?.[key as AWS_REGIONS_KEYS].code,
-      coordinates: AWS_REGIONS_COORDINATES[key],
-    }
-  })
-  .filter((x) => x.coordinates !== undefined)
+export const AVAILABLE_REPLICA_REGIONS: Region[] = (
+  Object.keys(AWS_REGIONS) as AWS_REGIONS_KEYS[]
+).map((key) => ({
+  key,
+  name: AWS_REGIONS[key].displayName,
+  region: AWS_REGIONS[key].code,
+  coordinates: AWS_REGIONS_COORDINATES[key],
+}))
 
 // [Joshen] Just a more user friendly language, so that all the verbs are progressive
 export const INIT_PROGRESS = {

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.utils.ts
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.utils.ts
@@ -1,11 +1,9 @@
 import dagre from '@dagrejs/dagre'
 import { Edge, Node, Position } from '@xyflow/react'
 import { groupBy } from 'lodash'
-import { AWS_REGIONS, AWS_REGIONS_KEYS } from 'shared-data'
 
 import {
   AVAILABLE_REPLICA_REGIONS,
-  AWS_REGIONS_COORDINATES,
   NODE_HEIGHT_FALLBACKS,
   NODE_SEP,
   NODE_WIDTH,
@@ -47,26 +45,9 @@ export const generateNodes = ({
         }
       : undefined
 
-  // [Joshen] We should be finding from AVAILABLE_REPLICA_REGIONS instead
-  // but because the new regions (zurich, stockholm, ohio, paris) dont have
-  // coordinates yet in AWS_REGIONS_COORDINATES - we'll need to add them in once
-  // they are ready to spin up coordinates for
-  const primaryRegion = Object.keys(AWS_REGIONS)
-    .map((key) => {
-      return {
-        key: key as AWS_REGIONS_KEYS,
-        name: AWS_REGIONS?.[key as AWS_REGIONS_KEYS].displayName,
-        region: AWS_REGIONS?.[key as AWS_REGIONS_KEYS].code,
-        coordinates: AWS_REGIONS_COORDINATES[key],
-      }
-    })
-    .find((region) => primary.region.includes(region.region))
-
-  // [Joshen] Once we have the coordinates for Zurich and Stockholm, we can remove the above
-  // and uncomment below for better simplicity
-  // const primaryRegion = AVAILABLE_REPLICA_REGIONS.find((region) =>
-  //   primary.region.includes(region.region)
-  // )
+  const primaryRegion = AVAILABLE_REPLICA_REGIONS.find((region) =>
+    primary.region.includes(region.region)
+  )
 
   const primaryNode: Node = {
     position,


### PR DESCRIPTION
Sentry: `ReferenceError: REGIONS is not defined` (SUPABASE-APP-K7P), thrown from the `Object.keys(AWS_REGIONS).map(...)` callback in `InstanceConfiguration.utils.ts`. No identifier named `REGIONS` exists in that scope in source, so this is a bundling/mangling issue in the minified production chunk rather than a logic bug.

That block was already marked as temporary: it existed only because some regions lacked entries in `AWS_REGIONS_COORDINATES`. All 17 `AWS_REGIONS` keys now have coordinates, so `AVAILABLE_REPLICA_REGIONS` is the full list and the duplicated mapping can go.

- Look up the primary region from `AVAILABLE_REPLICA_REGIONS`, same as the replica nodes right below it
- Removes the `AWS_REGIONS` / `AWS_REGIONS_COORDINATES` imports from the utils file

No behavior change expected: both paths resolve the same set of regions.