### PR TITLE
docs: fix api link path in pg_net.mdx

### DIFF
--- a/apps/docs/content/guides/database/extensions/pg_net.mdx
+++ b/apps/docs/content/guides/database/extensions/pg_net.mdx
@@ -442,7 +442,7 @@ inherit direct object-level access (for example, `SELECT`) on `net.http_request_
 
 This doesn't expose request data to unauthenticated or client-side users, for two reasons:
 
-- `net` isn't exposed through the [Data API](/apps/docs/content/guides/api), so anon/publishable keys can't
+- `net` isn't exposed through the [Data API](/docs/guides/api), so anon/publishable keys can't
   access or modify its objects through the API.
 - `anon` and `authenticated` are `NOLOGIN` roles, so they can't establish a direct database connection.
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES
## What kind of change does this PR introduce?

fix: Updates the Data API link in current permission section

## What is the current behavior?

The link currently points to the wrong path, resulting in a 404 error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Data API permissions documentation link to point to the current API guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->