### PR TITLE
fix(studio): refresh pgmq table metadata when a queue is deleted

### DIFF
--- a/apps/studio/data/database-queues/database-queues-delete-mutation.ts
+++ b/apps/studio/data/database-queues/database-queues-delete-mutation.ts
@@ -3,8 +3,12 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { databaseQueuesKeys } from './keys'
-import { isQueueNameValid } from '@/components/interfaces/Integrations/Queues/Queues.utils'
+import {
+  isQueueNameValid,
+  pgmqQueueTable,
+} from '@/components/interfaces/Integrations/Queues/Queues.utils'
 import { executeSql } from '@/data/sql/execute-sql-mutation'
+import { invalidateTableMetadata } from '@/data/tables/table-metadata-invalidation'
 import type { ResponseError, UseCustomMutationOptions } from '@/types'
 
 export type DatabaseQueueDeleteVariables = {
@@ -49,8 +53,19 @@ export const useDatabaseQueueDeleteMutation = ({
   return useMutation<DatabaseQueueDeleteData, ResponseError, DatabaseQueueDeleteVariables>({
     mutationFn: (vars) => deleteDatabaseQueue(vars),
     async onSuccess(data, variables, context) {
-      const { projectRef } = variables
-      await queryClient.invalidateQueries({ queryKey: databaseQueuesKeys.list(projectRef) })
+      const { projectRef, queueName } = variables
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: databaseQueuesKeys.list(projectRef) }),
+        // `pgmq.drop_queue` drops the queue's backing tables, so the pgmq table list has to be
+        // refreshed the same way creating a queue refreshes it. Otherwise the dropped table
+        // keeps counting towards the "queues without RLS" check that gates exposing queues
+        // over PostgREST.
+        invalidateTableMetadata(queryClient, {
+          projectRef,
+          schema: 'pgmq',
+          tableName: pgmqQueueTable(queueName),
+        }),
+      ])
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix, following #47541.

## What is the current behavior?

#47541 introduced `invalidateTableMetadata` and wired it into the queue create mutation, because creating a queue makes pgmq create the queue's backing tables and the table lists need to know. The delete mutation was left as it was:

```ts
// database-queues-create-mutation.ts
await Promise.all([
  queryClient.invalidateQueries({ queryKey: databaseQueuesKeys.list(projectRef) }),
  invalidateTableMetadata(queryClient, { projectRef, schema: 'pgmq', tableName: pgmqQueueTable(name) }),
])

// database-queues-delete-mutation.ts
await queryClient.invalidateQueries({ queryKey: databaseQueuesKeys.list(projectRef) })
```

`deleteDatabaseQueue` runs `select * from pgmq.drop_queue(...)`, which drops the same tables creating the queue made, so the pgmq table list goes stale in exactly the mirror case.

This is not only a cosmetic list. `QueuesSettings.tsx:58` derives

```ts
const tablesWithoutRLS = queueTables?.filter((x) => x.name.startsWith('q_') && !x.rls_enabled) ?? []
```

from that cached list, and a non-empty result both disables the "expose queues via PostgREST" toggle (`disabled={isLoading || tablesWithoutRLS.length > 0 || ...}`) and renders an Admonition listing the queues that must have RLS enabled first.

So: delete a queue that had RLS disabled, then open the Queues settings within the global 60 second `staleTime` from `data/query-client.ts`, and the toggle is still blocked and the warning still names a queue that no longer exists. The `queueDisplayName` helper right below already has a fallback for a `q_` relname that is missing from `list_queues()`, which is the same stale state.

## What is the new behavior?

The delete mutation invalidates pgmq table metadata alongside the queue list, in the same shape as create.

## Deliberately not changed

`pgmq.drop_queue` also drops the archive table `a_<name>`, and I am not passing that separately. The schema level keys the helper already invalidates (`tableKeys.list(projectRef, 'pgmq')` and `infiniteListPrefix`) cover it, which is what every reader here actually consumes, and `QueueSettings` finds the archive table by scanning that list rather than by a `retrieve` call. Passing only the queue table keeps this identical to the create path.

No test. #47541 put its coverage on `invalidateTableMetadata` itself (`tests/data/tables/table-metadata-invalidation.test.ts`) and did not add per mutation `onSuccess` tests for `table-create-mutation` or the others it converted, so a bespoke hook test only for this one would sit oddly in the family. Happy to add one if you would rather have it.

`database-queues-purge-mutation` and `database-queues-toggle-postgrest-mutation` are untouched on purpose: purging deletes messages and toggling changes PostgREST config, neither adds or drops a table.

## Additional context

Root cause at `apps/studio/data/database-queues/database-queues-delete-mutation.ts:55`.

Gates: `test:prettier` clean repo wide, `typecheck --filter=studio --force` 9/9, `lint:ratchet` reports rules improved, `tests/data/tables` plus `data/database-queues` 5/5, full studio vitest 5971 passed of 5972. The single failure is `lib/local-storage.test.ts`, which fails identically on clean master.

One thing worth flagging honestly: my first typecheck run emitted a single `TS2589 Type instantiation is excessively deep` with no file attributed, and it has not reproduced in three subsequent runs on this branch, nor on clean master. I could not tie it to this change and it looks like a tsc cache artifact locally, but I would rather mention it than quietly re run until it was green.

Freshman contributor, and I use Claude Code as an assistant. I found this by asking which mutations #47541 converted and which comparable ones it did not, then followed the stale key to something that actually renders.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Queue deletion now refreshes both the queue list and its associated backing-table metadata, ensuring the interface displays up-to-date information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->