### PR TITLE
fix(www): pricing table spacing and sticky offset

### DIFF
--- a/apps/www/components/Pricing/PricingComparisonTable.tsx
+++ b/apps/www/components/Pricing/PricingComparisonTable.tsx
@@ -4,8 +4,9 @@ import { PricingTableRowDesktop, PricingTableRowMobile } from '~/components/Pric
 import Solutions from '~/data/MainProducts'
 import { Organization } from '~/data/organizations'
 import { useSendTelemetryEvent } from '~/lib/telemetry'
+import { useIsomorphicLayoutEffect } from 'common'
 import Link from 'next/link'
-import { useEffect, useRef, useState } from 'react'
+import { useRef, useState } from 'react'
 import { plans } from 'shared-data/plans'
 import { pricing } from 'shared-data/pricing'
 import {
@@ -123,14 +124,14 @@ const PricingComparisonTable = ({
   const tableRef = useRef<HTMLTableElement>(null)
   const theadRef = useRef<HTMLTableSectionElement>(null)
 
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     const table = tableRef.current
     const thead = theadRef.current
     if (!table || !thead) return
 
     const observer = new ResizeObserver(() => {
       const theadTop = parseFloat(getComputedStyle(thead).top) || 0
-      const categoryTop = theadTop + thead.getBoundingClientRect().height
+      const categoryTop = Math.floor(theadTop + thead.getBoundingClientRect().height)
       table.style.setProperty('--pricing-category-top', `${categoryTop}px`)
     })
     observer.observe(thead)

--- a/apps/www/components/Pricing/PricingComparisonTable.tsx
+++ b/apps/www/components/Pricing/PricingComparisonTable.tsx
@@ -5,7 +5,7 @@ import Solutions from '~/data/MainProducts'
 import { Organization } from '~/data/organizations'
 import { useSendTelemetryEvent } from '~/lib/telemetry'
 import Link from 'next/link'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { plans } from 'shared-data/plans'
 import { pricing } from 'shared-data/pricing'
 import {
@@ -119,6 +119,23 @@ const PricingComparisonTable = ({
 
   const sendTelemetryEvent = useSendTelemetryEvent()
   const orgSlug = organizations?.[0]?.slug
+
+  const tableRef = useRef<HTMLTableElement>(null)
+  const theadRef = useRef<HTMLTableSectionElement>(null)
+
+  useEffect(() => {
+    const table = tableRef.current
+    const thead = theadRef.current
+    if (!table || !thead) return
+
+    const observer = new ResizeObserver(() => {
+      const theadTop = parseFloat(getComputedStyle(thead).top) || 0
+      const categoryTop = theadTop + thead.getBoundingClientRect().height
+      table.style.setProperty('--pricing-category-top', `${categoryTop}px`)
+    })
+    observer.observe(thead)
+    return () => observer.disconnect()
+  }, [])
 
   return (
     <div
@@ -372,9 +389,9 @@ const PricingComparisonTable = ({
 
       {/* <!-- lg+ --> */}
       <div className="hidden lg:block">
-        <table className="h-px w-full table-fixed">
+        <table ref={tableRef} className="h-px w-full table-fixed">
           <caption className="sr-only">Pricing plan comparison</caption>
-          <thead className="bg-background sticky top-[62px] z-10">
+          <thead ref={theadRef} className="bg-background sticky top-[62px] z-10">
             <tr>
               <th
                 className="text-foreground w-1/3 px-6 pt-2 pb-2 text-left text-sm font-normal"

--- a/apps/www/components/Pricing/PricingTableRow.tsx
+++ b/apps/www/components/Pricing/PricingTableRow.tsx
@@ -209,7 +209,7 @@ export const PricingTableRowDesktop = (props: any) => {
                   <td
                     key={i}
                     className={[
-                      `pl-6 pr-2 tier-${planName}`,
+                      `pl-6 pr-2 py-5 tier-${planName}`,
                       typeof planValue === 'boolean' ? 'text-center' : '',
                     ].join(' ')}
                   >
@@ -235,7 +235,7 @@ export const PricingTableRowDesktop = (props: any) => {
                         </span>
                         {Array.isArray(planValue) &&
                           planValue.slice(1).map((val, idx) => (
-                            <span key={`planval_${i}_${idx}`} className="text-lighter leading-5">
+                            <span key={`planval_${i}_${idx}`} className="text-lighter leading-4">
                               {val}
                             </span>
                           ))}

--- a/apps/www/components/Pricing/PricingTableRow.tsx
+++ b/apps/www/components/Pricing/PricingTableRow.tsx
@@ -220,7 +220,7 @@ export const PricingTableRowDesktop = (props: any) => {
                         <IconPricingMinus plan={planValue} />
                       </div>
                     ) : (
-                      <div className="text-foreground text-xs flex flex-col justify-center gap-1">
+                      <div className="text-foreground text-xs flex flex-col justify-center gap-2">
                         <span className="flex items-center gap-2">
                           {tooltips?.[planName] && (
                             <InfoTooltip

--- a/apps/www/components/Pricing/PricingTableRow.tsx
+++ b/apps/www/components/Pricing/PricingTableRow.tsx
@@ -166,8 +166,10 @@ export const PricingTableRowDesktop = (props: any) => {
         style={{ borderTop: 'none' }}
         id={`${props.sectionId}-desktop`}
       >
+        {/* 108px/84px are pre-hydration fallbacks only; after mount PricingComparisonTable
+            measures the sticky thead into --pricing-category-top and that value wins */}
         <th
-          className="bg-background text-foreground sticky top-[108px] xl:top-[84px] z-10 py-3 pl-6 text-left text-sm font-medium"
+          className="bg-background text-foreground sticky top-[var(--pricing-category-top,108px)] xl:top-[var(--pricing-category-top,84px)] z-10 py-3 pl-6 text-left text-sm font-medium"
           scope="colgroup"
         >
           <div className="flex items-center gap-4">

--- a/apps/www/components/Pricing/PricingTableRow.tsx
+++ b/apps/www/components/Pricing/PricingTableRow.tsx
@@ -218,7 +218,7 @@ export const PricingTableRowDesktop = (props: any) => {
                         <IconPricingMinus plan={planValue} />
                       </div>
                     ) : (
-                      <div className="text-foreground text-xs flex flex-col justify-center">
+                      <div className="text-foreground text-xs flex flex-col justify-center gap-1">
                         <span className="flex items-center gap-2">
                           {tooltips?.[planName] && (
                             <InfoTooltip
@@ -233,7 +233,7 @@ export const PricingTableRowDesktop = (props: any) => {
                         </span>
                         {Array.isArray(planValue) &&
                           planValue.slice(1).map((val, idx) => (
-                            <span key={`planval_${i}_${idx}`} className="text-lighter leading-4">
+                            <span key={`planval_${i}_${idx}`} className="text-lighter leading-5">
                               {val}
                             </span>
                           ))}


### PR DESCRIPTION
Multi-line cells in the /pricing comparison table rendered as one cramped block once lines wrapped: the stacked values had no gap between entries, and the continuation lines' `leading-4` is a no-op at `text-xs`. At the same narrow desktop widths (1024 to 1280px), category headers clipped behind the sticky plan header because their hardcoded `top-[108px] xl:top-[84px]` offsets desync from the plan header's variable height.

**Changed:**
- **Value cells get vertical padding**: the value tds were `pl-6 pr-2` with no vertical padding, so tall multi-line cells pressed text against the row dividers; they now carry `py-5` like the row-label column (text ink sits ~21px off both borders, measured).
- **Stacked price lines read as separate entries**: `gap-2` between entries while wrapped lines inside one entry stay tight (`leading-4`), so each price reads as its own block. Two earlier iterations that only widened the entry gap (`gap-1`, then `gap-2` with looser `leading-5` wraps) reviewed as still-cramped; the missing cell padding was the dominant cause. Mobile untouched.
- **Category headers never clip behind the plan header**: a ResizeObserver measures the sticky thead's real height and publishes `--pricing-category-top` as a CSS variable on the table; the category header consumes it via `var()`, keeping the old 108px/84px values as pre-hydration fallbacks so SSR paint is unchanged. Runs in a layout effect so the first client paint already has the measured value.

**Note:** I rejected re-tuning the hardcoded offsets: numbers desyncing from the header's content-driven height is the root cause, and new constants re-break on the next copy or breakpoint change.

## Before / after

**Before** (prod: multi-line prices pressed against the row dividers as one dense block; rows clipped under the sticky category header):
<img width="1442" height="450" alt="pr-before" src="https://github.com/user-attachments/assets/91d428df-e04c-4494-b454-84a8a46b3ddd" />

**After** (this PR: padded cells, each price its own block, headers pin flush):
<img width="1497" height="375" alt="pr-after" src="https://github.com/user-attachments/assets/5aa2c3c7-b41e-42c0-8159-bb294a5d1dea" />

## To test

Tested on the Vercel preview (Playwright, measured values in parens):
- [x] At a 1024 to 1280px viewport, open /pricing and find the Pipelines row: the 3 price lines in the Pro and Team cells read as distinct blocks (row-gap 8px between entries, tight 16px line boxes within an entry, 20px cell padding; verified on localhost pre-push and on the preview, light and dark)
- [x] Multi-line cell text no longer touches the row dividers: ~21px from border to text ink top and bottom (was 0-3px)
- [x] At the same width, scroll the whole comparison table: Database and Auth section headers pin flush below the plan-price header, with no row text clipped between them (pinned category top within 0.2px of thead bottom)
- [x] At ~1800px wide: Pipelines and Point in time recovery (Enterprise) cells show the same separated lines (PITR Enterprise is a single wrapping string, renders cleanly)
- [x] Resize across 1280px after load: category headers stay flush under the plan header (ResizeObserver refires; same 0.2px alignment after 1900px to 1150px resize without reload)
- [x] Below 1024px: the mobile comparison view is unchanged
- [x] Added: cold navigation to /pricing#compare-plans lands with `--pricing-category-top` already applied (151px at 1150px width) and the pinned header flush
- [x] Added: no new console errors versus the page's pre-existing baseline

## Linear
- fixes GROWTH-1137
