### PR TITLE
Fix running queyr cell marks notebook tab with unsaved change indicator

### DIFF
--- a/apps/studio/components/interfaces/Explorer/QueryCell/index.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryCell/index.tsx
@@ -81,8 +81,13 @@ export const QueryCell = forwardRef<QueryEditorHandle, QueryCellProps>(function 
     updateQueryCell((candidate) => ({ ...cloneQueryCell(candidate), title: nextTitle }))
   }
 
-  const handleSqlCommit = (value: string) =>
+  // Running a cell re-commits its current SQL (see QueryEditor's handleRunQuery) even when
+  // nothing changed — skip the store write so that doesn't spuriously mark the notebook
+  // unsaved.
+  const handleSqlCommit = (value: string) => {
+    if (value === cell.unchecked_sql) return
     updateQueryCell((candidate) => setCellSql(candidate, value))
+  }
 
   const handleDisplayChange = (display: QueryDisplay) =>
     updateQueryCell((candidate) => ({


### PR DESCRIPTION
## Context

Fixes a small bug whereby running any query cell within a notebook will mark the notebook tab with the unsaved changes status indicator

`handleSqlCommit` gets called when we run the query, and it flips the notebook's status to "unsaved" hence why its happening. Hence opting to skip committing the changes in `handleSqlCommit` if there's no change to the SQL content

<img width="224" height="69" alt="image" src="https://github.com/user-attachments/assets/7015b527-b249-4f2e-bcf1-948b5fe3f5a9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented unnecessary notebook updates when committed SQL is unchanged.
  - Continued saving SQL changes as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->