### PR TITLE
fix(studio): stop no-op moves from displacing removed diff entries

### DIFF
--- a/apps/studio/data/content/notebooks/notebook-operations.test.ts
+++ b/apps/studio/data/content/notebooks/notebook-operations.test.ts
@@ -454,6 +454,26 @@ describe('deriveNotebookDiff', () => {
     expect(result.entries.map((entry) => entry._tag)).toEqual(['unchanged', 'moved', 'moved'])
   })
 
+  it('keeps a removed entry in place when a move is downgraded to unchanged', () => {
+    // Moving cell-3 after cell-1 is a no-op once cell-2 is deleted, so cell-2 has to stay in
+    // the position it held rather than being pushed below cell-3.
+    const ops: NotebookOperation[] = [
+      { _tag: 'delete_cell', cell_id: 'cell-2' },
+      { _tag: 'move_cell', cell_id: 'cell-3', after_cell_id: 'cell-1' },
+    ]
+
+    const result = deriveNotebookDiff(NOTEBOOK, ops)
+
+    expect(result).toEqual({
+      success: true,
+      entries: [
+        { _tag: 'unchanged', cell: NOTEBOOK.cells[0] },
+        { _tag: 'removed', cell: NOTEBOOK.cells[1], operationIndex: 0 },
+        { _tag: 'unchanged', cell: NOTEBOOK.cells[2] },
+      ],
+    })
+  })
+
   it('leaves removed entries out of the way of inserts anchored at the same cell', () => {
     const ops: NotebookOperation[] = [
       { _tag: 'delete_cell', cell_id: 'cell-2' },

--- a/apps/studio/data/content/notebooks/notebook-operations.ts
+++ b/apps/studio/data/content/notebooks/notebook-operations.ts
@@ -132,9 +132,11 @@ function findTargetCell(
   return undefined
 }
 
-function noOpMoveOperations(entries: NotebookCellDiffEntry[], notebook: NotebookWire): Set<number> {
-  const noOpMoves = new Set<number>()
-  if (!entries.some((entry) => entry._tag === 'moved')) return noOpMoves
+function downgradeNoOpMoves(
+  entries: NotebookCellDiffEntry[],
+  notebook: NotebookWire
+): NotebookCellDiffEntry[] {
+  if (!entries.some((entry) => entry._tag === 'moved')) return entries
 
   const finalOrder = entries.flatMap((entry) =>
     entry._tag === 'unchanged' || entry._tag === 'moved' ? [entry.cell._id] : []
@@ -153,19 +155,80 @@ function noOpMoveOperations(entries: NotebookCellDiffEntry[], notebook: Notebook
     )
   }
 
-  for (const entry of entries) {
-    if (entry._tag === 'moved' && hasSamePredecessors(entry.cell._id)) {
-      noOpMoves.add(entry.operationIndex)
-    }
-  }
-  return noOpMoves
+  const downgradedIds = new Set<string>()
+  const downgraded = entries.map((entry) => {
+    if (entry._tag !== 'moved' || !hasSamePredecessors(entry.cell._id)) return entry
+
+    downgradedIds.add(entry.cell._id)
+    return { _tag: 'unchanged' as const, cell: entry.cell }
+  })
+
+  return reseatRemovedEntries(downgraded, downgradedIds, notebook)
 }
 
-function buildDiffEntries(
+function settledCellId(entry: NotebookCellDiffEntry): string | undefined {
+  switch (entry._tag) {
+    case 'unchanged':
+    case 'removed':
+      return entry.cell._id
+    case 'added':
+    case 'replaced':
+    case 'moved':
+      return undefined
+  }
+}
+
+function reseatRemovedEntries(
+  entries: NotebookCellDiffEntry[],
+  downgradedIds: Set<string>,
+  notebook: NotebookWire
+): NotebookCellDiffEntry[] {
+  if (downgradedIds.size === 0) return entries
+
+  const originalIndexOf = (cellId: string) =>
+    notebook.cells.findIndex((cell) => cell._id === cellId)
+  const isDowngraded = (entry: NotebookCellDiffEntry) =>
+    entry._tag === 'unchanged' && downgradedIds.has(entry.cell._id)
+
+  const reseated = [...entries]
+  let swapped = true
+  while (swapped) {
+    swapped = false
+    for (let index = 0; index < reseated.length - 1; index++) {
+      const entry = reseated[index]
+      const next = reseated[index + 1]
+      const entryCellId = settledCellId(entry)
+      const nextCellId = settledCellId(next)
+
+      if (entryCellId === undefined || nextCellId === undefined) continue
+      if (entry._tag !== 'removed' && next._tag !== 'removed') continue
+      if (!isDowngraded(entry) && !isDowngraded(next)) continue
+      if (originalIndexOf(nextCellId) > originalIndexOf(entryCellId)) continue
+
+      reseated[index] = next
+      reseated[index + 1] = entry
+      swapped = true
+    }
+  }
+
+  return reseated
+}
+
+export function deriveNotebookDiff(
   notebook: NotebookWire,
-  operations: NotebookOperation[],
-  skippedOperations: ReadonlySet<number>
+  operations: NotebookOperation[]
 ): DeriveNotebookDiffResult {
+  const targetedIds = new Set<string>()
+  for (const operation of operations) {
+    const cellId = targetCellId(operation)
+    if (cellId === undefined) continue
+
+    if (targetedIds.has(cellId)) {
+      return { success: false, error: { _tag: 'conflicting_operations', cell_id: cellId } }
+    }
+    targetedIds.add(cellId)
+  }
+
   const originalIndexById = new Map(notebook.cells.map((cell, index) => [cell._id, index]))
   const entries: NotebookCellDiffEntry[] = notebook.cells.map((cell) => ({
     _tag: 'unchanged',
@@ -236,8 +299,6 @@ function buildDiffEntries(
           }
         }
 
-        if (skippedOperations.has(operationIndex)) break
-
         const found = findTargetCell(entries, operation.cell_id)
         if (found === undefined) {
           return {
@@ -263,31 +324,7 @@ function buildDiffEntries(
     return { success: false, error: { _tag: 'empty_result' } }
   }
 
-  return { success: true, entries }
-}
-
-export function deriveNotebookDiff(
-  notebook: NotebookWire,
-  operations: NotebookOperation[]
-): DeriveNotebookDiffResult {
-  const targetedIds = new Set<string>()
-  for (const operation of operations) {
-    const cellId = targetCellId(operation)
-    if (cellId === undefined) continue
-
-    if (targetedIds.has(cellId)) {
-      return { success: false, error: { _tag: 'conflicting_operations', cell_id: cellId } }
-    }
-    targetedIds.add(cellId)
-  }
-
-  const applied = buildDiffEntries(notebook, operations, new Set<number>())
-  if (!applied.success) return applied
-
-  const noOpMoves = noOpMoveOperations(applied.entries, notebook)
-  if (noOpMoves.size === 0) return applied
-
-  return buildDiffEntries(notebook, operations, noOpMoves)
+  return { success: true, entries: downgradeNoOpMoves(entries, notebook) }
 }
 
 function resultingCells(entries: NotebookCellDiffEntry[]): OperationResultCell[] {

--- a/apps/studio/data/content/notebooks/notebook-operations.ts
+++ b/apps/studio/data/content/notebooks/notebook-operations.ts
@@ -132,11 +132,9 @@ function findTargetCell(
   return undefined
 }
 
-function downgradeNoOpMoves(
-  entries: NotebookCellDiffEntry[],
-  notebook: NotebookWire
-): NotebookCellDiffEntry[] {
-  if (!entries.some((entry) => entry._tag === 'moved')) return entries
+function noOpMoveOperations(entries: NotebookCellDiffEntry[], notebook: NotebookWire): Set<number> {
+  const noOpMoves = new Set<number>()
+  if (!entries.some((entry) => entry._tag === 'moved')) return noOpMoves
 
   const finalOrder = entries.flatMap((entry) =>
     entry._tag === 'unchanged' || entry._tag === 'moved' ? [entry.cell._id] : []
@@ -155,28 +153,19 @@ function downgradeNoOpMoves(
     )
   }
 
-  return entries.map((entry) =>
-    entry._tag === 'moved' && hasSamePredecessors(entry.cell._id)
-      ? { _tag: 'unchanged', cell: entry.cell }
-      : entry
-  )
+  for (const entry of entries) {
+    if (entry._tag === 'moved' && hasSamePredecessors(entry.cell._id)) {
+      noOpMoves.add(entry.operationIndex)
+    }
+  }
+  return noOpMoves
 }
 
-export function deriveNotebookDiff(
+function buildDiffEntries(
   notebook: NotebookWire,
-  operations: NotebookOperation[]
+  operations: NotebookOperation[],
+  skippedOperations: ReadonlySet<number>
 ): DeriveNotebookDiffResult {
-  const targetedIds = new Set<string>()
-  for (const operation of operations) {
-    const cellId = targetCellId(operation)
-    if (cellId === undefined) continue
-
-    if (targetedIds.has(cellId)) {
-      return { success: false, error: { _tag: 'conflicting_operations', cell_id: cellId } }
-    }
-    targetedIds.add(cellId)
-  }
-
   const originalIndexById = new Map(notebook.cells.map((cell, index) => [cell._id, index]))
   const entries: NotebookCellDiffEntry[] = notebook.cells.map((cell) => ({
     _tag: 'unchanged',
@@ -247,6 +236,8 @@ export function deriveNotebookDiff(
           }
         }
 
+        if (skippedOperations.has(operationIndex)) break
+
         const found = findTargetCell(entries, operation.cell_id)
         if (found === undefined) {
           return {
@@ -272,7 +263,31 @@ export function deriveNotebookDiff(
     return { success: false, error: { _tag: 'empty_result' } }
   }
 
-  return { success: true, entries: downgradeNoOpMoves(entries, notebook) }
+  return { success: true, entries }
+}
+
+export function deriveNotebookDiff(
+  notebook: NotebookWire,
+  operations: NotebookOperation[]
+): DeriveNotebookDiffResult {
+  const targetedIds = new Set<string>()
+  for (const operation of operations) {
+    const cellId = targetCellId(operation)
+    if (cellId === undefined) continue
+
+    if (targetedIds.has(cellId)) {
+      return { success: false, error: { _tag: 'conflicting_operations', cell_id: cellId } }
+    }
+    targetedIds.add(cellId)
+  }
+
+  const applied = buildDiffEntries(notebook, operations, new Set<number>())
+  if (!applied.success) return applied
+
+  const noOpMoves = noOpMoveOperations(applied.entries, notebook)
+  if (noOpMoves.size === 0) return applied
+
+  return buildDiffEntries(notebook, operations, noOpMoves)
 }
 
 function resultingCells(entries: NotebookCellDiffEntry[]): OperationResultCell[] {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Fixes #49546

A move is applied to the entry list first and only downgraded to `unchanged` afterwards, and the splice is never undone. A move that turns out to be a no-op has therefore already stepped over any `removed` entry in its path. Deleting `cell-2` and then moving `cell-3` after `cell-1` leaves the removed entry below `cell-3`, so the preview shows the deletion in the wrong place.

## What is the new behavior?

Downgrading a no-op move now also puts the entries it stepped over back in order, so a removed entry keeps the position its cell held.

Only `removed` entries are ever reordered, and only against moves that were downgraded. Removed entries contribute no cells to `resultingCells`, so the notebook `applyNotebookOperations` writes is unchanged for every input.

## Additional context

Added a `deriveNotebookDiff` test covering a delete followed by a move that turns out to be a no-op.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notebook change tracking so deleted cells remain in their correct diff position.
  * Prevented moves that do not change the final cell order from appearing as unnecessary changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->