### PR TITLE
[FE-4246] fix(studio): resolve notebook database labels

### DIFF
--- a/apps/studio/components/ui/AIAssistantPanel/AssistantNotebookPreview.test.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AssistantNotebookPreview.test.tsx
@@ -1,11 +1,14 @@
 import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { HttpResponse } from 'msw'
 import { describe, expect, it } from 'vitest'
 
 import { AssistantNotebookPreview } from './AssistantNotebookPreview'
+import type { components } from '@/data/api'
 import type { NotebookCellDiffEntry } from '@/data/content/notebooks/notebook-operations'
 import type { AgentCell, CellWire } from '@/data/content/notebooks/notebook-schema'
 import { customRender as render } from '@/tests/lib/custom-render'
+import { addAPIMock } from '@/tests/lib/msw'
 
 const wireMarkdownCell = (id: string, text: string): CellWire => ({
   _tag: 'markdown_cell',
@@ -64,22 +67,58 @@ describe('AssistantNotebookPreview', () => {
     expect(container.firstElementChild).toHaveClass('max-w-6xl')
   })
 
-  it('surfaces a metadata-only change on a replaced cell even when the sql is unchanged', () => {
+  it('surfaces a metadata-only database change after resolving the target', async () => {
+    addAPIMock({
+      method: 'get',
+      path: '/platform/projects/:ref/databases',
+      response: () =>
+        HttpResponse.json<components['schemas']['DatabaseDetailResponse'][]>([
+          {
+            identifier: 'default',
+            region: 'us-east-1',
+            status: 'ACTIVE_HEALTHY',
+            cloud_provider: 'AWS',
+            db_host: 'db.default.supabase.co',
+            db_name: 'postgres',
+            db_port: 5432,
+            db_user: 'postgres',
+            inserted_at: '2026-01-01T00:00:00.000Z',
+            restUrl: 'https://default.supabase.co/rest/v1',
+            size: 't4g.micro',
+          },
+          {
+            identifier: 'default-replica-3',
+            region: 'us-east-1',
+            status: 'ACTIVE_HEALTHY',
+            cloud_provider: 'AWS',
+            db_host: 'db.default-replica-3.supabase.co',
+            db_name: 'postgres',
+            db_port: 5432,
+            db_user: 'postgres',
+            inserted_at: '2026-01-01T00:00:00.000Z',
+            restUrl: 'https://default-replica-3.supabase.co/rest/v1',
+            size: 't4g.micro',
+          },
+        ]),
+    })
+
     const entries: NotebookCellDiffEntry[] = [
       {
         _tag: 'replaced',
-        before: wireDatabaseCell('cell-1', 'primary'),
-        after: agentDatabaseCell('replica-3'),
+        before: wireDatabaseCell('cell-1', 'default'),
+        after: agentDatabaseCell('default-replica-3'),
         operationIndex: 0,
       },
     ]
 
     render(<AssistantNotebookPreview entries={entries} mode="update" />)
 
-    expect(screen.getByText('Database: primary → Database: replica-3')).toBeInTheDocument()
+    expect(screen.getByText('Loading database…')).toBeInTheDocument()
+    const metadata = await screen.findByText('Database: Primary → Database: Replica')
+    expect(metadata).toBeInTheDocument()
     expect(
       screen.getByRole('button', { name: 'Replaced Query: Untitled query' })
-    ).toHaveTextContent('Database: primary → Database: replica-3')
+    ).toHaveTextContent('Database: Primary → Database: Replica')
   })
 
   it('hides entries past the limit behind a "Show N more" button', async () => {

--- a/apps/studio/components/ui/AIAssistantPanel/AssistantNotebookPreview.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AssistantNotebookPreview.tsx
@@ -1,11 +1,14 @@
+import { useParams } from 'common'
 import { NotebookText } from 'lucide-react'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { Button, cn } from 'ui'
 
 import {
   formatNotebookDiffSummary,
   getEntryKey,
+  notebookEntriesNeedDatabaseLookup,
   summarizeNotebookDiff,
+  type NotebookDatabaseContext,
 } from './AssistantNotebookPreview.utils'
 import { AssistantNotebookPreviewCell } from './AssistantNotebookPreviewCell'
 import {
@@ -16,6 +19,7 @@ import {
 } from '@/components/interfaces/Explorer/ExplorerToolbar'
 import type { QueryResult } from '@/components/interfaces/Explorer/types'
 import type { NotebookCellDiffEntry } from '@/data/content/notebooks/notebook-operations'
+import { useReadReplicasQuery } from '@/data/read-replicas/replicas-query'
 
 export interface AssistantNotebookPreviewProps {
   entries: NotebookCellDiffEntry[]
@@ -48,8 +52,27 @@ export const AssistantNotebookPreview = ({
   results,
   className,
 }: AssistantNotebookPreviewProps) => {
+  const { ref: projectRef } = useParams()
   const [isShowingAllEntries, setIsShowingAllEntries] = useState(false)
   const [expandedOverrides, setExpandedOverrides] = useState<Record<string, boolean>>({})
+
+  const needsDatabaseLookup = notebookEntriesNeedDatabaseLookup(entries, projectRef)
+  const {
+    data: databases,
+    isPending: isLoadingDatabases,
+    isError: isDatabaseError,
+  } = useReadReplicasQuery({ projectRef }, { enabled: needsDatabaseLookup })
+  const databasesByIdentifier = useMemo(
+    () => new Map((databases ?? []).map((database) => [database.identifier, database])),
+    [databases]
+  )
+  const databaseContext: NotebookDatabaseContext = !needsDatabaseLookup
+    ? { status: 'success', projectRef, databasesByIdentifier }
+    : isLoadingDatabases
+      ? { status: 'loading', projectRef }
+      : isDatabaseError
+        ? { status: 'error', projectRef }
+        : { status: 'success', projectRef, databasesByIdentifier }
 
   const summary = summarizeNotebookDiff(entries, mode)
   const visibleEntries = isShowingAllEntries ? entries : entries.slice(0, VISIBLE_ENTRY_LIMIT)
@@ -91,6 +114,7 @@ export const AssistantNotebookPreview = ({
                     mode={mode}
                     result={results?.[key]}
                     isExpanded={isExpanded(entry)}
+                    databaseContext={databaseContext}
                     onExpandedChange={(open) =>
                       setExpandedOverrides((prev) => ({ ...prev, [key]: open }))
                     }

--- a/apps/studio/components/ui/AIAssistantPanel/AssistantNotebookPreview.utils.test.ts
+++ b/apps/studio/components/ui/AIAssistantPanel/AssistantNotebookPreview.utils.test.ts
@@ -5,10 +5,13 @@ import {
   formatNotebookDiffSummary,
   formatTimeRange,
   getCellLabel,
-  getCellMetadataLine,
+  getCellMetadata,
   getEntryKey,
-  getEntryMetadataLine,
+  getEntryMetadata,
+  notebookEntriesNeedDatabaseLookup,
+  resolveNotebookDatabaseTarget,
   summarizeNotebookDiff,
+  type NotebookDatabaseContext,
 } from './AssistantNotebookPreview.utils'
 import type { NotebookCellDiffEntry } from '@/data/content/notebooks/notebook-operations'
 import type { AgentCell, CellWire } from '@/data/content/notebooks/notebook-schema'
@@ -43,6 +46,14 @@ const agentDatabaseCell = (database_identifier?: string): AgentCell => ({
   sql: 'select 1',
   row_limit: 100,
   database_identifier,
+})
+
+const successfulDatabaseContext = (
+  databases: Array<{ identifier: string; region: string }> = []
+): NotebookDatabaseContext => ({
+  status: 'success',
+  projectRef: 'project-1',
+  databasesByIdentifier: new Map(databases.map((database) => [database.identifier, database])),
 })
 
 describe('getEntryKey', () => {
@@ -116,56 +127,200 @@ describe('formatTimeRange', () => {
   })
 })
 
-describe('getCellMetadataLine', () => {
-  it('returns null for markdown cells', () => {
-    expect(getCellMetadataLine(wireMarkdownCell('cell-1'))).toBeNull()
+describe('resolveNotebookDatabaseTarget', () => {
+  it('resolves an omitted identifier as primary without waiting for databases', () => {
+    expect(
+      resolveNotebookDatabaseTarget(undefined, { status: 'loading', projectRef: 'project-1' })
+    ).toEqual({ status: 'primary' })
   })
 
-  it('returns null for a database cell with no database_identifier', () => {
-    expect(getCellMetadataLine(wireDatabaseCell('cell-1'))).toBeNull()
+  it('resolves the project ref as primary without waiting for databases', () => {
+    expect(
+      resolveNotebookDatabaseTarget('project-1', {
+        status: 'loading',
+        projectRef: 'project-1',
+      })
+    ).toEqual({ status: 'primary' })
   })
 
-  it('labels a database cell with a database_identifier', () => {
-    expect(getCellMetadataLine(wireDatabaseCell('cell-1', 'Signups', 'replica-3'))).toBe(
-      'Database: replica-3'
-    )
+  it('still resolves the loaded database matching the project ref as primary', () => {
+    expect(
+      resolveNotebookDatabaseTarget(
+        'project-1',
+        successfulDatabaseContext([{ identifier: 'project-1', region: 'us-east-1' }])
+      )
+    ).toEqual({ status: 'primary' })
   })
 
-  it('labels a log cell with its formatted time range', () => {
-    expect(getCellMetadataLine(wireLogCell('cell-1'))).toBe('Time range: Last 7 days')
+  it('keeps another identifier loading until databases resolve', () => {
+    expect(
+      resolveNotebookDatabaseTarget('replica-3', {
+        status: 'loading',
+        projectRef: 'project-1',
+      })
+    ).toEqual({ status: 'loading' })
+  })
+
+  it('resolves a matching loaded database as a replica', () => {
+    expect(
+      resolveNotebookDatabaseTarget(
+        'replica-3',
+        successfulDatabaseContext([{ identifier: 'replica-3', region: 'us-east-1' }])
+      )
+    ).toEqual({ status: 'replica' })
+  })
+
+  it('does not call an identifier absent from the loaded database list a replica', () => {
+    expect(resolveNotebookDatabaseTarget('replica-3', successfulDatabaseContext())).toEqual({
+      status: 'unknown',
+    })
+  })
+
+  it('preserves database lookup errors', () => {
+    expect(
+      resolveNotebookDatabaseTarget('replica-3', {
+        status: 'error',
+        projectRef: 'project-1',
+      })
+    ).toEqual({ status: 'error' })
   })
 })
 
-describe('getEntryMetadataLine', () => {
+describe('notebookEntriesNeedDatabaseLookup', () => {
+  it('skips lookup for implicit and explicit primary cells', () => {
+    const entries: NotebookCellDiffEntry[] = [
+      { _tag: 'unchanged', cell: wireDatabaseCell('cell-1') },
+      { _tag: 'unchanged', cell: wireDatabaseCell('cell-2', undefined, 'project-1') },
+    ]
+
+    expect(notebookEntriesNeedDatabaseLookup(entries, 'project-1')).toBe(false)
+  })
+
+  it('requires lookup when either side of a replacement has another identifier', () => {
+    const entries: NotebookCellDiffEntry[] = [
+      {
+        _tag: 'replaced',
+        before: wireDatabaseCell('cell-1'),
+        after: agentDatabaseCell('replica-3'),
+        operationIndex: 0,
+      },
+    ]
+
+    expect(notebookEntriesNeedDatabaseLookup(entries, 'project-1')).toBe(true)
+  })
+})
+
+describe('getCellMetadata', () => {
+  it('hides metadata for markdown cells', () => {
+    expect(getCellMetadata(wireMarkdownCell('cell-1'), successfulDatabaseContext())).toEqual({
+      status: 'hidden',
+    })
+  })
+
+  it('labels an implicit primary database', () => {
+    expect(getCellMetadata(wireDatabaseCell('cell-1'), successfulDatabaseContext())).toEqual({
+      status: 'ready',
+      text: 'Database: Primary',
+    })
+  })
+
+  it('labels a resolved replica descriptively', () => {
+    expect(
+      getCellMetadata(
+        wireDatabaseCell('cell-1', 'Signups', 'replica-3'),
+        successfulDatabaseContext([{ identifier: 'replica-3', region: 'us-east-1' }])
+      )
+    ).toEqual({
+      status: 'ready',
+      text: 'Database: Replica',
+    })
+  })
+
+  it('returns a loading state rather than guessing another identifier is a replica', () => {
+    expect(
+      getCellMetadata(wireDatabaseCell('cell-1', 'Signups', 'replica-3'), {
+        status: 'loading',
+        projectRef: 'project-1',
+      })
+    ).toEqual({ status: 'loading' })
+  })
+
+  it('labels a missing loaded identifier as unknown', () => {
+    expect(
+      getCellMetadata(
+        wireDatabaseCell('cell-1', 'Signups', 'missing-database'),
+        successfulDatabaseContext()
+      )
+    ).toEqual({ status: 'ready', text: 'Database: Unknown' })
+  })
+
+  it('labels a log cell with its formatted time range', () => {
+    expect(getCellMetadata(wireLogCell('cell-1'), successfulDatabaseContext())).toEqual({
+      status: 'ready',
+      text: 'Time range: Last 7 days',
+    })
+  })
+})
+
+describe('getEntryMetadata', () => {
   it('uses the cell metadata for non-replaced entries', () => {
     expect(
-      getEntryMetadataLine({
-        _tag: 'unchanged',
-        cell: wireDatabaseCell('cell-1', 'Signups', 'replica-3'),
-      })
-    ).toBe('Database: replica-3')
+      getEntryMetadata(
+        {
+          _tag: 'unchanged',
+          cell: wireDatabaseCell('cell-1', 'Signups', 'replica-3'),
+        },
+        successfulDatabaseContext([{ identifier: 'replica-3', region: 'us-east-1' }])
+      )
+    ).toEqual({
+      status: 'ready',
+      text: 'Database: Replica',
+    })
   })
 
   it('returns a before → after pair when a replacement changes only metadata', () => {
     expect(
-      getEntryMetadataLine({
-        _tag: 'replaced',
-        before: wireDatabaseCell('cell-1', 'Signups', 'primary'),
-        after: agentDatabaseCell('replica-3'),
-        operationIndex: 0,
-      })
-    ).toBe('Database: primary → Database: replica-3')
+      getEntryMetadata(
+        {
+          _tag: 'replaced',
+          before: wireDatabaseCell('cell-1', 'Signups'),
+          after: agentDatabaseCell('replica-3'),
+          operationIndex: 0,
+        },
+        successfulDatabaseContext([{ identifier: 'replica-3', region: 'us-east-1' }])
+      )
+    ).toEqual({
+      status: 'ready',
+      text: 'Database: Primary → Database: Replica',
+    })
+  })
+
+  it('returns a loading state when either side still needs database data', () => {
+    expect(
+      getEntryMetadata(
+        {
+          _tag: 'replaced',
+          before: wireDatabaseCell('cell-1', 'Signups'),
+          after: agentDatabaseCell('replica-3'),
+          operationIndex: 0,
+        },
+        { status: 'loading', projectRef: 'project-1' }
+      )
+    ).toEqual({ status: 'loading' })
   })
 
   it('returns a single line when replacement metadata is unchanged', () => {
     expect(
-      getEntryMetadataLine({
-        _tag: 'replaced',
-        before: wireDatabaseCell('cell-1', 'Signups', 'primary'),
-        after: agentDatabaseCell('primary'),
-        operationIndex: 0,
-      })
-    ).toBe('Database: primary')
+      getEntryMetadata(
+        {
+          _tag: 'replaced',
+          before: wireDatabaseCell('cell-1', 'Signups'),
+          after: agentDatabaseCell(),
+          operationIndex: 0,
+        },
+        successfulDatabaseContext()
+      )
+    ).toEqual({ status: 'ready', text: 'Database: Primary' })
   })
 })
 

--- a/apps/studio/components/ui/AIAssistantPanel/AssistantNotebookPreview.utils.ts
+++ b/apps/studio/components/ui/AIAssistantPanel/AssistantNotebookPreview.utils.ts
@@ -6,6 +6,27 @@ import type {
   OperationResultCell,
 } from '@/data/content/notebooks/notebook-operations'
 import type { TimeRange } from '@/data/content/notebooks/notebook-schema'
+import type { Database } from '@/data/read-replicas/replicas-query'
+
+type DatabaseDetails = Pick<Database, 'identifier'>
+
+export type NotebookDatabaseContext = { projectRef?: string } & (
+  | { status: 'loading' }
+  | { status: 'error' }
+  | { status: 'success'; databasesByIdentifier: ReadonlyMap<string, DatabaseDetails> }
+)
+
+export type NotebookDatabaseTarget =
+  | { status: 'primary' }
+  | { status: 'loading' }
+  | { status: 'replica' }
+  | { status: 'unknown' }
+  | { status: 'error' }
+
+export type NotebookCellMetadata =
+  | { status: 'hidden' }
+  | { status: 'loading' }
+  | { status: 'ready'; text: string }
 
 /** React key for a diff entry. Added/replaced cells have no `_id`, so they key off the operation. */
 export function getEntryKey(entry: NotebookCellDiffEntry): string {
@@ -18,6 +39,22 @@ export function getEntryKey(entry: NotebookCellDiffEntry): string {
     case 'replaced':
       return `op-${entry.operationIndex}`
   }
+}
+
+/** Whether any cell needs the database list before its target can be classified. */
+export function notebookEntriesNeedDatabaseLookup(
+  entries: NotebookCellDiffEntry[],
+  projectRef?: string
+): boolean {
+  return entries.some((entry) => {
+    const cells = entry._tag === 'replaced' ? [entry.before, entry.after] : [entry.cell]
+    return cells.some(
+      (cell) =>
+        cell._tag === 'database_cell' &&
+        cell.database_identifier !== undefined &&
+        cell.database_identifier !== projectRef
+    )
+  })
 }
 
 /** Human label for a collapsed/badge row. */
@@ -74,32 +111,77 @@ export function formatTimeRange(range: TimeRange): string {
   return `${format(range.start)} → ${format(range.end)}`
 }
 
-/**
- * Plain-text metadata line for a query cell (its source parameters, not its SQL) — `null`
- * when the cell has none. A `replace_cell` can change only this and leave `sql` identical,
- * so it's compared independently of the source text rather than folded into it.
- */
-export function getCellMetadataLine(cell: OperationResultCell): string | null {
+export function resolveNotebookDatabaseTarget(
+  identifier: string | undefined,
+  context: NotebookDatabaseContext
+): NotebookDatabaseTarget {
+  if (identifier === undefined || identifier === context.projectRef) return { status: 'primary' }
+  if (context.status === 'loading') return { status: 'loading' }
+  if (context.status === 'error') return { status: 'error' }
+
+  const database = context.databasesByIdentifier.get(identifier)
+  if (database === undefined) return { status: 'unknown' }
+  if (database.identifier === context.projectRef) return { status: 'primary' }
+
+  return { status: 'replica' }
+}
+
+function formatDatabaseTarget(target: Exclude<NotebookDatabaseTarget, { status: 'loading' }>) {
+  switch (target.status) {
+    case 'primary':
+      return 'Database: Primary'
+    case 'replica':
+      return 'Database: Replica'
+    case 'unknown':
+      return 'Database: Unknown'
+    case 'error':
+      return 'Database unavailable'
+  }
+}
+
+/** Metadata for a query cell's source parameters, kept separate from its SQL diff. */
+export function getCellMetadata(
+  cell: OperationResultCell,
+  databaseContext: NotebookDatabaseContext
+): NotebookCellMetadata {
   switch (cell._tag) {
     case 'markdown_cell':
-      return null
-    case 'database_cell':
-      return cell.database_identifier ? `Database: ${cell.database_identifier}` : null
+      return { status: 'hidden' }
+    case 'database_cell': {
+      const target = resolveNotebookDatabaseTarget(cell.database_identifier, databaseContext)
+      return target.status === 'loading'
+        ? { status: 'loading' }
+        : { status: 'ready', text: formatDatabaseTarget(target) }
+    }
     case 'log_cell':
-      return `Time range: ${formatTimeRange(cell.time_range)}`
+      return { status: 'ready', text: `Time range: ${formatTimeRange(cell.time_range)}` }
   }
 }
 
 /** Header metadata for a diff row, including a before → after pair on replacements. */
-export function getEntryMetadataLine(entry: NotebookCellDiffEntry): string | null {
+export function getEntryMetadata(
+  entry: NotebookCellDiffEntry,
+  databaseContext: NotebookDatabaseContext
+): NotebookCellMetadata {
   if (entry._tag !== 'replaced') {
-    return getCellMetadataLine(entry.cell)
+    return getCellMetadata(entry.cell, databaseContext)
   }
 
-  const beforeMetadata = getCellMetadataLine(entry.before)
-  const afterMetadata = getCellMetadataLine(entry.after)
-  if (beforeMetadata === afterMetadata) return afterMetadata
-  return `${beforeMetadata ?? 'No metadata'} → ${afterMetadata ?? 'No metadata'}`
+  const beforeMetadata = getCellMetadata(entry.before, databaseContext)
+  const afterMetadata = getCellMetadata(entry.after, databaseContext)
+  if (beforeMetadata.status === 'loading' || afterMetadata.status === 'loading') {
+    return { status: 'loading' }
+  }
+
+  const beforeText = beforeMetadata.status === 'ready' ? beforeMetadata.text : null
+  const afterText = afterMetadata.status === 'ready' ? afterMetadata.text : null
+  if (beforeText === null && afterText === null) return { status: 'hidden' }
+  if (beforeText === afterText) return { status: 'ready', text: afterText ?? 'No metadata' }
+
+  return {
+    status: 'ready',
+    text: `${beforeText ?? 'No metadata'} → ${afterText ?? 'No metadata'}`,
+  }
 }
 
 export type NotebookDiffSummary =

--- a/apps/studio/components/ui/AIAssistantPanel/AssistantNotebookPreviewCell.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AssistantNotebookPreviewCell.tsx
@@ -1,4 +1,4 @@
-import { ChevronRight, FileText, SquareCode } from 'lucide-react'
+import { ChevronRight, FileText, Loader2, SquareCode } from 'lucide-react'
 import {
   cn,
   Collapsible,
@@ -15,7 +15,8 @@ import {
   getCellLabel,
   getCellMonacoLanguage,
   getCellSourceText,
-  getEntryMetadataLine,
+  getEntryMetadata,
+  type NotebookDatabaseContext,
 } from './AssistantNotebookPreview.utils'
 import {
   ExplorerQueryFooter,
@@ -34,6 +35,7 @@ export interface AssistantNotebookPreviewCellProps {
   /** Create and run previews omit per-row change glyphs. */
   mode: 'create' | 'update' | 'run'
   result?: QueryResult
+  databaseContext: NotebookDatabaseContext
 }
 
 /**
@@ -62,12 +64,13 @@ export const AssistantNotebookPreviewCell = ({
   onExpandedChange,
   mode,
   result,
+  databaseContext,
 }: AssistantNotebookPreviewCellProps) => {
   const marker = CHANGE_MARKERS[entry._tag]
   const isRemoved = entry._tag === 'removed'
   const cell = getEntryCell(entry)
   const label = getCellLabel(cell)
-  const metadata = getEntryMetadataLine(entry)
+  const metadata = getEntryMetadata(entry, databaseContext)
 
   return (
     <Collapsible open={isExpanded} onOpenChange={onExpandedChange}>
@@ -89,11 +92,20 @@ export const AssistantNotebookPreviewCell = ({
         >
           {label}
         </span>
-        {metadata && (
+        {metadata.status !== 'hidden' ? (
           <span className="min-w-0 max-w-[45%] shrink truncate text-sm text-muted-foreground">
-            {metadata}
+            {metadata.status === 'loading' ? (
+              <span className="flex items-center gap-1.5">
+                <span className="animate-spin">
+                  <Loader2 aria-hidden size={12} />
+                </span>
+                Loading database…
+              </span>
+            ) : (
+              metadata.text
+            )}
           </span>
-        )}
+        ) : null}
       </CollapsibleTrigger>
       <CollapsibleContent>
         <div className="border-t">


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](<https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md>) file.

YES

## What kind of change does this PR introduce?

Bug fix for Studio notebook previews.

## What is the current behavior?

Notebook diffs display the raw database_identifier value. This exposes opaque database IDs and does not communicate whether the cell targets the primary database or a read replica.

Related issue: [https://linear.app/supabase/issue/FE-4246](<https://linear.app/supabase/issue/FE-4246>)

## What is the new behavior?

Notebook database metadata is resolved independently from existing selector formatting:

* an omitted database identifier is Primary
* an identifier matching the project ref is Primary
* other identifiers show a loading state while databases load
* a loaded non-primary match is Replica
* an unmatched identifier is Unknown
* database lookup failures use a neutral unavailable state

Labels are compact: Database: Primary, Database: Replica, and Database: Unknown.

The databases query is enabled only when a preview contains an explicit non-primary identifier.

## Additional context

Validation:

* 39 focused notebook preview tests
* Studio typecheck
* targeted ESLint
* Prettier check
* git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notebook previews now identify database targets as primary, read replica, or unknown.
  * Database metadata is resolved automatically when needed.
  * Loading states display a clear “Loading database…” indicator.
  * Database metadata now handles unavailable, hidden, and error states more clearly.
  * Notebook entries reflect updated database information before and after replacement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->