### PR TITLE
fix(studio): correct edge function URL validation for additional project domains

### DIFF
--- a/apps/studio/lib/api/edgeFunctions.test.ts
+++ b/apps/studio/lib/api/edgeFunctions.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
   buildDatabaseEdgeFunctionUrl,
@@ -151,5 +151,78 @@ describe('isValidEdgeFunctionURL', () => {
     for (const url of invalidEdgeFunctionUrls) {
       expect(isValidEdgeFunctionURL(url, false), `Expected ${url} to be invalid`).toBe(false)
     }
+  })
+
+  describe('with NIMBUS_PROD_PROJECTS_URL configured', () => {
+    const APEX = 'example-projects.com'
+    const REF = 'uniquetwentychararef'
+
+    afterEach(() => {
+      vi.unstubAllEnvs()
+    })
+
+    it.each([
+      { name: 'the documented wildcard form', value: `https://*.${APEX}` },
+      { name: 'a trailing slash', value: `https://*.${APEX}/` },
+      { name: 'no wildcard prefix', value: `https://${APEX}` },
+      { name: 'no scheme', value: `*.${APEX}` },
+      { name: 'surrounding whitespace', value: ` https://*.${APEX} ` },
+    ])('accepts a project URL when the env var is written with $name', ({ value }) => {
+      vi.stubEnv('NIMBUS_PROD_PROJECTS_URL', value)
+
+      expect(isValidEdgeFunctionURL(`https://${REF}.${APEX}/functions/v1/hello-world`, true)).toBe(
+        true
+      )
+    })
+
+    it.each([
+      { name: 'a functions subdomain', url: `https://${REF}.functions.${APEX}/functions/v1/hello` },
+      { name: 'a ref containing digits', url: `https://ref1234567890abcdefg.${APEX}/functions/v1/x` },
+      { name: 'an explicit port', url: `https://${REF}.${APEX}:8443/functions/v1/hello-world` },
+      { name: 'a query string', url: `https://${REF}.${APEX}/functions/v1/hello-world?name=1` },
+    ])('accepts $name', ({ url }) => {
+      vi.stubEnv('NIMBUS_PROD_PROJECTS_URL', `https://*.${APEX}`)
+
+      expect(isValidEdgeFunctionURL(url, true), `Expected ${url} to be valid`).toBe(true)
+    })
+
+    it('still accepts default platform URLs', () => {
+      vi.stubEnv('NIMBUS_PROD_PROJECTS_URL', `https://*.${APEX}`)
+
+      for (const url of validEdgeFunctionUrls) {
+        expect(isValidEdgeFunctionURL(url, true), `Expected ${url} to be valid`).toBe(true)
+      }
+    })
+
+    it('still accepts self-hosted URLs off platform', () => {
+      vi.stubEnv('NIMBUS_PROD_PROJECTS_URL', `https://*.${APEX}`)
+
+      for (const url of validLocalEdgeFunctionsUrls) {
+        expect(isValidEdgeFunctionURL(url, false), `Expected ${url} to be valid`).toBe(true)
+      }
+    })
+
+    it.each([
+      { name: 'an unrelated apex domain', url: 'https://someref.notexample.com/functions/v1/x' },
+      { name: 'a lookalike apex domain', url: `https://someref.evil-${APEX}/functions/v1/x` },
+      { name: 'the apex domain itself', url: `https://${APEX}/functions/v1/x` },
+      { name: 'a non-functions path', url: `https://${REF}.${APEX}/rest/v1/x` },
+      { name: 'plain http', url: `http://${REF}.${APEX}/functions/v1/x` },
+    ])('rejects $name', ({ url }) => {
+      vi.stubEnv('NIMBUS_PROD_PROJECTS_URL', `https://*.${APEX}`)
+
+      expect(isValidEdgeFunctionURL(url, true), `Expected ${url} to be invalid`).toBe(false)
+    })
+
+    it.each([{ value: '' }, { value: '   ' }])(
+      'falls back to the default hosts when the env var is blank ($value)',
+      ({ value }) => {
+        vi.stubEnv('NIMBUS_PROD_PROJECTS_URL', value)
+
+        for (const url of validEdgeFunctionUrls) {
+          expect(isValidEdgeFunctionURL(url, true), `Expected ${url} to be valid`).toBe(true)
+        }
+      }
+    )
   })
 })

--- a/apps/studio/lib/api/edgeFunctions.ts
+++ b/apps/studio/lib/api/edgeFunctions.ts
@@ -1,6 +1,5 @@
 import { IS_PLATFORM } from '@/lib/constants'
 
-const NIMBUS_PROD_PROJECTS_URL = process.env.NIMBUS_PROD_PROJECTS_URL
 // Cron jobs and database hooks run inside Postgres, where Kong is available by this network alias.
 const SELF_HOSTED_EDGE_FUNCTIONS_URL = 'http://kong:8000/functions/v1'
 const PLATFORM_TLDS = ['co', 'red'] as const
@@ -35,24 +34,52 @@ export const isEdgeFunctionUrl = (
   )
 }
 
-export const isValidEdgeFunctionURL = (url: string, isPlatform: boolean) => {
-  if (NIMBUS_PROD_PROJECTS_URL !== undefined) {
-    const apexDomain = NIMBUS_PROD_PROJECTS_URL.replace('https://*.', '').replace(/\./g, '\\.')
-    const nimbusRegex = new RegExp('^https://[a-z]*\\.' + apexDomain + '/functions/v[0-9]{1}/.*$')
-    return nimbusRegex.test(url)
-  }
+/**
+ * Normalises `NIMBUS_PROD_PROJECTS_URL` (e.g. `https://*.example.com`) down to its apex domain.
+ * Returns null when unset, blank, or whitespace-only so callers fall through to the default hosts.
+ * Read at call time rather than module scope so the value is stubbable in tests.
+ */
+const getAdditionalProjectsApexDomain = () => {
+  const configured = process.env.NIMBUS_PROD_PROJECTS_URL?.trim()
+  if (!configured) return null
 
-  if (!isPlatform) {
-    const regexValidLocalEdgeFunctionURL = new RegExp(
-      /^https?:\/\/[^\s/?#]+\/functions\/v[0-9]{1}\/.*$/
-    )
-
-    return regexValidLocalEdgeFunctionURL.test(url)
-  }
-
-  const regexValidEdgeFunctionURL = new RegExp(
-    /^https:\/\/[a-z]{20}\.supabase\.(red|co)\/functions\/v[0-9]{1}\/.*$/
+  return (
+    configured
+      .replace(/^https?:\/\//, '')
+      .replace(/^\*\./, '')
+      .replace(/\/+$/, '')
+      .toLowerCase() || null
   )
+}
 
-  return regexValidEdgeFunctionURL.test(url)
+const isFunctionsPath = (pathname: string) => /^\/functions\/v\d\/.+/.test(pathname)
+
+/**
+ * Guards the server-side fetch in `pages/api/edge-functions/test.ts`, so this doubles as an
+ * SSRF allowlist: only hosts that match are fetched with the caller's credentials attached.
+ */
+export const isValidEdgeFunctionURL = (url: string, isPlatform: boolean) => {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return false
+  }
+
+  // Parse rather than pattern-match the whole URL, so credentials/query smuggling such as
+  // `https://localhost?https://ref.supabase.co/functions/v1/x` can't satisfy the host check.
+  if (!isFunctionsPath(parsed.pathname)) return false
+
+  if (!isPlatform) return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+
+  if (parsed.protocol !== 'https:') return false
+
+  const host = parsed.hostname.toLowerCase()
+
+  // Additive: a deployment serving additional project domains must still validate the
+  // default ones, so this is checked alongside PLATFORM_TLDS rather than instead of them.
+  const additionalApexDomain = getAdditionalProjectsApexDomain()
+  if (additionalApexDomain && host.endsWith(`.${additionalApexDomain}`)) return true
+
+  return PLATFORM_TLDS.some((tld) => new RegExp(`^[a-z]{20}\\.supabase\\.${tld}$`).test(host))
 }


### PR DESCRIPTION
## What

`isValidEdgeFunctionURL` in `apps/studio/lib/api/edgeFunctions.ts` guards the server-side `fetch` in `pages/api/edge-functions/test.ts` — the request the **Test** panel in the edge functions UI makes. When it returns false the user gets a 400, `Provided URL is not a valid Supabase edge function URL`, and nothing reaches their function.

The `NIMBUS_PROD_PROJECTS_URL` branch built a regex by string concatenation. Bugs found:

1. **It replaced the other branches instead of adding to them.** The branch returns early, so a deployment with that variable set rejected every `*.supabase.co` / `*.supabase.red` URL, and rejected self-hosted URLs even with `isPlatform === false`.
2. **Blank env var rejected everything.** The guard was `!== undefined`, so a variable declared-but-empty in a deployment took the branch and produced `^https://[a-z]*\./functions/v[0-9]{1}/.*$`, which matches nothing.
3. **`[a-z]*` matched one label of letters only.** Refs containing digits, nested subdomains, and hosts with an explicit port all failed.
4. **Only `.` was escaped before interpolation.** A value missing the exact `https://*.` prefix, or carrying a trailing slash, silently produced a pattern matching nothing — e.g. `https://<apex>` yielded `^https://[a-z]*\.https://<apex>/...`. Other regex metacharacters in the value are still live.
5. **Untestable and untested.** `process.env` was read at module scope, and the branch had no coverage at all.

## How

Parse the URL rather than pattern-matching it end to end, and treat the additional domain as **additive** to the default hosts. Host matching is anchored on a leading dot so a lookalike apex can't match. The env value is normalised (scheme, `*.` prefix, trailing slashes, whitespace) so the documented form and the common near-misses all work.

Parsing also handles the query-smuggling cases (`https://localhost?https://ref.supabase.co/functions/v1/x`) structurally rather than by regex anchoring.

## Scope

The default `[a-z]{20}\.supabase\.(co|red)` host check is **unchanged**. This function doubles as an SSRF allowlist — the Studio server performs the fetch with the caller's credentials attached — so the default allowlist is deliberately left exactly as it was, and this PR only touches the additional-domain branch.

Noting a separate pre-existing gap for a follow-up: `isValidEdgeFunctionURL` rejects `<ref>.functions.supabase.<tld>`, which `isEdgeFunctionUrl` in the same file accepts. Not reachable from the Test panel today (it builds URLs from `app_config.endpoint`), so it's left alone here.

## Testing

`apps/studio/lib/api/edgeFunctions.test.ts` — 31 passing.

- All 13 pre-existing assertions pass unchanged against the new implementation.
- 18 new assertions cover the previously untested branch: env-var spelling variants, functions subdomains, refs with digits, ports, query strings, blank-value fallback, and rejection of unrelated/lookalike apexes, non-functions paths and plain `http`.
- Verified the new assertions **fail** against the old implementation, so they're load-bearing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Edge Function URL validation for platform and self-hosted deployments.
  * Added support for custom project domains while preserving default platform URL behavior.
  * More reliably rejects invalid protocols, hosts, and paths.
  * Safely falls back to default behavior when configuration is blank or malformed.

* **Tests**
  * Expanded coverage for valid URL formats, custom domains, self-hosted URLs, invalid inputs, and configuration fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->