### PR TITLE
Trigger native browser confirmation when exiting session if there's unsaved changes

### DIFF
--- a/apps/studio/components/interfaces/Explorer/ExplorerNotebookTabCoordinator.tsx
+++ b/apps/studio/components/interfaces/Explorer/ExplorerNotebookTabCoordinator.tsx
@@ -36,6 +36,19 @@ export const ExplorerNotebookTabCoordinator = () => {
   const tabs = useContext(TabsStateContext)
 
   useEffect(() => {
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      const hasUnsaved = Object.values(notebooksState.notebooks).some(hasDiscardableChanges)
+      if (hasUnsaved) {
+        event.preventDefault()
+        event.returnValue = true
+      }
+    }
+
+    window.addEventListener('beforeunload', handleBeforeUnload)
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload)
+  }, [])
+
+  useEffect(() => {
     return tabs.registerTabTypeHandler('notebook', {
       onClose: (tab) => {
         const notebookId = tab.metadata?.notebookId


### PR DESCRIPTION
## Context

As per PR title - triggers the native browser discard confirmation dialog while in the explorer UI if exiting the session (e.g by refreshing or closing the tab) and there's any tabs with unsaved changes

<img width="593" height="431" alt="image" src="https://github.com/user-attachments/assets/85b50c3e-ee69-4d27-8819-12151e6fc9f7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a warning when attempting to leave or close the page while a notebook has unsaved changes.
  * Prevented unnecessary warnings when no discardable changes are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->