### PR TITLE
docs: add Observe the data hub for logs, metrics, and advisors

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -3026,6 +3026,10 @@ export const telemetry: NavMenuConstant = {
   items: [
     { name: 'Overview', url: '/guides/monitoring-and-debugging' },
     {
+      name: 'Observe the data',
+      url: '/guides/monitoring-and-debugging/access-data' as `/${string}`,
+    },
+    {
       name: 'Debugging',
       url: undefined,
       items: [

--- a/apps/docs/content/guides/monitoring-and-debugging/access-data.mdx
+++ b/apps/docs/content/guides/monitoring-and-debugging/access-data.mdx
@@ -1,0 +1,80 @@
+---
+id: 'access-data'
+title: 'Observe the data'
+description: 'Query logs, metrics, and database diagnostics from MCP, the CLI, the API, or Studio.'
+---
+
+This guide explains how to observe a Supabase project.
+
+Use this page to:
+
+- See [what data you can observe](#what-data-you-can-observe)
+- Choose [where you can observe it](#access-via)
+
+## What data you can observe [#what-data-you-can-observe]
+
+The sources are logs, metrics, live Postgres diagnostics, and advisor findings. Open Logs and Reports in Studio when you want a UI on those sources. See [where you can observe it](#access-via).
+
+### Logs
+
+Request, database, Auth, Storage, Realtime, and function events in ClickHouse.
+
+- [Query and filter logs](/docs/guides/monitoring-and-debugging/advanced-log-filtering) — run ClickHouse SQL from Studio, MCP, the API, or a script. Record extra Postgres, API, and Realtime events.
+- [Logs field reference](/docs/guides/monitoring-and-debugging/log-field-reference) — sources and fields
+
+### Metrics [#metrics-api]
+
+Prometheus-compatible CPU, IO, WAL, connections, and query stats. Scrape the [Metrics API](/docs/guides/monitoring-and-debugging/metrics) for custom dashboards, alerting, or retention beyond Studio.
+
+### Database
+
+Live Postgres statistics such as bloat, cache hit rate, blocking sessions, index usage, and slow queries. See [Inspect the database](/docs/guides/monitoring-and-debugging/inspect) (`supabase inspect db`) for the command and SQL catalog.
+
+MCP `execute_sql` can run the same read-only queries.
+
+### Advisors
+
+Deterministic security and performance findings. Pull them from [Advisors](/docs/guides/monitoring-and-debugging/advisors).
+
+## Where you can observe it [#access-via]
+
+Use the interface that matches where you are working.
+
+### MCP [#mcp]
+
+Configure the [Supabase MCP server](/docs/guides/ai-tools/mcp) for one project with read-only mode. The debugging tools are:
+
+- `query_logs` for bounded log queries. Use the same ClickHouse SQL as [Query and filter logs](/docs/guides/monitoring-and-debugging/advanced-log-filtering).
+- `execute_sql` for read-only database inspection
+- `get_advisors` for security and performance findings
+
+Ask the agent to inspect a time window, error code, or advisor finding. Keep production connections project-scoped and read-only.
+
+### API [#api]
+
+Use the Management API when you want the same data from a script:
+
+- [Query project logs](/docs/reference/api/v1-get-project-logs). Pass ClickHouse SQL in the `sql` parameter. See [Query and filter logs](/docs/guides/monitoring-and-debugging/advanced-log-filtering).
+- [Security advisors](/docs/reference/api/v1-get-security-advisors) and [performance advisors](/docs/reference/api/v1-get-performance-advisors)
+- [API usage counts](/docs/reference/api/v1-get-project-usage-api-count)
+
+Scrape the [Metrics API](/docs/guides/monitoring-and-debugging/metrics) for Prometheus-compatible database series. That endpoint is a project URL, not a Management API route.
+
+### CLI [#cli]
+
+Use the [Supabase CLI](/docs/guides/local-development/cli/getting-started) against a linked project:
+
+- [`supabase inspect db`](/docs/guides/monitoring-and-debugging/inspect) for the database diagnostic catalog
+- [`supabase db advisors`](/docs/reference/cli/usage#supabase-db-advisors) for security and performance findings
+
+Run `supabase inspect db help` on the installed CLI to see the reports available in your version.
+
+### Studio [#studio]
+
+Use Studio when you want to inspect the project in the browser:
+
+- [Logs](/docs/guides/monitoring-and-debugging/logs) for the unified Logs view
+- [Reports](/docs/guides/monitoring-and-debugging/reports) for API, Auth, Storage, Realtime, and database dashboards
+- [Advisors](/docs/guides/monitoring-and-debugging/advisors) for deterministic security and performance findings
+
+To send logs or traces to your own stack, see [Log drains](/docs/guides/monitoring-and-debugging/log-drains), [Client-side tracing](/docs/guides/monitoring-and-debugging/client-side-tracing), and [Sentry integration](/docs/guides/monitoring-and-debugging/sentry-monitoring).

--- a/apps/docs/content/guides/monitoring-and-debugging/advanced-log-filtering.mdx
+++ b/apps/docs/content/guides/monitoring-and-debugging/advanced-log-filtering.mdx
@@ -30,7 +30,7 @@ Open [Logs](/dashboard/project/_/logs) to filter and inspect events. Open the [L
 
 ### MCP [#mcp]
 
-On hosted projects, call [`query_logs`](/docs/guides/ai-tools/mcp) with the same SQL as this guide. Keep the connection project-scoped and read-only.
+On hosted projects, call [`query_logs`](/docs/guides/ai-tools/mcp) with the same SQL as this guide. Keep the connection project-scoped and read-only. See [Observe the data](/docs/guides/monitoring-and-debugging/access-data#mcp).
 
 ### API [#api]
 
@@ -38,7 +38,7 @@ Pass ClickHouse SQL in the `sql` parameter of the [Management API logs endpoint]
 
 ### CLI [#cli]
 
-The Supabase CLI does not query ClickHouse logs. Call the [Management API](/docs/reference/api/v1-get-project-logs) from a script, or use [`supabase inspect db`](/docs/guides/monitoring-and-debugging/inspect) for database diagnostics.
+The Supabase CLI does not query ClickHouse logs. Call the [Management API](/docs/reference/api/v1-get-project-logs) from a script, or use [`supabase inspect db`](/docs/guides/monitoring-and-debugging/inspect) for database diagnostics. See [Observe the data](/docs/guides/monitoring-and-debugging/access-data#cli).
 
 ## Sources [#logs-explorer]
 

--- a/apps/docs/content/guides/monitoring-and-debugging/inspect.mdx
+++ b/apps/docs/content/guides/monitoring-and-debugging/inspect.mdx
@@ -13,7 +13,7 @@ Use this page to:
 - Run [CLI inspection commands](#using-the-cli)
 - Copy the matching [SQL](#using-sql)
 
-If you are checking whether something is wrong, start with the [debugging guide](/docs/guides/monitoring-and-debugging/debugging). For project logs and metrics, see the [Monitoring and Debugging overview](/docs/guides/monitoring-and-debugging).
+If you are checking whether something is wrong, start with the [debugging guide](/docs/guides/monitoring-and-debugging/debugging). For project logs, metrics, and advisors, see [Observe the data](/docs/guides/monitoring-and-debugging/access-data).
 
 ## Using the CLI
 

--- a/apps/docs/data/content-listings/index.ts
+++ b/apps/docs/data/content-listings/index.ts
@@ -27,7 +27,7 @@ import {
   selfHostingSupport,
 } from './self-hosting.data'
 import { storageExamples, storageGetStarted, storageResources } from './storage.data'
-import { telemetryDebugging, telemetryMonitoring } from './telemetry.data'
+import { telemetryAccessWhat, telemetryAccessWhere, telemetryDebugging, telemetryMonitoring } from './telemetry.data'
 
 const ALL_GROUPS: readonly ContentListingGroup[] = [
   aiToolsSupportedAgents,
@@ -63,6 +63,8 @@ const ALL_GROUPS: readonly ContentListingGroup[] = [
   storageResources,
   telemetryDebugging,
   telemetryMonitoring,
+  telemetryAccessWhat,
+  telemetryAccessWhere,
 ]
 
 export const CONTENT_LISTINGS: Readonly<Record<string, ContentListingGroup>> = Object.fromEntries(

--- a/apps/docs/data/content-listings/index.ts
+++ b/apps/docs/data/content-listings/index.ts
@@ -27,7 +27,12 @@ import {
   selfHostingSupport,
 } from './self-hosting.data'
 import { storageExamples, storageGetStarted, storageResources } from './storage.data'
-import { telemetryAccessWhat, telemetryAccessWhere, telemetryDebugging, telemetryMonitoring } from './telemetry.data'
+import {
+  telemetryAccessWhat,
+  telemetryAccessWhere,
+  telemetryDebugging,
+  telemetryMonitoring,
+} from './telemetry.data'
 
 const ALL_GROUPS: readonly ContentListingGroup[] = [
   aiToolsSupportedAgents,

--- a/apps/docs/data/content-listings/telemetry.data.ts
+++ b/apps/docs/data/content-listings/telemetry.data.ts
@@ -73,3 +73,68 @@ export const telemetryMonitoring: ContentListingGroup = {
     },
   ],
 }
+
+export const telemetryAccessWhat: ContentListingGroup = {
+  id: 'telemetry-access-what',
+  heading: 'What data you can observe',
+  headingLevel: 'h3',
+  type: 'grid',
+  columns: 2,
+  items: [
+    {
+      title: 'Logs',
+      href: '/guides/monitoring-and-debugging/advanced-log-filtering',
+      description:
+        'Query project logs and look up sources and fields. Record extra Postgres, API, and Realtime events.',
+    },
+    {
+      title: 'Metrics API',
+      href: '/guides/monitoring-and-debugging/metrics',
+      description: 'Scrape Prometheus-compatible database metrics for dashboards and alerting.',
+    },
+    {
+      title: 'Database',
+      href: '/guides/monitoring-and-debugging/inspect',
+      description:
+        'Inspect live Postgres stats such as bloat, cache hit rate, locks, and slow queries.',
+    },
+    {
+      title: 'Advisors',
+      href: '/guides/monitoring-and-debugging/advisors',
+      description:
+        'Pull deterministic security and performance findings as part of ongoing observability.',
+    },
+  ],
+}
+
+export const telemetryAccessWhere: ContentListingGroup = {
+  id: 'telemetry-access-where',
+  heading: 'Where you can observe it',
+  headingLevel: 'h3',
+  type: 'grid',
+  columns: 2,
+  items: [
+    {
+      title: 'MCP',
+      href: '/guides/monitoring-and-debugging/access-data#mcp',
+      description:
+        'Query logs, run read-only SQL, and fetch advisor findings from an agent harness.',
+    },
+    {
+      title: 'API',
+      href: '/guides/monitoring-and-debugging/access-data#api',
+      description: 'Read logs, advisors, and usage counts, or scrape the Metrics API.',
+    },
+    {
+      title: 'CLI',
+      href: '/guides/monitoring-and-debugging/access-data#cli',
+      description:
+        'Inspect the database and run security or performance advisors from the terminal.',
+    },
+    {
+      title: 'Studio',
+      href: '/guides/monitoring-and-debugging/access-data#studio',
+      description: 'Open Logs, Reports, and Advisors in the browser.',
+    },
+  ],
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Stack

Draft stack extracted from `docs/monitoring`. Merge bottom-up. Troubleshooting / debugging-guide rewrite is out of scope.

1. #49503 move inspect and advisors
2. #49501 split Studio logs from ClickHouse queries
3. #49500 treat reports as signal dashboards
4. **#49502** add Observe the data hub ← **this PR**
5. #49506 add agent setup components
6. #49504 add hire-an-agent templates
7. #49505 restructure observability nav and overview

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update. Fourth layer in the observability stack.

## What is the current behavior?

There is no single page that maps what you can observe (logs, metrics, database, advisors) to where you query it (MCP, API, CLI, Studio).

## What is the new behavior?

Adds `/guides/monitoring-and-debugging/access-data` as that hub, with content listings and nav. Inspect and Query and filter logs now point here for MCP/CLI context.

## Additional context

This page is the spine of the new observability IA. Later PRs add agent templates and restructure the sidebar around it.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a3cb5ece-925b-4046-b58a-5d69e9a9d794?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a3cb5ece-925b-4046-b58a-5d69e9a9d794&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

