### PR TITLE
Clarify pg_net net schema grants

### DIFF
--- a/apps/docs/content/guides/database/extensions/pg_net.mdx
+++ b/apps/docs/content/guides/database/extensions/pg_net.mdx
@@ -434,6 +434,19 @@ FROM "selected_table_rows";
 
 More examples can be seen on the [Extension's GitHub page](https://github.com/supabase/pg_net/)
 
+## Permissions
+
+By default, the `net` schema grants `USAGE` to `PUBLIC`. As a result, `anon` and `authenticated`
+inherit direct object-level access (for example, `SELECT`) on `net.http_request_queue`,
+`net._http_response`, and their associated sequences.
+
+This doesn't expose request data to unauthenticated or client-side users, for two reasons:
+
+- `net` isn't exposed through the [Data API](/apps/docs/content/guides/api), so anon/publishable keys can't
+  access or modify its objects through the API.
+- `anon` and `authenticated` are `NOLOGIN` roles, so they can't establish a direct database
+  connection.
+
 ## Limitations
 
 - To improve speed and performance, the requests and responses are stored in [unlogged tables](https://pgpedia.info/u/unlogged-table.html), which are not preserved during a crash or unclean shutdown.

--- a/apps/docs/content/guides/database/extensions/pg_net.mdx
+++ b/apps/docs/content/guides/database/extensions/pg_net.mdx
@@ -444,8 +444,7 @@ This doesn't expose request data to unauthenticated or client-side users, for tw
 
 - `net` isn't exposed through the [Data API](/apps/docs/content/guides/api), so anon/publishable keys can't
   access or modify its objects through the API.
-- `anon` and `authenticated` are `NOLOGIN` roles, so they can't establish a direct database
-  connection.
+- `anon` and `authenticated` are `NOLOGIN` roles, so they can't establish a direct database connection.
 
 ## Limitations
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

Yes

## What kind of change does this PR introduce?

Documentation update — adds a new "Permissions" section to the pg_net guide.

## What is the current behavior?

The pg_net docs don't explain the default permission model for the net schema. Customers running security reviews flag that net schema objects (net.http_request_queue, net._http_response) are readable by anon/authenticated via inherited PUBLIC grants, and some have run their own REVOKE scripts to lock this down. This breaks the pg_net background worker, since postgres (the role the worker runs as) inherits its own access through that same PUBLIC grant.

## What is the new behavior?

Adds a "Permissions" section clarifying that the default grants are safe as-is, net isn't exposed through the Data API, and anon/authenticated are NOLOGIN roles with no direct database connection.

## Additional context

For background and reviewer discussion on the accuracy of this, see the https://supabase.slack.com/archives/C02FHG9QQAF/p1787299415288589.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added permissions guidance for the `net` schema.
  * Clarified access available to `anon` and `authenticated` roles.
  * Explained why these permissions do not expose request data through the Data API or direct database connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->