### PR TITLE
feat: include log ingestion in free plan usage summary

### DIFF
--- a/apps/studio/components/interfaces/ProjectHome/PlanUsageCard.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/PlanUsageCard.tsx
@@ -251,7 +251,9 @@ export const PlanUsageCard = () => {
                   orgSlug={organization?.slug ?? '_'}
                 />
               ))
-            : METRICS.map((config) => <SkeletonMetricRow key={config.key} label={config.label} />)}
+            : metricsIncludingLogIngestion.map((config) => (
+                <SkeletonMetricRow key={config.key} label={config.label} />
+              ))}
         </div>
       </div>
     </li>

--- a/apps/studio/components/interfaces/ProjectHome/PlanUsageCard.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/PlanUsageCard.tsx
@@ -1,3 +1,4 @@
+import { useFlag } from 'common'
 import { ChevronRight } from 'lucide-react'
 import Link from 'next/link'
 import { cn } from 'ui'
@@ -37,6 +38,12 @@ const METRICS: MetricConfig[] = [
     label: 'File storage',
     unit: 'gigabytes',
     anchor: 'storageSize',
+  },
+  {
+    key: PricingMetric.LOG_INGESTION,
+    label: 'Log Ingestion',
+    unit: 'gigabytes',
+    anchor: 'logIngestion',
   },
 ]
 
@@ -189,14 +196,22 @@ export const PlanUsageCard = () => {
   const { data: organization } = useSelectedOrganizationQuery()
   const { data: usage, isSuccess, isError } = useOrgUsageQuery({ orgSlug: organization?.slug })
 
+  const logIngestionBillingEnabled = useFlag('logIngestionBillingEnabled')
+
+  const metricsIncludingLogIngestion = logIngestionBillingEnabled
+    ? METRICS
+    : METRICS.filter((m) => m.key !== PricingMetric.LOG_INGESTION)
+
   const visibleRows = isSuccess
-    ? METRICS.map((config) => {
-        const usageItem = usage.usages.find((u) => u.metric === config.key)
-        if (!usageItem) return null
-        if (!usageItem.available_in_plan) return null
-        if (!usageItem.pricing_free_units || usageItem.pricing_free_units <= 0) return null
-        return { config, usageItem }
-      }).filter((row): row is { config: MetricConfig; usageItem: OrgMetricsUsage } => row !== null)
+    ? metricsIncludingLogIngestion
+        .map((config) => {
+          const usageItem = usage.usages.find((u) => u.metric === config.key)
+          if (!usageItem) return null
+          if (!usageItem.available_in_plan) return null
+          if (!usageItem.pricing_free_units || usageItem.pricing_free_units <= 0) return null
+          return { config, usageItem }
+        })
+        .filter((row): row is { config: MetricConfig; usageItem: OrgMetricsUsage } => row !== null)
     : []
 
   // Hide entirely on hard error or when the org has zero applicable metrics — both


### PR DESCRIPTION
<img width="368" height="288" alt="Screenshot 2026-08-26 at 12 24 52 PM" src="https://github.com/user-attachments/assets/ec39a35d-a7fb-4957-8fee-b657125d1c95" />

Gated behind feature flags as rollout is still pending

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added conditional visibility for the Log Ingestion usage metric based on feature availability.
  * Updated usage displays and loading states to reflect the available metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->