### PR TITLE
Show loader for notebook counts

### DIFF
--- a/apps/studio/components/layouts/ExplorerLayout/ExplorerNavHome.tsx
+++ b/apps/studio/components/layouts/ExplorerLayout/ExplorerNavHome.tsx
@@ -2,6 +2,7 @@ import { useParams } from 'common'
 import { motion } from 'framer-motion'
 import { ChevronRight } from 'lucide-react'
 import Link from 'next/link'
+import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 
 import {
   EXPLORER_SECTIONS,
@@ -28,7 +29,10 @@ export const ExplorerNavHome = ({
   const notebooks = notebooksData?.pages.flatMap((page) => page.content) ?? []
   const chats = useAiAssistantChatList()
 
-  const { data: notebookCountData } = useContentCountQuery({ projectRef: ref, type: 'notebook' })
+  const { data: notebookCountData, isPending } = useContentCountQuery({
+    projectRef: ref,
+    type: 'notebook',
+  })
   // [Joshen] Notebooks are all shared by default, none private
   const notebookCount = notebookCountData?.shared ?? 0
 
@@ -57,9 +61,15 @@ export const ExplorerNavHome = ({
             >
               <Icon size={14} className="shrink-0" />
               <span className="flex-1 text-left">{label}</span>
-              <span className="text-xs text-foreground-lighter">
-                {type === 'notebook' ? notebookCount : chats.length}
-              </span>
+              {type === 'notebook' ? (
+                isPending ? (
+                  <ShimmeringLoader className="w-3 py-2" />
+                ) : (
+                  <span className="text-xs text-foreground-lighter">{notebookCount}</span>
+                )
+              ) : (
+                <span className="text-xs text-foreground-lighter">{chats.length}</span>
+              )}
               <ChevronRight size={14} className="shrink-0 text-foreground-muted" />
             </button>
           )


### PR DESCRIPTION
## Context

Shows a loader UI for the notebook count, otherwise it'll incorrectly show `0` initially

<img width="292" height="117" alt="image" src="https://github.com/user-attachments/assets/17e3841d-b60b-4869-a0f0-3b44feb461c0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a loading indicator for notebook counts while data is being retrieved.
  * Prevented incomplete or unavailable counts from appearing before loading finishes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->