### PR TITLE
fix(studio): hide legacy API keys on High Availability projects

### DIFF
--- a/apps/studio/components/interfaces/App/CommandMenu/ApiKeys.test.tsx
+++ b/apps/studio/components/interfaces/App/CommandMenu/ApiKeys.test.tsx
@@ -1,0 +1,116 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { components } from 'api-types'
+import { HttpResponse } from 'msw'
+import { Button } from 'ui'
+import { useCurrentPage, useSetPage } from 'ui-patterns/CommandMenu'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useApiKeysCommands } from './ApiKeys'
+import { customRender } from '@/tests/lib/custom-render'
+import { addAPIMock } from '@/tests/lib/msw'
+
+type ApiKeyResponse = components['schemas']['ApiKeyResponse']
+
+const { mockUseAsyncCheckPermissions, mockUseHighAvailability, mockUseSelectedProjectQuery } =
+  vi.hoisted(() => ({
+    mockUseAsyncCheckPermissions: vi.fn(),
+    mockUseHighAvailability: vi.fn(),
+    mockUseSelectedProjectQuery: vi.fn(),
+  }))
+
+vi.mock('@/hooks/misc/useCheckPermissions', () => ({
+  useAsyncCheckPermissions: mockUseAsyncCheckPermissions,
+}))
+
+vi.mock('@/hooks/misc/useHighAvailability', () => ({
+  useHighAvailability: mockUseHighAvailability,
+}))
+
+vi.mock('@/hooks/misc/useSelectedProject', () => ({
+  useSelectedProjectQuery: mockUseSelectedProjectQuery,
+}))
+
+const API_KEYS: ApiKeyResponse[] = [
+  { api_key: 'anon-key', name: 'anon', type: 'legacy' },
+  { api_key: 'service-key', name: 'service_role', type: 'legacy' },
+  {
+    api_key: 'publishable-key',
+    hash: 'hash',
+    id: 'publishable-id',
+    inserted_at: '2025-02-16T22:24:42.115195Z',
+    name: 'default',
+    type: 'publishable',
+  },
+  {
+    api_key: 'secret-key',
+    hash: 'hash',
+    id: 'secret-id',
+    inserted_at: '2025-02-16T22:24:42.115195Z',
+    name: 'sb_secret',
+    type: 'secret',
+  },
+]
+
+/** Renders the API keys command page so its commands can be asserted on. */
+const CommandPageHarness = () => {
+  useApiKeysCommands()
+  const setPage = useSetPage()
+  const page = useCurrentPage()
+  const commands =
+    page && 'sections' in page ? page.sections.flatMap((section) => section.commands) : []
+
+  return (
+    <>
+      <Button onClick={() => setPage('API Keys')}>Open API keys page</Button>
+      <ul>
+        {commands.map((command) => (
+          <li key={command.id}>{command.name}</li>
+        ))}
+      </ul>
+    </>
+  )
+}
+
+async function renderCommandPage() {
+  customRender(<CommandPageHarness />)
+
+  await userEvent.click(screen.getByRole('button', { name: 'Open API keys page' }))
+}
+
+describe('useApiKeysCommands', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockUseAsyncCheckPermissions.mockReturnValue({ can: true })
+    mockUseSelectedProjectQuery.mockReturnValue({
+      data: { id: 1, ref: 'default', name: 'default' },
+    })
+    mockUseHighAvailability.mockReturnValue({ isHighAvailability: false, isPending: false })
+    addAPIMock({
+      method: 'get',
+      path: '/v1/projects/:ref/api-keys',
+      response: () => HttpResponse.json<ApiKeyResponse[]>(API_KEYS),
+    })
+  })
+
+  it('omits the legacy key commands on High Availability projects', async () => {
+    mockUseHighAvailability.mockReturnValue({ isHighAvailability: true, isPending: false })
+
+    await renderCommandPage()
+
+    expect(await screen.findByText('Copy publishable key')).toBeInTheDocument()
+    expect(screen.getByText('Copy secret key (sb_secret)')).toBeInTheDocument()
+    expect(screen.queryByText('Copy anonymous API key')).not.toBeInTheDocument()
+    expect(screen.queryByText('Copy service API key')).not.toBeInTheDocument()
+  })
+
+  it('includes the legacy key commands on other projects', async () => {
+    await renderCommandPage()
+
+    expect(await screen.findByText('Copy anonymous API key')).toBeInTheDocument()
+    expect(screen.getByText('Copy service API key')).toBeInTheDocument()
+    expect(screen.getByText('Copy publishable key')).toBeInTheDocument()
+    expect(screen.getByText('Copy secret key (sb_secret)')).toBeInTheDocument()
+  })
+})

--- a/apps/studio/components/interfaces/App/CommandMenu/ApiKeys.tsx
+++ b/apps/studio/components/interfaces/App/CommandMenu/ApiKeys.tsx
@@ -17,6 +17,7 @@ import { COMMAND_MENU_SECTIONS } from './CommandMenu.utils'
 import { orderCommandSectionsByPriority } from './ordering'
 import { useAPIKeys } from '@/data/api-keys/api-keys-query'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
+import { useHighAvailability } from '@/hooks/misc/useHighAvailability'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 
 const API_KEYS_PAGE_NAME = 'API Keys'
@@ -30,15 +31,22 @@ export function useApiKeysCommands() {
   const ref = project?.ref || '_'
 
   const { can: canReadAPIKeys } = useAsyncCheckPermissions(PermissionAction.SECRETS_READ, '*')
+  const { isHighAvailability } = useHighAvailability()
 
   const { data: apiKeysData } = useAPIKeys(
     { projectRef: project?.ref, reveal: true },
     { enabled: canReadAPIKeys }
   )
   const commands = useMemo(() => {
-    const { anonKey, serviceKey, publishableKey, allSecretKeys } = canReadAPIKeys
-      ? (apiKeysData ?? {})
-      : {}
+    const {
+      anonKey: legacyAnonKey,
+      serviceKey: legacyServiceKey,
+      publishableKey,
+      allSecretKeys,
+    } = canReadAPIKeys ? (apiKeysData ?? {}) : {}
+
+    const anonKey = isHighAvailability ? undefined : legacyAnonKey
+    const serviceKey = isHighAvailability ? undefined : legacyServiceKey
 
     return [
       project &&
@@ -127,7 +135,7 @@ export function useApiKeysCommands() {
         icon: () => <Key />,
       },
     ].filter(Boolean) as ICommand[]
-  }, [canReadAPIKeys, apiKeysData, project, ref, resetCommandMenu, setIsOpen])
+  }, [canReadAPIKeys, apiKeysData, isHighAvailability, project, ref, resetCommandMenu, setIsOpen])
 
   useRegisterPage(
     API_KEYS_PAGE_NAME,

--- a/apps/studio/components/layouts/APIKeys/APIKeysLayout.test.tsx
+++ b/apps/studio/components/layouts/APIKeys/APIKeysLayout.test.tsx
@@ -1,0 +1,51 @@
+import { screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import ApiKeysLayout from './APIKeysLayout'
+import { customRender } from '@/tests/lib/custom-render'
+
+const { mockUseHighAvailability } = vi.hoisted(() => ({
+  mockUseHighAvailability: vi.fn(),
+}))
+
+vi.mock('@/hooks/misc/useHighAvailability', () => ({
+  useHighAvailability: mockUseHighAvailability,
+}))
+
+const LEGACY_TAB = 'Legacy anon, service_role API keys'
+const NEW_TAB = 'Publishable and secret API keys'
+
+describe('ApiKeysLayout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('hides the legacy keys tab on High Availability projects', () => {
+    mockUseHighAvailability.mockReturnValue({ isHighAvailability: true, isPending: false })
+
+    customRender(
+      <ApiKeysLayout>
+        <div>content</div>
+      </ApiKeysLayout>
+    )
+
+    expect(screen.getByText(NEW_TAB)).toBeInTheDocument()
+    expect(screen.queryByText(LEGACY_TAB)).not.toBeInTheDocument()
+  })
+
+  it('shows the legacy keys tab on other projects', () => {
+    mockUseHighAvailability.mockReturnValue({ isHighAvailability: false, isPending: false })
+
+    customRender(
+      <ApiKeysLayout>
+        <div>content</div>
+      </ApiKeysLayout>
+    )
+
+    expect(screen.getByText(NEW_TAB)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: LEGACY_TAB })).toHaveAttribute(
+      'href',
+      '/project/default/settings/api-keys/legacy'
+    )
+  })
+})

--- a/apps/studio/components/layouts/APIKeys/APIKeysLayout.tsx
+++ b/apps/studio/components/layouts/APIKeys/APIKeysLayout.tsx
@@ -4,10 +4,12 @@ import { PropsWithChildren } from 'react'
 import { PageLayout } from '@/components/layouts/PageLayout/PageLayout'
 import { ScaffoldContainer } from '@/components/layouts/Scaffold'
 import { DocsButton } from '@/components/ui/DocsButton'
+import { useHighAvailability } from '@/hooks/misc/useHighAvailability'
 import { DOCS_URL } from '@/lib/constants'
 
 const ApiKeysLayout = ({ children }: PropsWithChildren) => {
   const { ref: projectRef } = useParams()
+  const { isHighAvailability } = useHighAvailability()
 
   const navigationItems = [
     {
@@ -15,11 +17,15 @@ const ApiKeysLayout = ({ children }: PropsWithChildren) => {
       href: `/project/${projectRef}/settings/api-keys`,
       id: 'new-keys',
     },
-    {
-      label: 'Legacy anon, service_role API keys',
-      href: `/project/${projectRef}/settings/api-keys/legacy`,
-      id: 'legacy-keys',
-    },
+    ...(isHighAvailability
+      ? []
+      : [
+          {
+            label: 'Legacy anon, service_role API keys',
+            href: `/project/${projectRef}/settings/api-keys/legacy`,
+            id: 'legacy-keys',
+          },
+        ]),
   ]
 
   return (

--- a/apps/studio/pages/project/[ref]/settings/api-keys/legacy.tsx
+++ b/apps/studio/pages/project/[ref]/settings/api-keys/legacy.tsx
@@ -3,11 +3,24 @@ import { IS_PLATFORM } from 'common'
 import ApiKeysLayout from '@/components/layouts/APIKeys/APIKeysLayout'
 import { DefaultLayout } from '@/components/layouts/DefaultLayout'
 import SettingsLayout from '@/components/layouts/ProjectSettingsLayout/SettingsLayout'
+import { HighAvailabilityDisabledEmptyState } from '@/components/ui/HighAvailability/HighAvailabilityDisabledEmptyState'
 import { DisplayApiSettings } from '@/components/ui/ProjectSettings/DisplayApiSettings'
 import { ToggleLegacyApiKeysPanel } from '@/components/ui/ProjectSettings/ToggleLegacyApiKeys'
+import { useHighAvailability } from '@/hooks/misc/useHighAvailability'
 import type { NextPageWithLayout } from '@/types'
 
 const ApiKeysLegacyPage: NextPageWithLayout = () => {
+  const { isHighAvailability } = useHighAvailability()
+
+  if (isHighAvailability) {
+    return (
+      <HighAvailabilityDisabledEmptyState
+        title="Legacy API keys are unavailable on High Availability projects"
+        description="High Availability projects only support publishable and secret API keys."
+      />
+    )
+  }
+
   return (
     <>
       <DisplayApiSettings showTitle={false} showNotice={false} />

--- a/apps/studio/pages/project/[ref]/settings/api-keys/legacy.tsx
+++ b/apps/studio/pages/project/[ref]/settings/api-keys/legacy.tsx
@@ -15,6 +15,7 @@ const ApiKeysLegacyPage: NextPageWithLayout = () => {
   if (isHighAvailability) {
     return (
       <HighAvailabilityDisabledEmptyState
+        className="max-w-full"
         title="Legacy API keys are unavailable on High Availability projects"
         description="High Availability projects only support publishable and secret API keys."
       />

--- a/apps/studio/tests/pages/project/[ref]/settings/api-keys/legacy.test.tsx
+++ b/apps/studio/tests/pages/project/[ref]/settings/api-keys/legacy.test.tsx
@@ -1,11 +1,13 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import ApiKeysLegacyPage from '@/pages/project/[ref]/settings/api-keys/legacy'
+import { customRender } from '@/tests/lib/custom-render'
 
-const { mockIsPlatform } = vi.hoisted(() => ({
+const { mockIsPlatform, mockUseHighAvailability } = vi.hoisted(() => ({
   mockIsPlatform: { value: true },
+  mockUseHighAvailability: vi.fn(),
 }))
 
 vi.mock('common', async () => {
@@ -41,13 +43,18 @@ vi.mock('@/components/ui/ProjectSettings/ToggleLegacyApiKeys', () => ({
   ToggleLegacyApiKeysPanel: () => <div>ToggleLegacyApiKeysPanel</div>,
 }))
 
+vi.mock('@/hooks/misc/useHighAvailability', () => ({
+  useHighAvailability: mockUseHighAvailability,
+}))
+
 describe('/project/[ref]/settings/api-keys/legacy', () => {
   beforeEach(() => {
     mockIsPlatform.value = true
+    mockUseHighAvailability.mockReturnValue({ isHighAvailability: false, isPending: false })
   })
 
   it('renders both legacy keys and the disable toggle on platform', () => {
-    render(<ApiKeysLegacyPage dehydratedState={{}} />)
+    customRender(<ApiKeysLegacyPage dehydratedState={{}} />)
 
     expect(screen.getByText('DisplayApiSettings')).toBeInTheDocument()
     expect(screen.getByText('ToggleLegacyApiKeysPanel')).toBeInTheDocument()
@@ -56,9 +63,21 @@ describe('/project/[ref]/settings/api-keys/legacy', () => {
   it('renders legacy keys but hides the disable toggle on self-hosted', () => {
     mockIsPlatform.value = false
 
-    render(<ApiKeysLegacyPage dehydratedState={{}} />)
+    customRender(<ApiKeysLegacyPage dehydratedState={{}} />)
 
     expect(screen.getByText('DisplayApiSettings')).toBeInTheDocument()
+    expect(screen.queryByText('ToggleLegacyApiKeysPanel')).not.toBeInTheDocument()
+  })
+
+  it('hides the legacy keys entirely on High Availability projects', () => {
+    mockUseHighAvailability.mockReturnValue({ isHighAvailability: true, isPending: false })
+
+    customRender(<ApiKeysLegacyPage dehydratedState={{}} />)
+
+    expect(
+      screen.getByText('Legacy API keys are unavailable on High Availability projects')
+    ).toBeInTheDocument()
+    expect(screen.queryByText('DisplayApiSettings')).not.toBeInTheDocument()
     expect(screen.queryByText('ToggleLegacyApiKeysPanel')).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
Multigres (High Availability) projects ship with legacy API keys disabled and the management API rejects re-enabling them, so the Dashboard should not surface them at all.

Hides the "Legacy anon, service_role API keys" tab, renders an empty state on the legacy page for direct URL access, and drops the "Copy anonymous API key" / "Copy service API key" commands from the command menu. Non-HA projects are unchanged.

Fixes FE-4276

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * High Availability projects now hide legacy API key navigation and commands.
  * Legacy API key settings display an unavailable message for High Availability projects.
  * Publishable and secret key options remain available where supported.
  * Other projects continue to provide access to supported legacy API key options.

* **Bug Fixes**
  * Prevented unsupported legacy API key controls from appearing on High Availability projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->