### PR TITLE
fix(studio): scope the notebook unload warning to the current project

### DIFF
--- a/apps/studio/components/interfaces/Explorer/ExplorerNotebookTabCoordinator.tsx
+++ b/apps/studio/components/interfaces/Explorer/ExplorerNotebookTabCoordinator.tsx
@@ -37,7 +37,13 @@ export const ExplorerNotebookTabCoordinator = () => {
 
   useEffect(() => {
     const handleBeforeUnload = (event: BeforeUnloadEvent) => {
-      const hasUnsaved = Object.values(notebooksState.notebooks).some(hasDiscardableChanges)
+      // `notebooksState.notebooks` is keyed by notebook id across every project the session
+      // has visited, so it has to be filtered by `projectRef` the way every other reader of
+      // the store does. Without it, a dirty notebook left over from another project warns
+      // about unsaved changes the user cannot see from here.
+      const hasUnsaved = Object.values(notebooksState.notebooks).some(
+        (stateNotebook) => stateNotebook.projectRef === ref && hasDiscardableChanges(stateNotebook)
+      )
       if (hasUnsaved) {
         event.preventDefault()
         event.returnValue = true
@@ -46,7 +52,7 @@ export const ExplorerNotebookTabCoordinator = () => {
 
     window.addEventListener('beforeunload', handleBeforeUnload)
     return () => window.removeEventListener('beforeunload', handleBeforeUnload)
-  }, [])
+  }, [ref])
 
   useEffect(() => {
     return tabs.registerTabTypeHandler('notebook', {

--- a/apps/studio/components/interfaces/Explorer/__tests__/ExplorerNotebookTabCoordinator.test.tsx
+++ b/apps/studio/components/interfaces/Explorer/__tests__/ExplorerNotebookTabCoordinator.test.tsx
@@ -20,7 +20,11 @@ vi.mock('common', async (importOriginal) => {
 
 const NOTEBOOK_ID = 'notebook-coordinator-test'
 
-const seedNotebook = (status: 'new' | 'saved', cells: Notebooks.Cell[] = []) => {
+const seedNotebook = (
+  status: 'new' | 'saved',
+  cells: Notebooks.Cell[] = [],
+  projectRef = 'default'
+) => {
   delete notebooksState.notebooks[NOTEBOOK_ID]
   const notebook: Notebook = {
     id: NOTEBOOK_ID,
@@ -32,8 +36,8 @@ const seedNotebook = (status: 'new' | 'saved', cells: Notebooks.Cell[] = []) => 
     project_id: 1,
     content: { schema_version: 1, cells },
   }
-  if (status === 'new') notebooksState.addNotebook({ projectRef: 'default', notebook })
-  else notebooksState.setNotebook({ projectRef: 'default', notebook })
+  if (status === 'new') notebooksState.addNotebook({ projectRef, notebook })
+  else notebooksState.setNotebook({ projectRef, notebook })
 }
 
 const renderCoordinator = (queryClient: QueryClient) => {
@@ -103,5 +107,25 @@ describe('ExplorerNotebookTabCoordinator', () => {
     const { tabsState, tabId } = renderCoordinator(new QueryClient())
 
     expect(tabsState.getCloseConfirmation([tabId])).toBeNull()
+  })
+
+  it('warns before unload when this project has a notebook with unsaved changes', () => {
+    seedNotebook('new', [createQueryCellSkeleton()])
+    renderCoordinator(new QueryClient())
+
+    const event = new Event('beforeunload', { cancelable: true })
+    window.dispatchEvent(event)
+
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  it('does not warn before unload for a dirty notebook belonging to another project', () => {
+    seedNotebook('new', [createQueryCellSkeleton()], 'some-other-project')
+    renderCoordinator(new QueryClient())
+
+    const event = new Event('beforeunload', { cancelable: true })
+    window.dispatchEvent(event)
+
+    expect(event.defaultPrevented).toBe(false)
   })
 })


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix, following #49465.

## What is the current behavior?

#49465 added a `beforeunload` warning to `ExplorerNotebookTabCoordinator` so refreshing or closing the tab prompts when a notebook has unsaved changes. The check is:

```ts
const hasUnsaved = Object.values(notebooksState.notebooks).some(hasDiscardableChanges)
```

`notebooksState.notebooks` is a flat `Record<string, StateNotebook>` keyed by notebook id, not per project, and it is a module level valtio proxy, so it keeps entries for every project visited during the session. Each `StateNotebook` carries its own `projectRef` precisely because of this, and every other reader filters on it: `useNotebooks` does `.filter((x) => x.projectRef === projectRef)`, and `useCurrentNotebook` bails with `currentNotebook.projectRef !== ref`. This handler is the only reader that does not.

So: open a notebook in project A and leave it dirty, navigate to project B (client side, the store is never cleared), then close the browser tab. You get the native "changes you made may not be saved" prompt for a notebook you cannot see from project B.

I confirmed it rather than reasoning about it. Rendering the coordinator with `ref` as `default` and a dirty notebook seeded under `some-other-project`:

```
current project ref     : default
notebook projectRef     : some-other-project
prompt was triggered    : true
```

## What is the new behavior?

The check filters by `projectRef` like the store's other consumers, and `ref` joins the effect deps so the listener follows a client side project switch instead of closing over the first `ref` it saw.

Two tests in the file that already covers this component. The important one is the cross project case: reverting only the source change and keeping both tests gives

```
FAIL  ExplorerNotebookTabCoordinator > does not warn before unload for a dirty notebook belonging to another project
AssertionError: expected true to be false
Tests  1 failed | 6 passed (7)
```

The same project test would pass either way, so it is not proof of the bug. I kept it deliberately because the failure mode of getting this filter wrong is silent data loss (no warning at all), and that is worth pinning down.

## Additional context

Root cause at `apps/studio/components/interfaces/Explorer/ExplorerNotebookTabCoordinator.tsx:40`.

`ref` is `string | undefined`, so when it is absent nothing warns. That matches the `onClose` handler a few lines below, which already starts `if (!ref || !notebookId) return`, and this component only mounts inside the per project `ExplorerLayout`.

Deliberately unchanged: `event.returnValue = true` on the line below. It is redundant next to `preventDefault()` in modern browsers but harmless, it came in with #49465, and it is not what this PR is about.

Heads up that #49415 also edits this file, in the `evictNotebookFromCaches` call rather than this effect. Different hunk, but worth knowing if both land close together.

Gates: `test:prettier` clean repo wide, `typecheck --filter=studio --force` 9/9, `lint:ratchet` reports rules improved, full studio vitest 5844 passed of 5845. The single failure is `lib/local-storage.test.ts`, which fails identically on clean master (I checked out master and reran it to be sure) and is unrelated to this change.

Freshman contributor, and I use Claude Code as an assistant. I found this by looking at what #49465 changed, checked how the rest of the store is read, and verified the repro and the test myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unsaved notebooks when leaving a project.
  * Only unsaved notebooks in the current project now trigger a leave-page warning.
  * Project changes are reflected correctly, preventing outdated warnings.

* **Tests**
  * Added coverage for unload warnings across notebooks from current and other projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->