### PR TITLE
refine display settings ui

### DIFF
--- a/apps/studio/components/interfaces/Explorer/QueryEditor/DisplaySettingsButton.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryEditor/DisplaySettingsButton.tsx
@@ -9,7 +9,6 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-  Separator,
   Switch,
   ToggleGroup,
   ToggleGroupItem,
@@ -112,191 +111,189 @@ export const DisplaySettingsButton = ({
         aria-label="Result display settings"
         className="mr-8 flex w-80 flex-col p-3"
       >
-        <div className="flex flex-col">
-          <FormItemLayout isReactForm={false} layout="horizontal" size="tiny" label="View as">
-            <ToggleGroup
-              value={view}
-              onValueChange={(value) => {
-                if (value === 'table' || value === 'chart') onChangeView(value)
-              }}
-              aria-label="View result as"
-              variant="default"
-              size="tiny"
-              type="single"
-              className="w-full"
-            >
-              <ToggleGroupItem value="table" className="w-full gap-2">
-                <Table size={14} />
-                <span>Table</span>
-              </ToggleGroupItem>
-              <ToggleGroupItem value="chart" className="w-full gap-2">
-                <BarChart2 size={14} />
-                <span>Chart</span>
-              </ToggleGroupItem>
-            </ToggleGroup>
-          </FormItemLayout>
-
-          <Separator className="my-2.5" />
-
-          <fieldset
-            disabled={view === 'table'}
-            aria-disabled={view === 'table'}
-            className="m-0 flex min-w-0 flex-col gap-y-2.5 border-0 p-0"
+        <div className="flex flex-col gap-y-2.5">
+          <ToggleGroup
+            value={view}
+            onValueChange={(value) => {
+              if (value === 'table' || value === 'chart') onChangeView(value)
+            }}
+            aria-label="View result as"
+            variant="outline"
+            size="tiny"
+            type="single"
+            className="w-full"
           >
-            <FormItemLayout isReactForm={false} layout="horizontal" size="tiny" label="Chart type">
-              <ToggleGroup
-                value={type}
-                onValueChange={(value) => {
-                  if (value === 'bar' || value === 'line') onUpdateChartConfig({ type: value })
-                }}
-                aria-label="Chart type"
-                variant="default"
-                size="tiny"
-                type="single"
-                className="w-full"
-              >
-                <ToggleGroupItem value="bar" className="w-full gap-2">
-                  <BarChart2 size={14} />
-                  <span>Bar</span>
-                </ToggleGroupItem>
-                <ToggleGroupItem value="line" className="w-full gap-2">
-                  <LineChart size={14} />
-                  <span>Line</span>
-                </ToggleGroupItem>
-              </ToggleGroup>
-            </FormItemLayout>
+            <ToggleGroupItem value="table" className="w-full gap-2">
+              <Table size={14} />
+              <span>Table</span>
+            </ToggleGroupItem>
+            <ToggleGroupItem value="chart" className="w-full gap-2">
+              <BarChart2 size={14} />
+              <span>Chart</span>
+            </ToggleGroupItem>
+          </ToggleGroup>
 
-            <FormItemLayout
-              id="result-x-axis"
-              isReactForm={false}
-              layout="horizontal"
-              size="tiny"
-              label="X axis"
-            >
-              <Select
-                value={x_column}
-                onValueChange={(x_column) => onUpdateChartConfig({ x_column })}
-              >
-                <SelectTrigger id="result-x-axis" size="tiny" className="w-full">
-                  <SelectValue placeholder="Select a column" />
-                </SelectTrigger>
-                <SelectContent>
-                  {columns.map((x) => (
-                    <SelectItem key={x} value={x}>
-                      {x}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </FormItemLayout>
+          {view === 'chart' && (
+            <div className="flex min-w-0 flex-col gap-y-2.5">
+              <FormItemLayout isReactForm={false} layout="horizontal" size="tiny" label="Chart type">
+                <ToggleGroup
+                  value={type}
+                  onValueChange={(value) => {
+                    if (value === 'bar' || value === 'line') onUpdateChartConfig({ type: value })
+                  }}
+                  aria-label="Chart type"
+                  variant="default"
+                  size="tiny"
+                  type="single"
+                  className="w-full"
+                >
+                  <ToggleGroupItem value="bar" className="w-full gap-2">
+                    <BarChart2 size={14} />
+                    <span>Bar</span>
+                  </ToggleGroupItem>
+                  <ToggleGroupItem value="line" className="w-full gap-2">
+                    <LineChart size={14} />
+                    <span>Line</span>
+                  </ToggleGroupItem>
+                </ToggleGroup>
+              </FormItemLayout>
 
-            <FormItemLayout
-              id="result-y-axis"
-              isReactForm={false}
-              layout="horizontal"
-              size="tiny"
-              label="Y axis"
-            >
-              <MultiSelector
+              <FormItemLayout
+                id="result-x-axis"
+                isReactForm={false}
+                layout="horizontal"
                 size="tiny"
-                values={y_series}
-                onValuesChange={(values) => {
-                  if (values.length > MAX_CHART_Y_SERIES) return
-                  onUpdateChartConfig({ y_series: values })
-                }}
-                className="w-full"
+                label="X axis"
               >
-                <MultiSelectorTrigger
-                  id="result-y-axis"
-                  mode="inline-combobox"
-                  label={`Select up to ${MAX_CHART_Y_SERIES} columns`}
-                  deletableBadge
-                  badgeLimit={1}
-                  showIcon={false}
-                  className="min-w-0"
-                />
-                <MultiSelectorContent>
-                  <MultiSelectorList>
+                <Select
+                  value={x_column}
+                  onValueChange={(x_column) => onUpdateChartConfig({ x_column })}
+                >
+                  <SelectTrigger id="result-x-axis" size="tiny" className="w-full">
+                    <SelectValue placeholder="Select a column" />
+                  </SelectTrigger>
+                  <SelectContent>
                     {columns.map((x) => (
-                      <MultiSelectorItem
-                        key={x}
-                        value={x}
-                        disabled={y_series.length >= MAX_CHART_Y_SERIES && !y_series.includes(x)}
-                      >
+                      <SelectItem key={x} value={x}>
                         {x}
-                      </MultiSelectorItem>
+                      </SelectItem>
                     ))}
-                  </MultiSelectorList>
-                </MultiSelectorContent>
-              </MultiSelector>
-            </FormItemLayout>
+                  </SelectContent>
+                </Select>
+              </FormItemLayout>
 
-            <FormItemLayout isReactForm={false} layout="horizontal" size="tiny" label="Scale">
-              <ToggleGroup
-                value={scale}
-                onValueChange={(value) => {
-                  if (value === 'linear' || (value === 'log' && canToggleLogScale)) {
-                    onUpdateChartConfig({ scale: value })
-                  }
-                }}
-                aria-label="Chart scale"
-                variant="default"
+              <FormItemLayout
+                id="result-y-axis"
+                isReactForm={false}
+                layout="horizontal"
                 size="tiny"
-                type="single"
-                className="w-full"
+                label="Y axis"
               >
-                <ToggleGroupItem value="linear" className="w-full">
-                  Linear
-                </ToggleGroupItem>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="flex w-full">
-                      <ToggleGroupItem value="log" disabled={!canToggleLogScale} className="w-full">
-                        Log
-                      </ToggleGroupItem>
-                    </span>
-                  </TooltipTrigger>
-                  {!canToggleLogScale && (
-                    <TooltipContent side="left">
-                      {getLogScaleDisabledReason(y_series)}
-                    </TooltipContent>
-                  )}
-                </Tooltip>
-              </ToggleGroup>
-            </FormItemLayout>
+                <MultiSelector
+                  size="tiny"
+                  values={y_series}
+                  onValuesChange={(values) => {
+                    if (values.length > MAX_CHART_Y_SERIES) return
+                    onUpdateChartConfig({ y_series: values })
+                  }}
+                  className="w-full"
+                >
+                  <MultiSelectorTrigger
+                    id="result-y-axis"
+                    mode="inline-combobox"
+                    label={`Select up to ${MAX_CHART_Y_SERIES} columns`}
+                    deletableBadge
+                    badgeLimit={1}
+                    showIcon={false}
+                    className="min-w-0"
+                  />
+                  <MultiSelectorContent>
+                    <MultiSelectorList>
+                      {columns.map((x) => (
+                        <MultiSelectorItem
+                          key={x}
+                          value={x}
+                          disabled={y_series.length >= MAX_CHART_Y_SERIES && !y_series.includes(x)}
+                        >
+                          {x}
+                        </MultiSelectorItem>
+                      ))}
+                    </MultiSelectorList>
+                  </MultiSelectorContent>
+                </MultiSelector>
+              </FormItemLayout>
 
-            <FormItemLayout
-              id="cumulative"
-              isReactForm={false}
-              layout="horizontal"
-              size="tiny"
-              label="Cumulative"
-            >
-              <Switch
+              <FormItemLayout isReactForm={false} layout="horizontal" size="tiny" label="Scale">
+                <ToggleGroup
+                  value={scale}
+                  onValueChange={(value) => {
+                    if (value === 'linear' || (value === 'log' && canToggleLogScale)) {
+                      onUpdateChartConfig({ scale: value })
+                    }
+                  }}
+                  aria-label="Chart scale"
+                  variant="default"
+                  size="tiny"
+                  type="single"
+                  className="w-full"
+                >
+                  <ToggleGroupItem value="linear" className="w-full">
+                    Linear
+                  </ToggleGroupItem>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="flex w-full" tabIndex={!canToggleLogScale ? 0 : undefined}>
+                        <ToggleGroupItem
+                          value="log"
+                          disabled={!canToggleLogScale}
+                          className="w-full"
+                        >
+                          Log
+                        </ToggleGroupItem>
+                      </span>
+                    </TooltipTrigger>
+                    {!canToggleLogScale && (
+                      <TooltipContent side="left">
+                        {getLogScaleDisabledReason(y_series)}
+                      </TooltipContent>
+                    )}
+                  </Tooltip>
+                </ToggleGroup>
+              </FormItemLayout>
+
+              <FormItemLayout
                 id="cumulative"
-                aria-label="Cumulative"
-                size="small"
-                checked={cumulative}
-                onCheckedChange={(cumulative) => onUpdateChartConfig({ cumulative })}
-              />
-            </FormItemLayout>
+                isReactForm={false}
+                layout="horizontal"
+                size="tiny"
+                label="Cumulative"
+              >
+                <Switch
+                  id="cumulative"
+                  aria-label="Cumulative"
+                  size="small"
+                  checked={cumulative}
+                  onCheckedChange={(cumulative) => onUpdateChartConfig({ cumulative })}
+                />
+              </FormItemLayout>
 
-            <FormItemLayout
-              id="show_labels"
-              isReactForm={false}
-              layout="horizontal"
-              size="tiny"
-              label="Show labels"
-            >
-              <Switch
+              <FormItemLayout
                 id="show_labels"
-                aria-label="Show labels"
-                size="small"
-                checked={show_labels}
-                onCheckedChange={(show_labels) => onUpdateChartConfig({ show_labels })}
-              />
-            </FormItemLayout>
-          </fieldset>
+                isReactForm={false}
+                layout="horizontal"
+                size="tiny"
+                label="Show labels"
+              >
+                <Switch
+                  id="show_labels"
+                  aria-label="Show labels"
+                  size="small"
+                  checked={show_labels}
+                  onCheckedChange={(show_labels) => onUpdateChartConfig({ show_labels })}
+                />
+              </FormItemLayout>
+            </div>
+          )}
         </div>
       </PopoverContent>
     </Popover>

--- a/apps/studio/components/interfaces/Explorer/QueryEditor/DisplaySettingsButton.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryEditor/DisplaySettingsButton.tsx
@@ -1,16 +1,16 @@
-import { BarChart2, Settings2, Table } from 'lucide-react'
+import { BarChart2, LineChart, Settings2, Table } from 'lucide-react'
 import { useEffect, useEffectEvent, useMemo } from 'react'
 import {
-  Checkbox,
   Popover,
   PopoverContent,
-  PopoverSeparator,
   PopoverTrigger,
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
+  Separator,
+  Switch,
   ToggleGroup,
   ToggleGroupItem,
   Tooltip,
@@ -107,181 +107,197 @@ export const DisplaySettingsButton = ({
       <PopoverTrigger asChild>
         <ExplorerToolbarAction disabled={disabled} icon={<Settings2 />} tooltip="Result settings" />
       </PopoverTrigger>
-      <PopoverContent side="bottom" className="flex flex-col gap-y-3 p-0 py-3 mr-8 w-80">
-        <div className="flex flex-col gap-y-3 px-3">
-          <p className="text-xs tracking-tighter uppercase font-mono text-foreground-lighter">
-            Result display settings
-          </p>
-
-          <FormItemLayout isReactForm={false} label="View data as">
+      <PopoverContent
+        side="bottom"
+        aria-label="Result display settings"
+        className="mr-8 flex w-80 flex-col p-3"
+      >
+        <div className="flex flex-col">
+          <FormItemLayout isReactForm={false} layout="horizontal" size="tiny" label="View as">
             <ToggleGroup
               value={view}
               onValueChange={(value) => {
                 if (value === 'table' || value === 'chart') onChangeView(value)
               }}
-              variant="outline"
+              aria-label="View result as"
+              variant="default"
+              size="tiny"
               type="single"
+              className="w-full"
             >
-              <ToggleGroupItem value="table" className="w-full gap-x-2 data-[state=on]:bg-accent">
+              <ToggleGroupItem value="table" className="w-full gap-2">
                 <Table size={14} />
-                <p>Table</p>
+                <span>Table</span>
               </ToggleGroupItem>
-              <ToggleGroupItem value="chart" className="w-full gap-x-2 data-[state=on]:bg-accent">
+              <ToggleGroupItem value="chart" className="w-full gap-2">
                 <BarChart2 size={14} />
-                <p>Chart</p>
+                <span>Chart</span>
               </ToggleGroupItem>
             </ToggleGroup>
           </FormItemLayout>
-        </div>
 
-        {view === 'chart' && (
-          <>
-            <PopoverSeparator />
+          <Separator className="my-2.5" />
 
-            <FormItemLayout isReactForm={false} label="Render chart as" className="px-3 mb-1">
+          <fieldset
+            disabled={view === 'table'}
+            aria-disabled={view === 'table'}
+            className="m-0 flex min-w-0 flex-col gap-y-2.5 border-0 p-0"
+          >
+            <FormItemLayout isReactForm={false} layout="horizontal" size="tiny" label="Chart type">
               <ToggleGroup
                 value={type}
                 onValueChange={(value) => {
                   if (value === 'bar' || value === 'line') onUpdateChartConfig({ type: value })
                 }}
-                variant="outline"
+                aria-label="Chart type"
+                variant="default"
+                size="tiny"
                 type="single"
+                className="w-full"
               >
-                <ToggleGroupItem value="bar" className="w-full data-[state=on]:bg-accent">
-                  Bar
+                <ToggleGroupItem value="bar" className="w-full gap-2">
+                  <BarChart2 size={14} />
+                  <span>Bar</span>
                 </ToggleGroupItem>
-                <ToggleGroupItem value="line" className="w-full data-[state=on]:bg-accent">
-                  Line
+                <ToggleGroupItem value="line" className="w-full gap-2">
+                  <LineChart size={14} />
+                  <span>Line</span>
                 </ToggleGroupItem>
               </ToggleGroup>
             </FormItemLayout>
 
-            <div className="px-3 flex flex-col gap-y-2">
-              <FormItemLayout
-                isReactForm={false}
-                layout="flex-row-reverse"
-                label="X axis"
-                className="[&>div:first-child]:xl:w-3/5"
+            <FormItemLayout
+              id="result-x-axis"
+              isReactForm={false}
+              layout="horizontal"
+              size="tiny"
+              label="X axis"
+            >
+              <Select
+                value={x_column}
+                onValueChange={(x_column) => onUpdateChartConfig({ x_column })}
               >
-                <Select
-                  value={x_column}
-                  onValueChange={(x_column) => onUpdateChartConfig({ x_column })}
-                >
-                  <SelectTrigger className="w-full">
-                    <SelectValue placeholder="Select a column" />
-                  </SelectTrigger>
-                  <SelectContent>
+                <SelectTrigger id="result-x-axis" size="tiny" className="w-full">
+                  <SelectValue placeholder="Select a column" />
+                </SelectTrigger>
+                <SelectContent>
+                  {columns.map((x) => (
+                    <SelectItem key={x} value={x}>
+                      {x}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </FormItemLayout>
+
+            <FormItemLayout
+              id="result-y-axis"
+              isReactForm={false}
+              layout="horizontal"
+              size="tiny"
+              label="Y axis"
+            >
+              <MultiSelector
+                size="tiny"
+                values={y_series}
+                onValuesChange={(values) => {
+                  if (values.length > MAX_CHART_Y_SERIES) return
+                  onUpdateChartConfig({ y_series: values })
+                }}
+                className="w-full"
+              >
+                <MultiSelectorTrigger
+                  id="result-y-axis"
+                  mode="inline-combobox"
+                  label={`Select up to ${MAX_CHART_Y_SERIES} columns`}
+                  deletableBadge
+                  badgeLimit={1}
+                  showIcon={false}
+                  className="min-w-0"
+                />
+                <MultiSelectorContent>
+                  <MultiSelectorList>
                     {columns.map((x) => (
-                      <SelectItem key={x} value={x}>
+                      <MultiSelectorItem
+                        key={x}
+                        value={x}
+                        disabled={y_series.length >= MAX_CHART_Y_SERIES && !y_series.includes(x)}
+                      >
                         {x}
-                      </SelectItem>
+                      </MultiSelectorItem>
                     ))}
-                  </SelectContent>
-                </Select>
-              </FormItemLayout>
+                  </MultiSelectorList>
+                </MultiSelectorContent>
+              </MultiSelector>
+            </FormItemLayout>
 
-              <FormItemLayout
-                isReactForm={false}
-                layout="flex-row-reverse"
-                label="Y Axis"
-                className="[&>div:first-child]:xl:w-3/5"
-              >
-                <MultiSelector
-                  values={y_series}
-                  onValuesChange={(values) => {
-                    if (values.length > MAX_CHART_Y_SERIES) return
-                    onUpdateChartConfig({ y_series: values })
-                  }}
-                  className="w-full"
-                >
-                  <MultiSelectorTrigger
-                    mode="inline-combobox"
-                    label={`Select up to ${MAX_CHART_Y_SERIES} columns`}
-                    deletableBadge
-                    badgeLimit="wrap"
-                    showIcon={false}
-                    className="min-w-32!"
-                  />
-                  <MultiSelectorContent>
-                    <MultiSelectorList>
-                      {columns.map((x) => (
-                        <MultiSelectorItem
-                          key={x}
-                          value={x}
-                          disabled={y_series.length >= MAX_CHART_Y_SERIES && !y_series.includes(x)}
-                        >
-                          {x}
-                        </MultiSelectorItem>
-                      ))}
-                    </MultiSelectorList>
-                  </MultiSelectorContent>
-                </MultiSelector>
-              </FormItemLayout>
-
-              <FormItemLayout
-                isReactForm={false}
-                layout="flex-row-reverse"
-                label="Scale"
-                className="[&>div:first-child]:xl:w-3/5"
-              >
-                <Select
-                  value={scale}
-                  onValueChange={(scale) =>
-                    onUpdateChartConfig({ scale: scale as 'log' | 'linear' })
+            <FormItemLayout isReactForm={false} layout="horizontal" size="tiny" label="Scale">
+              <ToggleGroup
+                value={scale}
+                onValueChange={(value) => {
+                  if (value === 'linear' || (value === 'log' && canToggleLogScale)) {
+                    onUpdateChartConfig({ scale: value })
                   }
-                >
-                  <SelectTrigger className="w-full">
-                    <SelectValue placeholder="Select a column" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="linear">Linear</SelectItem>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <SelectItem
-                          disabled={!canToggleLogScale}
-                          value="log"
-                          className={!canToggleLogScale ? '!pointer-events-auto' : undefined}
-                        >
-                          Logarithmic
-                        </SelectItem>
-                      </TooltipTrigger>
-                      {!canToggleLogScale && (
-                        <TooltipContent side="left">
-                          {getLogScaleDisabledReason(y_series)}
-                        </TooltipContent>
-                      )}
-                    </Tooltip>
-                  </SelectContent>
-                </Select>
-              </FormItemLayout>
+                }}
+                aria-label="Chart scale"
+                variant="default"
+                size="tiny"
+                type="single"
+                className="w-full"
+              >
+                <ToggleGroupItem value="linear" className="w-full">
+                  Linear
+                </ToggleGroupItem>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="flex w-full">
+                      <ToggleGroupItem value="log" disabled={!canToggleLogScale} className="w-full">
+                        Log
+                      </ToggleGroupItem>
+                    </span>
+                  </TooltipTrigger>
+                  {!canToggleLogScale && (
+                    <TooltipContent side="left">
+                      {getLogScaleDisabledReason(y_series)}
+                    </TooltipContent>
+                  )}
+                </Tooltip>
+              </ToggleGroup>
+            </FormItemLayout>
 
-              <FormItemLayout id="cumulative" isReactForm={false} layout="flex" label="Cumulative">
-                <Checkbox
-                  id="cumulative"
-                  checked={cumulative}
-                  onCheckedChange={(cumulative) =>
-                    onUpdateChartConfig({ cumulative: Boolean(cumulative) })
-                  }
-                />
-              </FormItemLayout>
+            <FormItemLayout
+              id="cumulative"
+              isReactForm={false}
+              layout="horizontal"
+              size="tiny"
+              label="Cumulative"
+            >
+              <Switch
+                id="cumulative"
+                aria-label="Cumulative"
+                size="small"
+                checked={cumulative}
+                onCheckedChange={(cumulative) => onUpdateChartConfig({ cumulative })}
+              />
+            </FormItemLayout>
 
-              <FormItemLayout
+            <FormItemLayout
+              id="show_labels"
+              isReactForm={false}
+              layout="horizontal"
+              size="tiny"
+              label="Show labels"
+            >
+              <Switch
                 id="show_labels"
-                isReactForm={false}
-                layout="flex"
-                label="Show labels"
-              >
-                <Checkbox
-                  id="show_labels"
-                  checked={show_labels}
-                  onCheckedChange={(show_labels) =>
-                    onUpdateChartConfig({ show_labels: Boolean(show_labels) })
-                  }
-                />
-              </FormItemLayout>
-            </div>
-          </>
-        )}
+                aria-label="Show labels"
+                size="small"
+                checked={show_labels}
+                onCheckedChange={(show_labels) => onUpdateChartConfig({ show_labels })}
+              />
+            </FormItemLayout>
+          </fieldset>
+        </div>
       </PopoverContent>
     </Popover>
   )

--- a/apps/studio/components/interfaces/Explorer/QueryEditor/DisplaySettingsButton.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryEditor/DisplaySettingsButton.tsx
@@ -135,7 +135,12 @@ export const DisplaySettingsButton = ({
 
           {view === 'chart' && (
             <div className="flex min-w-0 flex-col gap-y-2.5">
-              <FormItemLayout isReactForm={false} layout="horizontal" size="tiny" label="Chart type">
+              <FormItemLayout
+                isReactForm={false}
+                layout="horizontal"
+                size="tiny"
+                label="Chart type"
+              >
                 <ToggleGroup
                   value={type}
                   onValueChange={(value) => {

--- a/packages/ui-patterns/src/multi-select/multi-select.test.tsx
+++ b/packages/ui-patterns/src/multi-select/multi-select.test.tsx
@@ -48,6 +48,16 @@ function MultiSelectDemo() {
 }
 
 describe('multi-select', () => {
+  it('supports the tiny control size', () => {
+    render(
+      <MultiSelector size="tiny" values={[]} onValuesChange={() => undefined}>
+        <MultiSelectorTrigger label="Select fruits" />
+      </MultiSelector>
+    )
+
+    expect(screen.getByRole('combobox')).toHaveClass('h-[26px]')
+  })
+
   it('renders selected values with a custom label', () => {
     render(
       <MultiSelector values={['101']} onValuesChange={() => undefined}>

--- a/packages/ui-patterns/src/multi-select/multi-select.test.tsx
+++ b/packages/ui-patterns/src/multi-select/multi-select.test.tsx
@@ -55,7 +55,7 @@ describe('multi-select', () => {
       </MultiSelector>
     )
 
-    expect(screen.getByRole('combobox')).toHaveClass('h-[26px]')
+    expect(screen.getByRole('combobox')).toHaveClass('h-[26px]', 'p-0.5')
   })
 
   it('renders selected values with a custom label', () => {

--- a/packages/ui-patterns/src/multi-select/multi-select.tsx
+++ b/packages/ui-patterns/src/multi-select/multi-select.tsx
@@ -212,6 +212,21 @@ export interface MultiSelectorTriggerProps extends React.HTMLAttributes<HTMLButt
   renderValue?: (value: string) => React.ReactNode
 }
 
+const MultiSelectorTriggerVariants = cva('', {
+  variants: {
+    size: {
+      tiny: 'h-[26px] px-2.5 py-0.5 text-xs',
+      small: 'min-h-[34px] px-3 py-1.5 text-sm',
+      medium: 'min-h-[38px] px-4 py-2 text-sm',
+      large: 'min-h-[42px] px-4 py-2 text-base',
+      xlarge: 'min-h-[50px] px-6 py-3 text-base',
+    },
+  },
+  defaultVariants: {
+    size: SIZE_VARIANTS_DEFAULT,
+  },
+})
+
 const MultiSelectorTrigger = React.forwardRef<HTMLButtonElement, MultiSelectorTriggerProps>(
   (
     {
@@ -228,7 +243,7 @@ const MultiSelectorTrigger = React.forwardRef<HTMLButtonElement, MultiSelectorTr
     },
     ref
   ) => {
-    const { activeIndex, values, setInputValue, toggleValue, disabled, open, setOpen } =
+    const { activeIndex, values, setInputValue, toggleValue, disabled, open, setOpen, size } =
       useMultiSelect()
 
     const inputRef = React.useRef<HTMLButtonElement>(null)
@@ -293,8 +308,8 @@ const MultiSelectorTrigger = React.forwardRef<HTMLButtonElement, MultiSelectorTr
           type="button"
           role="combobox"
           className={cn(
-            'flex w-full min-w-[200px] min-h-[34px] items-center justify-between rounded-md border',
-            'border-strong px-3 py-1.5 text-sm',
+            'flex w-full min-w-[200px] items-center justify-between rounded-md border',
+            'border-strong',
             // Empty: raised plate. Filled: sunk well for chips.
             values.length > 0 ? 'bg-field' : 'bg-control-raised',
             'placeholder:text-muted-foreground',
@@ -302,6 +317,7 @@ const MultiSelectorTrigger = React.forwardRef<HTMLButtonElement, MultiSelectorTr
             'disabled:cursor-not-allowed disabled:opacity-50',
             'hover:border-control-hover transition-colors duration-200',
             open && 'border-control-hover',
+            MultiSelectorTriggerVariants({ size }),
             className
           )}
           {...props}

--- a/packages/ui-patterns/src/multi-select/multi-select.tsx
+++ b/packages/ui-patterns/src/multi-select/multi-select.tsx
@@ -215,7 +215,7 @@ export interface MultiSelectorTriggerProps extends React.HTMLAttributes<HTMLButt
 const MultiSelectorTriggerVariants = cva('', {
   variants: {
     size: {
-      tiny: 'h-[26px] px-2.5 py-0.5 text-xs',
+      tiny: 'h-[26px] p-0.5 text-xs',
       small: 'min-h-[34px] px-3 py-1.5 text-sm',
       medium: 'min-h-[38px] px-4 py-2 text-sm',
       large: 'min-h-[42px] px-4 py-2 text-base',
@@ -325,7 +325,8 @@ const MultiSelectorTrigger = React.forwardRef<HTMLButtonElement, MultiSelectorTr
           <div
             ref={badgesRef}
             className={cn(
-              'flex gap-1 -ml-1 overflow-hidden flex-1',
+              'flex gap-1 overflow-hidden flex-1',
+              size !== 'tiny' && '-ml-1',
               IS_BADGE_LIMIT_WRAP && 'flex-wrap',
               !IS_BADGE_LIMIT_WRAP &&
                 'overflow-x-auto scrollbar-thin scrollbar-track-transparent transition-colors scrollbar-thumb-muted-foreground dark:scrollbar-thumb-muted scrollbar-thumb-rounded-lg'

--- a/packages/ui/src/components/shadcn/ui/toggle.test.tsx
+++ b/packages/ui/src/components/shadcn/ui/toggle.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { Toggle } from './toggle'
+
+describe('Toggle', () => {
+  it('aligns its compact sizes with form controls', () => {
+    const { rerender } = render(<Toggle size="tiny">Tiny</Toggle>)
+
+    expect(screen.getByRole('button', { name: 'Tiny' })).toHaveClass('h-[26px]')
+
+    rerender(<Toggle size="sm">Small</Toggle>)
+
+    expect(screen.getByRole('button', { name: 'Small' })).toHaveClass('h-[34px]')
+  })
+})

--- a/packages/ui/src/components/shadcn/ui/toggle.tsx
+++ b/packages/ui/src/components/shadcn/ui/toggle.tsx
@@ -7,7 +7,7 @@ import * as React from 'react'
 import { cn } from '../../../lib/utils/cn'
 
 const toggleVariants = cva(
-  'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors text-foreground-light data-[state=on]:bg-accent data-[state=on]:text-foreground aria-checked:bg-accent aria-checked:text-foreground focus-ring disabled:pointer-events-none disabled:opacity-50 bg-surface-200 hover:bg-surface-300 px-3 py-1 h-auto',
+  'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors text-foreground-light data-[state=on]:bg-accent data-[state=on]:text-foreground aria-checked:bg-accent aria-checked:text-foreground focus-ring disabled:pointer-events-none disabled:opacity-50 bg-surface-200 hover:bg-muted px-3 py-1 h-auto',
   {
     variants: {
       variant: {

--- a/packages/ui/src/components/shadcn/ui/toggle.tsx
+++ b/packages/ui/src/components/shadcn/ui/toggle.tsx
@@ -7,7 +7,7 @@ import * as React from 'react'
 import { cn } from '../../../lib/utils/cn'
 
 const toggleVariants = cva(
-  'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors text-foreground-light data-[state=on]:bg-accent data-[state=on]:bg-surface-300 data-[state=on]:text-foreground aria-checked:bg-accent aria-checked:bg-surface-300 aria-checked:text-foreground focus-ring disabled:pointer-events-none disabled:opacity-50 bg-surface-200 hover:bg-surface-300 px-3 py-1 h-auto',
+  'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors text-foreground-light data-[state=on]:bg-accent data-[state=on]:text-foreground aria-checked:bg-accent aria-checked:text-foreground focus-ring disabled:pointer-events-none disabled:opacity-50 bg-surface-200 hover:bg-surface-300 px-3 py-1 h-auto',
   {
     variants: {
       variant: {
@@ -16,8 +16,9 @@ const toggleVariants = cva(
           'bg-transparent border border-control hover:bg-accent hover:text-accent-foreground',
       },
       size: {
+        tiny: 'h-[26px] px-2.5 text-xs',
         default: 'h-10 px-3',
-        sm: 'h-9 px-2.5',
+        sm: 'h-[34px] px-2.5',
         lg: 'h-11 px-5',
       },
     },


### PR DESCRIPTION

<img width="392" height="343" alt="image" src="https://github.com/user-attachments/assets/4a17e3ad-364d-45c6-9770-0f937ad18418" />


## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Studio UI refinement.

## What is the current behavior?

The Explorer result settings popover uses a spacious vertical layout with mixed control heights and local active-state overrides.

## What is the new behavior?

- Condenses the result settings into the horizontal form layout used by compact settings surfaces.
- Uses base ToggleGroup, Select, MultiSelector, and Switch component variants.
- Adds shared tiny Toggle and MultiSelector sizes so the compact controls render at 26px.
- Uses the accent token for shared toggle active states.
- Keeps the chart configuration behavior and disabled states intact.

## Verification

- UI and UI Patterns focused tests
- UI, UI Patterns, and Studio typechecks
- Studio ESLint
- Local visual verification against the supplied prototype



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Chart-specific configuration options now appear only when chart view is selected, keeping display settings focused and relevant.
  * Updated chart controls provide clearer options for scale, cumulative values, and labels.
  * Added compact sizing for multi-select fields and toggles to improve alignment with other form controls.
  * Refined toggle styling and adjusted small-size dimensions for a more consistent interface.

* **Tests**
  * Added coverage for compact multi-select and toggle sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->