### PR TITLE
docs: remove deprecated processLock from react-native auth quickstart

### DIFF
--- a/examples/auth/quickstarts/react-native/lib/supabase.ts
+++ b/examples/auth/quickstarts/react-native/lib/supabase.ts
@@ -1,7 +1,7 @@
 import { AppState, Platform } from 'react-native'
 import 'react-native-url-polyfill/auto'
 import AsyncStorage from '@react-native-async-storage/async-storage'
-import { createClient, processLock } from '@supabase/supabase-js'
+import { createClient } from '@supabase/supabase-js'
 
 const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL!
 const supabasePublishableKey = process.env.EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY!
@@ -12,7 +12,6 @@ export const supabase = createClient(supabaseUrl, supabasePublishableKey, {
     autoRefreshToken: true,
     persistSession: true,
     detectSessionInUrl: false,
-    lock: processLock,
   },
 })
 


### PR DESCRIPTION
Removes `lock: processLock` from the React Native auth quickstart. Since supabase-js 2.107.0 the client coordinates session refreshes without a lock (single-flight dedupe within the client, with concurrent refresh races resolved server-side), so the option is no longer needed; it is deprecated and will be removed in v3, and upcoming 2.x releases log a one-time deprecation warning when it is passed. The quickstart installs `@supabase/supabase-js@^2`, so anyone following it gets the lockless behavior out of the box.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the React Native authentication quickstart to initialize the client without the removed locking configuration, improving compatibility with current authentication setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->