### PR TITLE
feat: add learn more link for enterprise mcp auth

### DIFF
--- a/apps/studio/components/interfaces/Organization/SSO/SSOAdvancedSettings.tsx
+++ b/apps/studio/components/interfaces/Organization/SSO/SSOAdvancedSettings.tsx
@@ -26,8 +26,8 @@ export const SSOAdvancedSettings = ({ form }: { form: UseFormReturn<SSOConfigFor
       render={({ field }) => (
         <FormItemLayout
           layout="flex-row-reverse"
-          label="IDJAG Issuer"
-          description="The IDJAG issuer URL of your identity provider."
+          label="ID-JAG Issuer"
+          description="The ID-JAG issuer URL of your identity provider."
         >
           <FormControl>
             <Input placeholder="https://your-org.okta.com" {...field} />

--- a/apps/studio/components/interfaces/Organization/SSO/SSOAdvancedSettings.tsx
+++ b/apps/studio/components/interfaces/Organization/SSO/SSOAdvancedSettings.tsx
@@ -4,11 +4,21 @@ import { CollapsibleCardSection } from 'ui-patterns/CollapsibleCardSection'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
 import type { SSOConfigFormSchema } from './SSOConfig'
+import { InlineLink } from '@/components/ui/InlineLink'
+import { DOCS_URL } from '@/lib/constants'
 
 export const SSOAdvancedSettings = ({ form }: { form: UseFormReturn<SSOConfigFormSchema> }) => (
   <CollapsibleCardSection
     title="Advanced settings"
-    description="Required for enterprise-managed MCP authentication"
+    description={
+      <>
+        Required for enterprise-managed MCP authentication.{' '}
+        <InlineLink href={`${DOCS_URL}/guides/platform/sso/enterprise-mcp-authentication`}>
+          Learn more
+        </InlineLink>
+        .
+      </>
+    }
   >
     <FormField
       control={form.control}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

add "Learn more" link for enterprise mcp auth


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a link to enterprise MCP authentication guidance in the advanced SSO settings.
  * Clarified the field label and description by updating “IDJAG” to “ID-JAG” terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->