### PR TITLE
[MUL-1364] fix(studio): use multipooler copy for dedicated pooler chart on HA

### DIFF
--- a/apps/studio/data/reports/database-charts.test.ts
+++ b/apps/studio/data/reports/database-charts.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+
+import { getReportAttributesV2 } from './database-charts'
+import { Project } from '@/data/projects/project-detail-query'
+
+const PROJECT: Project = {
+  cloud_provider: 'AWS',
+  connectionString: 'postgresql://postgres:password@db.project-ref.supabase.co:5432/postgres',
+  db_host: 'db.project-ref.supabase.co',
+  dbVersion: 'supabase-postgres-15.1.0',
+  high_availability: false,
+  id: 1,
+  infra_compute_size: 'micro',
+  inserted_at: '2026-01-01T00:00:00.000Z',
+  integration_source: null,
+  is_branch_enabled: false,
+  is_physical_backups_enabled: false,
+  name: 'Production',
+  organization_id: 1,
+  ref: 'project-ref',
+  region: 'us-east-1',
+  restUrl: 'https://project-ref.supabase.co',
+  status: 'ACTIVE_HEALTHY',
+  subscription_id: 'subscription-1',
+  updated_at: '2026-01-01T00:00:00.000Z',
+}
+
+const ENTITLED_FEATURES = ['database']
+
+const getDedicatedPoolerChart = (project: Project) => {
+  const chart = getReportAttributesV2(ENTITLED_FEATURES, project).find(
+    (attribute) => attribute.id === 'pgbouncer-connections'
+  )
+  if (!chart) throw new Error('Expected the dedicated pooler chart to exist')
+  return chart
+}
+
+const getClientConnectionsAttribute = (chart: ReturnType<typeof getDedicatedPoolerChart>) => {
+  const attribute = chart.attributes?.find(
+    (attr) => attr !== false && attr.attribute === 'client_connections_pgbouncer'
+  )
+  if (!attribute) throw new Error('Expected the client connections attribute to exist')
+  return attribute
+}
+
+describe('getReportAttributesV2 dedicated pooler chart', () => {
+  it('uses PgBouncer copy and links to the docs for standard projects', () => {
+    const chart = getDedicatedPoolerChart(PROJECT)
+    const attribute = getClientConnectionsAttribute(chart)
+
+    expect(chart.titleTooltip).toBeUndefined()
+    expect(chart.docsUrl).toContain('/guides/platform/compute-and-disk#limits-and-constraints')
+    expect(attribute).toMatchObject({ label: 'pgbouncer', tooltip: 'PgBouncer connections' })
+  })
+
+  it('uses multipooler copy and drops the docs link for High Availability projects', () => {
+    const chart = getDedicatedPoolerChart({ ...PROJECT, high_availability: true })
+    const attribute = getClientConnectionsAttribute(chart)
+
+    expect(chart.docsUrl).toBeUndefined()
+    expect(chart.titleTooltip).toContain('multipooler')
+    expect(chart.titleTooltip).toContain('docs coming soon')
+    expect(attribute).toMatchObject({ label: 'multipooler', tooltip: 'Multipooler connections' })
+  })
+})

--- a/apps/studio/data/reports/database-charts.ts
+++ b/apps/studio/data/reports/database-charts.ts
@@ -9,6 +9,7 @@ import { ReportAttributes } from '@/components/ui/Charts/ComposedChart.utils'
 import { DiskAttributesData } from '@/data/config/disk-attributes-query'
 import { MaxConnectionsData } from '@/data/database/max-connections-query'
 import { Project } from '@/data/projects/project-detail-query'
+import { resolveHighAvailability } from '@/hooks/misc/useHighAvailability.constants'
 import { DOCS_URL } from '@/lib/constants'
 import { formatBytes, formatBytesMinMB } from '@/lib/helpers'
 
@@ -32,6 +33,9 @@ export const getReportAttributesV2: (
   showMemoryCommitmentChart
 ) => {
   const computeVariantId = mapComputeSizeNameToAddonVariantId(project?.infra_compute_size)
+  // High Availability projects run Multigres, whose dedicated pooler is multipooler rather
+  // than PgBouncer. Multipooler docs aren't published yet, so the docs link is dropped for now.
+  const isHighAvailability = resolveHighAvailability(project)
   const provisionedDiskIops = diskConfig?.attributes?.iops
   const computeIopsLimit = COMPUTE_MAX_IOPS[computeVariantId]
   const effectiveMaxIops =
@@ -503,13 +507,18 @@ export const getReportAttributesV2: (
       YAxisProps: { width: 30 },
       hideChartType: false,
       defaultChartStyle: 'bar',
-      docsUrl: `${DOCS_URL}/guides/platform/compute-and-disk#limits-and-constraints`,
+      titleTooltip: isHighAvailability
+        ? 'Client connections to multipooler, the dedicated pooler for High Availability projects (docs coming soon)'
+        : undefined,
+      docsUrl: isHighAvailability
+        ? undefined
+        : `${DOCS_URL}/guides/platform/compute-and-disk#limits-and-constraints`,
       attributes: [
         {
           attribute: 'client_connections_pgbouncer',
           provider: 'infra-monitoring',
-          label: 'pgbouncer',
-          tooltip: 'PgBouncer connections',
+          label: isHighAvailability ? 'multipooler' : 'pgbouncer',
+          tooltip: isHighAvailability ? 'Multipooler connections' : 'PgBouncer connections',
         },
         {
           attribute: 'pg_pooler_max_connections',


### PR DESCRIPTION
The "Dedicated Pooler Client Connections" chart on the Database observability page labels its series `pgbouncer` and links to PgBouncer limits docs. High Availability projects run Multigres, whose dedicated pooler is multipooler, so that copy was misleading. This swaps the copy for HA projects and drops the docs link until multipooler docs exist (per the ticket, disabling the link for now is fine).

**Changed:**
- HA projects: legend label `pgbouncer` → `multipooler`, series tooltip → "Multipooler connections"
- HA projects: the info icon shows a "docs coming soon" tooltip instead of linking to the compute-and-disk limits docs
- Non-HA projects are unchanged

**Added:**
- Unit test for `getReportAttributesV2` covering both the PgBouncer and multipooler branches

Out of scope (flagging for follow-up): the "Max pooler connections" reference line still uses the PgBouncer value on HA projects, and the Supavisor chart still renders for HA projects.

Addresses https://linear.app/supabase/issue/MUL-1364/database-dashboard-update-dedicated-poolers-copy

## To test

- On a High Availability project, open Observability → Database and find "Dedicated Pooler Client Connections"
- Legend and hover tooltip should say `multipooler`; the info icon should show a tooltip ending in "(docs coming soon)" with no link
- On a non-HA project, the chart should be unchanged: `pgbouncer` legend and the info icon links to the compute-and-disk docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - High Availability projects now display dedicated connection pooler charts with multipooler-specific labels and guidance.
  - Standard projects continue to show PgBouncer information and documentation links.
  - High Availability charts include a tooltip indicating that documentation is coming soon.
  - Eligible burstable, non-High Availability projects now display a Disk IO Burst Balance chart.

- **Bug Fixes**
  - Disk IO Burst Balance is hidden for High Availability projects, unsupported compute sizes, and when the feature is disabled.

- **Tests**
  - Added coverage for pooler and Disk IO Burst Balance chart visibility and content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->