### PR TITLE
Remove box shadow on explorer home tab button

### DIFF
--- a/apps/studio/components/layouts/ExplorerLayout/ExplorerLayout.tsx
+++ b/apps/studio/components/layouts/ExplorerLayout/ExplorerLayout.tsx
@@ -110,7 +110,7 @@ const HomeTabButton = () => {
       value={EXPLORER_HOME_TAB_ID}
       className={cn(
         TabClassName,
-        'relative group border-b border-default',
+        'relative group border-b border-default shadow-none!',
         explorerTabs.length === 0 && 'border-r border-r-default!',
         'bg-dash-sidebar/50 dark:bg-surface-100/50',
         'data-[state=active]:bg-dash-sidebar dark:data-[state=active]:bg-surface-100',


### PR DESCRIPTION
## Context

Explorer home tab has a box shadow when selected (more visible in light mode) so this PR removes it

Before:
<img width="237" height="218" alt="image" src="https://github.com/user-attachments/assets/17abd73b-2328-47ad-bb58-94cb5761dbb1" />

After:
<img width="242" height="208" alt="image" src="https://github.com/user-attachments/assets/ef159dd7-61b9-4027-8b58-25229ae2283a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the active Explorer home tab appearance to remove its default shadow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->