### PR TITLE
fix(studio): make projects domain available to the edge function test route

### DIFF
--- a/apps/studio/next.config.ts
+++ b/apps/studio/next.config.ts
@@ -54,6 +54,15 @@ const nextConfig = {
   basePath: process.env.NEXT_PUBLIC_BASE_PATH,
   assetPrefix: getAssetPrefix(),
   output: 'standalone',
+  // `csp.ts` reads these at build time, but `lib/api/edgeFunctions.ts` reads
+  // them at request time from inside an API route. Deployments that supply the
+  // values to the build without also exposing them to the function runtime get
+  // a CSP that allows the projects domain while edge function URL validation
+  // still rejects it. Inlining here pins both readers to the same value.
+  env: {
+    NIMBUS_PROD_PROJECTS_URL: process.env.NIMBUS_PROD_PROJECTS_URL,
+    NIMBUS_PROD_PROJECTS_URL_WS: process.env.NIMBUS_PROD_PROJECTS_URL_WS,
+  },
   experimental: {
     clientRouterFilter: false,
   },


### PR DESCRIPTION
## Problem

On a deployment where `NIMBUS_PROD_PROJECTS_URL` is supplied to the build but not to the function runtime, testing an edge function returns a 400:

```
Provided URL is not a valid Supabase edge function URL
```

while the CSP served on the very same page already allows the projects domain. Observed on a live deployment:

```
default-src ... https://*.nmb-proj.com wss://*.nmb-proj.com ...
img-src     ... https://*.nmb-proj.com
```

## Cause

The two readers of this variable run at different times.

- `csp.ts` is imported by `next.config.ts` and evaluated **during the build**, so it sees the value and emits it into the CSP.
- `lib/api/edgeFunctions.ts` is evaluated **inside the API route at request time**, where the variable is absent. `isValidEdgeFunctionURL` then falls through to the default `<ref>.supabase.(co|red)` check, which no projects URL can match.

Confirmed against the deployed route rather than inferred. Posting to `/api/edge-functions/test`:

| URL | Response |
|---|---|
| `<ref>.<projects-apex>/functions/v1/x` | `400` — not a valid edge function URL |
| `<ref>.example.com/functions/v1/x` | `400` — expected |
| `<20-char-ref>.supabase.co/functions/v1/x` | `500 "fetch failed"` |

The third case is the diagnostic: it means validation **passed** and the fetch was attempted. Under the additional-domain branch that URL would be rejected, since the branch returns early and allows only the configured apex. So the branch never ran, i.e. the variable is `undefined` at runtime.

## Fix

Declare the variables under `env` in `next.config.ts`, which pins both readers to the same build-time value.

Verified the mechanism in `next@15.5.2` rather than assuming it:

- `getNextConfigEnv(config)` (`dist/lib/static-env.js`) maps each `config.env` key to a define `process.env.<key>`.
- `getDefineEnv` (`dist/build/define-env.js`) spreads `nextConfigEnv` **unconditionally** — it is not gated on `isClient` / `isNodeServer` / `isEdgeServer` — so the substitution reaches the Node server compilation where pages API routes live.

## Safety

- **No-op when unset.** `getNextConfigEnv` skips null values (`if (value != null)`), so no define is emitted and `process.env.*` stays an ordinary runtime lookup. Self-hosted and OSS builds are unaffected.
- **Nothing new is exposed.** `env` inlines into the client bundle too, but both values are wildcard domains already published in the CSP response header.

## Related

- supabase#49564 — hardens `isValidEdgeFunctionURL` itself (blank value currently rejects every URL; branch is early-return rather than additive; refs with digits, ports, env-var spelling variants). Independent of this; neither fixes the other.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Improved runtime configuration for production project services.
  * Production environments now receive the required project and WebSocket service URLs automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->