### PR TITLE
fix(studio): reset anchor offsets on cell move and preserve stationary entry order on no-op move downgrade

### DIFF
--- a/apps/studio/data/content/notebooks/notebook-operations.test.ts
+++ b/apps/studio/data/content/notebooks/notebook-operations.test.ts
@@ -518,4 +518,51 @@ describe('deriveNotebookDiff', () => {
       ])
     ).toEqual({ success: false, error: { _tag: 'empty_result' } })
   })
+
+  it('places a later same-anchor insert after the anchor after that anchor moves', () => {
+    const notebook: NotebookWire = {
+      schema_version: 1,
+      cells: [
+        { _tag: 'markdown_cell', _id: 'cell-1', text: '# One' },
+        { _tag: 'markdown_cell', _id: 'cell-2', text: '# Two' },
+        { _tag: 'markdown_cell', _id: 'cell-3', text: '# Three' },
+        { _tag: 'markdown_cell', _id: 'cell-4', text: '# Four' },
+      ],
+    }
+    const first = { _tag: 'markdown_cell' as const, text: 'first' }
+    const second = { _tag: 'markdown_cell' as const, text: 'second' }
+    const result = deriveNotebookDiff(notebook, [
+      { _tag: 'insert_cell', after_cell_id: 'cell-1', cell: first },
+      { _tag: 'move_cell', cell_id: 'cell-1', after_cell_id: 'cell-3' },
+      { _tag: 'insert_cell', after_cell_id: 'cell-1', cell: second },
+    ])
+    expect(result).toEqual({
+      success: true,
+      entries: [
+        { _tag: 'added', cell: first, operationIndex: 0 },
+        { _tag: 'unchanged', cell: notebook.cells[1] },
+        { _tag: 'unchanged', cell: notebook.cells[2] },
+        { _tag: 'moved', cell: notebook.cells[0], fromIndex: 0, operationIndex: 1 },
+        { _tag: 'added', cell: second, operationIndex: 2 },
+        { _tag: 'unchanged', cell: notebook.cells[3] },
+      ],
+    })
+  })
+
+  it('does not let a no-op move after a deletion reorder the removed entry', () => {
+    const ops: NotebookOperation[] = [
+      { _tag: 'delete_cell', cell_id: 'cell-2' },
+      { _tag: 'move_cell', cell_id: 'cell-3', after_cell_id: 'cell-1' },
+    ]
+    const result = deriveNotebookDiff(NOTEBOOK, ops)
+    expect(result).toEqual({
+      success: true,
+      entries: [
+        { _tag: 'unchanged', cell: NOTEBOOK.cells[0] },
+        { _tag: 'removed', cell: NOTEBOOK.cells[1], operationIndex: 0 },
+        { _tag: 'unchanged', cell: NOTEBOOK.cells[2] },
+      ],
+    })
+  })
 })
+

--- a/apps/studio/data/content/notebooks/notebook-operations.ts
+++ b/apps/studio/data/content/notebooks/notebook-operations.ts
@@ -132,11 +132,29 @@ function findTargetCell(
   return undefined
 }
 
+function getOriginalIndex(
+  entry: NotebookCellDiffEntry,
+  originalIndexById: Map<string, number>
+): number | undefined {
+  switch (entry._tag) {
+    case 'unchanged':
+    case 'moved':
+    case 'removed':
+      return originalIndexById.get(entry.cell._id)
+    case 'replaced':
+      return originalIndexById.get(entry.before._id)
+    case 'added':
+      return undefined
+  }
+}
+
 function downgradeNoOpMoves(
   entries: NotebookCellDiffEntry[],
   notebook: NotebookWire
 ): NotebookCellDiffEntry[] {
   if (!entries.some((entry) => entry._tag === 'moved')) return entries
+
+  const originalIndexById = new Map(notebook.cells.map((cell, index) => [cell._id, index]))
 
   const finalOrder = entries.flatMap((entry) =>
     entry._tag === 'unchanged' || entry._tag === 'moved' ? [entry.cell._id] : []
@@ -155,11 +173,39 @@ function downgradeNoOpMoves(
     )
   }
 
-  return entries.map((entry) =>
-    entry._tag === 'moved' && hasSamePredecessors(entry.cell._id)
-      ? { _tag: 'unchanged', cell: entry.cell }
-      : entry
-  )
+  let hasDowngraded = false
+  const downgradedEntries = entries.map((entry) => {
+    if (entry._tag === 'moved' && hasSamePredecessors(entry.cell._id)) {
+      hasDowngraded = true
+      return { _tag: 'unchanged' as const, cell: entry.cell }
+    }
+    return entry
+  })
+
+  if (!hasDowngraded) return downgradedEntries
+
+  const stationaryIndices: number[] = []
+  const stationaryEntries: NotebookCellDiffEntry[] = []
+
+  downgradedEntries.forEach((entry, idx) => {
+    if (entry._tag !== 'moved' && entry._tag !== 'added') {
+      stationaryIndices.push(idx)
+      stationaryEntries.push(entry)
+    }
+  })
+
+  stationaryEntries.sort((a, b) => {
+    const idxA = getOriginalIndex(a, originalIndexById) ?? 0
+    const idxB = getOriginalIndex(b, originalIndexById) ?? 0
+    return idxA - idxB
+  })
+
+  const result = [...downgradedEntries]
+  stationaryIndices.forEach((targetIdx, i) => {
+    result[targetIdx] = stationaryEntries[i]
+  })
+
+  return result
 }
 
 export function deriveNotebookDiff(
@@ -256,6 +302,7 @@ export function deriveNotebookDiff(
         }
 
         entries.splice(found.index, 1)
+        insertedAfter.delete(operation.cell_id)
         const error = insertAfter(operation.after_cell_id, {
           _tag: 'moved',
           cell: found.cell,


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Closes #49545
Closes #49546

1. In `deriveNotebookDiff`, inserting a cell after an anchor that was previously moved shifts the new cell past its intended target position because `insertedAfter` retains accumulated offset counts from the anchor's pre-move location (#49545).
2. In `deriveNotebookDiff`, a move that is downgraded to `unchanged` (`downgradeNoOpMoves`) leaves `{ _tag: 'removed' }` entries displaced below cells whose moves were cancelled out (#49546).

## What is the new behavior?

1. `insertedAfter.delete(operation.cell_id)` is invoked when handling `move_cell` operations so anchor insertion offsets reset when a cell relocates.
2. `downgradeNoOpMoves` sorts stationary entries (`unchanged`, `removed`, `replaced`) by their original notebook index when downgrading a no-op move, ensuring deleted entries remain in their original relative position.

## Additional context

Added focused regression unit tests covering both operation composition scenarios in `notebook-operations.test.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notebook cell reordering to preserve the relative order of unchanged entries.
  * Fixed cases where moving a cell without changing its position could incorrectly reorder removed entries.
  * Corrected insertion behavior when placing cells after an anchor that has moved.
  * Ensured previous insertion positioning is cleared before a cell is reinserted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->