### PR TITLE
fix(ui): clamp Popover, Select, and DropdownMenu content height to available viewport (#49155)

### DIFF
--- a/packages/ui/src/components/shadcn/ui/dropdown-menu.tsx
+++ b/packages/ui/src/components/shadcn/ui/dropdown-menu.tsx
@@ -68,6 +68,7 @@ const DropdownMenuSubContent = React.forwardRef<
     ref={ref}
     className={cn(
       'z-50 min-w-32 overflow-hidden rounded-md border border-overlay bg-overlay p-1 text-foreground-light shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+      'max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto',
       className
     )}
     {...props}
@@ -85,6 +86,7 @@ const DropdownMenuContent = React.forwardRef<
       sideOffset={sideOffset}
       className={cn(
         'z-50 min-w-32 overflow-hidden rounded-md border border-overlay bg-overlay p-1 text-foreground-light shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 w-64',
+        'max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto',
         className
       )}
       {...props}

--- a/packages/ui/src/components/shadcn/ui/popover.tsx
+++ b/packages/ui/src/components/shadcn/ui/popover.tsx
@@ -47,6 +47,7 @@ const PopoverContent = React.forwardRef<
         className={cn(
           sameWidthAsTrigger ? styles['popover-trigger-width'] : '',
           'z-50 w-72 rounded-md border border-overlay bg-overlay p-4 text-popover-foreground shadow-md outline-hidden animate-in data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+          'max-h-[var(--radix-popover-content-available-height)] overflow-y-auto',
           className
         )}
         {...props}

--- a/packages/ui/src/components/shadcn/ui/select.tsx
+++ b/packages/ui/src/components/shadcn/ui/select.tsx
@@ -109,7 +109,7 @@ const SelectContent = React.forwardRef<
       className={cn(
         'relative z-50 max-h-96 min-w-32 overflow-hidden rounded-md border bg-overlay text-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         position === 'popper' &&
-          'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+          'max-h-[var(--radix-select-content-available-height)] w-full min-w-[var(--radix-select-trigger-width)] overflow-y-auto data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
         className
       )}
       position={position}
@@ -120,7 +120,7 @@ const SelectContent = React.forwardRef<
         className={cn(
           'p-1',
           position === 'popper' &&
-            'h-(--radix-select-trigger-height) w-full min-w-(--radix-select-trigger-width)'
+            'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]'
         )}
       >
         {children}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When `Popover`, `Select`, or `DropdownMenu` components contain long lists or are triggered near the bottom of the screen, their rendered content overlays off the screen past the visible viewport. Users cannot scroll through the hidden items, causing critical UI clipping issues.

Fixes #49155

## What is the new behavior?

- Clamped the max height of `PopoverContent`, `SelectContent`, `DropdownMenuContent`, and `DropdownMenuSubContent` using Radix UI's dynamic CSS variables (`--radix-*-content-available-height`).
- Enabled vertical scrolling (`overflow-y-auto`) across all content overlay wrappers so users can comfortably scroll through options when viewport height is restricted.
- Corrected Tailwind CSS arbitrary value syntax for CSS variables in `select.tsx`.

## Additional context

Tested across narrow viewport heights to ensure overlays remain fully accessible and scrollable without overflowing page bounds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dropdown menus now scroll vertically when their content exceeds the available screen height.
  * Popover panels now stay within the viewport and support scrolling for longer content.
  * Select menus now correctly size themselves using available viewport and trigger dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->