### PR TITLE
fix(docs): make code blocks reachable and readable by keyboard and screen reader

### DIFF
--- a/apps/docs/features/ui/CodeBlock/CodeBlock.client.tsx
+++ b/apps/docs/features/ui/CodeBlock/CodeBlock.client.tsx
@@ -119,6 +119,8 @@ export function CodeCopyButton({ className, content }: { className?: string; con
               className
             )}
             aria-label="Copy code"
+            // Tooltip repeats the label; the description would read the name twice
+            aria-describedby={undefined}
           >
             {copied ? (
               <Check size={14} className="text-lighter" />
@@ -135,29 +137,33 @@ export function CodeCopyButton({ className, content }: { className?: string; con
 
 export function CodeBlockControls({ content }: { content: string }) {
   const [isWrapped, setIsWrapped] = useState(false)
+  // Empty until the first toggle, so nothing is announced on mount
+  const [wrapStatus, setWrapStatus] = useState('')
   const wrapperRef = useRef<HTMLDivElement>(null)
 
   const toggleWrap = useCallback(() => {
-    setIsWrapped((prev) => {
-      const newValue = !prev
-      // Find the parent code block and toggle the wrap data attribute
-      const codeBlock = wrapperRef.current?.closest('.shiki')
-      if (codeBlock) {
-        if (newValue) {
-          codeBlock.setAttribute('data-wrapped', 'true')
-        } else {
-          codeBlock.removeAttribute('data-wrapped')
-        }
+    const newValue = !isWrapped
+    setIsWrapped(newValue)
+    setWrapStatus(newValue ? 'Word wrap enabled' : 'Word wrap disabled')
+
+    const codeBlock = wrapperRef.current?.closest('.shiki')
+    if (codeBlock) {
+      if (newValue) {
+        codeBlock.setAttribute('data-wrapped', 'true')
+      } else {
+        codeBlock.removeAttribute('data-wrapped')
       }
-      return newValue
-    })
-  }, [])
+    }
+  }, [isWrapped])
 
   return (
     <div
       ref={wrapperRef}
-      className="opacity-0 flex group-hover:opacity-100 focus-within:opacity-100 absolute top-2 right-2 gap-1"
+      className="opacity-0 flex group-hover:opacity-100 group-focus-within:opacity-100 absolute top-2 right-2 gap-1"
     >
+      <span className="sr-only" aria-live="polite">
+        {wrapStatus}
+      </span>
       <Tooltip>
         <TooltipTrigger asChild>
           <button
@@ -165,6 +171,8 @@ export function CodeBlockControls({ content }: { content: string }) {
             onClick={toggleWrap}
             className={cn('cursor-pointer border rounded-md p-1', 'hover:bg-selection transition')}
             aria-label={isWrapped ? 'Disable word wrap' : 'Enable word wrap'}
+            // Tooltip repeats the label; the description would read the name twice
+            aria-describedby={undefined}
           >
             {isWrapped ? (
               <ArrowRightFromLine size={14} className="text-lighter" />

--- a/apps/docs/features/ui/CodeBlock/CodeBlock.tsx
+++ b/apps/docs/features/ui/CodeBlock/CodeBlock.tsx
@@ -4,7 +4,7 @@ import { createTwoslasher, type ExtraFiles, type NodeHover } from 'twoslash'
 import { cn } from 'ui'
 
 import { AnnotatedSpan, CodeBlockControls } from './CodeBlock.client'
-import { getFontStyle } from './CodeBlock.utils'
+import { getCodeBlockLabel, getFontStyle } from './CodeBlock.utils'
 import theme from './supabase-2.json' with { type: 'json' }
 import denoTypes from './types/lib.deno.d.ts.include'
 
@@ -46,11 +46,7 @@ export async function CodeBlock({
       twoslashed = annotationsByLine(hoverNodes)
       code = editedCode
     } catch (_err) {
-      // Silently ignore, if imports aren't defined type compilation fails
-      // Uncomment lines below to debug in dev
-      // console.log('\n==========CODE==========\n')
-      // console.log(code)
-      // console.error(_err.recommendation)
+      // Type compilation fails when imports aren't defined
     }
   }
 
@@ -66,52 +62,64 @@ export async function CodeBlock({
         'group',
         'relative',
         'not-prose',
-        'w-full overflow-x-auto',
+        'w-full',
         'border border-default rounded-lg',
         'bg-200',
         'text-sm',
         className
       )}
-      role="group"
-      aria-roledescription="code block"
     >
+      <div
+        className={cn(
+          'code-scroll',
+          'w-full overflow-x-auto rounded-lg',
+          'focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring'
+        )}
+        role="group"
+        aria-roledescription="code block"
+        aria-label={getCodeBlockLabel(lang, tokens.length)}
+        tabIndex={0}
+      >
+        <pre>
+          <code className={lineNumbers ? 'grid grid-cols-[auto_1fr]' : ''}>
+            {lineNumbers ? (
+              <>
+                {tokens.map((line, idx) => (
+                  <Fragment key={idx}>
+                    <div
+                      aria-hidden="true"
+                      className={cn(
+                        'select-none text-right text-muted bg-control px-2 min-h-5 leading-5',
+                        idx === 0 && 'pt-6',
+                        idx === tokens.length - 1 && 'pb-6'
+                      )}
+                    >
+                      {idx + 1}
+                    </div>
+                    <div
+                      className={cn(
+                        'code-content min-h-5 leading-5 pl-6 pr-6',
+                        idx === 0 && 'pt-6',
+                        idx === tokens.length - 1 && 'pb-6'
+                      )}
+                    >
+                      <CodeLine tokens={line} twoslash={twoslashed?.get(idx)} />
+                    </div>
+                  </Fragment>
+                ))}
+              </>
+            ) : (
+              <div className="code-content p-6">
+                {tokens.map((line, idx) => (
+                  <CodeLine key={idx} tokens={line} twoslash={twoslashed?.get(idx)} />
+                ))}
+              </div>
+            )}
+          </code>
+        </pre>
+      </div>
+      {/* After the code so the block is named before its controls, and outside the scroller so they stay pinned */}
       {!hideControls && <CodeBlockControls content={code.trim()} />}
-      <pre>
-        <code className={lineNumbers ? 'grid grid-cols-[auto_1fr]' : ''}>
-          {lineNumbers ? (
-            <>
-              {tokens.map((line, idx) => (
-                <Fragment key={idx}>
-                  <div
-                    className={cn(
-                      'select-none text-right text-muted bg-control px-2 min-h-5 leading-5',
-                      idx === 0 && 'pt-6',
-                      idx === tokens.length - 1 && 'pb-6'
-                    )}
-                  >
-                    {idx + 1}
-                  </div>
-                  <div
-                    className={cn(
-                      'code-content min-h-5 leading-5 pl-6 pr-6',
-                      idx === 0 && 'pt-6',
-                      idx === tokens.length - 1 && 'pb-6'
-                    )}
-                  >
-                    <CodeLine tokens={line} twoslash={twoslashed?.get(idx)} />
-                  </div>
-                </Fragment>
-              ))}
-            </>
-          ) : (
-            <div className="code-content p-6">
-              {tokens.map((line, idx) => (
-                <CodeLine key={idx} tokens={line} twoslash={twoslashed?.get(idx)} />
-              ))}
-            </div>
-          )}
-        </code>
-      </pre>
     </div>
   )
 }

--- a/apps/docs/features/ui/CodeBlock/CodeBlock.utils.ts
+++ b/apps/docs/features/ui/CodeBlock/CodeBlock.utils.ts
@@ -1,8 +1,6 @@
 import { type CSSProperties } from 'react'
 
-/*
- * As defined in @shikijs/core/dist/chunk-tokens.d.mts
- */
+// As defined in @shikijs/core/dist/chunk-tokens.d.mts
 enum FontStyle {
   NotSet = -1,
   None = 0,
@@ -27,4 +25,27 @@ export function getFontStyle(styleFlags: number): CSSProperties {
   }
 
   return style
+}
+
+// Fence aliases a screen reader would otherwise read letter by letter
+const LANGUAGE_LABELS: Record<string, string> = {
+  c: 'C',
+  html: 'HTML',
+  js: 'JavaScript',
+  json: 'JSON',
+  jsx: 'JavaScript',
+  py: 'Python',
+  sh: 'Shell',
+  shell: 'Shell',
+  sql: 'SQL',
+  toml: 'TOML',
+  ts: 'TypeScript',
+  tsx: 'TypeScript',
+  yaml: 'YAML',
+}
+
+export function getCodeBlockLabel(lang: string | null, lineCount: number): string {
+  const lines = `${lineCount} ${lineCount === 1 ? 'line' : 'lines'}`
+  if (!lang) return lines
+  return `${LANGUAGE_LABELS[lang] ?? lang}, ${lines}`
 }

--- a/apps/docs/styles/globals.css
+++ b/apps/docs/styles/globals.css
@@ -452,7 +452,7 @@ th code {
 }
 
 /* Word wrap styles for code blocks */
-.shiki[data-wrapped='true'] {
+.shiki[data-wrapped='true'] .code-scroll {
   overflow-x: hidden !important;
 }
 


### PR DESCRIPTION
Closes DOCS-1283


https://github.com/user-attachments/assets/6e55a27f-6f73-453b-b98f-e91d3c14a9e4



## Problem

Three defects in the docs code block:

- The scroll container has no `tabindex`. On `/guides/database/tables`, 18 blocks, none focusable, 2 overflowing at 1280px. Tab skips the scroll region, so a keyboard-only user cannot scroll code that runs off the edge.
- The container has `role="group"` with no accessible name, so it announces as bare "group".
- The line-number gutter has no `aria-hidden`, so digits are read inline with the code. A block linearizes as `1import { createClient } from '@supabase/supabase-js'23const supabase = ...`, with lines 2 and 3 collapsing into "23".

Four more surfaced while testing the fix:

- The wrap and copy buttons were absolutely positioned inside the element that scrolls, so `right-2` measured against the scrollable content box. Scrolling dragged them out of the corner into the middle of the code. This one predates the PR.
- The buttons preceded the code in the DOM, so a screen reader read two actions before naming what they act on.
- `focus-within` only fired for the buttons, so focusing the block left the controls invisible.
- Both buttons set an `aria-label` identical to their tooltip text, and Radix points `aria-describedby` at the tooltip on focus, producing "Copy code, button, Copy code".

## Solution

Keyboard:

- Split the scroll region out of the positioning container, so the controls stay pinned.
- Give the scroll region a `tabIndex` and a focus ring.
- Reveal the controls on `group-focus-within`.

Screen reader:

- Name the region `<language>, <n> lines`. Code content stays readable; the summary goes in the name so the group can be skipped or stepped into.
- Map fence aliases to spoken names, so `ts` announces as TypeScript. Only the ambiguous ones; `bash`, `python`, `kotlin`, `dart`, `swift` already read fine.
- `aria-hidden` the gutter. The numbers are already `select-none`, and copy takes its content from the source string rather than the DOM, so copy behavior is unchanged.
- Order the controls after the code.
- Announce the word wrap toggle through a live region, matching the copy button.
- Opt both buttons out of Radix's generated description.

Also moved the `data-wrapped` side effect out of the `setIsWrapped` updater, since React calls updaters twice under StrictMode.

## Manual testing

1. Open `/docs/guides/database/tables`.
2. Run `document.querySelectorAll('.code-scroll[tabindex="0"]').length` in the console. Expect `18`.
3. Run `[...document.querySelectorAll('.code-scroll')].map(b => b.getAttribute('aria-label'))`. Expect entries like `SQL, 11 lines` and `bash, 2 lines`, plus one bare `2 lines` for the fence with no language.
4. Tab to a code block. Expect a visible focus ring, and the wrap and copy buttons to appear.
5. Press ArrowRight on the block under "Basic data loading", which overflows. Expect it to scroll, and the buttons to stay in the top-right corner.
6. Press Enter on the wrap button. Expect the code to wrap and a screen reader to announce "Word wrap enabled".
7. With VoiceOver on, focus a code block. Expect "SQL, 11 lines, code block", then the code read without line numbers interleaved. Focus each button and expect its name once, not twice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Improved code block labels for screen readers, including programming language and line count.
  - Added announcements when word wrap is enabled or disabled.
  - Enhanced keyboard focus behavior for code block controls.

- **Usability**
  - Kept code block controls visible while scrolling through code.
  - Improved wrapped-code overflow handling.
  - Removed redundant tooltip descriptions for copy and word-wrap controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->