### PR TITLE
fix(studio): treat region flags as decorative by default

### DIFF
--- a/apps/studio/components/interfaces/ProjectCreation/RegionSelector.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/RegionSelector.tsx
@@ -251,11 +251,7 @@ export const RegionSelector = ({
                           <div className="flex items-center gap-x-3">
                             {isLoading && <Loader2 size={14} className="animate-spin" />}
                             {selectedRegion?.code && (
-                              <RegionFlag
-                                role="presentation"
-                                className="w-5"
-                                region={selectedRegion.code}
-                              />
+                              <RegionFlag className="w-5" region={selectedRegion.code} />
                             )}
                             <span className="text-foreground">{triggerLabel}</span>
                           </div>

--- a/apps/studio/components/ui/RegionFlag.tsx
+++ b/apps/studio/components/ui/RegionFlag.tsx
@@ -8,14 +8,14 @@ interface RegionFlagProps extends Omit<ImgHTMLAttributes<HTMLImageElement>, 'src
 
 export const RegionFlag = ({
   alt = '',
-  'aria-hidden': ariaHidden = true,
+  'aria-hidden': ariaHidden,
   className,
   region,
   ...props
 }: RegionFlagProps) => (
   <img
     alt={alt}
-    aria-hidden={ariaHidden}
+    aria-hidden={ariaHidden ?? alt === ''}
     className={`rounded-xs border border-foreground-muted/20 ${className ?? ''}`}
     src={`${BASE_PATH}/img/regions/${region}.svg`}
     {...props}

--- a/apps/studio/components/ui/RegionFlag.tsx
+++ b/apps/studio/components/ui/RegionFlag.tsx
@@ -6,9 +6,16 @@ interface RegionFlagProps extends Omit<ImgHTMLAttributes<HTMLImageElement>, 'src
   region: string
 }
 
-export const RegionFlag = ({ alt = '', className, region, ...props }: RegionFlagProps) => (
+export const RegionFlag = ({
+  alt = '',
+  'aria-hidden': ariaHidden = true,
+  className,
+  region,
+  ...props
+}: RegionFlagProps) => (
   <img
     alt={alt}
+    aria-hidden={ariaHidden}
     className={`rounded-xs border border-foreground-muted/20 ${className ?? ''}`}
     src={`${BASE_PATH}/img/regions/${region}.svg`}
     {...props}

--- a/apps/studio/pages/project/[ref]/observability/edge-functions.tsx
+++ b/apps/studio/pages/project/[ref]/observability/edge-functions.tsx
@@ -243,7 +243,7 @@ const EdgeFunctionsUsage = () => {
                   value: region.key,
                   label: (
                     <div className="flex items-center gap-x-2">
-                      <RegionFlag aria-hidden="true" className="w-4" region={region.key} />
+                      <RegionFlag className="w-4" region={region.key} />
                       <div className="flex flex-wrap gap-x-2 items-center">
                         <span className="text-foreground text-xs">{region.label}</span>
                         <span className="text-foreground-lighter text-xs">{region.key}</span>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Studio accessibility fix.

## What is the current behavior?

`RegionFlag` defaults to `alt=""`, but only some callsites also pass `aria-hidden` / `role="presentation"`. Decorative flags beside visible region names can still be announced inconsistently.

## What is the new behavior?

`RegionFlag` defaults to `aria-hidden` when `alt` is empty, matching how the component is used next to visible region text. Redundant callsite a11y props from #49517 are removed.

## To test

- Open [Edge Function observability](https://studio-staging-git-dnywh-region-flag-decorative-a11y-supabase.vercel.app/dashboard/project/_/observability/edge-functions). Open the **Region** filter and confirm each option still shows a flag beside the region label. The DOM has `aria-hidden` on the flag `img`.
Open the new project flow region selector. Confirm the selected-region flag still renders without role="presentation".
- Open [New project](https://studio-staging-git-dnywh-region-flag-decorative-a11y-supabase.vercel.app/dashboard/new/_). Open the region selector and confirm the selected value and menu items still show flags beside the region names. The DOM has `aria-hidden` on the flag `img`.