### PR TITLE
fix(studio): invalidate minimal cron jobs list on toggle so switch reflects new status

### DIFF
--- a/apps/studio/data/database-cron-jobs/database-cron-jobs-toggle-mutation.ts
+++ b/apps/studio/data/database-cron-jobs/database-cron-jobs-toggle-mutation.ts
@@ -50,9 +50,15 @@ export const useDatabaseCronJobToggleMutation = ({
     mutationFn: (vars) => toggleDatabaseCronJob(vars),
     async onSuccess(data, variables, context) {
       const { projectRef, searchTerm } = variables
-      await queryClient.invalidateQueries({
-        queryKey: databaseCronJobsKeys.listInfinite(projectRef, searchTerm),
-      })
+      // Invalidate the whole jobs prefix (list, count, etc.) plus the minimal list,
+      // which renders the table when the main query hits the cost threshold — without
+      // this, the switch keeps showing the stale active state after a toggle
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: databaseCronJobsKeys.jobs(projectRef) }),
+        queryClient.invalidateQueries({
+          queryKey: databaseCronJobsKeys.listInfiniteMinimal(projectRef, searchTerm),
+        }),
+      ])
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {


### PR DESCRIPTION
Fixes #49009

## Root cause

When a cron job is toggled from the table, the mutation only invalidated `databaseCronJobsKeys.listInfinite(projectRef, searchTerm)`.

However, `useCronJobsData` doesn't always render from that query: when the main list query fails with the SQL cost-threshold error (`COST_THRESHOLD_ERROR`), the grid silently falls back to `useCronJobsMinimalInfiniteQuery`, keyed under `listInfiniteMinimal`. That query was never invalidated by the toggle, so after the modal closed and the refetch completed, the switch kept showing the old `active` state — while the header's manual refresh button worked, because it calls `grid.refetch()`, which refetches whichever query (normal or minimal) is actually mounted.

## Fix

Aligns the toggle mutation's invalidation with what the delete mutation already does (`database-cron-jobs-delete-mutation.ts`):

- invalidate the whole `databaseCronJobsKeys.jobs(projectRef)` prefix (covers list, count, etc.)
- additionally invalidate `databaseCronJobsKeys.listInfiniteMinimal(projectRef, searchTerm)`

so the table refreshes regardless of which query is currently backing it.

## Verification

- Follows the exact existing pattern used by the delete mutation in the same folder.
- Normal path behavior unchanged for users on the main query (its key is covered by the `jobs` prefix).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Database cron job lists now refresh correctly after enabling or disabling a cron job.
  * Updated views consistently reflect the latest job status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->