### PR TITLE
fix(docs)link-ch-sql-syntax

### DIFF
--- a/apps/docs/content/guides/monitoring-and-debugging/debugging.mdx
+++ b/apps/docs/content/guides/monitoring-and-debugging/debugging.mdx
@@ -12,7 +12,7 @@ An AI agent can work through this loop for you, but only if it can read your pro
 
 Debugging with an agent needs two things:
 
-- The [Supabase MCP server](/docs/guides/ai-tools/mcp) provides the tools this guide relies on: `get_logs` for a per-service log dump, `query_logs` to run read-only SQL against your logs for filtering and aggregation, `get_advisors` for security and performance findings, and `execute_sql` to inspect your schema and policies.
+- The [Supabase MCP server](/docs/guides/ai-tools/mcp) provides the tools this guide relies on: `get_logs` for a per-service log dump, `query_logs` to run read-only SQL against your logs for filtering and aggregation (see [Querying with the Logs Explorer](/docs/guides/monitoring-and-debugging/logs#querying-with-the-logs-explorer) for the ClickHouse SQL syntax it accepts), `get_advisors` for security and performance findings, and `execute_sql` to inspect your schema and policies.
 - The [Supabase agent skill](/docs/guides/ai-tools/ai-skills) teaches the agent this workflow: locate the failing layer, gather evidence from the matching log source, and verify the fix by re-running the operation that failed.
 
 Install both in one step with the [Supabase plugin for AI coding agents](/docs/guides/ai-tools/plugins). Connecting an agent to your project carries security risks, so read the [MCP security best practices](/docs/guides/ai-tools/mcp#security-risks) first.


### PR DESCRIPTION
semi related to this PR: https://github.com/supabase/changelog/pull/234

Trying to ensure the information architecture links someone reading the debugging docs to the correct info on SQL syntax required by CH. This is a simple QOL change vs doing a larger IA fix

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Does not direct users to CH sql syntax doc

## What is the new behavior?

Directs users to CH sql syntax doc

## Additional context

https://supabase.com/changelog/48235-migration-of-supabase-management-api-logs-all-analytics-endpoint-to-logs-endpoint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the MCP server description to link to Logs Explorer documentation for the supported ClickHouse SQL syntax used when querying logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->