### PR TITLE
fix(pg-meta): preserve special role names in table privileges

### DIFF
--- a/packages/pg-meta/src/pg-meta-table-privileges.ts
+++ b/packages/pg-meta/src/pg-meta-table-privileges.ts
@@ -2,14 +2,7 @@ import { z } from 'zod'
 
 import { DEFAULT_SYSTEM_SCHEMAS } from './constants'
 import { filterByList } from './helpers'
-import {
-  ident,
-  joinSqlFragments,
-  keyword,
-  literal,
-  safeSql,
-  type SafeSqlFragment,
-} from './pg-format'
+import { joinSqlFragments, keyword, literal, safeSql, type SafeSqlFragment } from './pg-format'
 import { getScopedTablePrivilegesSql, TABLE_PRIVILEGES_SQL } from './sql/table-privileges'
 
 const pgTablePrivilegesZod = z.object({
@@ -186,20 +179,46 @@ type TablePrivilegesGrant = {
     | 'MAINTAIN'
   isGrantable?: boolean
 }
+
+function getGranteeFormat(grantee: string): {
+  format: SafeSqlFragment
+  value: SafeSqlFragment
+} {
+  if (grantee === 'public') {
+    return { format: safeSql`public`, value: safeSql`` }
+  }
+
+  // Keep the role name as a format argument rather than embedding its quoted
+  // identifier in the format string. This preserves names containing apostrophes.
+  return { format: safeSql`%I`, value: safeSql`, ${literal(grantee)}` }
+}
+
+function getDoBlockDelimiter(grantees: string[]): SafeSqlFragment {
+  let suffix = 0
+  while (true) {
+    const delimiter = suffix === 0 ? safeSql`$pg_meta$` : safeSql`$pg_meta_${literal(suffix)}$`
+    if (grantees.every((grantee) => !grantee.includes(delimiter))) {
+      return delimiter
+    }
+    suffix += 1
+  }
+}
+
 function grant(grants: TablePrivilegesGrant[]): { sql: SafeSqlFragment } {
+  const doBlockDelimiter = getDoBlockDelimiter(grants.map(({ grantee }) => grantee))
   const sql = safeSql`
-do $$
+do ${doBlockDelimiter}
 begin
 ${joinSqlFragments(
-  grants.map(
-    ({ privilegeType, relationId, grantee, isGrantable }) =>
-      safeSql`execute format('grant ${keyword(privilegeType)} on table %s to ${
-        grantee.toLowerCase() === 'public' ? safeSql`public` : ident(grantee)
-      } ${isGrantable ? safeSql`with grant option` : safeSql``}', ${literal(relationId)}::regclass);`
-  ),
+  grants.map(({ privilegeType, relationId, grantee, isGrantable }) => {
+    const granteeFormat = getGranteeFormat(grantee)
+    return safeSql`execute format('grant ${keyword(privilegeType)} on table %s to ${granteeFormat.format} ${
+      isGrantable ? safeSql`with grant option` : safeSql``
+    }', ${literal(relationId)}::regclass${granteeFormat.value});`
+  }),
   '\n'
 )}
-end $$;
+end ${doBlockDelimiter};
 `
   return { sql }
 }
@@ -219,19 +238,20 @@ type TablePrivilegesRevoke = {
     | 'MAINTAIN'
 }
 function revoke(revokes: TablePrivilegesRevoke[]): { sql: SafeSqlFragment } {
+  const doBlockDelimiter = getDoBlockDelimiter(revokes.map(({ grantee }) => grantee))
   const sql = safeSql`
-do $$
+do ${doBlockDelimiter}
 begin
 ${joinSqlFragments(
-  revokes.map(
-    ({ privilegeType, relationId, grantee }) =>
-      safeSql`execute format('revoke ${keyword(privilegeType)} on table %s from ${
-        grantee.toLowerCase() === 'public' ? safeSql`public` : ident(grantee)
-      }', ${literal(relationId)}::regclass);`
-  ),
+  revokes.map(({ privilegeType, relationId, grantee }) => {
+    const granteeFormat = getGranteeFormat(grantee)
+    return safeSql`execute format('revoke ${keyword(privilegeType)} on table %s from ${granteeFormat.format}', ${literal(
+      relationId
+    )}::regclass${granteeFormat.value});`
+  }),
   '\n'
 )}
-end $$;
+end ${doBlockDelimiter};
 `
   return { sql }
 }

--- a/packages/pg-meta/test/table-privilege-quoted-role.test.ts
+++ b/packages/pg-meta/test/table-privilege-quoted-role.test.ts
@@ -1,0 +1,89 @@
+import { afterAll, expect, test } from 'vitest'
+
+import pgMeta from '../src/index'
+import { cleanupRoot, createTestDatabase } from './db/utils'
+
+afterAll(async () => {
+  await cleanupRoot()
+})
+
+test('grant and revoke table privileges for special role identifiers', async () => {
+  const db = await createTestDatabase()
+  try {
+    await db.executeQuery(`
+      DROP ROLE IF EXISTS "grant'er", "x$$y", "Public", table_privilege_other;
+      CREATE ROLE "grant'er";
+      CREATE ROLE "x$$y";
+      CREATE ROLE "Public";
+      CREATE ROLE table_privilege_other;
+      CREATE TABLE public.privilege_quote_probe (id integer);
+    `)
+
+    const retrieved = pgMeta.tables.retrieve({
+      name: 'privilege_quote_probe',
+      schema: 'public',
+    })
+    const table = retrieved.zod.parse((await db.executeQuery(retrieved.sql))[0])
+
+    const { sql: grantSql } = pgMeta.tablePrivileges.grant([
+      {
+        relationId: table!.id,
+        grantee: "grant'er",
+        privilegeType: 'SELECT',
+        isGrantable: true,
+      },
+      { relationId: table!.id, grantee: 'x$$y', privilegeType: 'SELECT' },
+      { relationId: table!.id, grantee: 'Public', privilegeType: 'SELECT' },
+    ])
+    await db.executeQuery(grantSql)
+
+    const granted = await db.executeQuery<{ role_name: string; granted: boolean }[]>(
+      `
+        SELECT role_name, has_table_privilege(role_name, 'public.privilege_quote_probe', 'SELECT') AS granted
+        FROM unnest(ARRAY['grant''er', 'x$$y', 'Public', 'table_privilege_other']) AS role_name;
+      `
+    )
+    expect(granted).toEqual([
+      { role_name: "grant'er", granted: true },
+      { role_name: 'x$$y', granted: true },
+      { role_name: 'Public', granted: true },
+      { role_name: 'table_privilege_other', granted: false },
+    ])
+
+    const grantOptions = await db.executeQuery<{ is_grantable: boolean }[]>(`
+      SELECT acl.is_grantable
+      FROM pg_class AS c
+      CROSS JOIN LATERAL aclexplode(c.relacl) AS acl
+      JOIN pg_roles AS r ON r.oid = acl.grantee
+      WHERE c.oid = 'public.privilege_quote_probe'::regclass
+        AND r.rolname = 'grant''er'
+        AND acl.privilege_type = 'SELECT';
+    `)
+    expect(grantOptions).toEqual([{ is_grantable: true }])
+
+    const { sql: revokeSql } = pgMeta.tablePrivileges.revoke([
+      { relationId: table!.id, grantee: "grant'er", privilegeType: 'SELECT' },
+      { relationId: table!.id, grantee: 'x$$y', privilegeType: 'SELECT' },
+      { relationId: table!.id, grantee: 'Public', privilegeType: 'SELECT' },
+    ])
+    await db.executeQuery(revokeSql)
+
+    const revoked = await db.executeQuery<{ role_name: string; granted: boolean }[]>(
+      `
+        SELECT role_name, has_table_privilege(role_name, 'public.privilege_quote_probe', 'SELECT') AS granted
+        FROM unnest(ARRAY['grant''er', 'x$$y', 'Public', 'table_privilege_other']) AS role_name;
+      `
+    )
+    expect(revoked).toEqual([
+      { role_name: "grant'er", granted: false },
+      { role_name: 'x$$y', granted: false },
+      { role_name: 'Public', granted: false },
+      { role_name: 'table_privilege_other', granted: false },
+    ])
+  } finally {
+    await db
+      .executeQuery(`DROP ROLE IF EXISTS "grant'er", "x$$y", "Public", table_privilege_other;`)
+      .catch(() => undefined)
+    await db.cleanup()
+  }
+})

--- a/packages/pg-meta/test/table-privilege-quoted-role.test.ts
+++ b/packages/pg-meta/test/table-privilege-quoted-role.test.ts
@@ -11,9 +11,11 @@ test('grant and revoke table privileges for special role identifiers', async () 
   const db = await createTestDatabase()
   try {
     await db.executeQuery(`
-      DROP ROLE IF EXISTS "grant'er", "x$$y", "Public", table_privilege_other;
+      DROP ROLE IF EXISTS "grant'er", "x$$y", "x$pg_meta$y", "x$pg_meta_1$y", "Public", table_privilege_other;
       CREATE ROLE "grant'er";
       CREATE ROLE "x$$y";
+      CREATE ROLE "x$pg_meta$y";
+      CREATE ROLE "x$pg_meta_1$y";
       CREATE ROLE "Public";
       CREATE ROLE table_privilege_other;
       CREATE TABLE public.privilege_quote_probe (id integer);
@@ -33,6 +35,8 @@ test('grant and revoke table privileges for special role identifiers', async () 
         isGrantable: true,
       },
       { relationId: table!.id, grantee: 'x$$y', privilegeType: 'SELECT' },
+      { relationId: table!.id, grantee: 'x$pg_meta$y', privilegeType: 'SELECT' },
+      { relationId: table!.id, grantee: 'x$pg_meta_1$y', privilegeType: 'SELECT' },
       { relationId: table!.id, grantee: 'Public', privilegeType: 'SELECT' },
     ])
     await db.executeQuery(grantSql)
@@ -40,12 +44,14 @@ test('grant and revoke table privileges for special role identifiers', async () 
     const granted = await db.executeQuery<{ role_name: string; granted: boolean }[]>(
       `
         SELECT role_name, has_table_privilege(role_name, 'public.privilege_quote_probe', 'SELECT') AS granted
-        FROM unnest(ARRAY['grant''er', 'x$$y', 'Public', 'table_privilege_other']) AS role_name;
+        FROM unnest(ARRAY['grant''er', 'x$$y', 'x$pg_meta$y', 'x$pg_meta_1$y', 'Public', 'table_privilege_other']) AS role_name;
       `
     )
     expect(granted).toEqual([
       { role_name: "grant'er", granted: true },
       { role_name: 'x$$y', granted: true },
+      { role_name: 'x$pg_meta$y', granted: true },
+      { role_name: 'x$pg_meta_1$y', granted: true },
       { role_name: 'Public', granted: true },
       { role_name: 'table_privilege_other', granted: false },
     ])
@@ -64,6 +70,8 @@ test('grant and revoke table privileges for special role identifiers', async () 
     const { sql: revokeSql } = pgMeta.tablePrivileges.revoke([
       { relationId: table!.id, grantee: "grant'er", privilegeType: 'SELECT' },
       { relationId: table!.id, grantee: 'x$$y', privilegeType: 'SELECT' },
+      { relationId: table!.id, grantee: 'x$pg_meta$y', privilegeType: 'SELECT' },
+      { relationId: table!.id, grantee: 'x$pg_meta_1$y', privilegeType: 'SELECT' },
       { relationId: table!.id, grantee: 'Public', privilegeType: 'SELECT' },
     ])
     await db.executeQuery(revokeSql)
@@ -71,18 +79,22 @@ test('grant and revoke table privileges for special role identifiers', async () 
     const revoked = await db.executeQuery<{ role_name: string; granted: boolean }[]>(
       `
         SELECT role_name, has_table_privilege(role_name, 'public.privilege_quote_probe', 'SELECT') AS granted
-        FROM unnest(ARRAY['grant''er', 'x$$y', 'Public', 'table_privilege_other']) AS role_name;
+        FROM unnest(ARRAY['grant''er', 'x$$y', 'x$pg_meta$y', 'x$pg_meta_1$y', 'Public', 'table_privilege_other']) AS role_name;
       `
     )
     expect(revoked).toEqual([
       { role_name: "grant'er", granted: false },
       { role_name: 'x$$y', granted: false },
+      { role_name: 'x$pg_meta$y', granted: false },
+      { role_name: 'x$pg_meta_1$y', granted: false },
       { role_name: 'Public', granted: false },
       { role_name: 'table_privilege_other', granted: false },
     ])
   } finally {
     await db
-      .executeQuery(`DROP ROLE IF EXISTS "grant'er", "x$$y", "Public", table_privilege_other;`)
+      .executeQuery(
+        `DROP ROLE IF EXISTS "grant'er", "x$$y", "x$pg_meta$y", "x$pg_meta_1$y", "Public", table_privilege_other;`
+      )
       .catch(() => undefined)
     await db.cleanup()
   }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

`pg-meta` table privilege mutations fail for valid PostgreSQL role names containing special characters. In particular, `grant()` and `revoke()` fail for role names containing apostrophes or `$$` because the generated role value is embedded inside a PL/pgSQL `DO` block and `format()` string. A quoted role named `"Public"` is also incorrectly treated as the `PUBLIC` pseudo-role because grantee matching is case-insensitive.

## What is the new behavior?

- Role names are passed to PostgreSQL `format()` as `%I` arguments rather than embedded identifier text.
- The outer `DO` block uses a generated dollar-quote delimiter that is checked against all grantee values.
- Only the exact catalog pseudo-role value `public` is emitted as `PUBLIC`; quoted roles such as `"Public"` remain distinct roles.
- Grant and revoke behavior, including `WITH GRANT OPTION`, is covered by an integration regression test.

## Additional context

The regression test covers role names containing an apostrophe, `$$`, and the quoted role `"Public"`, and verifies actual grant/revoke state plus grant-option semantics against PostgreSQL.

Verification performed:

```text
33 test files / 479 tests passed
pnpm --filter @supabase/pg-meta typecheck
Prettier check
 git diff --check
```

The full test command used was:

```bash
bash test/run-tests.sh pnpm vitest run --coverage=false --maxWorkers=1 --no-file-parallelism --testTimeout 30000
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table privilege grants and revocations for roles with special characters, mixed casing, apostrophes, or dollar signs in their names.
  * Ensured the `public` role continues to be handled correctly.
* **Tests**
  * Added coverage verifying grants, effective read access, revocations, and cleanup for quoted and complex role names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->