### PR TITLE
pg-meta: renaming or deleting a mixed-case schema by name fails

### DIFF
--- a/packages/pg-meta/src/pg-meta-schemas.ts
+++ b/packages/pg-meta/src/pg-meta-schemas.ts
@@ -97,7 +97,7 @@ function update(
   const sql = safeSql`
 do $$
 declare
-  id oid := ${id === undefined ? safeSql`${literal(name)}::regnamespace` : literal(id)};
+  id oid := ${id === undefined ? safeSql`quote_ident(${literal(name)})::regnamespace` : literal(id)};
   old record;
   new_name text := ${newName === undefined ? literal(null) : literal(newName)};
   new_owner text := ${owner === undefined ? literal(null) : literal(owner)};
@@ -139,7 +139,7 @@ function remove(
   const sql = safeSql`
 do $$
 declare
-  id oid := ${id === undefined ? safeSql`${literal(name)}::regnamespace` : literal(id)};
+  id oid := ${id === undefined ? safeSql`quote_ident(${literal(name)})::regnamespace` : literal(id)};
   old record;
   cascade bool := ${literal(cascade)};
 begin

--- a/packages/pg-meta/test/schemas.test.ts
+++ b/packages/pg-meta/test/schemas.test.ts
@@ -135,3 +135,41 @@ withTestDatabase('retrieve, create, update, delete', async ({ executeQuery }) =>
   const finalRes = await executeQuery(finalRetrieveSql)
   expect(finalRes).toMatchInlineSnapshot(`[]`)
 })
+
+withTestDatabase(
+  'update and remove by name for a mixed-case schema name',
+  async ({ executeQuery }) => {
+    // Create a schema whose name is not all-lowercase
+    const { sql: createSql } = pgMeta.schemas.create({ name: 'App' })
+    await executeQuery(createSql)
+
+    // Rename it via the { name } identifier path.
+    // The generated SQL resolves the target through 'name'::regnamespace, which
+    // case-folds unless the identifier is quoted — an unquoted literal fails to
+    // find any mixed-case schema.
+    const { sql: updateSql } = pgMeta.schemas.update({ name: 'App' }, { name: 'Apps' })
+    await executeQuery(updateSql)
+
+    const { sql: retrieveSql, zod } = pgMeta.schemas.retrieve({ name: 'Apps' })
+    const updateRes = zod.parse((await executeQuery(retrieveSql))[0])
+    expect(updateRes).toMatchInlineSnapshot(
+      { id: expect.any(Number) },
+      `
+    {
+      "comment": null,
+      "id": Any<Number>,
+      "name": "Apps",
+      "owner": "postgres",
+    }
+  `
+    )
+
+    // Delete it via the { name } identifier path as well
+    const { sql: deleteSql } = pgMeta.schemas.remove({ name: 'Apps' })
+    await executeQuery(deleteSql)
+
+    const { sql: finalRetrieveSql } = pgMeta.schemas.retrieve({ name: 'Apps' })
+    const finalRes = await executeQuery(finalRetrieveSql)
+    expect(finalRes).toMatchInlineSnapshot(`[]`)
+  }
+)

--- a/packages/pg-meta/test/schemas.test.ts
+++ b/packages/pg-meta/test/schemas.test.ts
@@ -143,10 +143,11 @@ withTestDatabase(
     const { sql: createSql } = pgMeta.schemas.create({ name: 'App' })
     await executeQuery(createSql)
 
-    // Rename it via the { name } identifier path.
-    // The generated SQL resolves the target through 'name'::regnamespace, which
-    // case-folds unless the identifier is quoted — an unquoted literal fails to
-    // find any mixed-case schema.
+    // Rename it via the { name } identifier path. The generated SQL resolves
+    // the target through quote_ident('App')::regnamespace, so the mixed-case
+    // name is quoted before the cast and matched exactly; a bare
+    // 'App'::regnamespace literal would be case-folded by Postgres and miss
+    // the schema.
     const { sql: updateSql } = pgMeta.schemas.update({ name: 'App' }, { name: 'Apps' })
     await executeQuery(updateSql)
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`pgMeta.schemas.update()` and `pgMeta.schemas.remove()` fail whenever they are identified by name and the schema name is not entirely lowercase. Renaming or deleting a schema like `App`, `Archive`, or anything created with quoted mixed-case identifiers errors out with:

```
ERROR: schema "app" does not exist
```

There is no open issue for this one; it was found by running the package's mutation builders against a database containing mixed-case schema names.

The cause is that both builders resolve the caller-supplied name through an identifier-parsing cast using a plain string literal:

```sql
id oid := 'App'::regnamespace;
```

Postgres resolves unquoted strings in `regnamespace` casts with identifier rules rather than string rules, so `'App'` case-folds to `app` and the lookup misses the real schema.

## What is the new behavior?

The name is resolved through `quote_ident()` first:

```sql
id oid := quote_ident('App')::regnamespace;
```

`quote_ident()` applies identifier quoting to the supplied string, so the case of the original name is preserved and the lookup finds the schema. The `id`-based overloads are untouched. This follows the same approach already used inside the table-definition SQL in this package.

## Additional context

- Regression test added to `packages/pg-meta/test/schemas.test.ts`: create schema `App`, rename via `{ name }`, verify via retrieve, delete via `{ name }`, verify gone.
- The new test fails on master with `Failed to execute query: schema "app" does not exist` and passes with this patch.
- Full pg-meta suite passes after the change (479 tests / 32 files, run against the package's Dockerized Postgres harness).
- `pnpm --filter @supabase/pg-meta typecheck` and Prettier checks pass.
- Verified on Windows locally; the SQL itself is platform-independent Postgres behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed updating and removing schemas with mixed-case names.
  * Schema operations now correctly preserve identifier capitalization.

* **Tests**
  * Added coverage for renaming, retrieving, and deleting mixed-case schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->