### PR TITLE
feat(www): homepage json-ld, canonical, 404 links

### DIFF
--- a/apps/www/app/(home)/page.tsx
+++ b/apps/www/app/(home)/page.tsx
@@ -7,8 +7,8 @@ import { mdAlternates } from '@/lib/md-alternates'
 
 export const metadata: Metadata = {
   alternates: {
-    canonical: 'https://supabase.com',
     ...mdAlternates('index'),
+    canonical: 'https://supabase.com',
   },
 }
 

--- a/apps/www/app/(home)/page.tsx
+++ b/apps/www/app/(home)/page.tsx
@@ -2,12 +2,28 @@ import type { Metadata } from 'next'
 
 import { FrameworksSection } from './_components/FrameworksSection'
 import { HomeContent } from './_components/HomeContent'
+import { organizationSchema, serializeJsonLd, websiteSchema } from '@/lib/json-ld'
 import { mdAlternates } from '@/lib/md-alternates'
 
 export const metadata: Metadata = {
-  alternates: mdAlternates('index'),
+  alternates: {
+    canonical: 'https://supabase.com',
+    ...mdAlternates('index'),
+  },
 }
 
 export default function HomePage() {
-  return <HomeContent frameworksSlot={<FrameworksSection />} />
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(organizationSchema()) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(websiteSchema()) }}
+      />
+      <HomeContent frameworksSlot={<FrameworksSection />} />
+    </>
+  )
 }

--- a/apps/www/components/Error404.tsx
+++ b/apps/www/components/Error404.tsx
@@ -31,13 +31,13 @@ const Error404 = () => {
           </nav>
         </div>
         <div className="absolute">
-          <h1
+          <div
             className={`text-foreground select-none text-[14rem] opacity-5 filter transition duration-200 sm:text-[18rem] lg:text-[28rem] ${
               show404 ? 'blur-xs' : 'blur-none'
             }`}
           >
             404
-          </h1>
+          </div>
         </div>
         <div
           className={`flex flex-col items-center justify-center space-y-6 transition ${
@@ -55,6 +55,19 @@ const Error404 = () => {
               <Link href="/">Head back</Link>
             </Button>
           </div>
+          <p className="text-foreground-lighter text-xs">
+            <a href="/docs" className="hover:text-foreground underline">
+              Documentation
+            </a>
+            {' · '}
+            <a href="/sitemap.xml" className="hover:text-foreground underline">
+              Sitemap
+            </a>
+            {' · '}
+            <a href="/llms.txt" className="hover:text-foreground underline">
+              llms.txt
+            </a>
+          </p>
         </div>
       </div>
     </DefaultLayout>

--- a/apps/www/components/Error404.tsx
+++ b/apps/www/components/Error404.tsx
@@ -30,7 +30,7 @@ const Error404 = () => {
             </div>
           </nav>
         </div>
-        <div className="absolute" aria-hidden="true">
+        <div className="pointer-events-none absolute" aria-hidden="true">
           <div
             className={`text-foreground select-none text-[14rem] opacity-5 filter transition duration-200 sm:text-[18rem] lg:text-[28rem] ${
               show404 ? 'blur-xs' : 'blur-none'

--- a/apps/www/components/Error404.tsx
+++ b/apps/www/components/Error404.tsx
@@ -32,7 +32,7 @@ const Error404 = () => {
         </div>
         <div className="pointer-events-none absolute" aria-hidden="true">
           <div
-            className={`text-foreground select-none text-[14rem] opacity-5 filter transition duration-200 sm:text-[18rem] lg:text-[28rem] ${
+            className={`text-foreground select-none text-[14rem] opacity-5 filter transition duration-200 motion-reduce:transition-none sm:text-[18rem] lg:text-[28rem] ${
               show404 ? 'blur-xs' : 'blur-none'
             }`}
           >
@@ -40,7 +40,7 @@ const Error404 = () => {
           </div>
         </div>
         <div
-          className={`flex flex-col items-center justify-center space-y-6 transition ${
+          className={`flex flex-col items-center justify-center space-y-6 transition motion-reduce:transition-none ${
             show404 ? 'opacity-100' : 'opacity-0'
           }`}
         >

--- a/apps/www/components/Error404.tsx
+++ b/apps/www/components/Error404.tsx
@@ -30,7 +30,7 @@ const Error404 = () => {
             </div>
           </nav>
         </div>
-        <div className="absolute">
+        <div className="absolute" aria-hidden="true">
           <div
             className={`text-foreground select-none text-[14rem] opacity-5 filter transition duration-200 sm:text-[18rem] lg:text-[28rem] ${
               show404 ? 'blur-xs' : 'blur-none'

--- a/apps/www/md-alternates.test.ts
+++ b/apps/www/md-alternates.test.ts
@@ -65,9 +65,10 @@ describe('markdown alternate drift', () => {
       const appPagePath = appPages.get(slug)
       if (appPagePath) {
         const source = await fs.readFile(appPagePath, 'utf-8')
+        const wiringShapes = [`alternates: mdAlternates('${slug}')`, `...mdAlternates('${slug}')`]
         expect(
-          source.includes(`alternates: mdAlternates('${slug}')`),
-          `${path.relative(process.cwd(), appPagePath)} must contain "alternates: mdAlternates('${slug}')" in its metadata export`
+          wiringShapes.some((shape) => source.includes(shape)),
+          `${path.relative(process.cwd(), appPagePath)} must wire mdAlternates('${slug}') into its metadata export, either as "alternates: mdAlternates('${slug}')" or spread into a wider alternates object as "...mdAlternates('${slug}')"`
         ).toBe(true)
       } else {
         expect(


### PR DESCRIPTION
An agent-readiness scan of supabase.com (is-agentic.com, public report) flagged that the homepage serves no structured data and no canonical tag in raw HTML, and that the 404 page gives crawlers and agents no recovery path. I fixed both.

**Changed:**
- **Homepage structured data**: the raw HTML now carries Organization and WebSite JSON-LD plus `<link rel="canonical" href="https://supabase.com">`. The schema builders already existed in `lib/json-ld.ts` but were never wired to any page; this reuses the exact inline-script pattern from the blog post pages. The canonical is hardcoded to the production origin on purpose: `SITE_ORIGIN` resolves to the branch URL on previews.
- **404 recovery links**: the 404 body now links to the docs, the sitemap, and llms.txt, so a dead URL leads somewhere instead of a dead end. The decorative giant "404" backdrop is a `div` instead of a second `h1`, marked `aria-hidden`, and gets `pointer-events-none`: browser testing showed the absolutely positioned backdrop was silently swallowing clicks on the new links (positioned elements paint above static siblings for hit-testing even when visually behind).
- **Drift-guard test**: `md-alternates.test.ts` asserted the literal one-liner `alternates: mdAlternates('<slug>')`, which the canonical wrapper breaks. I broadened the assertion to accept the spread shape too; the rule it guards (every markdown-served slug advertises its `.md` sibling) is unchanged and still enforced.

## To test
Tested locally against the dev server:
- [x] `curl -s localhost:3000` and parse the two `application/ld+json` blocks: both valid JSON, types Organization and WebSite
- [x] `curl -s localhost:3000 | grep canonical`: expect `<link rel="canonical" href="https://supabase.com"/>`, with the existing `text/markdown` alternate link still present
- [x] `curl -s localhost:3000/some-nonexistent-page`: expect HTTP 404 with hrefs to `/docs`, `/sitemap.xml`, `/llms.txt` and exactly one `<h1>` in the body

On the Vercel preview (verified via curl + Playwright browser run):
- [x] View source on the preview homepage: the two JSON-LD blocks present and a canonical pointing at `https://supabase.com` (prod origin, even on the preview host)
- [x] Open a nonexistent preview URL: 404 page renders the new link row under the "Head back" button, visually unchanged otherwise (screenshots in session records)
- [x] Added: click each recovery link: element hit-testing returns the anchor for all three, and clicking Sitemap navigates to a valid `/sitemap.xml` document (this check caught the pointer-events regression, fixed in this PR)

## Linear
- Part of GROWTH-1124 (kept open: remaining scan findings are tracked in a sub-issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **SEO & Discoverability**
  - Added canonical URL metadata and structured organization and website information to the homepage.
  - Improved 404 page navigation with links to Documentation, Sitemap, and `llms.txt`.

- **Accessibility**
  - Updated the 404 page’s decorative background marker to be non-interactive and hidden from screen readers.
  - Added reduced-motion handling for page transitions.

- **Tests**
  - Updated metadata validation to support multiple alternate metadata configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->