### PR TITLE
Assistant notebook confirm button CTAs to have loading states

### DIFF
--- a/apps/studio/components/ui/AIAssistantPanel/Confirm.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/Confirm.tsx
@@ -61,7 +61,13 @@ export const ConfirmFooter = ({
                 {cancelLabel}
               </Button>
               {!denyOnly && (
-                <Button size="tiny" variant="primary" onClick={onConfirm} disabled={isInactive}>
+                <Button
+                  size="tiny"
+                  variant="primary"
+                  onClick={onConfirm}
+                  loading={isLoading}
+                  disabled={isInactive}
+                >
                   {isLoading ? confirmLabelLoading : confirmLabel}
                 </Button>
               )}


### PR DESCRIPTION
## Context

Sets the loading state for the Assistant's Notebook actions for CTA button behaviour consistency - currently only gets disabled when clicked.

<img width="281" height="155" alt="image" src="https://github.com/user-attachments/assets/c65c267b-9eb4-4669-aae4-e81b574e880c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The AI Assistant confirmation button now displays a loading state while processing, while preserving its disabled behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->