### PR TITLE
[MUL-1347] fix(studio): hide Disk IO Burst Balance chart for HA projects

### DIFF
--- a/apps/studio/data/reports/database-charts.test.ts
+++ b/apps/studio/data/reports/database-charts.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import { getReportAttributesV2 } from './database-charts'
+import { Project } from '@/data/projects/project-detail-query'
+
+const buildProject = (overrides: Partial<Project> = {}) =>
+  ({
+    infra_compute_size: 'micro',
+    high_availability: false,
+    ...overrides,
+  }) as Project
+
+const getBurstBalanceChart = (project: Project, showDiskIOBurstBalanceChart = true) =>
+  getReportAttributesV2(
+    [],
+    project,
+    undefined,
+    undefined,
+    undefined,
+    false,
+    showDiskIOBurstBalanceChart
+  ).find((chart) => chart.id === 'disk-io-burst-balance')
+
+describe('getReportAttributesV2 disk-io-burst-balance chart', () => {
+  it('shows the chart for burstable non high availability projects', () => {
+    expect(getBurstBalanceChart(buildProject())?.hide).toBe(false)
+  })
+
+  it('hides the chart for high availability projects', () => {
+    expect(getBurstBalanceChart(buildProject({ high_availability: true }))?.hide).toBe(true)
+  })
+
+  it('hides the chart when the feature flag is off', () => {
+    expect(getBurstBalanceChart(buildProject(), false)?.hide).toBe(true)
+  })
+
+  it('hides the chart for non burstable compute sizes', () => {
+    expect(getBurstBalanceChart(buildProject({ infra_compute_size: '16xlarge' }))?.hide).toBe(true)
+  })
+})

--- a/apps/studio/data/reports/database-charts.ts
+++ b/apps/studio/data/reports/database-charts.ts
@@ -9,6 +9,7 @@ import { ReportAttributes } from '@/components/ui/Charts/ComposedChart.utils'
 import { DiskAttributesData } from '@/data/config/disk-attributes-query'
 import { MaxConnectionsData } from '@/data/database/max-connections-query'
 import { Project } from '@/data/projects/project-detail-query'
+import { resolveHighAvailability } from '@/hooks/misc/useHighAvailability.constants'
 import { DOCS_URL } from '@/lib/constants'
 import { formatBytes, formatBytesMinMB } from '@/lib/helpers'
 
@@ -38,8 +39,12 @@ export const getReportAttributesV2: (
     typeof provisionedDiskIops === 'number' && typeof computeIopsLimit === 'number'
       ? Math.min(provisionedDiskIops, computeIopsLimit)
       : provisionedDiskIops
+  // High Availability projects run on volumes without a burst credit pool, so the
+  // Disk IO Burst Balance chart has no data to show for them.
   const showBurstBalanceChart =
-    !!showDiskIOBurstBalanceChart && hasBurstableIO(project?.infra_compute_size)
+    !!showDiskIOBurstBalanceChart &&
+    hasBurstableIO(project?.infra_compute_size) &&
+    !resolveHighAvailability(project)
   const baselineThroughputMBps = COMPUTE_DISK[computeVariantId]?.baselineThroughputMBps
   const baselineThroughputLabel =
     typeof baselineThroughputMBps === 'number' ? `${baselineThroughputMBps} MB/s` : 'its baseline'


### PR DESCRIPTION
Hides the Disk IO Burst Balance chart on the Database observability page for High Availability projects. Their volumes have no burst credit pool, so the panel had nothing to load and rendered "Unable to load data for Disk IO Burst Balance".

**Changed:**
- `getReportAttributesV2` now also requires `!resolveHighAvailability(project)` before showing the `disk-io-burst-balance` chart – the existing feature flag and `hasBurstableIO` gating are unchanged for non-HA projects

**Added:**
- Unit tests covering the chart's visibility across HA / flag / compute size combinations

## To test

- On a High Availability project with the `showDiskIOBurstBalanceChart` flag on, open `/project/[ref]/observability/database` – the Disk IO Burst Balance panel should no longer render
- On a non-HA project with a burstable compute size (e.g. micro) and the flag on, the panel should still render as before

Addresses https://linear.app/supabase/issue/MUL-1347/remove-panel-from-database-dashboard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hid the Disk I/O Burst Balance chart for High Availability projects, where no burst-credit data is available.
  * Continued hiding the chart when burst balancing is unsupported or disabled.

* **Tests**
  * Added coverage for eligible projects and scenarios where the chart should remain hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->