### PR TITLE
fix(ui-patterns): give the shared code block theme a real light palette

### DIFF
--- a/packages/ui-patterns/src/CodeBlock/CodeBlock.tsx
+++ b/packages/ui-patterns/src/CodeBlock/CodeBlock.tsx
@@ -30,7 +30,7 @@ import xml from 'react-syntax-highlighter/dist/cjs/languages/hljs/xml'
 import yaml from 'react-syntax-highlighter/dist/cjs/languages/hljs/yaml'
 import { Button, cn, copyToClipboard } from 'ui'
 
-import { monokaiCustomTheme } from './CodeBlock.utils'
+import { getCodeBlockPalette, monokaiCustomTheme } from './CodeBlock.utils'
 
 const codeBlockLangs = [
   'js',
@@ -244,7 +244,7 @@ export const CodeBlock = ({
               paddingLeft: '4px',
               paddingRight: '4px',
               marginRight: '12px',
-              color: styleConfig?.lineNumber ?? '#828282',
+              color: styleConfig?.lineNumber ?? getCodeBlockPalette(isDarkTheme).lineNumber,
               textAlign: 'center',
               fontSize: large ? 14 : 12,
               paddingTop: '4px',

--- a/packages/ui-patterns/src/CodeBlock/CodeBlock.utils.ts
+++ b/packages/ui-patterns/src/CodeBlock/CodeBlock.utils.ts
@@ -1,108 +1,139 @@
+// Light values clear 4.5:1 on white, taken from the docs shiki palette
+const PALETTES = {
+  dark: {
+    foreground: '#ddd',
+    keyword: '#569cd6',
+    code: '#66d9ef',
+    accent: '#bf79db',
+    entity: '#3ECF8E',
+    comment: '#999',
+    muted: '#75715e',
+    title: 'gray',
+    lineNumber: '#828282',
+  },
+  light: {
+    foreground: '#444',
+    keyword: '#5f2fc4',
+    code: '#0e7490',
+    accent: '#a21caf',
+    entity: '#15593b',
+    comment: '#6a6a6a',
+    muted: '#6a6a6a',
+    title: '#6a6a6a',
+    lineNumber: '#6a6a6a',
+  },
+} as const
+
+export const getCodeBlockPalette = (isDarkMode: boolean) =>
+  isDarkMode ? PALETTES.dark : PALETTES.light
+
 export const monokaiCustomTheme = (isDarkMode: boolean) => {
+  const c = getCodeBlockPalette(isDarkMode)
+
   return {
     hljs: {
       display: 'block',
       overflowX: 'auto',
-      color: isDarkMode ? '#ddd' : '#444',
+      color: c.foreground,
     },
     'hljs-tag': {
-      color: '#569cd6',
+      color: c.keyword,
     },
     'hljs-keyword': {
-      color: '#569cd6',
+      color: c.keyword,
       fontWeight: 'normal',
     },
     'hljs-selector-tag': {
-      color: '#569cd6',
+      color: c.keyword,
       fontWeight: 'normal',
     },
     'hljs-literal': {
-      color: '#569cd6',
+      color: c.keyword,
       fontWeight: 'normal',
     },
     'hljs-strong': {
-      color: '#569cd6',
+      color: c.keyword,
     },
     'hljs-name': {
-      color: '#569cd6',
+      color: c.keyword,
     },
     'hljs-code': {
-      color: '#66d9ef',
+      color: c.code,
     },
     'hljs-class .hljs-title': {
-      color: 'gray',
+      color: c.title,
     },
     'hljs-attribute': {
-      color: '#bf79db',
+      color: c.accent,
     },
     'hljs-symbol': {
-      color: '#bf79db',
+      color: c.accent,
     },
     'hljs-regexp': {
-      color: '#bf79db',
+      color: c.accent,
     },
     'hljs-link': {
-      color: '#bf79db',
+      color: c.accent,
     },
     'hljs-string': {
       color: `hsl(var(--brand-link))`,
     },
     'hljs-bullet': {
-      color: '#3ECF8E',
+      color: c.entity,
     },
     'hljs-subst': {
-      color: '#3ECF8E',
+      color: c.entity,
     },
     'hljs-title': {
-      color: '#3ECF8E',
+      color: c.entity,
       fontWeight: 'normal',
     },
     'hljs-section': {
-      color: '#3ECF8E',
+      color: c.entity,
       fontWeight: 'normal',
     },
     'hljs-emphasis': {
-      color: '#3ECF8E',
+      color: c.entity,
     },
     'hljs-type': {
-      color: '#3ECF8E',
+      color: c.entity,
       fontWeight: 'normal',
     },
     'hljs-built_in': {
-      color: '#3ECF8E',
+      color: c.entity,
     },
     'hljs-builtin-name': {
-      color: '#3ECF8E',
+      color: c.entity,
     },
     'hljs-selector-attr': {
-      color: '#3ECF8E',
+      color: c.entity,
     },
     'hljs-selector-pseudo': {
-      color: '#3ECF8E',
+      color: c.entity,
     },
     'hljs-addition': {
-      color: '#3ECF8E',
+      color: c.entity,
     },
     'hljs-variable': {
-      color: '#3ECF8E',
+      color: c.entity,
     },
     'hljs-template-tag': {
-      color: '#3ECF8E',
+      color: c.entity,
     },
     'hljs-template-variable': {
-      color: '#3ECF8E',
+      color: c.entity,
     },
     'hljs-comment': {
-      color: isDarkMode ? '#999' : '#888',
+      color: c.comment,
     },
     'hljs-quote': {
-      color: '#75715e',
+      color: c.muted,
     },
     'hljs-deletion': {
-      color: '#75715e',
+      color: c.muted,
     },
     'hljs-meta': {
-      color: '#75715e',
+      color: c.muted,
     },
     'hljs-doctag': {
       fontWeight: 'normal',


### PR DESCRIPTION
Closes DOCS-1369

<img width="3200" height="514" alt="image-1787698255570" src="https://github.com/user-attachments/assets/c643c49c-9a2c-46bd-a08c-516992614cbe" />


## Problem

Fixes color contrast errors in light-mode code blocks. The shared `CodeBlock` uses one set of colors for both themes, so dark-mode colors end up painted on a white background.

axe DevTools flags these as errors. AA needs 4.5:1:

| Color | Shows up on | Ratio |
| -- | -- | -- |
| `#66d9ef` | inline code | 1.65:1 |
| `#3ECF8E` | built-ins like `count` and `max` | 2.00:1 |
| `#bf79db` | attributes and regexes | 2.90:1 |
| `#569cd6` | keywords like `select` and `from` | 2.95:1 |
| `#888888` | comments | 3.54:1 |
| `#828282` | line numbers | 3.84:1 |
| `gray` | class names | 3.95:1 |

Line numbers are the exception. axe files those under Needs review rather than Errors, because one character is too short for it to judge.

You see this in Studio, not in docs, even though the ticket sits with the Docs team. The failing colors only appear on keywords and built-ins, which means SQL, JS, TS, and Python. That is the SQL Editor, the Connect sheet, and the AI Assistant, across 52 call sites. The four docs pages using this component show TOML, HCL, and bash, which is nearly all strings, and strings already pass at 4.75:1.

## Solution

- Split the tokens into light and dark palettes behind one `PALETTES` constant.
- Light values come from the docs shiki palette in `apps/docs/styles/globals.css`, already verified against WCAG AA.
- Make the hardcoded line-number color theme-aware.

Every light token now clears 4.5:1 on white, checked by calling the function and testing all 30+ tokens rather than spot-checking pages.

**The dark palette is byte-identical to before.** Verified by diffing the function output against `master`: `JSON.stringify(before(true)) === JSON.stringify(after(true))`. Studio, www, and ui-library are unchanged in dark mode.

Not folded in: consolidating the four near-duplicate `--code-token-*` variable sets across `apps/{docs,design-system,learn,ui-library}`. They disagree on values today, so unifying them changes shiki rendering in three more apps.

## Manual testing

Install [axe DevTools for Chrome](https://chromewebstore.google.com/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd), then compare production against this branch.

**Before, on production:**

1. Open [supabase.com/dashboard](https://supabase.com/dashboard) in **light mode** and go to the SQL Editor.
2. Run a query so **Advisors > Query Performance** has something to show:

   ```sql
   select t.table_name, count(c.column_name) as column_count
   from information_schema.tables t
   join information_schema.columns c on c.table_name = t.table_name
   where t.table_schema = 'public'
   group by t.table_name
   order by column_count desc;
   ```

   Then open **Advisors > Query Performance**, select that query, and view its index detail. The SQL renders in a code block there. If Query Performance is empty on your project, the Cron Jobs job detail and the GraphQL introspection modal render the same component.
3. Open DevTools, pick the **axe DevTools** tab, and choose **Scan all of my page**.
4. Filter to **color contrast**. Expect errors on the SQL keywords, around 2.89:1 against white. `select`, `from`, and `where` are the clearest examples.

**After, on this branch:**

5. Run Studio from this branch. Open the same surface in light mode, and scan again.
6. Expect zero color-contrast errors inside the code block.
7. Switch to dark mode and confirm the block looks exactly as it did before.


