### PR TITLE
fix(ui): anchor radio group bubble inputs to their group

### DIFF
--- a/packages/ui/src/components/radio-group-card.tsx
+++ b/packages/ui/src/components/radio-group-card.tsx
@@ -10,7 +10,13 @@ const RadioGroupCard = React.forwardRef<
   React.ElementRef<typeof RadioGroupPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>
 >(({ className, ...props }, ref) => {
-  return <RadioGroupPrimitive.Root className={cn('grid gap-2', className)} {...props} ref={ref} />
+  return (
+    <RadioGroupPrimitive.Root
+      className={cn('relative grid gap-2', className)}
+      {...props}
+      ref={ref}
+    />
+  )
 })
 RadioGroupCard.displayName = RadioGroupPrimitive.Root.displayName
 

--- a/packages/ui/src/components/radio-group-stacked.tsx
+++ b/packages/ui/src/components/radio-group-stacked.tsx
@@ -13,7 +13,7 @@ const RadioGroupStacked = React.forwardRef<
 >(({ className, ...props }, ref) => {
   return (
     <RadioGroupPrimitive.Root
-      className={cn('flex flex-col -space-y-px w-full', className)}
+      className={cn('relative flex flex-col -space-y-px w-full', className)}
       {...props}
       ref={ref}
     />

--- a/packages/ui/src/components/shadcn/ui/radio-group.tsx
+++ b/packages/ui/src/components/shadcn/ui/radio-group.tsx
@@ -10,7 +10,13 @@ const RadioGroup = React.forwardRef<
   React.ElementRef<typeof RadioGroupPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>
 >(({ className, ...props }, ref) => {
-  return <RadioGroupPrimitive.Root className={cn('grid gap-2', className)} {...props} ref={ref} />
+  return (
+    <RadioGroupPrimitive.Root
+      className={cn('relative grid gap-2', className)}
+      {...props}
+      ref={ref}
+    />
+  )
 })
 RadioGroup.displayName = RadioGroupPrimitive.Root.displayName
 


### PR DESCRIPTION
Radix renders a hidden `position: absolute` input per radio item, sized to the control. With no positioned ancestor on the RadioGroup root these anchored to `#__next` and landed below the fold on Settings → Infrastructure, making the whole document scrollable — so scrolling over the left menu dragged the 100vh app shell, header included, out of view.

Adds `relative` to the three RadioGroup roots so the inputs stay inside the group.

Fixes FE-4261

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved positioning behavior for radio group components.
  * Updated radio group layouts to support more consistent visual placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->