### PR TITLE
fix(studio): allow newlines in SMS OTP template

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
@@ -128,6 +128,9 @@ export const ProviderForm = ({ config, provider, isActive }: ProviderFormProps) 
     Object.keys(values).map((x: string) => {
       if (doubleNegativeKeys.includes(x)) payload[x] = !values[x]
       if (payload[x] === '') payload[x] = null
+      if (x === 'SMS_TEMPLATE' && typeof payload[x] === 'string') {
+        payload[x] = payload[x].replace(/\\n/g, '\n')
+      }
     })
 
     // The backend uses empty string to represent no required characters in the password


### PR DESCRIPTION
Resolves #6435 by converting literal \\n\ to actual newlines in the payload before sending.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SMS authentication templates now correctly preserve line breaks when saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->