### PR TITLE
fix(functions): reject a non-string query in search-embeddings

### DIFF
--- a/supabase/functions/search-embeddings/index.ts
+++ b/supabase/functions/search-embeddings/index.ts
@@ -40,7 +40,10 @@ Deno.serve(async (req) => {
 
     const { query, useAlternateSearchIndex } = requestData
 
-    if (!query) {
+    // `typeof` as well as truthiness: this function is deployed with `verify_jwt = false`, so a
+    // caller can reach it directly rather than through the docs route that already checks this,
+    // and a non-string `query` would fall through to `query.trim()` below as a 500.
+    if (!query || typeof query !== 'string') {
       throw new UserError('Missing query in request data')
     }
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix. One line, plus a comment.

## What is the current behavior?

The two sides of this boundary disagree about what `query` may be.

`apps/docs/app/api/search/embeddings/route.utils.ts`, which proxies to the function:

```ts
const { query } = await request.json()
if (!query || typeof query !== 'string') {
  return Response.json({ error: 'Missing query in request data' }, { status: 400 })
}
```

`supabase/functions/search-embeddings/index.ts`, the function itself:

```ts
const { query, useAlternateSearchIndex } = requestData
if (!query) {
  throw new UserError('Missing query in request data')
}
const sanitizedQuery = query.trim()
```

Only truthiness is checked, so anything truthy and non-string falls through to `query.trim()`, throws a `TypeError`, and lands in the catch-all as a 500 rather than the 400 the same input gets one layer up:

```
query    passes !query   has .trim
123      yes             no
{}       yes             no
[]       yes             no
true     yes             no
""       no              (rejected already)
```

The reason the weaker check is the one that matters: `supabase/config.toml` deploys this with

```toml
[functions.search-embeddings]
verify_jwt = false
```

so it is reachable directly, not only through the docs route that already validates. The route's guard protects the docs path, not the function.

## What is the new behavior?

The function uses the same condition and the same message as its caller, so a malformed `query` gets a 400 from either entry point instead of a 400 from one and a 500 from the other.

## Deliberately not changed

`console.log({ query })` a few lines below is marked "Intentionally log the query", so I left it. Worth noting it currently runs before `query.trim()`, meaning a malformed body is logged and then 500s; after this change it is rejected first.

I also left `useAlternateSearchIndex` alone. It only selects between two hardcoded RPC names, so it is not interpolated into anything and does not need the same treatment.

## Additional context

Root cause at `supabase/functions/search-embeddings/index.ts:43`.

No test. There is no Deno test harness for `supabase/functions` (`deno.json` is empty and no `*_test.ts` exists), so there is nowhere for one to live without introducing a runner, which seemed out of proportion to a one-line guard. The caller-side tests in `apps/docs/app/api/search/embeddings/route.test.ts` still pass, 3 of 3.

Gates: `test:prettier` clean repo wide, `typecheck --force` 16/16, docs route tests 3/3.

One practical note: no CODEOWNERS rule covers `supabase/`, so this PR will not auto-request anyone. Going by `git log`, @charislam added the alternate search index branch in this function (#38662), so they may be the one with context here. Happy to be pointed elsewhere.

Freshman contributor, and I use Claude Code as an assistant. I found this by reading the function and its caller side by side and noticing only one of them checks the type.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search request validation to reject missing, empty, or invalid query values gracefully.
  * Prevented malformed searches from causing server errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->