### PR TITLE
Allow pasting multiple redirect URLs at once

### DIFF
--- a/apps/studio/components/interfaces/Auth/RedirectUrls/AddNewURLModal.test.tsx
+++ b/apps/studio/components/interfaces/Auth/RedirectUrls/AddNewURLModal.test.tsx
@@ -3,8 +3,30 @@ import userEvent from '@testing-library/user-event'
 import { toast } from 'sonner'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { urlRegex } from '../Auth.constants'
 import { AddNewURLModal } from './AddNewURLModal'
 import { render } from '@/tests/helpers'
+
+// One entry per URL shape urlRegex() accepts. None may be split by the paste separator,
+// otherwise pasting a valid URL would produce invalid rows.
+const SUPPORTED_URL_FORMS = [
+  'https://example.com',
+  'https://example.com/auth/callback',
+  'https://example.com/callback?next=1&mode=dark',
+  'https://example.com:3000/callback',
+  'http://localhost:3000',
+  'http://localhost:3000/*',
+  'http://localhost:3000/**',
+  'http://localhost:3000/?',
+  'http://localhost:3000/[!a-z]',
+  'https://*-supabase.vercel.app/*/*',
+  'https://**--my_org.netlify.app/**',
+  'com.example.app://callback',
+  'my-app://auth/callback',
+  'chrome-extension://abcdefghijklmnop',
+  'myapp://',
+  'myapp:/callback',
+]
 
 const { mutateMock, useAuthConfigUpdateMutationMock } = vi.hoisted(() => ({
   mutateMock: vi.fn(),
@@ -105,6 +127,114 @@ describe('AddNewURLModal', () => {
     )
 
     expect(toast.success).toHaveBeenCalledWith('Successfully added 1 URL')
+  })
+
+  it('splits a pasted list on commas, spaces and line breaks', async () => {
+    const user = userEvent.setup()
+    mutateMock.mockImplementation((_vars, callbacks) => callbacks?.onSuccess?.())
+
+    render(
+      <AddNewURLModal visible allowList={['https://existing.example.com']} onClose={vi.fn()} />
+    )
+
+    await screen.findByRole('dialog')
+
+    await user.click(screen.getByPlaceholderText('https://mydomain.com'))
+    await user.paste(
+      'https://a.example.com\nhttps://b.example.com,https://c.example.com https://d.example.com'
+    )
+
+    expect(screen.getAllByPlaceholderText('https://mydomain.com')).toHaveLength(4)
+
+    fireEvent.submit(screen.getByRole('dialog').querySelector('form') as HTMLFormElement)
+
+    await waitFor(() =>
+      expect(mutateMock).toHaveBeenCalledWith(
+        {
+          projectRef: 'project-ref',
+          config: {
+            URI_ALLOW_LIST:
+              'https://existing.example.com,https://a.example.com,https://b.example.com,https://c.example.com,https://d.example.com',
+          },
+        },
+        expect.any(Object)
+      )
+    )
+
+    expect(toast.success).toHaveBeenCalledWith('Successfully added 4 URLs')
+  })
+
+  it('flags a duplicate within a pasted list instead of collapsing it', async () => {
+    const user = userEvent.setup()
+
+    render(<AddNewURLModal visible allowList={[]} onClose={vi.fn()} />)
+
+    await screen.findByRole('dialog')
+
+    await user.click(screen.getByPlaceholderText('https://mydomain.com'))
+    await user.paste('https://a.example.com\nhttps://a.example.com')
+
+    expect(screen.getAllByPlaceholderText('https://mydomain.com')).toHaveLength(2)
+
+    fireEvent.submit(screen.getByRole('dialog').querySelector('form') as HTMLFormElement)
+
+    expect(await screen.findByText('URL already exists in this list')).toBeInTheDocument()
+    expect(mutateMock).not.toHaveBeenCalled()
+  })
+
+  it.each(SUPPORTED_URL_FORMS)('leaves the supported URL form %s on one row', async (url) => {
+    const user = userEvent.setup()
+
+    expect(urlRegex().test(url)).toBe(true)
+
+    render(<AddNewURLModal visible allowList={[]} onClose={vi.fn()} />)
+
+    await screen.findByRole('dialog')
+
+    await user.click(screen.getByPlaceholderText('https://mydomain.com'))
+    await user.paste(url)
+
+    const inputs = screen.getAllByPlaceholderText('https://mydomain.com') as HTMLInputElement[]
+    expect(inputs).toHaveLength(1)
+    expect(inputs[0].value).toBe(url)
+  })
+
+  it('splits a list of every supported URL form back into that list', async () => {
+    const user = userEvent.setup()
+
+    render(<AddNewURLModal visible allowList={[]} onClose={vi.fn()} />)
+
+    await screen.findByRole('dialog')
+
+    await user.click(screen.getByPlaceholderText('https://mydomain.com'))
+    await user.paste(SUPPORTED_URL_FORMS.join('\n'))
+
+    const values = (
+      screen.getAllByPlaceholderText('https://mydomain.com') as HTMLInputElement[]
+    ).map((input) => input.value)
+
+    expect(values).toEqual(SUPPORTED_URL_FORMS)
+    values.forEach((value) => expect(urlRegex().test(value)).toBe(true))
+  })
+
+  it('validates each pasted URL on its own row', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <AddNewURLModal visible allowList={['https://existing.example.com']} onClose={vi.fn()} />
+    )
+
+    await screen.findByRole('dialog')
+
+    await user.click(screen.getByPlaceholderText('https://mydomain.com'))
+    await user.paste('https://a.example.com https://existing.example.com')
+
+    expect(screen.getAllByPlaceholderText('https://mydomain.com')).toHaveLength(2)
+
+    fireEvent.submit(screen.getByRole('dialog').querySelector('form') as HTMLFormElement)
+
+    expect(await screen.findByText('URL already exists in the allow list')).toBeInTheDocument()
+    expect(mutateMock).not.toHaveBeenCalled()
   })
 
   it('rejects a trailing-comma URL when it already exists in the allow list', async () => {

--- a/apps/studio/components/interfaces/Auth/RedirectUrls/AddNewURLModal.tsx
+++ b/apps/studio/components/interfaces/Auth/RedirectUrls/AddNewURLModal.tsx
@@ -143,7 +143,7 @@ export const AddNewURLModal = ({ visible, allowList, onClose }: AddNewURLModalPr
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)}>
             <DialogSection className="flex flex-col gap-y-2 px-0">
-              <div className="flex flex-col gap-y-1 px-5">
+              <div className="flex flex-col gap-y-1">
                 <Label>URL</Label>
                 <p className="text-sm text-foreground-light">
                   Paste multiple URLs at once — one per line

--- a/apps/studio/components/interfaces/Auth/RedirectUrls/AddNewURLModal.tsx
+++ b/apps/studio/components/interfaces/Auth/RedirectUrls/AddNewURLModal.tsx
@@ -146,7 +146,7 @@ export const AddNewURLModal = ({ visible, allowList, onClose }: AddNewURLModalPr
               <div className="flex flex-col gap-y-1 px-5">
                 <Label>URL</Label>
                 <p className="text-sm text-foreground-light">
-                  Paste multiple URLs separated by commas, spaces, or line breaks
+                  Paste multiple URLs at once — one per line
                 </p>
               </div>
               <ScrollArea className={cn(urls.length > 4 ? 'h-[220px]' : '')}>

--- a/apps/studio/components/interfaces/Auth/RedirectUrls/AddNewURLModal.tsx
+++ b/apps/studio/components/interfaces/Auth/RedirectUrls/AddNewURLModal.tsx
@@ -27,6 +27,8 @@ import { useAuthConfigUpdateMutation } from '@/data/auth/auth-config-update-muta
 
 const MAX_URLS_LENGTH = 2 * 1024
 
+const URL_PASTE_SEPARATOR = /[\s,]+/
+
 interface AddNewURLModalProps {
   visible: boolean
   allowList: string[]
@@ -141,7 +143,12 @@ export const AddNewURLModal = ({ visible, allowList, onClose }: AddNewURLModalPr
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)}>
             <DialogSection className="flex flex-col gap-y-2 px-0">
-              <Label className="px-5">URL</Label>
+              <div className="flex flex-col gap-y-1 px-5">
+                <Label>URL</Label>
+                <p className="text-sm text-foreground-light">
+                  Paste multiple URLs separated by commas, spaces, or line breaks
+                </p>
+              </div>
               <ScrollArea className={cn(urls.length > 4 ? 'h-[220px]' : '')}>
                 <div className="px-5 py-1">
                   <FormItemLayout className="[&>div>div]:mt-0">
@@ -150,6 +157,7 @@ export const AddNewURLModal = ({ visible, allowList, onClose }: AddNewURLModalPr
                       name="urls"
                       valueFieldName="value"
                       createEmptyRow={() => ({ value: '' })}
+                      pasteSeparator={URL_PASTE_SEPARATOR}
                       placeholder="https://mydomain.com"
                       addLabel="Add URL"
                       removeLabel="Remove URL"

--- a/packages/ui-patterns/src/form/SingleValueFieldArray/SingleValueFieldArray.test.tsx
+++ b/packages/ui-patterns/src/form/SingleValueFieldArray/SingleValueFieldArray.test.tsx
@@ -1,6 +1,7 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import type { UserEvent } from '@testing-library/user-event'
 import { useForm } from 'react-hook-form'
 import { Button, Form } from 'ui'
 import { describe, expect, it, vi } from 'vitest'
@@ -31,9 +32,11 @@ type NameFormValues = z.infer<typeof nameSchema>
 const ValueForm = ({
   defaultValues = { urls: [] },
   onSubmit = vi.fn(),
+  pasteSeparator,
 }: {
   defaultValues?: ValueFormValues
   onSubmit?: (values: ValueFormValues) => void
+  pasteSeparator?: RegExp
 }) => {
   const form = useForm<ValueFormValues>({
     resolver: zodResolver(valueSchema),
@@ -48,6 +51,7 @@ const ValueForm = ({
           name="urls"
           valueFieldName="value"
           createEmptyRow={() => ({ value: '' })}
+          pasteSeparator={pasteSeparator}
           placeholder="https://example.com/callback"
           addLabel="Add URL"
           removeLabel="Remove URL"
@@ -145,6 +149,225 @@ describe('SingleValueFieldArray', () => {
         expect.anything()
       )
     )
+  })
+
+  it('expands a multi-value paste into one row per value', async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn()
+
+    render(
+      <ValueForm
+        defaultValues={{ urls: [{ value: '' }] }}
+        onSubmit={onSubmit}
+        pasteSeparator={/[\s,]+/}
+      />
+    )
+
+    await user.click(screen.getByPlaceholderText('https://example.com/callback'))
+    await user.paste('https://a.example.com\nhttps://b.example.com https://c.example.com')
+
+    expect(screen.getAllByPlaceholderText('https://example.com/callback')).toHaveLength(3)
+
+    await user.click(screen.getByRole('button', { name: 'Submit' }))
+
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        {
+          urls: [
+            { value: 'https://a.example.com' },
+            { value: 'https://b.example.com' },
+            { value: 'https://c.example.com' },
+          ],
+        },
+        expect.anything()
+      )
+    )
+  })
+
+  it('inserts pasted values after the row being pasted into', async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn()
+
+    render(
+      <ValueForm
+        defaultValues={{ urls: [{ value: '' }, { value: 'https://last.example.com' }] }}
+        onSubmit={onSubmit}
+        pasteSeparator={/[\s,]+/}
+      />
+    )
+
+    await user.click(screen.getAllByPlaceholderText('https://example.com/callback')[0])
+    await user.paste('https://a.example.com,https://b.example.com')
+
+    await user.click(screen.getByRole('button', { name: 'Submit' }))
+
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        {
+          urls: [
+            { value: 'https://a.example.com' },
+            { value: 'https://b.example.com' },
+            { value: 'https://last.example.com' },
+          ],
+        },
+        expect.anything()
+      )
+    )
+  })
+
+  it('leaves a single-value paste to the browser', async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn()
+
+    render(
+      <ValueForm
+        defaultValues={{ urls: [{ value: '' }] }}
+        onSubmit={onSubmit}
+        pasteSeparator={/[\s,]+/}
+      />
+    )
+
+    await user.click(screen.getByPlaceholderText('https://example.com/callback'))
+    await user.paste('https://a.example.com')
+
+    expect(screen.getAllByPlaceholderText('https://example.com/callback')).toHaveLength(1)
+
+    await user.click(screen.getByRole('button', { name: 'Submit' }))
+
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        { urls: [{ value: 'https://a.example.com' }] },
+        expect.anything()
+      )
+    )
+  })
+
+  describe('pasteSeparator', () => {
+    const pasteInto = async (user: UserEvent, text: string) => {
+      await user.click(screen.getAllByPlaceholderText('https://example.com/callback')[0])
+      await user.paste(text)
+
+      return screen
+        .getAllByPlaceholderText('https://example.com/callback')
+        .map((input) => (input as HTMLInputElement).value)
+    }
+
+    const renderWithSeparator = (separator?: RegExp) =>
+      render(<ValueForm defaultValues={{ urls: [{ value: '' }] }} pasteSeparator={separator} />)
+
+    it('does not split when no separator is given, leaving the input to flatten the paste', async () => {
+      const user = userEvent.setup()
+      renderWithSeparator()
+
+      expect(await pasteInto(user, 'https://a.example.com\nhttps://b.example.com')).toEqual([
+        'https://a.example.comhttps://b.example.com',
+      ])
+    })
+
+    it('splits on line breaks', async () => {
+      const user = userEvent.setup()
+      renderWithSeparator(/[\s,]+/)
+
+      expect(await pasteInto(user, 'https://a.example.com\nhttps://b.example.com')).toEqual([
+        'https://a.example.com',
+        'https://b.example.com',
+      ])
+    })
+
+    it('splits on carriage return line breaks', async () => {
+      const user = userEvent.setup()
+      renderWithSeparator(/[\s,]+/)
+
+      expect(await pasteInto(user, 'https://a.example.com\r\nhttps://b.example.com')).toEqual([
+        'https://a.example.com',
+        'https://b.example.com',
+      ])
+    })
+
+    it('splits on commas', async () => {
+      const user = userEvent.setup()
+      renderWithSeparator(/[\s,]+/)
+
+      expect(await pasteInto(user, 'https://a.example.com,https://b.example.com')).toEqual([
+        'https://a.example.com',
+        'https://b.example.com',
+      ])
+    })
+
+    it('splits on spaces', async () => {
+      const user = userEvent.setup()
+      renderWithSeparator(/[\s,]+/)
+
+      expect(await pasteInto(user, 'https://a.example.com https://b.example.com')).toEqual([
+        'https://a.example.com',
+        'https://b.example.com',
+      ])
+    })
+
+    it('splits on tabs', async () => {
+      const user = userEvent.setup()
+      renderWithSeparator(/[\s,]+/)
+
+      expect(await pasteInto(user, 'https://a.example.com\thttps://b.example.com')).toEqual([
+        'https://a.example.com',
+        'https://b.example.com',
+      ])
+    })
+
+    it('splits on a mix of separators', async () => {
+      const user = userEvent.setup()
+      renderWithSeparator(/[\s,]+/)
+
+      expect(
+        await pasteInto(
+          user,
+          'https://a.example.com, https://b.example.com\nhttps://c.example.com\t https://d.example.com'
+        )
+      ).toEqual([
+        'https://a.example.com',
+        'https://b.example.com',
+        'https://c.example.com',
+        'https://d.example.com',
+      ])
+    })
+
+    it('collapses repeated separators instead of creating empty rows', async () => {
+      const user = userEvent.setup()
+      renderWithSeparator(/[\s,]+/)
+
+      expect(
+        await pasteInto(user, 'https://a.example.com,,,\n\n  ,\thttps://b.example.com')
+      ).toEqual(['https://a.example.com', 'https://b.example.com'])
+    })
+
+    it('ignores leading and trailing separators', async () => {
+      const user = userEvent.setup()
+      renderWithSeparator(/[\s,]+/)
+
+      expect(
+        await pasteInto(user, '\n  https://a.example.com,\nhttps://b.example.com,  \n')
+      ).toEqual(['https://a.example.com', 'https://b.example.com'])
+    })
+
+    it('trims each value when the separator does not cover whitespace', async () => {
+      const user = userEvent.setup()
+      renderWithSeparator(/,/)
+
+      expect(await pasteInto(user, ' https://a.example.com , https://b.example.com ')).toEqual([
+        'https://a.example.com',
+        'https://b.example.com',
+      ])
+    })
+
+    it('keeps duplicate values as separate rows', async () => {
+      const user = userEvent.setup()
+      renderWithSeparator(/[\s,]+/)
+
+      expect(await pasteInto(user, 'https://a.example.com\nhttps://a.example.com')).toEqual([
+        'https://a.example.com',
+        'https://a.example.com',
+      ])
+    })
   })
 
   it('shows RHF field errors through FormMessage', async () => {

--- a/packages/ui-patterns/src/form/SingleValueFieldArray/SingleValueFieldArray.tsx
+++ b/packages/ui-patterns/src/form/SingleValueFieldArray/SingleValueFieldArray.tsx
@@ -26,6 +26,7 @@ export interface SingleValueFieldArrayProps<
   addLabel: string
   removeLabel?: string
   disabled?: boolean
+  pasteSeparator?: RegExp
   minimumRows?: number
   inputSize?: React.ComponentProps<typeof Input>['size']
   inputAutoComplete?: string
@@ -61,6 +62,7 @@ export const SingleValueFieldArray = <
   addLabel,
   removeLabel = 'Remove row',
   disabled = false,
+  pasteSeparator,
   minimumRows = 0,
   inputSize = 'small',
   inputAutoComplete,
@@ -75,7 +77,11 @@ export const SingleValueFieldArray = <
   removeButtonType = 'default',
   removeButtonSize = 'tiny',
 }: SingleValueFieldArrayProps<TFieldValues, TFieldArrayName, TItem>) => {
-  const { fields, append, remove } = useFieldArray<TFieldValues, TFieldArrayName, 'fieldId'>({
+  const { fields, append, insert, remove } = useFieldArray<
+    TFieldValues,
+    TFieldArrayName,
+    'fieldId'
+  >({
     control,
     name,
     keyName: 'fieldId',
@@ -83,6 +89,28 @@ export const SingleValueFieldArray = <
 
   const typedFields = fields as FieldArrayWithId<TFieldValues, TFieldArrayName, 'fieldId'>[]
   const disableRemove = disabled || typedFields.length <= minimumRows
+
+  const createRow = (value: string) =>
+    ({ ...(createEmptyRow() as object), [valueFieldName]: value }) as TItem
+
+  const handlePaste = (
+    event: React.ClipboardEvent<HTMLInputElement>,
+    index: number,
+    onChange: (value: string) => void
+  ) => {
+    if (!pasteSeparator) return
+
+    const values = event.clipboardData
+      .getData('text')
+      .split(pasteSeparator)
+      .map((value) => value.trim())
+      .filter(Boolean)
+    if (values.length <= 1) return
+
+    event.preventDefault()
+    onChange(values[0])
+    insert(index + 1, values.slice(1).map(createRow))
+  }
 
   return (
     <div className={cn('space-y-3', className)}>
@@ -102,6 +130,7 @@ export const SingleValueFieldArray = <
                       className={cn('w-full', inputClassName)}
                       placeholder={placeholder}
                       disabled={disabled}
+                      onPaste={(event) => handlePaste(event, index, field.onChange)}
                     />
                   </FormControl>
                   <FormMessage />


### PR DESCRIPTION
Redirect URLs had to be added one at a time through the modal, and a whitespace-separated paste silently saved as a single malformed allow list entry.

Adds an opt-in `pasteSeparator` prop to `SingleValueFieldArray` that expands a multi-value paste into one row per value, and wires it up in the auth redirect URL modal so commas, spaces and line breaks all work. Each URL lands on its own row, so the existing per-row validation applies individually.

Fixes FE-4220

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redirect URL fields now support pasting multiple URLs separated by commas, spaces, or line breaks.
  * Pasted values are automatically split into separate rows for easier editing and individual validation.
  * Supported URL formats are retained, including when multiple values are pasted together.
  * Existing single-value paste behavior remains unchanged.
  * Duplicate values are preserved so they can be reviewed and validated individually.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->