### PR TITLE
fix(studio): keep region flags visible on light surfaces

### DIFF
--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/index.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/index.tsx
@@ -63,6 +63,7 @@ import { ValidationFailuresSection } from './ValidationFailuresSection'
 import { ValidationWarningsDialog } from './ValidationWarningsDialog'
 import { CreateAnalyticsBucketSheet } from '@/components/interfaces/Storage/AnalyticsBuckets/CreateAnalyticsBucketSheet'
 import { InlineLinkClassName } from '@/components/ui/InlineLink'
+import { RegionFlag } from '@/components/ui/RegionFlag'
 import { useAPIKeys } from '@/data/api-keys/api-keys-query'
 import { useProjectSettingsV2Query } from '@/data/config/project-settings-v2-query'
 import { useReplicationDestinationByIdQuery } from '@/data/replication/destination-by-id-query'
@@ -70,7 +71,7 @@ import { useReplicationPipelineByIdQuery } from '@/data/replication/pipeline-by-
 import { useReplicationPublicationsQuery } from '@/data/replication/publications-query'
 import { useReplicationSourceId } from '@/data/replication/sources-query'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
-import { BASE_PATH, IS_STAGING_OR_LOCAL } from '@/lib/constants'
+import { IS_STAGING_OR_LOCAL } from '@/lib/constants'
 
 const formId = 'destination-editor'
 
@@ -492,11 +493,7 @@ export const DestinationForm = ({
                         <SelectContent>
                           <SelectItem value={PIPELINE_REGION.code}>
                             <div className="flex gap-x-3 items-center">
-                              <img
-                                alt="region icon"
-                                className="w-5 rounded-xs"
-                                src={`${BASE_PATH}/img/regions/${PIPELINE_REGION.code}.svg`}
-                              />
+                              <RegionFlag className="w-5" region={PIPELINE_REGION.code} />
                               <p className="flex items-center gap-x-2">
                                 <span>{PIPELINE_REGION.displayName}</span>
                                 <span className="text-xs text-foreground-lighter font-mono">

--- a/apps/studio/components/interfaces/Database/Replication/ReplicationDiagram/Nodes.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/ReplicationDiagram/Nodes.tsx
@@ -8,11 +8,11 @@ import { DestinationIcon } from '../DestinationIcon'
 import { getStatusName } from '../Pipeline.utils'
 import { STATUS_REFRESH_FREQUENCY_MS } from '../Replication.constants'
 import { getReplicationDestinationType } from './Nodes.utils'
+import { RegionFlag } from '@/components/ui/RegionFlag'
 import { useReplicationDestinationsQuery } from '@/data/replication/destinations-query'
 import { useReplicationPipelineStatusQuery } from '@/data/replication/pipeline-status-query'
 import { useReplicationPipelinesQuery } from '@/data/replication/pipelines-query'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
-import { BASE_PATH } from '@/lib/constants'
 
 export const NODE_WIDTH = 480
 
@@ -46,13 +46,7 @@ export const PrimaryDatabaseNode = () => {
         <p className="text-foreground-light">{region?.displayName}</p>
         <p className="text-foreground-light">{region?.code}</p>
       </div>
-      {!!project && (
-        <img
-          alt="region icon"
-          className="w-8 rounded-xs mt-0.5"
-          src={`${BASE_PATH}/img/regions/${project?.region}.svg`}
-        />
-      )}
+      {!!project && <RegionFlag className="mt-0.5 w-8" region={project.region} />}
       <Handle
         type="source"
         position={Position.Right}

--- a/apps/studio/components/interfaces/ProjectCreation/RegionSelector.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/RegionSelector.tsx
@@ -33,11 +33,11 @@ import {
 import { AlertError } from '@/components/ui/AlertError'
 import { InlineLink } from '@/components/ui/InlineLink'
 import Panel from '@/components/ui/Panel'
+import { RegionFlag } from '@/components/ui/RegionFlag'
 import { useDefaultRegionQuery } from '@/data/misc/get-default-region-query'
 import { useOrganizationAvailableRegionsQuery } from '@/data/organizations/organization-available-regions-query'
 import { useIncidentStatusQuery } from '@/data/platform/incident-status-query'
 import type { DesiredInstanceSize } from '@/data/projects/new-project.constants'
-import { BASE_PATH } from '@/lib/constants'
 
 interface RegionSelectorProps {
   form: UseFormReturn<CreateProjectForm>
@@ -251,13 +251,10 @@ export const RegionSelector = ({
                           <div className="flex items-center gap-x-3">
                             {isLoading && <Loader2 size={14} className="animate-spin" />}
                             {selectedRegion?.code && (
-                              // For some reason, Safari considered the empty string alt text on this icon as misspelled (with VoiceOver)
-                              // Only way to fix it is to set the role. Not needed for the combobox options
-                              // eslint-disable-next-line jsx-a11y/alt-text
-                              <img
+                              <RegionFlag
                                 role="presentation"
-                                className="w-5 rounded-xs"
-                                src={`${BASE_PATH}/img/regions/${selectedRegion.code}.svg`}
+                                className="w-5"
+                                region={selectedRegion.code}
                               />
                             )}
                             <span className="text-foreground">{triggerLabel}</span>
@@ -279,11 +276,7 @@ export const RegionSelector = ({
                                 >
                                   <div className="flex flex-row items-center justify-between w-full">
                                     <div className="flex items-center gap-x-3">
-                                      <img
-                                        alt=""
-                                        className="w-5 rounded-xs"
-                                        src={`${BASE_PATH}/img/regions/${value.code}.svg`}
-                                      />
+                                      <RegionFlag className="w-5" region={value.code} />
                                       <span className="text-foreground">
                                         {getDisplayNameForSmartRegion(value.name)}
                                       </span>
@@ -322,11 +315,7 @@ export const RegionSelector = ({
                             >
                               <div className="flex flex-row items-center justify-between w-full gap-x-2">
                                 <div className="flex items-center gap-x-3">
-                                  <img
-                                    alt=""
-                                    className="w-5 rounded-xs"
-                                    src={`${BASE_PATH}/img/regions/${value.code}.svg`}
-                                  />
+                                  <RegionFlag className="w-5" region={value.code} />
                                   <div className="flex items-center gap-x-2">
                                     <span className="text-foreground">{value.name}</span>
                                     <span className="text-xs text-foreground-lighter font-mono">

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceNode.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceNode.tsx
@@ -35,6 +35,7 @@ import { formatSeconds } from './InstanceConfiguration.utils'
 import { metricColor } from './InstanceNode.utils'
 import { getReadReplicaPath } from '@/components/interfaces/Settings/Infrastructure/Infrastructure.utils'
 import { REPLICA_STATUS } from '@/components/interfaces/Settings/Infrastructure/ReadReplicas/ReadReplicas.constants'
+import { RegionFlag } from '@/components/ui/RegionFlag'
 import { SparkBar } from '@/components/ui/SparkBar'
 import {
   DatabaseInitEstimations,
@@ -44,7 +45,6 @@ import {
 import { formatDatabaseID } from '@/data/read-replicas/replicas.utils'
 import { useComputeMetrics } from '@/hooks/analytics/useComputeMetrics'
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
-import { BASE_PATH } from '@/lib/constants'
 import { useDatabaseSelectorStateSnapshot } from '@/state/database-selector'
 
 export const LoadBalancerNode = ({ data }: NodeProps<Node<LoadBalancerData>>) => {
@@ -156,11 +156,7 @@ export const PrimaryNode = ({ data }: NodeProps<Node<PrimaryNodeData>>) => {
               </p>
             </div>
           </div>
-          <img
-            alt="region icon"
-            className="w-8 rounded-xs mt-0.5"
-            src={`${BASE_PATH}/img/regions/${region.region}.svg`}
-          />
+          <RegionFlag className="mt-0.5 w-8" region={region.region} />
         </div>
         {numReplicas > 0 && (
           <div className="border-t p-3 py-2">
@@ -438,11 +434,7 @@ export const RegionNode = ({ data }: any) => {
       style={{ width: regionNodeWidth, height: REGION_NODE_HEIGHT }}
     >
       <div className="absolute bottom-2 flex items-center justify-between gap-x-2">
-        <img
-          alt="region icon"
-          className="w-5 rounded-xs"
-          src={`${BASE_PATH}/img/regions/${region.region}.svg`}
-        />
+        <RegionFlag className="w-5" region={region.region} />
         <p className="text-sm">{region.name}</p>
       </div>
     </div>

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/MapView.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/MapView.tsx
@@ -29,10 +29,10 @@ import { AVAILABLE_REPLICA_REGIONS } from './InstanceConfiguration.constants'
 import GeographyData from './MapData.json'
 import { getReadReplicaPath } from '@/components/interfaces/Settings/Infrastructure/Infrastructure.utils'
 import { REPLICA_STATUS } from '@/components/interfaces/Settings/Infrastructure/ReadReplicas/ReadReplicas.constants'
+import { RegionFlag } from '@/components/ui/RegionFlag'
 import { useReadReplicasQuery } from '@/data/read-replicas/replicas-query'
 import { formatDatabaseID } from '@/data/read-replicas/replicas.utils'
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
-import { BASE_PATH } from '@/lib/constants'
 import { useDatabaseSelectorStateSnapshot } from '@/state/database-selector'
 
 const MapView = () => {
@@ -202,11 +202,7 @@ const MapView = () => {
                 <div className="bg-studio/50 rounded-sm border">
                   <div className="px-3 py-2 flex flex-col">
                     <div className="flex items-center gap-x-2">
-                      <img
-                        alt="region icon"
-                        className="w-4 rounded-xs"
-                        src={`${BASE_PATH}/img/regions/${tooltip.region.region}.svg`}
-                      />
+                      <RegionFlag className="w-4" region={tooltip.region.region ?? ''} />
                       <p className="text-[10px]">{tooltip.region.country}</p>
                     </div>
                     <p
@@ -234,11 +230,7 @@ const MapView = () => {
               </p>
               <p className="text-sm">{selectedRegion.name}</p>
             </div>
-            <img
-              alt="region icon"
-              className="w-10 rounded-xs"
-              src={`${BASE_PATH}/img/regions/${selectedRegion.region}.svg`}
-            />
+            <RegionFlag className="w-10" region={selectedRegion.region} />
           </div>
 
           {databasesInSelectedRegion.length > 0 && (

--- a/apps/studio/components/interfaces/Settings/Infrastructure/ReadReplicas/ReadReplicaDetails.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/ReadReplicas/ReadReplicaDetails.tsx
@@ -20,13 +20,13 @@ import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 import { REPLICA_STATUS } from './ReadReplicas.constants'
 import { REPORT_DATERANGE_HELPER_LABELS } from '@/components/interfaces/Reports/Reports.constants'
 import { ScaffoldContainer, ScaffoldSection } from '@/components/layouts/Scaffold'
+import { RegionFlag } from '@/components/ui/RegionFlag'
 import { useInfraMonitoringAttributesQuery } from '@/data/analytics/infra-monitoring-query'
 import { useLoadBalancersQuery } from '@/data/read-replicas/load-balancers-query'
 import { useReplicationLagQuery } from '@/data/read-replicas/replica-lag-query'
 import { useReadReplicasQuery } from '@/data/read-replicas/replicas-query'
 import { useReadReplicasStatusesQuery } from '@/data/read-replicas/replicas-status-query'
 import { useReportDateRange } from '@/hooks/misc/useReportDateRange'
-import { BASE_PATH } from '@/lib/constants'
 
 const attribute = 'physical_replication_lag_physical_replication_lag_seconds'
 
@@ -151,13 +151,7 @@ export const ReadReplicaDetails = () => {
                       readOnly
                       className="input-mono"
                       value={regionLabel}
-                      icon={
-                        <img
-                          alt="region icon"
-                          className="w-5 rounded-xs"
-                          src={`${BASE_PATH}/img/regions/${region ?? ''}.svg`}
-                        />
-                      }
+                      icon={<RegionFlag className="w-5" region={region ?? ''} />}
                     />
                   </FormItemLayout>
                   <FormItemLayout

--- a/apps/studio/components/interfaces/Settings/Infrastructure/ReadReplicas/ReadReplicaForm/index.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/ReadReplicas/ReadReplicaForm/index.tsx
@@ -20,9 +20,10 @@ import { ReadReplicaPricingDialog } from './ReadReplicaPricingDialog'
 import { useCheckEligibilityDeployReplica } from './useCheckEligibilityDeployReplica'
 import { AVAILABLE_REPLICA_REGIONS } from '@/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.constants'
 import type { RecommendedComputeForReadReplicas } from '@/components/interfaces/Settings/Infrastructure/ReadReplicas/recommendCompute'
+import { RegionFlag } from '@/components/ui/RegionFlag'
 import { Region, useReadReplicaSetUpMutation } from '@/data/read-replicas/replica-setup-mutation'
 import { useReadReplicasQuery } from '@/data/read-replicas/replicas-query'
-import { AWS_REGIONS_DEFAULT, BASE_PATH } from '@/lib/constants'
+import { AWS_REGIONS_DEFAULT } from '@/lib/constants'
 
 interface ReadReplicaFormProps {
   typeSelection?: ReactNode
@@ -115,11 +116,7 @@ export const ReadReplicaForm = ({
               {availableRegions.map((region) => (
                 <SelectItem key={region.key} value={region.key}>
                   <div className="flex gap-x-3 items-center">
-                    <img
-                      alt="region icon"
-                      className="w-5 rounded-xs"
-                      src={`${BASE_PATH}/img/regions/${region.region}.svg`}
-                    />
+                    <RegionFlag className="w-5" region={region.region} />
                     <p className="flex items-center gap-x-2">
                       <span>{region.name}</span>
                       <span className="text-xs text-foreground-lighter font-mono">

--- a/apps/studio/components/ui/RegionFlag.tsx
+++ b/apps/studio/components/ui/RegionFlag.tsx
@@ -1,5 +1,4 @@
 import type { ImgHTMLAttributes } from 'react'
-import { cn } from 'ui'
 
 import { BASE_PATH } from '@/lib/constants'
 
@@ -10,7 +9,7 @@ interface RegionFlagProps extends Omit<ImgHTMLAttributes<HTMLImageElement>, 'src
 export const RegionFlag = ({ alt = '', className, region, ...props }: RegionFlagProps) => (
   <img
     alt={alt}
-    className={cn('rounded-xs outline outline-1 outline-foreground-muted/20', className)}
+    className={`rounded-xs border border-foreground-muted/20 ${className ?? ''}`}
     src={`${BASE_PATH}/img/regions/${region}.svg`}
     {...props}
   />

--- a/apps/studio/components/ui/RegionFlag.tsx
+++ b/apps/studio/components/ui/RegionFlag.tsx
@@ -1,0 +1,17 @@
+import type { ImgHTMLAttributes } from 'react'
+import { cn } from 'ui'
+
+import { BASE_PATH } from '@/lib/constants'
+
+interface RegionFlagProps extends Omit<ImgHTMLAttributes<HTMLImageElement>, 'src'> {
+  region: string
+}
+
+export const RegionFlag = ({ alt = '', className, region, ...props }: RegionFlagProps) => (
+  <img
+    alt={alt}
+    className={cn('rounded-xs outline outline-1 outline-foreground-muted/20', className)}
+    src={`${BASE_PATH}/img/regions/${region}.svg`}
+    {...props}
+  />
+)

--- a/apps/studio/pages/project/[ref]/observability/edge-functions.tsx
+++ b/apps/studio/pages/project/[ref]/observability/edge-functions.tsx
@@ -31,11 +31,11 @@ import { ReportSettings } from '@/components/ui/Charts/ReportSettings'
 import { useChartHoverState } from '@/components/ui/Charts/useChartHoverState'
 import { DocsButton } from '@/components/ui/DocsButton'
 import { ObservabilityLink } from '@/components/ui/ObservabilityLink'
+import { RegionFlag } from '@/components/ui/RegionFlag'
 import { ShortcutTooltip } from '@/components/ui/ShortcutTooltip'
 import { useEdgeFunctionsQuery } from '@/data/edge-functions/edge-functions-query'
 import { edgeFunctionReports } from '@/data/reports/v2/edge-functions.config'
 import { useRefreshHandler, useReportDateRange } from '@/hooks/misc/useReportDateRange'
-import { BASE_PATH } from '@/lib/constants'
 import { SHORTCUT_IDS } from '@/state/shortcuts/registry'
 import { useShortcut } from '@/state/shortcuts/useShortcut'
 import type { NextPageWithLayout } from '@/types'
@@ -243,11 +243,7 @@ const EdgeFunctionsUsage = () => {
                   value: region.key,
                   label: (
                     <div className="flex items-center gap-x-2">
-                      <img
-                        src={`${BASE_PATH}/img/regions/${region.key}.svg`}
-                        alt={region.key}
-                        className="w-4 h-4"
-                      />
+                      <RegionFlag alt={region.key} className="w-4" region={region.key} />
                       <div className="flex flex-wrap gap-x-2 items-center">
                         <span className="text-foreground text-xs">{region.label}</span>
                         <span className="text-foreground-lighter text-xs">{region.key}</span>

--- a/apps/studio/pages/project/[ref]/observability/edge-functions.tsx
+++ b/apps/studio/pages/project/[ref]/observability/edge-functions.tsx
@@ -243,7 +243,7 @@ const EdgeFunctionsUsage = () => {
                   value: region.key,
                   label: (
                     <div className="flex items-center gap-x-2">
-                      <RegionFlag alt={region.key} className="w-4" region={region.key} />
+                      <RegionFlag aria-hidden="true" className="w-4" region={region.key} />
                       <div className="flex flex-wrap gap-x-2 items-center">
                         <span className="text-foreground text-xs">{region.label}</span>
                         <span className="text-foreground-lighter text-xs">{region.key}</span>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Studio interface fix.

## What is the current behavior?

Region flags with light backgrounds, such as Japan, can disappear against light Studio surfaces. Flag rendering is also repeated across region selectors and infrastructure views.

## What is the new behavior?

Region flags use a shared `RegionFlag` component with the existing small radius and a subtle 1px border. The treatment is applied consistently across project creation, replication, read replicas, infrastructure, and Edge Function observability.

| Before | After |
| --- | --- |
| <img width="746" height="246" alt="CleanShot 2026-08-25 at 14 01 07@2x" src="https://github.com/user-attachments/assets/5ccffccd-f253-47ca-a587-e97d1e8306a8" /> | <img width="746" height="234" alt="CleanShot 2026-08-25 at 14 09 20@2x" src="https://github.com/user-attachments/assets/9d59f7f6-4364-4c2c-8b97-a9673616736a" /> |

## To test

- Open the new project flow and inspect the selected region and region menu. Confirm light flags remain visible without changing size or aspect ratio.
- Open Database Replication and inspect region flags in the diagram and destination form.
- Open `/project/<ref>/settings/infrastructure` and inspect flags in the topology, map, and read replica details.
- Open Edge Function observability and inspect the region filter options.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Standardized region flag displays across project creation, replication, infrastructure, read replica, and observability views.
  * Region flags now use consistent styling, rounded borders, and rendering throughout the Studio interface.
  * Improved visual consistency for selected regions, database nodes, tooltips, and region options.
  * Decorative flags in observability views are handled appropriately for assistive technologies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->