### PR TITLE
fix: remove X-Source-Version header to stabilize OAuth config hash (Fixes #48544)

### DIFF
--- a/apps/studio/lib/ai/supabase-mcp.test.ts
+++ b/apps/studio/lib/ai/supabase-mcp.test.ts
@@ -63,30 +63,21 @@ describe('createSupabaseMCPClient', () => {
   })
 
   it('identifies assistant traffic with the x-source-name header', async () => {
-    process.env.NEXT_PUBLIC_MCP_URL = 'https://mcp.supabase.com/mcp'
+      process.env.NEXT_PUBLIC_MCP_URL = 'https://mcp.supabase.com/mcp'
 
-    await createSupabaseMCPClient({ accessToken: ACCESS_TOKEN, projectRef: PROJECT_REF })
+      await createSupabaseMCPClient({ accessToken: ACCESS_TOKEN, projectRef: PROJECT_REF })
 
-    expect(getTransportConfig().transport.headers['x-source-name']).toBe('supabase-studio')
-  })
+      expect(getTransportConfig().transport.headers['x-source-name']).toBe('supabase-studio')
+    })
 
-  it('sends x-source-version from VERCEL_GIT_COMMIT_SHA when available', async () => {
-    process.env.NEXT_PUBLIC_MCP_URL = 'https://mcp.supabase.com/mcp'
-    process.env.VERCEL_GIT_COMMIT_SHA = 'abc1234'
+    it('does not send x-source-version header (stabilizes OAuth config hash)', async () => {
+      process.env.NEXT_PUBLIC_MCP_URL = 'https://mcp.supabase.com/mcp'
+      process.env.VERCEL_GIT_COMMIT_SHA = 'abc1234'
 
-    await createSupabaseMCPClient({ accessToken: ACCESS_TOKEN, projectRef: PROJECT_REF })
+      await createSupabaseMCPClient({ accessToken: ACCESS_TOKEN, projectRef: PROJECT_REF })
 
-    expect(getTransportConfig().transport.headers['x-source-version']).toBe('abc1234')
-  })
-
-  it('omits x-source-version when VERCEL_GIT_COMMIT_SHA is not set', async () => {
-    process.env.NEXT_PUBLIC_MCP_URL = 'https://mcp.supabase.com/mcp'
-    delete process.env.VERCEL_GIT_COMMIT_SHA
-
-    await createSupabaseMCPClient({ accessToken: ACCESS_TOKEN, projectRef: PROJECT_REF })
-
-    expect(getTransportConfig().transport.headers).not.toHaveProperty('x-source-version')
-  })
+      expect(getTransportConfig().transport.headers).not.toHaveProperty('x-source-version')
+    })
 
   it('never leaks the access token into the URL', async () => {
     process.env.NEXT_PUBLIC_MCP_URL = 'https://mcp.supabase.com/mcp'

--- a/apps/studio/lib/ai/supabase-mcp.ts
+++ b/apps/studio/lib/ai/supabase-mcp.ts
@@ -60,9 +60,6 @@ export async function createSupabaseMCPClient({
   accessToken: string
   projectRef: string
 }) {
-  // Identifies the deployed build in the MCP server's `source_version` log field.
-  const sourceVersion = process.env.VERCEL_GIT_COMMIT_SHA
-
   const client = await createMCPClient({
     name: SOURCE_NAME,
     transport: {
@@ -72,7 +69,6 @@ export async function createSupabaseMCPClient({
         Authorization: `Bearer ${accessToken}`,
         // Identify assistant traffic in the remote MCP server's logs
         'x-source-name': SOURCE_NAME,
-        ...(sourceVersion ? { 'x-source-version': sourceVersion } : {}),
       },
     },
   })


### PR DESCRIPTION
## Summary
Removes the `X-Source-Version` header that was causing OAuth config hash instability in Claude Code's keychain storage.

## Root Cause
The `X-Source-Version` header was set to `VERCEL_GIT_COMMIT_SHA` which changes on every deployment. This header gets hashed into the OAuth config key used by Claude Code's keychain storage. When the header changes, the config hash changes, causing token stranding in old keychain slots.

## Fix #48544 
Removed the `X-Source-Version` header from `apps/studio/lib/ai/supabase-mcp.ts`. The header was only used for logging in the MCP server (`source_version` log field) and is not required for authentication or functionality.

## Testing
- All 10 tests pass (`pnpm --filter=studio run test lib/ai/supabase-mcp.test.ts`)
- Lint passes
- Typecheck passes
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the unnecessary source version header from remote MCP requests.
  * Continued sending required source identification and authorization headers.
  * Updated validation to ensure the removed header is never transmitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->