### PR TITLE
fix: reset copy droupdown timeout ux fix

### DIFF
--- a/apps/studio/components/interfaces/ProjectHome/ProjectConnectionPopover.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/ProjectConnectionPopover.tsx
@@ -1,7 +1,7 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { Check, ChevronDown, Copy, Database, KeyRound, Link2, Terminal } from 'lucide-react'
 import { parseAsBoolean, useQueryState } from 'nuqs'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef , useState } from 'react'
 import {
   Button,
   cn,
@@ -39,6 +39,8 @@ interface ProjectConnectionPopoverProps {
 export const ProjectConnectionPopover = ({ projectRef }: ProjectConnectionPopoverProps) => {
   const [open, setOpen] = useState(false)
   const [copiedItem, setCopiedItem] = useState<string | null>(null)
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout>>()
+
   const [, setShowConnect] = useQueryState('showConnect', parseAsBoolean.withDefault(false))
 
   const { isLoading: isLoadingPermissions, can: canReadAPIKeys } = useAsyncCheckPermissions(
@@ -164,8 +166,10 @@ export const ProjectConnectionPopover = ({ projectRef }: ProjectConnectionPopove
   useEffect(() => {
     if (!open) {
       setCopiedItem(null)
+      clearTimeout(copyTimeoutRef.current)
     }
   }, [open])
+  useEffect(() => () => clearTimeout(copyTimeoutRef.current), [])
 
   return (
     <div className="mt-3 flex items-center gap-3">
@@ -206,6 +210,8 @@ export const ProjectConnectionPopover = ({ projectRef }: ProjectConnectionPopove
                     event.preventDefault()
                     if (item.disabled) return
 
+                    clearTimeout(copyTimeoutRef.current)
+                    copyTimeoutRef.current = setTimeout(() => setCopiedItem(null), 2000)
                     copyToClipboard(item.value)
                     setCopiedItem(item.label)
                   }}


### PR DESCRIPTION
hey i fixed a small issue i found in user experience , when copying project url , publisheable key , cli setup commands , etc from copy dropdown it didnt timeout ad let user copy again so i fixed that up and im thankful for getting to contribute to such a massive platform as a beginner! 

i dont have before and afters please try the feature out im sorry for this inconvience !

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved copy-status handling in the connection popover.
  * Copy feedback now resets reliably when the popover closes, the component is removed, or a new copy action starts.
  * Prevented stale copy notifications from persisting or overlapping during repeated copy actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->