### PR TITLE
feat(studio): track assistant notebook divergence

### DIFF
--- a/apps/studio/lib/ai/notebook-cache-invalidation.test.ts
+++ b/apps/studio/lib/ai/notebook-cache-invalidation.test.ts
@@ -122,6 +122,7 @@ describe('applyNotebookCacheEffects', () => {
   afterEach(() => {
     delete notebooksState.notebooks[NOTEBOOK.id]
     notebooksState.needsSaving.clear()
+    notebooksState.serverDivergedWhileDirty.clear()
   })
 
   it('invalidates the nav list and evicts an upserted, saved notebook from the cache', async () => {
@@ -170,7 +171,7 @@ describe('applyNotebookCacheEffects', () => {
     expect(notebooksState.notebooks[NOTEBOOK.id]).toBeUndefined()
   })
 
-  it('leaves a dirty (unsaved) notebook in the store untouched', async () => {
+  it('records an assistant update while leaving a dirty notebook untouched', async () => {
     notebooksState.addNotebook({ projectRef: PROJECT_REF, notebook: NOTEBOOK })
     const queryClient = new QueryClient()
 
@@ -181,9 +182,10 @@ describe('applyNotebookCacheEffects', () => {
     })
 
     expect(notebooksState.notebooks[NOTEBOOK.id]).toBeDefined()
+    expect(notebooksState.serverDivergedWhileDirty.get(NOTEBOOK.id)).toBe('updated')
   })
 
-  it('leaves an edited (unsaved, non-empty) notebook untouched', async () => {
+  it('records an assistant deletion while leaving an edited notebook untouched', async () => {
     notebooksState.setNotebook({ projectRef: PROJECT_REF, notebook: NOTEBOOK })
     notebooksState.updateCells({
       id: NOTEBOOK.id,
@@ -195,10 +197,25 @@ describe('applyNotebookCacheEffects', () => {
     await applyNotebookCacheEffects({
       queryClient,
       projectRef: PROJECT_REF,
-      effects: [{ _tag: 'upserted', toolCallId: 'call-1', id: NOTEBOOK.id }],
+      effects: [{ _tag: 'deleted', toolCallId: 'call-1', id: NOTEBOOK.id }],
     })
 
     expect(notebooksState.notebooks[NOTEBOOK.id]).toBeDefined()
+    expect(notebooksState.serverDivergedWhileDirty.get(NOTEBOOK.id)).toBe('deleted')
+  })
+
+  it('does not record a conflict for a different notebook', async () => {
+    notebooksState.addNotebook({ projectRef: PROJECT_REF, notebook: NOTEBOOK })
+    const queryClient = new QueryClient()
+
+    await applyNotebookCacheEffects({
+      queryClient,
+      projectRef: PROJECT_REF,
+      effects: [{ _tag: 'upserted', toolCallId: 'call-1', id: 'other-notebook' }],
+    })
+
+    expect(notebooksState.serverDivergedWhileDirty.has(NOTEBOOK.id)).toBe(false)
+    expect(notebooksState.serverDivergedWhileDirty.has('other-notebook')).toBe(false)
   })
 
   it('no-ops entirely for an empty effects list', async () => {

--- a/apps/studio/lib/ai/notebook-cache-invalidation.ts
+++ b/apps/studio/lib/ai/notebook-cache-invalidation.ts
@@ -67,7 +67,13 @@ export async function applyNotebookCacheEffects({
   await Promise.all(
     effects.map((effect) => {
       const stateNotebook = notebooksState.notebooks[effect.id]
-      if (stateNotebook && stateNotebook.status !== 'saved') return
+      if (stateNotebook && stateNotebook.status !== 'saved') {
+        notebooksState.markServerDivergence({
+          id: effect.id,
+          type: effect._tag === 'deleted' ? 'deleted' : 'updated',
+        })
+        return
+      }
 
       return evictNotebookFromCaches({ queryClient, projectRef, id: effect.id })
     })

--- a/apps/studio/state/notebooks/notebooks-state.test.ts
+++ b/apps/studio/state/notebooks/notebooks-state.test.ts
@@ -27,6 +27,7 @@ describe('notebooksState', () => {
     }
     notebooksState.needsSaving.clear()
     notebooksState.cellLocalState.clear()
+    notebooksState.serverDivergedWhileDirty.clear()
   })
 
   it('addNotebook marks a locally-created notebook as new', () => {
@@ -101,5 +102,35 @@ describe('notebooksState', () => {
     notebooksState.setNotebook({ projectRef: 'ref', notebook: makeNotebook('notebook-1') })
 
     expect(notebooksState.notebooks['notebook-1'].status).toBe('unsaved')
+  })
+
+  it('marks and explicitly clears server divergence', () => {
+    notebooksState.markServerDivergence({ id: 'notebook-1', type: 'updated' })
+
+    expect(notebooksState.serverDivergedWhileDirty.get('notebook-1')).toBe('updated')
+
+    notebooksState.clearServerDivergence({ id: 'notebook-1' })
+
+    expect(notebooksState.serverDivergedWhileDirty.has('notebook-1')).toBe(false)
+  })
+
+  it('clears server divergence after saving a notebook', () => {
+    notebooksState.addNotebook({ projectRef: 'ref', notebook: makeNotebook('notebook-1') })
+    notebooksState.markServerDivergence({ id: 'notebook-1', type: 'updated' })
+
+    notebooksState.markSaved({ id: 'notebook-1' })
+
+    expect(notebooksState.notebooks['notebook-1'].status).toBe('saved')
+    expect(notebooksState.serverDivergedWhileDirty.has('notebook-1')).toBe(false)
+  })
+
+  it('clears server divergence when removing a notebook', () => {
+    notebooksState.addNotebook({ projectRef: 'ref', notebook: makeNotebook('notebook-1') })
+    notebooksState.markServerDivergence({ id: 'notebook-1', type: 'deleted' })
+
+    notebooksState.removeNotebook({ id: 'notebook-1' })
+
+    expect(notebooksState.notebooks['notebook-1']).toBeUndefined()
+    expect(notebooksState.serverDivergedWhileDirty.has('notebook-1')).toBe(false)
   })
 })

--- a/apps/studio/state/notebooks/notebooks-state.ts
+++ b/apps/studio/state/notebooks/notebooks-state.ts
@@ -23,6 +23,8 @@ export const notebooksState = proxy({
   needsSaving: proxyMap<string, boolean>([]),
   /** Session-only UI state keyed by cell ID; never persisted with notebook content. */
   cellLocalState: proxyMap<string, NotebookCellLocalState>([]),
+  /** Session-only conflicts where an assistant changed the server while local edits remain. */
+  serverDivergedWhileDirty: proxyMap<string, 'updated' | 'deleted'>([]),
 
   /**
    * Load notebook into the Valtio store. No-ops if already present.
@@ -62,7 +64,14 @@ export const notebooksState = proxy({
   markSaved: ({ id }: { id: string }) => {
     const stateNotebook = notebooksState.notebooks[id]
     if (stateNotebook) stateNotebook.status = 'saved'
+    notebooksState.clearServerDivergence({ id })
   },
+
+  markServerDivergence: ({ id, type }: { id: string; type: 'updated' | 'deleted' }) =>
+    notebooksState.serverDivergedWhileDirty.set(id, type),
+
+  clearServerDivergence: ({ id }: { id: string }) =>
+    notebooksState.serverDivergedWhileDirty.delete(id),
 
   /**
    * Rename follows its own async save directly at the call site rather than going
@@ -86,6 +95,7 @@ export const notebooksState = proxy({
     )
     notebooksState.notebooks = otherNotebooks
     if (!skipSave) notebooksState.needsSaving.delete(id)
+    notebooksState.clearServerDivergence({ id })
   },
 
   /**


### PR DESCRIPTION
## Summary
- record server divergence when an assistant changes a notebook with local unsaved edits
- clear the session-only marker after a successful save or notebook removal
- cover update, delete, saved eviction, and lifecycle behavior

## Verification
- pnpm --dir apps/studio exec vitest run state/notebooks/notebooks-state.test.ts lib/ai/notebook-cache-invalidation.test.ts
- pnpm --dir apps/studio exec eslint state/notebooks/notebooks-state.ts state/notebooks/notebooks-state.test.ts lib/ai/notebook-cache-invalidation.ts lib/ai/notebook-cache-invalidation.test.ts
- pnpm --dir apps/studio typecheck

Stacked on the approval-warning PR for FE-4255.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of server changes to notebooks with unsaved local edits.
  * Server updates and deletions are now tracked as divergences instead of being silently skipped.
  * Divergence indicators are cleared when changes are saved or notebooks are removed.
  * Unrelated notebook changes no longer create false conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->