### PR TITLE
feat(www + studio): broaden Select 2026 banner reach and soften www edges

### DIFF
--- a/apps/studio/components/interfaces/App/AppBannerWrapper.tsx
+++ b/apps/studio/components/interfaces/App/AppBannerWrapper.tsx
@@ -2,6 +2,10 @@ import { IS_PLATFORM, LOCAL_STORAGE_KEYS, useFlag } from 'common'
 import dayjs from 'dayjs'
 import { usePathname } from 'next/navigation'
 import { PropsWithChildren, useEffect, useRef, useState } from 'react'
+import {
+  SELECT_26_STUDIO_DISMISSAL_KEY,
+  useSelect26PromotionActive,
+} from 'ui-patterns/Banners/Select26Promotion'
 
 import { OrganizationResourceBanner } from '../Organization/HeaderBanner'
 import { isLogsOrObservabilityPath } from './AppBannerWrapper.utils'
@@ -9,6 +13,11 @@ import { ClockSkewBanner } from '@/components/layouts/AppLayout/ClockSkewBanner'
 import { NoticeBanner } from '@/components/layouts/AppLayout/NoticeBanner'
 import { StatusPageBanner } from '@/components/layouts/AppLayout/StatusPageBanner'
 import { BannerLogsAllDeprecation } from '@/components/ui/BannerStack/Banners/BannerLogsAllDeprecation'
+import { BannerSelect2026 } from '@/components/ui/BannerStack/Banners/BannerSelect2026'
+import {
+  SELECT_26_BANNER_PRIORITY,
+  shouldShowSelect26Banner,
+} from '@/components/ui/BannerStack/Banners/BannerSelect2026.utils'
 import { BannerTOSUpdate } from '@/components/ui/BannerStack/Banners/BannerTOSUpdate'
 import { BANNER_ID, useBannerStack } from '@/components/ui/BannerStack/BannerStackProvider'
 import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
@@ -35,6 +44,38 @@ export const AppBannerWrapper = ({ children }: PropsWithChildren<{}>) => {
     LOCAL_STORAGE_KEYS.TERMS_OF_SERVICE_UPDATE,
     false
   )
+
+  const [isSelect26BannerDismissed, , { isSuccess: isSelect26DismissalLoaded }] =
+    useLocalStorageQuery(SELECT_26_STUDIO_DISMISSAL_KEY, false)
+  const isSelect26PromotionActive = useSelect26PromotionActive()
+
+  useEffect(() => {
+    if (!isSelect26DismissalLoaded) return
+
+    const shouldShow = shouldShowSelect26Banner({
+      isPlatform: IS_PLATFORM,
+      dismissalLoaded: isSelect26DismissalLoaded,
+      isActive: isSelect26PromotionActive,
+      isDismissed: isSelect26BannerDismissed,
+    })
+
+    if (shouldShow) {
+      addBanner({
+        id: BANNER_ID.SELECT_26,
+        isDismissed: false,
+        content: <BannerSelect2026 />,
+        priority: SELECT_26_BANNER_PRIORITY,
+      })
+    } else {
+      dismissBanner(BANNER_ID.SELECT_26)
+    }
+  }, [
+    isSelect26DismissalLoaded,
+    isSelect26PromotionActive,
+    isSelect26BannerDismissed,
+    addBanner,
+    dismissBanner,
+  ])
 
   useEffect(() => {
     if (Date.now() >= TOSUpdateExpiry.getTime()) return

--- a/apps/studio/components/layouts/ProjectLayout/index.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/index.tsx
@@ -23,10 +23,6 @@ import {
   useIsMobile,
   usePanelRef,
 } from 'ui'
-import {
-  SELECT_26_STUDIO_DISMISSAL_KEY,
-  useSelect26PromotionActive,
-} from 'ui-patterns/Banners/Select26Promotion'
 
 import { useEditorType } from '../editors/EditorsLayout.hooks'
 import { useMainScrollContainer, useSetMainScrollContainer } from '../MainScrollContainerContext'
@@ -47,11 +43,6 @@ import { UpgradingState } from './UpgradingState'
 import { CreateBranchModal } from '@/components/interfaces/BranchManagement/CreateBranchModal'
 import { ProjectAPIDocs } from '@/components/interfaces/ProjectAPIDocs/ProjectAPIDocs'
 import { BannerFreeMicroUpgrade } from '@/components/ui/BannerStack/Banners/BannerFreeMicroUpgrade'
-import { BannerSelect2026 } from '@/components/ui/BannerStack/Banners/BannerSelect2026'
-import {
-  SELECT_26_BANNER_PRIORITY,
-  shouldShowSelect26Banner,
-} from '@/components/ui/BannerStack/Banners/BannerSelect2026.utils'
 import { BANNER_ID, useBannerStack } from '@/components/ui/BannerStack/BannerStackProvider'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import PartnerIcon from '@/components/ui/PartnerIcon'
@@ -165,9 +156,6 @@ export const ProjectLayout = forwardRef<HTMLDivElement, PropsWithChildren<Projec
       LOCAL_STORAGE_KEYS.FREE_MICRO_UPGRADE_BANNER_DISMISSED(selectedProject?.ref ?? ''),
       false
     )
-    const [isSelect26BannerDismissed, , { isSuccess: isSelect26DismissalLoaded }] =
-      useLocalStorageQuery(SELECT_26_STUDIO_DISMISSAL_KEY, false)
-    const isSelect26PromotionActive = useSelect26PromotionActive()
     const [isProjectIntegrationBannerDismissed, setIsProjectIntegrationBannerDismissed] =
       useLocalStorageQuery(
         getProjectIntegrationBannerDismissKey({
@@ -241,38 +229,6 @@ export const ProjectLayout = forwardRef<HTMLDivElement, PropsWithChildren<Projec
       selectedProject?.ref,
       showUpgradeBanner,
       isFreeMicroUpgradeBannerDismissed,
-      addBanner,
-      dismissBanner,
-    ])
-
-    useEffect(() => {
-      // Wait until project + dismissal state are known so we do not call
-      // dismissBanner on every early render (it always schedules a setState).
-      if (!selectedProject?.ref || !isSelect26DismissalLoaded) return
-
-      const shouldShow = shouldShowSelect26Banner({
-        isPlatform: IS_PLATFORM,
-        projectRef: selectedProject.ref,
-        dismissalLoaded: isSelect26DismissalLoaded,
-        isActive: isSelect26PromotionActive,
-        isDismissed: isSelect26BannerDismissed,
-      })
-
-      if (shouldShow) {
-        addBanner({
-          id: BANNER_ID.SELECT_26,
-          isDismissed: false,
-          content: <BannerSelect2026 />,
-          priority: SELECT_26_BANNER_PRIORITY,
-        })
-      } else {
-        dismissBanner(BANNER_ID.SELECT_26)
-      }
-    }, [
-      selectedProject?.ref,
-      isSelect26DismissalLoaded,
-      isSelect26PromotionActive,
-      isSelect26BannerDismissed,
       addBanner,
       dismissBanner,
     ])

--- a/apps/studio/components/layouts/ProjectLayout/index.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/index.tsx
@@ -1,4 +1,4 @@
-import { IS_PLATFORM, LOCAL_STORAGE_KEYS, mergeRefs, useParams } from 'common'
+import { LOCAL_STORAGE_KEYS, mergeRefs, useParams } from 'common'
 import { AnimatePresence, motion } from 'framer-motion'
 import { XIcon } from 'lucide-react'
 import Head from 'next/head'

--- a/apps/studio/components/ui/BannerStack/Banners/BannerSelect2026.utils.test.ts
+++ b/apps/studio/components/ui/BannerStack/Banners/BannerSelect2026.utils.test.ts
@@ -4,20 +4,18 @@ import { SELECT_26_BANNER_PRIORITY, shouldShowSelect26Banner } from './BannerSel
 
 const visibleState = {
   isPlatform: true,
-  projectRef: 'project-ref',
   dismissalLoaded: true,
   isActive: true,
   isDismissed: false,
 }
 
 describe('shouldShowSelect26Banner', () => {
-  it('shows the promotion on hosted project pages', () => {
+  it('shows the promotion on hosted Studio', () => {
     expect(shouldShowSelect26Banner(visibleState)).toBe(true)
   })
 
   it.each([
     ['self-hosted Studio', { isPlatform: false }],
-    ['outside a project', { projectRef: undefined }],
     ['before dismissal state loads', { dismissalLoaded: false }],
     ['after campaign expiry', { isActive: false }],
     ['after dismissal', { isDismissed: true }],

--- a/apps/studio/components/ui/BannerStack/Banners/BannerSelect2026.utils.ts
+++ b/apps/studio/components/ui/BannerStack/Banners/BannerSelect2026.utils.ts
@@ -2,14 +2,12 @@ export const SELECT_26_BANNER_PRIORITY = -1
 
 export const shouldShowSelect26Banner = ({
   isPlatform,
-  projectRef,
   dismissalLoaded,
   isActive,
   isDismissed,
 }: {
   isPlatform: boolean
-  projectRef?: string
   dismissalLoaded: boolean
   isActive: boolean
   isDismissed: boolean
-}) => isPlatform && !!projectRef && dismissalLoaded && isActive && !isDismissed
+}) => isPlatform && dismissalLoaded && isActive && !isDismissed

--- a/packages/ui-patterns/src/Banners/Select26Banner.tsx
+++ b/packages/ui-patterns/src/Banners/Select26Banner.tsx
@@ -7,7 +7,7 @@ import { SELECT_26_CTA, SELECT_26_TITLE, SELECT_26_URL, Select26Field } from './
 
 /** Three visible rows; top/bottom reach further inward than the middle row. */
 const WWW_FIELD_BASE_COLS = 24
-const WWW_FIELD_ROW_WIDTHS = [30, 24, 34]
+const WWW_FIELD_ROW_WIDTHS = [26, 24, 28]
 
 export const Select26Banner = () => (
   <div className="relative isolate flex min-h-14 w-full items-center overflow-hidden border-b border-[#00482f]/15 bg-[#f8f3ef] px-4 py-2.5 pr-12 text-base font-medium text-[#001a10] dark:border-white/10 dark:bg-[#0b0e0d] dark:text-[#f8f3ef] sm:px-6 sm:pr-14">
@@ -16,7 +16,7 @@ export const Select26Banner = () => (
       rows={WWW_FIELD_ROW_WIDTHS.length}
       rowWidths={WWW_FIELD_ROW_WIDTHS}
       rowAlign="start"
-      className="absolute inset-y-0 left-0 -z-10 my-auto hidden text-sm opacity-80 dark:opacity-70 sm:flex md:text-base xl:text-[0.95rem]"
+      className="absolute left-0 top-1/2 -z-10 hidden -translate-y-1/2 flex-col text-sm opacity-80 dark:opacity-70 sm:flex md:text-base xl:text-[0.95rem]"
     />
     <Select26Field
       cols={WWW_FIELD_BASE_COLS}
@@ -24,7 +24,7 @@ export const Select26Banner = () => (
       rowWidths={WWW_FIELD_ROW_WIDTHS}
       rowAlign="end"
       mirror
-      className="absolute inset-y-0 right-0 -z-10 my-auto flex text-sm opacity-80 dark:opacity-70 md:text-base xl:text-[0.95rem]"
+      className="absolute right-0 top-1/2 -z-10 flex -translate-y-1/2 flex-col text-sm opacity-80 dark:opacity-70 md:text-base xl:text-[0.95rem]"
     />
     <div className="relative z-10 ml-0 mr-auto flex w-fit max-w-full flex-wrap items-center justify-start gap-x-2 gap-y-1.5 rounded-md bg-[#f8f3ef] px-2.5 py-1 sm:mx-auto sm:flex-nowrap sm:justify-center sm:gap-x-2.5 sm:px-3.5 dark:bg-[#0b0e0d]">
       <p className="text-left leading-5 sm:text-center">

--- a/packages/ui-patterns/src/Banners/Select26Banner.tsx
+++ b/packages/ui-patterns/src/Banners/Select26Banner.tsx
@@ -16,7 +16,7 @@ export const Select26Banner = () => (
       rows={WWW_FIELD_ROW_WIDTHS.length}
       rowWidths={WWW_FIELD_ROW_WIDTHS}
       rowAlign="start"
-      className="absolute left-0 top-1/2 -z-10 hidden -translate-y-1/2 flex-col text-sm opacity-80 dark:opacity-70 sm:flex md:text-base xl:text-[0.95rem]"
+      className="absolute left-0 top-1/2 -z-10 !hidden -translate-y-1/2 text-sm opacity-80 dark:opacity-70 sm:!flex md:text-base xl:text-[0.95rem]"
     />
     <Select26Field
       cols={WWW_FIELD_BASE_COLS}
@@ -24,7 +24,7 @@ export const Select26Banner = () => (
       rowWidths={WWW_FIELD_ROW_WIDTHS}
       rowAlign="end"
       mirror
-      className="absolute right-0 top-1/2 -z-10 flex -translate-y-1/2 flex-col text-sm opacity-80 dark:opacity-70 md:text-base xl:text-[0.95rem]"
+      className="absolute right-0 top-1/2 -z-10 -translate-y-1/2 text-sm opacity-80 dark:opacity-70 md:text-base xl:text-[0.95rem]"
     />
     <div className="relative z-10 ml-0 mr-auto flex w-fit max-w-full flex-wrap items-center justify-start gap-x-2 gap-y-1.5 rounded-md bg-[#f8f3ef] px-2.5 py-1 sm:mx-auto sm:flex-nowrap sm:justify-center sm:gap-x-2.5 sm:px-3.5 dark:bg-[#0b0e0d]">
       <p className="text-left leading-5 sm:text-center">

--- a/packages/ui-patterns/src/Banners/Select26Banner.tsx
+++ b/packages/ui-patterns/src/Banners/Select26Banner.tsx
@@ -5,17 +5,26 @@ import Link from 'next/link'
 
 import { SELECT_26_CTA, SELECT_26_TITLE, SELECT_26_URL, Select26Field } from './Select26Promotion'
 
+/** Three visible rows; top/bottom reach further inward than the middle row. */
+const WWW_FIELD_BASE_COLS = 24
+const WWW_FIELD_ROW_WIDTHS = [30, 24, 34]
+
 export const Select26Banner = () => (
   <div className="relative isolate flex min-h-14 w-full items-center overflow-hidden border-b border-[#00482f]/15 bg-[#f8f3ef] px-4 py-2.5 pr-12 text-base font-medium text-[#001a10] dark:border-white/10 dark:bg-[#0b0e0d] dark:text-[#f8f3ef] sm:px-6 sm:pr-14">
     <Select26Field
-      cols={24}
-      rows={7}
-      className="absolute left-0 top-1/2 -z-10 hidden -translate-y-1/2 text-sm opacity-80 dark:opacity-70 sm:grid md:text-base xl:text-[0.95rem]"
+      cols={WWW_FIELD_BASE_COLS}
+      rows={WWW_FIELD_ROW_WIDTHS.length}
+      rowWidths={WWW_FIELD_ROW_WIDTHS}
+      rowAlign="start"
+      className="absolute inset-y-0 left-0 -z-10 my-auto hidden text-sm opacity-80 dark:opacity-70 sm:flex md:text-base xl:text-[0.95rem]"
     />
     <Select26Field
-      cols={24}
-      rows={7}
-      className="absolute right-0 top-1/2 -z-10 grid -translate-y-1/2 -scale-x-100 text-sm opacity-80 dark:opacity-70 md:text-base xl:text-[0.95rem]"
+      cols={WWW_FIELD_BASE_COLS}
+      rows={WWW_FIELD_ROW_WIDTHS.length}
+      rowWidths={WWW_FIELD_ROW_WIDTHS}
+      rowAlign="end"
+      mirror
+      className="absolute inset-y-0 right-0 -z-10 my-auto flex text-sm opacity-80 dark:opacity-70 md:text-base xl:text-[0.95rem]"
     />
     <div className="relative z-10 ml-0 mr-auto flex w-fit max-w-full flex-wrap items-center justify-start gap-x-2 gap-y-1.5 rounded-md bg-[#f8f3ef] px-2.5 py-1 sm:mx-auto sm:flex-nowrap sm:justify-center sm:gap-x-2.5 sm:px-3.5 dark:bg-[#0b0e0d]">
       <p className="text-left leading-5 sm:text-center">

--- a/packages/ui-patterns/src/Banners/Select26Promotion.module.css
+++ b/packages/ui-patterns/src/Banners/Select26Promotion.module.css
@@ -7,6 +7,9 @@
 }
 
 .field {
+  display: flex;
+  flex-direction: column;
+  width: max-content;
   font-family: 'Departure Mono Superbase', ui-monospace, monospace;
   font-weight: 400;
   letter-spacing: 0;
@@ -28,6 +31,20 @@
   --select26-b2: #95e6b8;
   --select26-b3: #e1fcd7;
   --select26-b4: #ffffff;
+}
+
+.row {
+  display: grid;
+  width: fit-content;
+  flex-shrink: 0;
+}
+
+.fieldAlignStart {
+  align-items: flex-start;
+}
+
+.fieldAlignEnd {
+  align-items: flex-end;
 }
 
 .cell {

--- a/packages/ui-patterns/src/Banners/Select26Promotion.module.css
+++ b/packages/ui-patterns/src/Banners/Select26Promotion.module.css
@@ -38,10 +38,14 @@
 }
 
 .fieldAlignStart {
+  display: flex;
+  flex-direction: column;
   align-items: flex-start;
 }
 
 .fieldAlignEnd {
+  display: flex;
+  flex-direction: column;
   align-items: flex-end;
 }
 

--- a/packages/ui-patterns/src/Banners/Select26Promotion.module.css
+++ b/packages/ui-patterns/src/Banners/Select26Promotion.module.css
@@ -7,8 +7,6 @@
 }
 
 .field {
-  display: flex;
-  flex-direction: column;
   width: max-content;
   font-family: 'Departure Mono Superbase', ui-monospace, monospace;
   font-weight: 400;

--- a/packages/ui-patterns/src/Banners/Select26Promotion.tsx
+++ b/packages/ui-patterns/src/Banners/Select26Promotion.tsx
@@ -133,6 +133,7 @@ export const Select26Field = ({
     if (rowWidths) return rowWidths
     return Array.from({ length: rows }, () => cols)
   }, [rowWidths, rows, cols])
+  const fieldRows = widths.length
 
   useEffect(() => {
     const node = rootRef.current
@@ -173,11 +174,11 @@ export const Select26Field = ({
     return widths.map((rowCols, y) => {
       const rowCells: FieldCell[] = []
       for (let x = 0; x < rowCols; x++) {
-        rowCells.push(cellAt(x, y, rowCols, rows, timeMs, mirror))
+        rowCells.push(cellAt(x, y, rowCols, fieldRows, timeMs, mirror))
       }
       return rowCells
     })
-  }, [widths, rows, timeMs, mirror])
+  }, [widths, fieldRows, timeMs, mirror])
 
   return (
     <div

--- a/packages/ui-patterns/src/Banners/Select26Promotion.tsx
+++ b/packages/ui-patterns/src/Banners/Select26Promotion.tsx
@@ -67,7 +67,14 @@ type FieldCell = {
   weight: number
 }
 
-const cellAt = (x: number, y: number, cols: number, rows: number, timeMs: number): FieldCell => {
+const cellAt = (
+  x: number,
+  y: number,
+  cols: number,
+  rows: number,
+  timeMs: number,
+  mirror = false
+): FieldCell => {
   const cx = (cols - 1) / 2
   const cy = (rows - 1) / 2
   const nx = x - cx
@@ -77,7 +84,8 @@ const cellAt = (x: number, y: number, cols: number, rows: number, timeMs: number
 
   const step = Math.floor(timeMs / BRACKET_STEP_MS + y * 1.7 + Math.abs(nx) * 0.8)
   const idx = positiveModulo(step, OPEN_BRACKETS.length)
-  const ch = x <= cx ? OPEN_BRACKETS[idx] : CLOSE_BRACKETS[idx]
+  const onLeft = mirror ? x > cx : x <= cx
+  const ch = onLeft ? OPEN_BRACKETS[idx] : CLOSE_BRACKETS[idx]
 
   const hue = positiveModulo(angle - sweep, Math.PI * 2) / (Math.PI * 2)
   const band = Math.min(4, Math.floor(hue * 5))
@@ -95,6 +103,12 @@ const cellAt = (x: number, y: number, cols: number, rows: number, timeMs: number
 type Select26FieldProps = HTMLAttributes<HTMLDivElement> & {
   cols?: number
   rows?: number
+  /** Per-row column counts; defaults to `cols` for every row. */
+  rowWidths?: number[]
+  /** Which edge shorter rows hug when widths vary. */
+  rowAlign?: 'start' | 'end'
+  /** Mirror bracket glyphs (for right-hand fields; prefer over CSS scale-x). */
+  mirror?: boolean
 }
 
 /**
@@ -102,10 +116,23 @@ type Select26FieldProps = HTMLAttributes<HTMLDivElement> & {
  * radar beam falloff. Stepped updates mirror the Select glyph-engine without
  * shipping its canvas runtime.
  */
-export const Select26Field = ({ cols = 10, rows = 6, className, ...props }: Select26FieldProps) => {
+export const Select26Field = ({
+  cols = 10,
+  rows = 6,
+  rowWidths,
+  rowAlign = 'start',
+  mirror = false,
+  className,
+  ...props
+}: Select26FieldProps) => {
   const rootRef = useRef<HTMLDivElement>(null)
   const [timeMs, setTimeMs] = useState(0)
   const [isVisible, setIsVisible] = useState(true)
+
+  const widths = useMemo(() => {
+    if (rowWidths) return rowWidths
+    return Array.from({ length: rows }, () => cols)
+  }, [rowWidths, rows, cols])
 
   useEffect(() => {
     const node = rootRef.current
@@ -142,34 +169,53 @@ export const Select26Field = ({ cols = 10, rows = 6, className, ...props }: Sele
     return () => cancelAnimationFrame(raf)
   }, [isVisible])
 
-  const cells = useMemo(() => {
-    const next: FieldCell[] = []
-    for (let y = 0; y < rows; y++) {
-      for (let x = 0; x < cols; x++) {
-        next.push(cellAt(x, y, cols, rows, timeMs))
+  const cellsByRow = useMemo(() => {
+    return widths.map((rowCols, y) => {
+      const rowCells: FieldCell[] = []
+      for (let x = 0; x < rowCols; x++) {
+        rowCells.push(cellAt(x, y, rowCols, rows, timeMs, mirror))
       }
-    }
-    return next
-  }, [cols, rows, timeMs])
+      return rowCells
+    })
+  }, [widths, rows, timeMs, mirror])
 
   return (
     <div
       ref={rootRef}
       aria-hidden
-      className={cn(styles.field, 'grid', className)}
-      style={{ gridTemplateColumns: `repeat(${cols}, calc(22 / 34 * 1em))` }}
+      className={cn(
+        styles.field,
+        rowAlign === 'end' ? styles.fieldAlignEnd : styles.fieldAlignStart,
+        className
+      )}
       {...props}
     >
-      {cells.map((cell, index) => (
-        <span
-          key={index}
-          className={styles.cell}
-          data-band={cell.band}
-          style={{ opacity: cell.weight }}
-        >
-          {cell.ch}
-        </span>
-      ))}
+      {cellsByRow.map((rowCells, y) => {
+        const rowCols = widths[y]
+        const cellWidth = 'calc(22 / 34 * 1em)'
+
+        return (
+          <div
+            key={y}
+            className={styles.row}
+            style={{
+              gridTemplateColumns: `repeat(${rowCols}, ${cellWidth})`,
+              width: `calc(${rowCols} * 22 / 34 * 1em)`,
+            }}
+          >
+            {rowCells.map((cell, index) => (
+              <span
+                key={index}
+                className={styles.cell}
+                data-band={cell.band}
+                style={{ opacity: cell.weight }}
+              >
+                {cell.ch}
+              </span>
+            ))}
+          </div>
+        )
+      })}
     </div>
   )
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature polish for the Select 2026 promotion.

## What is the current behavior?

- Studio only shows the Select Banner Stack card inside `ProjectLayout` (project routes).
- www glyph fields read as hard rectangles on each side of the announcement banner.

## What is the new behavior?

- Studio registers the Select banner from `AppBannerWrapper`, so it also appears outside project context (org / account surfaces).
- www fields use per-row widths with edge alignment: top/middle shorter, bottom longer, growing inward from each side for a softer silhouette.

https://github.com/user-attachments/assets/c5275967-63d0-40dd-a472-e3db08d1c39d

## To test

- **Studio (non-project):** open an org home or account page on the deploy preview. Confirm the Select Banner Stack card appears in the usual stack and dismisses as before.
- **Studio (project):** open any project route. Confirm the same card still appears and does not double-register.
- **www:** open the marketing homepage. On `sm+`, confirm each side of the cream announcement bar has a 3-row field where the bottom row reaches further inward than the top, and the middle row is shortest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the Select 2026 promotional banner to eligible hosted Studio environments.
  * Banner visibility reflects promotion status, platform eligibility, loading state, and dismissal preferences.

* **Style**
  * Refined decorative field layouts with improved row alignment, mirrored visuals, and flexible sizing.

* **Bug Fixes**
  * Updated visibility behavior so the banner is no longer tied to being inside a specific project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->