### PR TITLE
fix(studio): anchor notebook inserts on the anchor cell's current position

### DIFF
--- a/apps/studio/data/content/notebooks/notebook-operations.test.ts
+++ b/apps/studio/data/content/notebooks/notebook-operations.test.ts
@@ -496,7 +496,7 @@ describe('deriveNotebookDiff', () => {
     })
   })
 
-  it('resolves an insert anchored on a cell an earlier operation moved using its new position', () => {
+  it('resolves an insert anchored on a moved cell using its new position', () => {
     // cell-2 moves to the start between the two inserts, so the second one belongs directly
     // after it there, not after the cell that took over its old slot.
     const ops: NotebookOperation[] = [
@@ -522,6 +522,43 @@ describe('deriveNotebookDiff', () => {
         { _tag: 'added', cell: { _tag: 'markdown_cell', text: '2nd' }, operationIndex: 2 },
         { _tag: 'unchanged', cell: NOTEBOOK.cells[0] },
         { _tag: 'added', cell: { _tag: 'markdown_cell', text: '1st' }, operationIndex: 0 },
+        { _tag: 'unchanged', cell: NOTEBOOK.cells[2] },
+      ],
+    })
+  })
+
+  it('keeps earlier same-anchor inserts in place when the anchor moves away', () => {
+    // cell-1 moves after cell-2 once two inserts are already anchored on it; those two stay
+    // where they are, and only the third insert follows cell-1 to its new position.
+    const ops: NotebookOperation[] = [
+      {
+        _tag: 'insert_cell',
+        after_cell_id: 'cell-1',
+        cell: { _tag: 'markdown_cell', text: '1st' },
+      },
+      {
+        _tag: 'insert_cell',
+        after_cell_id: 'cell-1',
+        cell: { _tag: 'markdown_cell', text: '2nd' },
+      },
+      { _tag: 'move_cell', cell_id: 'cell-1', after_cell_id: 'cell-2' },
+      {
+        _tag: 'insert_cell',
+        after_cell_id: 'cell-1',
+        cell: { _tag: 'markdown_cell', text: '3rd' },
+      },
+    ]
+
+    const result = deriveNotebookDiff(NOTEBOOK, ops)
+
+    expect(result).toEqual({
+      success: true,
+      entries: [
+        { _tag: 'added', cell: { _tag: 'markdown_cell', text: '1st' }, operationIndex: 0 },
+        { _tag: 'added', cell: { _tag: 'markdown_cell', text: '2nd' }, operationIndex: 1 },
+        { _tag: 'unchanged', cell: NOTEBOOK.cells[1] },
+        { _tag: 'moved', cell: NOTEBOOK.cells[0], fromIndex: 0, operationIndex: 2 },
+        { _tag: 'added', cell: { _tag: 'markdown_cell', text: '3rd' }, operationIndex: 3 },
         { _tag: 'unchanged', cell: NOTEBOOK.cells[2] },
       ],
     })

--- a/apps/studio/data/content/notebooks/notebook-operations.test.ts
+++ b/apps/studio/data/content/notebooks/notebook-operations.test.ts
@@ -496,6 +496,37 @@ describe('deriveNotebookDiff', () => {
     })
   })
 
+  it('resolves an insert anchored on a cell an earlier operation moved using its new position', () => {
+    // cell-2 moves to the start between the two inserts, so the second one belongs directly
+    // after it there, not after the cell that took over its old slot.
+    const ops: NotebookOperation[] = [
+      {
+        _tag: 'insert_cell',
+        after_cell_id: 'cell-2',
+        cell: { _tag: 'markdown_cell', text: '1st' },
+      },
+      { _tag: 'move_cell', cell_id: 'cell-2', after_cell_id: 'start' },
+      {
+        _tag: 'insert_cell',
+        after_cell_id: 'cell-2',
+        cell: { _tag: 'markdown_cell', text: '2nd' },
+      },
+    ]
+
+    const result = deriveNotebookDiff(NOTEBOOK, ops)
+
+    expect(result).toEqual({
+      success: true,
+      entries: [
+        { _tag: 'moved', cell: NOTEBOOK.cells[1], fromIndex: 1, operationIndex: 1 },
+        { _tag: 'added', cell: { _tag: 'markdown_cell', text: '2nd' }, operationIndex: 2 },
+        { _tag: 'unchanged', cell: NOTEBOOK.cells[0] },
+        { _tag: 'added', cell: { _tag: 'markdown_cell', text: '1st' }, operationIndex: 0 },
+        { _tag: 'unchanged', cell: NOTEBOOK.cells[2] },
+      ],
+    })
+  })
+
   it('reports the same errors as applyNotebookOperations', () => {
     expect(deriveNotebookDiff(NOTEBOOK, [{ _tag: 'delete_cell', cell_id: 'missing' }])).toEqual({
       success: false,

--- a/apps/studio/data/content/notebooks/notebook-operations.ts
+++ b/apps/studio/data/content/notebooks/notebook-operations.ts
@@ -183,7 +183,7 @@ export function deriveNotebookDiff(
     cell,
   }))
 
-  const insertedAfter = new Map<string, number>()
+  const insertedAfter = new Map<string, Set<NotebookCellDiffEntry>>()
   const insertAfter = (
     anchor: string,
     entry: NotebookCellDiffEntry
@@ -193,9 +193,12 @@ export function deriveNotebookDiff(
       return { _tag: 'unknown_cell_id', cell_id: anchor }
     }
 
-    const offset = insertedAfter.get(anchor) ?? 0
-    entries.splice(anchorIndex + 1 + offset, 0, entry)
-    insertedAfter.set(anchor, offset + 1)
+    const previous = insertedAfter.get(anchor) ?? new Set<NotebookCellDiffEntry>()
+    let index = anchorIndex + 1
+    while (index < entries.length && previous.has(entries[index])) index++
+
+    entries.splice(index, 0, entry)
+    insertedAfter.set(anchor, previous.add(entry))
     return undefined
   }
 

--- a/apps/studio/data/content/notebooks/notebook-operations.ts
+++ b/apps/studio/data/content/notebooks/notebook-operations.ts
@@ -193,12 +193,15 @@ export function deriveNotebookDiff(
       return { _tag: 'unknown_cell_id', cell_id: anchor }
     }
 
-    const previous = insertedAfter.get(anchor) ?? new Set<NotebookCellDiffEntry>()
+    const inserted = insertedAfter.get(anchor) ?? new Set<NotebookCellDiffEntry>()
     let index = anchorIndex + 1
-    while (index < entries.length && previous.has(entries[index])) index++
+    while (index < entries.length && inserted.has(entries[index])) {
+      index++
+    }
 
     entries.splice(index, 0, entry)
-    insertedAfter.set(anchor, previous.add(entry))
+    inserted.add(entry)
+    insertedAfter.set(anchor, inserted)
     return undefined
   }
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Fixes #49545. `deriveNotebookDiff` kept a per-anchor insert counter and added it to the anchor's index, so once an earlier operation moved the anchor cell, the counter still pointed at the anchor's old slot and the insert landed after whatever cell had taken that slot.

## What is the new behavior?

The counter is now a set of the entries already inserted for that anchor, and the insert skips past only those when they still directly follow the anchor. Inserts anchored at the same cell keep their order, and an insert anchored on a moved cell lands next to that cell's current position, matching how moves already resolve their anchors.

## Additional context

Added a `deriveNotebookDiff` test covering an insert, a move of the anchor, and a second insert on the same anchor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notebook change tracking so newly inserted cells remain in the correct order when their anchor cell is moved.
  * Preserved accurate cell placement and operation indexes across multiple insertions and intervening changes.

* **Tests**
  * Added coverage for insertions anchored to cells that have been relocated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->