### PR TITLE
feat(studio): polish replication destination sheet form

### DIFF
--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/AdvancedSettings.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/AdvancedSettings.tsx
@@ -65,7 +65,7 @@ export const AdvancedSettings = ({
     <div className={cn('px-5', className)}>
       <Accordion type="single" collapsible>
         <AccordionItem value="item-1" className="border-none">
-          <AccordionTrigger className="font-normal gap-2 justify-between text-sm py-1 hover:no-underline">
+          <AccordionTrigger className="font-normal gap-2 justify-between text-sm py-3 hover:no-underline">
             <div className="flex flex-col items-start gap-0.5">
               <span className="text-sm font-medium">Advanced settings</span>
               <span className="text-sm text-foreground-lighter font-normal">{description}</span>

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/AdvancedSettings.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/AdvancedSettings.tsx
@@ -6,6 +6,7 @@ import {
   AccordionItem,
   AccordionTrigger,
   Badge,
+  cn,
   FormControl,
   FormField,
   FormInputGroupInput,
@@ -28,13 +29,32 @@ import {
 } from './DestinationForm.constants'
 import { type DestinationPanelSchemaType } from './DestinationForm.schema'
 
+export type AdvancedSettingsGroup = 'all' | 'connection' | 'data'
+
+const CONNECTION_DESCRIPTION = 'Optional settings for how data is written to the destination.'
+const DATA_DESCRIPTION = 'Optional settings for initial sync and replication slots.'
+const ALL_DESCRIPTION = 'Optional settings to control the pipeline in more depth.'
+
 export const AdvancedSettings = ({
   type,
   form,
+  group = 'all',
+  className,
 }: {
   type: DestinationType
   form: UseFormReturn<DestinationPanelSchemaType>
+  group?: AdvancedSettingsGroup
+  className?: string
 }) => {
+  const showConnection = group === 'all' || group === 'connection'
+  const showData = group === 'all' || group === 'data'
+  const description =
+    group === 'connection'
+      ? CONNECTION_DESCRIPTION
+      : group === 'data'
+        ? DATA_DESCRIPTION
+        : ALL_DESCRIPTION
+
   const handleNumberChange =
     (field: { onChange: (value?: number) => void }) => (e: ChangeEvent<HTMLInputElement>) => {
       const val = e.target.value
@@ -42,139 +62,144 @@ export const AdvancedSettings = ({
     }
 
   return (
-    <div className="px-5">
+    <div className={cn('px-5', className)}>
       <Accordion type="single" collapsible>
         <AccordionItem value="item-1" className="border-none">
-          <AccordionTrigger className="font-normal gap-2 justify-between text-sm py-3 hover:no-underline">
+          <AccordionTrigger className="font-normal gap-2 justify-between text-sm py-1 hover:no-underline">
             <div className="flex flex-col items-start gap-0.5">
               <span className="text-sm font-medium">Advanced settings</span>
-              <span className="text-sm text-foreground-lighter font-normal">
-                Optional settings to control the pipeline in more depth
-              </span>
+              <span className="text-sm text-foreground-lighter font-normal">{description}</span>
             </div>
           </AccordionTrigger>
           <AccordionContent className="pb-0! pt-3 [&>div]:flex [&>div]:flex-col [&>div]:gap-y-4">
-            {/* Batch wait time - applies to all destinations */}
-            <FormField
-              control={form.control}
-              name="maxFillMs"
-              render={({ field }) => (
-                <FormItemLayout
-                  layout="horizontal"
-                  label="Batch wait time"
-                  description="How long the pipeline waits before sending a partially filled batch."
-                >
-                  <FormControl>
-                    <InputGroup>
-                      <FormInputGroupInput
-                        {...field}
-                        type="number"
-                        min={0}
-                        step={1}
-                        value={field.value ?? ''}
-                        onChange={handleNumberChange(field)}
-                        placeholder={`Default: ${DEFAULT_MAX_FILL_MS}`}
-                      />
-                      <InputGroupAddon align="inline-end">
-                        <InputGroupText>milliseconds</InputGroupText>
-                      </InputGroupAddon>
-                    </InputGroup>
-                  </FormControl>
-                </FormItemLayout>
-              )}
-            />
+            {showConnection && (
+              <FormField
+                control={form.control}
+                name="maxFillMs"
+                render={({ field }) => (
+                  <FormItemLayout
+                    layout="horizontal"
+                    label="Batch wait time"
+                    description="How long the pipeline waits before sending a partially filled batch."
+                  >
+                    <FormControl>
+                      <InputGroup>
+                        <FormInputGroupInput
+                          {...field}
+                          type="number"
+                          min={0}
+                          step={1}
+                          value={field.value ?? ''}
+                          onChange={handleNumberChange(field)}
+                          placeholder={`Default: ${DEFAULT_MAX_FILL_MS}`}
+                        />
+                        <InputGroupAddon align="inline-end">
+                          <InputGroupText>milliseconds</InputGroupText>
+                        </InputGroupAddon>
+                      </InputGroup>
+                    </FormControl>
+                  </FormItemLayout>
+                )}
+              />
+            )}
 
-            <FormField
-              control={form.control}
-              name="maxTableSyncWorkers"
-              render={({ field }) => (
-                <FormItemLayout
-                  label="Table sync workers"
-                  layout="horizontal"
-                  description="Maximum number of tables synced at the same time."
-                >
-                  <FormControl>
-                    <InputGroup>
-                      <FormInputGroupInput
-                        {...field}
-                        type="number"
-                        min={1}
-                        step={1}
-                        value={field.value ?? ''}
-                        onChange={handleNumberChange(field)}
-                        placeholder={`Default: ${DEFAULT_MAX_TABLE_SYNC_WORKERS}`}
-                      />
-                      <InputGroupAddon align="inline-end">
-                        <InputGroupText>workers</InputGroupText>
-                      </InputGroupAddon>
-                    </InputGroup>
-                  </FormControl>
-                </FormItemLayout>
-              )}
-            />
+            {showData && (
+              <>
+                <FormField
+                  control={form.control}
+                  name="maxTableSyncWorkers"
+                  render={({ field }) => (
+                    <FormItemLayout
+                      label="Table sync workers"
+                      layout="horizontal"
+                      description="Maximum number of tables synced at the same time."
+                    >
+                      <FormControl>
+                        <InputGroup>
+                          <FormInputGroupInput
+                            {...field}
+                            type="number"
+                            min={1}
+                            step={1}
+                            value={field.value ?? ''}
+                            onChange={handleNumberChange(field)}
+                            placeholder={`Default: ${DEFAULT_MAX_TABLE_SYNC_WORKERS}`}
+                          />
+                          <InputGroupAddon align="inline-end">
+                            <InputGroupText>workers</InputGroupText>
+                          </InputGroupAddon>
+                        </InputGroup>
+                      </FormControl>
+                    </FormItemLayout>
+                  )}
+                />
 
-            <FormField
-              control={form.control}
-              name="maxCopyConnectionsPerTable"
-              render={({ field }) => (
-                <FormItemLayout
-                  label="Initial sync connections per table"
-                  layout="horizontal"
-                  description="Maximum number of source connections used to sync existing rows for each table."
-                >
-                  <FormControl>
-                    <InputGroup>
-                      <FormInputGroupInput
-                        {...field}
-                        type="number"
-                        min={1}
-                        step={1}
-                        value={field.value ?? ''}
-                        onChange={handleNumberChange(field)}
-                        placeholder={`Default: ${DEFAULT_MAX_COPY_CONNECTIONS_PER_TABLE}`}
-                      />
-                      <InputGroupAddon align="inline-end">
-                        <InputGroupText>connections</InputGroupText>
-                      </InputGroupAddon>
-                    </InputGroup>
-                  </FormControl>
-                </FormItemLayout>
-              )}
-            />
+                <FormField
+                  control={form.control}
+                  name="maxCopyConnectionsPerTable"
+                  render={({ field }) => (
+                    <FormItemLayout
+                      label="Initial sync connections per table"
+                      layout="horizontal"
+                      description="Maximum number of source connections used to sync existing rows for each table."
+                    >
+                      <FormControl>
+                        <InputGroup>
+                          <FormInputGroupInput
+                            {...field}
+                            type="number"
+                            min={1}
+                            step={1}
+                            value={field.value ?? ''}
+                            onChange={handleNumberChange(field)}
+                            placeholder={`Default: ${DEFAULT_MAX_COPY_CONNECTIONS_PER_TABLE}`}
+                          />
+                          <InputGroupAddon align="inline-end">
+                            <InputGroupText>connections</InputGroupText>
+                          </InputGroupAddon>
+                        </InputGroup>
+                      </FormControl>
+                    </FormItemLayout>
+                  )}
+                />
 
-            <FormField
-              control={form.control}
-              name="invalidatedSlotBehavior"
-              render={({ field }) => (
-                <FormItemLayout
-                  label="Invalidated slot behavior"
-                  layout="horizontal"
-                  description="What the pipeline does when its replication slot becomes invalid."
-                >
-                  <FormControl>
-                    <Select value={field.value ?? 'error'} onValueChange={field.onChange}>
-                      <SelectTrigger className="capitalize">{field.value ?? 'error'}</SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="error" className="[&>span]:top-2.5">
-                          <p>Error</p>
-                          <p className="text-foreground-lighter">
-                            Blocks startup for manual recovery.
-                          </p>
-                        </SelectItem>
-                        <SelectItem value="recreate" className="[&>span]:top-2.5">
-                          <p>Recreate</p>
-                          <p className="text-foreground-lighter">
-                            Replaces destination tables and runs a new, billable initial sync.
-                          </p>
-                        </SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </FormControl>
-                </FormItemLayout>
-              )}
-            />
+                <FormField
+                  control={form.control}
+                  name="invalidatedSlotBehavior"
+                  render={({ field }) => (
+                    <FormItemLayout
+                      label="Invalidated slot behavior"
+                      layout="horizontal"
+                      description="What the pipeline does when its replication slot becomes invalid."
+                    >
+                      <FormControl>
+                        <Select value={field.value ?? 'error'} onValueChange={field.onChange}>
+                          <SelectTrigger className="capitalize">
+                            {field.value ?? 'error'}
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="error" className="[&>span]:top-2.5">
+                              <p>Error</p>
+                              <p className="text-foreground-lighter">
+                                Blocks startup for manual recovery.
+                              </p>
+                            </SelectItem>
+                            <SelectItem value="recreate" className="[&>span]:top-2.5">
+                              <p>Recreate</p>
+                              <p className="text-foreground-lighter">
+                                Replaces destination tables and runs a new, billable initial sync.
+                              </p>
+                            </SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </FormControl>
+                    </FormItemLayout>
+                  )}
+                />
+              </>
+            )}
 
-            {type === 'BigQuery' && (
+            {showConnection && type === 'BigQuery' && (
               <>
                 <FormField
                   control={form.control}
@@ -182,10 +207,14 @@ export const AdvancedSettings = ({
                   render={({ field }) => (
                     <FormItemLayout
                       label={
-                        <div className="flex flex-col gap-y-2">
-                          <span>Connection pool size</span>
-                          <Badge className="w-min">BigQuery only</Badge>
-                        </div>
+                        group === 'all' ? (
+                          <div className="flex flex-col gap-y-2">
+                            <span>Connection pool size</span>
+                            <Badge className="w-min">BigQuery only</Badge>
+                          </div>
+                        ) : (
+                          'Connection pool size'
+                        )
                       }
                       layout="horizontal"
                       description="Number of BigQuery connections used for destination writes."
@@ -216,10 +245,14 @@ export const AdvancedSettings = ({
                   render={({ field }) => (
                     <FormItemLayout
                       label={
-                        <div className="flex flex-col gap-y-2">
-                          <span>Maximum staleness</span>
-                          <Badge className="w-min">BigQuery only</Badge>
-                        </div>
+                        group === 'all' ? (
+                          <div className="flex flex-col gap-y-2">
+                            <span>Maximum staleness</span>
+                            <Badge className="w-min">BigQuery only</Badge>
+                          </div>
+                        ) : (
+                          'Maximum staleness'
+                        )
                       }
                       layout="horizontal"
                       description="How old query results can be while BigQuery applies ongoing changes."

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/AdvancedSettings.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/AdvancedSettings.tsx
@@ -33,7 +33,7 @@ export type AdvancedSettingsGroup = 'all' | 'connection' | 'data'
 
 const CONNECTION_DESCRIPTION = 'Optional settings for how data is written to the destination.'
 const DATA_DESCRIPTION = 'Optional settings for initial sync and replication slots.'
-const ALL_DESCRIPTION = 'Optional settings to control the pipeline in more depth.'
+const ALL_DESCRIPTION = 'Optional settings to control the pipeline in more depth'
 
 export const AdvancedSettings = ({
   type,

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/AdvancedSettings.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/AdvancedSettings.tsx
@@ -6,7 +6,6 @@ import {
   AccordionItem,
   AccordionTrigger,
   Badge,
-  cn,
   FormControl,
   FormField,
   FormInputGroupInput,
@@ -29,33 +28,13 @@ import {
 } from './DestinationForm.constants'
 import { type DestinationPanelSchemaType } from './DestinationForm.schema'
 
-export type AdvancedSettingsGroup = 'all' | 'connection' | 'data'
-
-const CONNECTION_DESCRIPTION = 'Optional settings for how data is written to the destination.'
-const DATA_DESCRIPTION = 'Optional settings for initial sync and replication slots.'
-const ALL_DESCRIPTION = 'Optional settings to control the pipeline in more depth'
-
-const GROUP_DESCRIPTIONS: Record<AdvancedSettingsGroup, string> = {
-  all: ALL_DESCRIPTION,
-  connection: CONNECTION_DESCRIPTION,
-  data: DATA_DESCRIPTION,
-}
-
 export const AdvancedSettings = ({
   type,
   form,
-  group = 'all',
-  className,
 }: {
   type: DestinationType
   form: UseFormReturn<DestinationPanelSchemaType>
-  group?: AdvancedSettingsGroup
-  className?: string
 }) => {
-  const showConnection = group === 'all' || group === 'connection'
-  const showData = group === 'all' || group === 'data'
-  const description = GROUP_DESCRIPTIONS[group]
-
   const handleNumberChange =
     (field: { onChange: (value?: number) => void }) => (e: ChangeEvent<HTMLInputElement>) => {
       const val = e.target.value
@@ -63,144 +42,139 @@ export const AdvancedSettings = ({
     }
 
   return (
-    <div className={cn('px-5', className)}>
+    <div className="px-5">
       <Accordion type="single" collapsible>
         <AccordionItem value="item-1" className="border-none">
           <AccordionTrigger className="font-normal gap-2 justify-between text-sm py-3 hover:no-underline">
             <div className="flex flex-col items-start gap-0.5">
               <span className="text-sm font-medium">Advanced settings</span>
-              <span className="text-sm text-foreground-lighter font-normal">{description}</span>
+              <span className="text-sm text-foreground-lighter font-normal">
+                Optional settings to control the pipeline in more depth
+              </span>
             </div>
           </AccordionTrigger>
           <AccordionContent className="pb-0! pt-3 [&>div]:flex [&>div]:flex-col [&>div]:gap-y-4">
-            {showConnection && (
-              <FormField
-                control={form.control}
-                name="maxFillMs"
-                render={({ field }) => (
-                  <FormItemLayout
-                    layout="horizontal"
-                    label="Batch wait time"
-                    description="How long the pipeline waits before sending a partially filled batch."
-                  >
-                    <FormControl>
-                      <InputGroup>
-                        <FormInputGroupInput
-                          {...field}
-                          type="number"
-                          min={0}
-                          step={1}
-                          value={field.value ?? ''}
-                          onChange={handleNumberChange(field)}
-                          placeholder={`Default: ${DEFAULT_MAX_FILL_MS}`}
-                        />
-                        <InputGroupAddon align="inline-end">
-                          <InputGroupText>milliseconds</InputGroupText>
-                        </InputGroupAddon>
-                      </InputGroup>
-                    </FormControl>
-                  </FormItemLayout>
-                )}
-              />
-            )}
+            {/* Batch wait time - applies to all destinations */}
+            <FormField
+              control={form.control}
+              name="maxFillMs"
+              render={({ field }) => (
+                <FormItemLayout
+                  layout="horizontal"
+                  label="Batch wait time"
+                  description="How long the pipeline waits before sending a partially filled batch."
+                >
+                  <FormControl>
+                    <InputGroup>
+                      <FormInputGroupInput
+                        {...field}
+                        type="number"
+                        min={0}
+                        step={1}
+                        value={field.value ?? ''}
+                        onChange={handleNumberChange(field)}
+                        placeholder={`Default: ${DEFAULT_MAX_FILL_MS}`}
+                      />
+                      <InputGroupAddon align="inline-end">
+                        <InputGroupText>milliseconds</InputGroupText>
+                      </InputGroupAddon>
+                    </InputGroup>
+                  </FormControl>
+                </FormItemLayout>
+              )}
+            />
 
-            {showData && (
-              <>
-                <FormField
-                  control={form.control}
-                  name="maxTableSyncWorkers"
-                  render={({ field }) => (
-                    <FormItemLayout
-                      label="Table sync workers"
-                      layout="horizontal"
-                      description="Maximum number of tables synced at the same time."
-                    >
-                      <FormControl>
-                        <InputGroup>
-                          <FormInputGroupInput
-                            {...field}
-                            type="number"
-                            min={1}
-                            step={1}
-                            value={field.value ?? ''}
-                            onChange={handleNumberChange(field)}
-                            placeholder={`Default: ${DEFAULT_MAX_TABLE_SYNC_WORKERS}`}
-                          />
-                          <InputGroupAddon align="inline-end">
-                            <InputGroupText>workers</InputGroupText>
-                          </InputGroupAddon>
-                        </InputGroup>
-                      </FormControl>
-                    </FormItemLayout>
-                  )}
-                />
+            <FormField
+              control={form.control}
+              name="maxTableSyncWorkers"
+              render={({ field }) => (
+                <FormItemLayout
+                  label="Table sync workers"
+                  layout="horizontal"
+                  description="Maximum number of tables synced at the same time."
+                >
+                  <FormControl>
+                    <InputGroup>
+                      <FormInputGroupInput
+                        {...field}
+                        type="number"
+                        min={1}
+                        step={1}
+                        value={field.value ?? ''}
+                        onChange={handleNumberChange(field)}
+                        placeholder={`Default: ${DEFAULT_MAX_TABLE_SYNC_WORKERS}`}
+                      />
+                      <InputGroupAddon align="inline-end">
+                        <InputGroupText>workers</InputGroupText>
+                      </InputGroupAddon>
+                    </InputGroup>
+                  </FormControl>
+                </FormItemLayout>
+              )}
+            />
 
-                <FormField
-                  control={form.control}
-                  name="maxCopyConnectionsPerTable"
-                  render={({ field }) => (
-                    <FormItemLayout
-                      label="Initial sync connections per table"
-                      layout="horizontal"
-                      description="Maximum number of source connections used to sync existing rows for each table."
-                    >
-                      <FormControl>
-                        <InputGroup>
-                          <FormInputGroupInput
-                            {...field}
-                            type="number"
-                            min={1}
-                            step={1}
-                            value={field.value ?? ''}
-                            onChange={handleNumberChange(field)}
-                            placeholder={`Default: ${DEFAULT_MAX_COPY_CONNECTIONS_PER_TABLE}`}
-                          />
-                          <InputGroupAddon align="inline-end">
-                            <InputGroupText>connections</InputGroupText>
-                          </InputGroupAddon>
-                        </InputGroup>
-                      </FormControl>
-                    </FormItemLayout>
-                  )}
-                />
+            <FormField
+              control={form.control}
+              name="maxCopyConnectionsPerTable"
+              render={({ field }) => (
+                <FormItemLayout
+                  label="Initial sync connections per table"
+                  layout="horizontal"
+                  description="Maximum number of source connections used to sync existing rows for each table."
+                >
+                  <FormControl>
+                    <InputGroup>
+                      <FormInputGroupInput
+                        {...field}
+                        type="number"
+                        min={1}
+                        step={1}
+                        value={field.value ?? ''}
+                        onChange={handleNumberChange(field)}
+                        placeholder={`Default: ${DEFAULT_MAX_COPY_CONNECTIONS_PER_TABLE}`}
+                      />
+                      <InputGroupAddon align="inline-end">
+                        <InputGroupText>connections</InputGroupText>
+                      </InputGroupAddon>
+                    </InputGroup>
+                  </FormControl>
+                </FormItemLayout>
+              )}
+            />
 
-                <FormField
-                  control={form.control}
-                  name="invalidatedSlotBehavior"
-                  render={({ field }) => (
-                    <FormItemLayout
-                      label="Invalidated slot behavior"
-                      layout="horizontal"
-                      description="What the pipeline does when its replication slot becomes invalid."
-                    >
-                      <FormControl>
-                        <Select value={field.value ?? 'error'} onValueChange={field.onChange}>
-                          <SelectTrigger className="capitalize">
-                            {field.value ?? 'error'}
-                          </SelectTrigger>
-                          <SelectContent>
-                            <SelectItem value="error" className="[&>span]:top-2.5">
-                              <p>Error</p>
-                              <p className="text-foreground-lighter">
-                                Blocks startup for manual recovery.
-                              </p>
-                            </SelectItem>
-                            <SelectItem value="recreate" className="[&>span]:top-2.5">
-                              <p>Recreate</p>
-                              <p className="text-foreground-lighter">
-                                Replaces destination tables and runs a new, billable initial sync.
-                              </p>
-                            </SelectItem>
-                          </SelectContent>
-                        </Select>
-                      </FormControl>
-                    </FormItemLayout>
-                  )}
-                />
-              </>
-            )}
+            <FormField
+              control={form.control}
+              name="invalidatedSlotBehavior"
+              render={({ field }) => (
+                <FormItemLayout
+                  label="Invalidated slot behavior"
+                  layout="horizontal"
+                  description="What the pipeline does when its replication slot becomes invalid."
+                >
+                  <FormControl>
+                    <Select value={field.value ?? 'error'} onValueChange={field.onChange}>
+                      <SelectTrigger className="capitalize">{field.value ?? 'error'}</SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="error" className="[&>span]:top-2.5">
+                          <p>Error</p>
+                          <p className="text-foreground-lighter">
+                            Blocks startup for manual recovery.
+                          </p>
+                        </SelectItem>
+                        <SelectItem value="recreate" className="[&>span]:top-2.5">
+                          <p>Recreate</p>
+                          <p className="text-foreground-lighter">
+                            Replaces destination tables and runs a new, billable initial sync.
+                          </p>
+                        </SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </FormControl>
+                </FormItemLayout>
+              )}
+            />
 
-            {showConnection && type === 'BigQuery' && (
+            {type === 'BigQuery' && (
               <>
                 <FormField
                   control={form.control}
@@ -208,14 +182,10 @@ export const AdvancedSettings = ({
                   render={({ field }) => (
                     <FormItemLayout
                       label={
-                        group === 'all' ? (
-                          <div className="flex flex-col gap-y-2">
-                            <span>Connection pool size</span>
-                            <Badge className="w-min">BigQuery only</Badge>
-                          </div>
-                        ) : (
-                          'Connection pool size'
-                        )
+                        <div className="flex flex-col gap-y-2">
+                          <span>Connection pool size</span>
+                          <Badge className="w-min">BigQuery only</Badge>
+                        </div>
                       }
                       layout="horizontal"
                       description="Number of BigQuery connections used for destination writes."
@@ -246,14 +216,10 @@ export const AdvancedSettings = ({
                   render={({ field }) => (
                     <FormItemLayout
                       label={
-                        group === 'all' ? (
-                          <div className="flex flex-col gap-y-2">
-                            <span>Maximum staleness</span>
-                            <Badge className="w-min">BigQuery only</Badge>
-                          </div>
-                        ) : (
-                          'Maximum staleness'
-                        )
+                        <div className="flex flex-col gap-y-2">
+                          <span>Maximum staleness</span>
+                          <Badge className="w-min">BigQuery only</Badge>
+                        </div>
                       }
                       layout="horizontal"
                       description="How old query results can be while BigQuery applies ongoing changes."

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/AdvancedSettings.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/AdvancedSettings.tsx
@@ -35,6 +35,12 @@ const CONNECTION_DESCRIPTION = 'Optional settings for how data is written to the
 const DATA_DESCRIPTION = 'Optional settings for initial sync and replication slots.'
 const ALL_DESCRIPTION = 'Optional settings to control the pipeline in more depth'
 
+const GROUP_DESCRIPTIONS: Record<AdvancedSettingsGroup, string> = {
+  all: ALL_DESCRIPTION,
+  connection: CONNECTION_DESCRIPTION,
+  data: DATA_DESCRIPTION,
+}
+
 export const AdvancedSettings = ({
   type,
   form,
@@ -48,12 +54,7 @@ export const AdvancedSettings = ({
 }) => {
   const showConnection = group === 'all' || group === 'connection'
   const showData = group === 'all' || group === 'data'
-  const description =
-    group === 'connection'
-      ? CONNECTION_DESCRIPTION
-      : group === 'data'
-        ? DATA_DESCRIPTION
-        : ALL_DESCRIPTION
+  const description = GROUP_DESCRIPTIONS[group]
 
   const handleNumberChange =
     (field: { onChange: (value?: number) => void }) => (e: ChangeEvent<HTMLInputElement>) => {

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/BigQuery/BigQuery.utils.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/BigQuery/BigQuery.utils.ts
@@ -7,6 +7,8 @@ export type BigQueryValidationIssue = {
   message: string
 }
 
+export const BIGQUERY_SERVICE_ACCOUNT_JSON_MESSAGE = 'Service account key must be valid JSON'
+
 const BIGQUERY_REQUIRED_FIELDS: {
   path: Exclude<BigQueryFieldPath, 'serviceAccountKey'>
   message: string
@@ -26,8 +28,9 @@ const isValidJsonString = (value: string) => {
 
 export const getBigQueryValidationIssues = (
   data: Pick<DestinationPanelSchemaType, BigQueryFieldPath>,
-  options: { secretsOptional?: boolean } = {}
+  options: { secretsOptional?: boolean; validateJson?: boolean } = {}
 ): BigQueryValidationIssue[] => {
+  const { secretsOptional = false, validateJson = true } = options
   const issues: BigQueryValidationIssue[] = BIGQUERY_REQUIRED_FIELDS.filter(
     ({ path }) => !data[path]?.trim().length
   ).map(({ path, message }) => ({ path, message }))
@@ -35,16 +38,18 @@ export const getBigQueryValidationIssues = (
   const serviceAccountKey = data.serviceAccountKey?.trim() ?? ''
 
   if (!serviceAccountKey) {
-    if (!options.secretsOptional) {
+    if (!secretsOptional) {
       issues.push({ path: 'serviceAccountKey', message: 'Service account key is required' })
     }
     return issues
   }
 
-  if (!isValidJsonString(serviceAccountKey)) {
+  // JSON shape is checked on submit only. Live onChange validation would fail on every
+  // keystroke while the user is still pasting or typing a key.
+  if (validateJson && !isValidJsonString(serviceAccountKey)) {
     issues.push({
       path: 'serviceAccountKey',
-      message: 'Service account key must be valid JSON',
+      message: BIGQUERY_SERVICE_ACCOUNT_JSON_MESSAGE,
     })
   }
 

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/BigQuery/BigQuery.utils.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/BigQuery/BigQuery.utils.ts
@@ -7,18 +7,46 @@ export type BigQueryValidationIssue = {
   message: string
 }
 
-const BIGQUERY_REQUIRED_FIELDS: { path: BigQueryFieldPath; message: string }[] = [
+const BIGQUERY_REQUIRED_FIELDS: {
+  path: Exclude<BigQueryFieldPath, 'serviceAccountKey'>
+  message: string
+}[] = [
   { path: 'projectId', message: 'Project ID is required' },
   { path: 'datasetId', message: 'Dataset ID is required' },
-  { path: 'serviceAccountKey', message: 'Service account key is required' },
 ]
+
+const isValidJsonString = (value: string) => {
+  try {
+    JSON.parse(value)
+    return true
+  } catch {
+    return false
+  }
+}
 
 export const getBigQueryValidationIssues = (
   data: Pick<DestinationPanelSchemaType, BigQueryFieldPath>,
   options: { secretsOptional?: boolean } = {}
-): BigQueryValidationIssue[] =>
-  BIGQUERY_REQUIRED_FIELDS.filter(({ path }) => {
-    if (options.secretsOptional && path === 'serviceAccountKey') return false
+): BigQueryValidationIssue[] => {
+  const issues: BigQueryValidationIssue[] = BIGQUERY_REQUIRED_FIELDS.filter(
+    ({ path }) => !data[path]?.trim().length
+  ).map(({ path, message }) => ({ path, message }))
 
-    return !data[path]?.trim().length
-  })
+  const serviceAccountKey = data.serviceAccountKey?.trim() ?? ''
+
+  if (!serviceAccountKey) {
+    if (!options.secretsOptional) {
+      issues.push({ path: 'serviceAccountKey', message: 'Service account key is required' })
+    }
+    return issues
+  }
+
+  if (!isValidJsonString(serviceAccountKey)) {
+    issues.push({
+      path: 'serviceAccountKey',
+      message: 'Service account key must be valid JSON',
+    })
+  }
+
+  return issues
+}

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationForm.utils.test.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationForm.utils.test.ts
@@ -769,6 +769,45 @@ describe('DestinationForm.utils BigQuery', () => {
     expect(issues).toEqual([])
   })
 
+  it('rejects invalid JSON in the service account key', () => {
+    const issues = getBigQueryValidationIssues({
+      projectId: 'my-project',
+      datasetId: 'my_dataset',
+      serviceAccountKey: '{ "type": "service_account" ',
+    })
+
+    expect(issues).toEqual([
+      { path: 'serviceAccountKey', message: 'Service account key must be valid JSON' },
+    ])
+  })
+
+  it('rejects non-JSON text in the service account key', () => {
+    const issues = getBigQueryValidationIssues({
+      projectId: 'my-project',
+      datasetId: 'my_dataset',
+      serviceAccountKey: 'not-json',
+    })
+
+    expect(issues).toEqual([
+      { path: 'serviceAccountKey', message: 'Service account key must be valid JSON' },
+    ])
+  })
+
+  it('validates JSON when replacing credentials in edit mode', () => {
+    const issues = getBigQueryValidationIssues(
+      {
+        projectId: 'my-project',
+        datasetId: 'my_dataset',
+        serviceAccountKey: '{ invalid',
+      },
+      { secretsOptional: true }
+    )
+
+    expect(issues).toEqual([
+      { path: 'serviceAccountKey', message: 'Service account key must be valid JSON' },
+    ])
+  })
+
   it('allows an omitted BigQuery service account key in edit mode', () => {
     const issues = getBigQueryValidationIssues(
       {

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationForm.utils.test.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationForm.utils.test.ts
@@ -781,6 +781,19 @@ describe('DestinationForm.utils BigQuery', () => {
     ])
   })
 
+  it('skips JSON shape checks when validateJson is false', () => {
+    const issues = getBigQueryValidationIssues(
+      {
+        projectId: 'my-project',
+        datasetId: 'my_dataset',
+        serviceAccountKey: '{ "type": "service_account" ',
+      },
+      { validateJson: false }
+    )
+
+    expect(issues).toEqual([])
+  })
+
   it('rejects non-JSON text in the service account key', () => {
     const issues = getBigQueryValidationIssues({
       projectId: 'my-project',

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationNameInput.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationNameInput.tsx
@@ -16,7 +16,15 @@ export const DestinationNameInput = ({ form }: DestinationNameInputProps) => {
       render={({ field }) => (
         <FormItemLayout label="Name" layout="horizontal">
           <FormControl>
-            <Input {...field} placeholder="My destination" />
+            <Input
+              {...field}
+              autoFocus
+              placeholder="My destination"
+              data-1p-ignore
+              data-lpignore="true"
+              data-form-type="other"
+              data-bwignore
+            />
           </FormControl>
         </FormItemLayout>
       )}

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/PipelineRegionField.test.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/PipelineRegionField.test.tsx
@@ -1,0 +1,36 @@
+import { screen } from '@testing-library/react'
+import { describe, expect, test } from 'vitest'
+
+import {
+  getPipelineRegionDescription,
+  PIPELINE_REGION,
+  PipelineRegionField,
+} from './PipelineRegionField'
+import { customRender } from '@/tests/lib/custom-render'
+
+describe('getPipelineRegionDescription', () => {
+  test('includes the fixed-region note and destination-specific hint', () => {
+    expect(getPipelineRegionDescription('BigQuery')).toBe(
+      'All pipelines run from this region. Choose a nearby BigQuery dataset where possible.'
+    )
+  })
+
+  test('falls back to a generic destination hint', () => {
+    expect(getPipelineRegionDescription()).toBe(
+      'All pipelines run from this region. Choose a nearby destination region where possible.'
+    )
+  })
+})
+
+describe('PipelineRegionField', () => {
+  test('shows the managed region as read-only information, not a combobox', () => {
+    customRender(<PipelineRegionField destinationType="BigQuery" />)
+
+    expect(screen.getByText('Pipeline region')).toBeInTheDocument()
+    expect(screen.getByText(PIPELINE_REGION.displayName)).toBeInTheDocument()
+    expect(screen.getByText(PIPELINE_REGION.code)).toBeInTheDocument()
+    expect(screen.getByText(/All pipelines run from this region/)).toBeInTheDocument()
+    expect(screen.getByText(/nearby BigQuery dataset/)).toBeInTheDocument()
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+  })
+})

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/PipelineRegionField.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/PipelineRegionField.tsx
@@ -1,0 +1,59 @@
+import { AWS_REGIONS } from 'shared-data'
+import { cn } from 'ui'
+import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
+
+import type { DestinationType } from '../DestinationPanel.types'
+import { RegionFlag } from '@/components/ui/RegionFlag'
+import { IS_STAGING_OR_LOCAL } from '@/lib/constants'
+
+// Pipelines always run from a single fixed region per environment, regardless of the source
+// project's region.
+export const PIPELINE_REGION = IS_STAGING_OR_LOCAL
+  ? AWS_REGIONS.SOUTHEAST_ASIA
+  : AWS_REGIONS.CENTRAL_EU
+
+const DESTINATION_REGION_HINT: Record<DestinationType, string> = {
+  BigQuery: 'Choose a nearby BigQuery dataset where possible.',
+  'Analytics Bucket': 'Keep this bucket in the same region where possible.',
+  DuckLake: 'Keep catalog and object storage close to this region where possible.',
+  Snowflake: 'Choose a nearby Snowflake account region where possible.',
+  ClickHouse: 'Choose a nearby ClickHouse cluster where possible.',
+}
+
+export const getPipelineRegionDescription = (destinationType?: DestinationType) => {
+  const destinationHint = destinationType
+    ? DESTINATION_REGION_HINT[destinationType]
+    : 'Choose a nearby destination region where possible.'
+
+  return `All pipelines run from this region. ${destinationHint}`
+}
+
+export const PipelineRegionField = ({
+  destinationType,
+  className,
+}: {
+  destinationType?: DestinationType
+  className?: string
+}) => {
+  return (
+    <FormItemLayout
+      isReactForm={false}
+      layout="horizontal"
+      label="Pipeline region"
+      description={getPipelineRegionDescription(destinationType)}
+    >
+      <div
+        className={cn(
+          'flex h-9 min-w-0 items-center gap-x-2 rounded-md border bg-surface-200 px-3 text-sm',
+          className
+        )}
+      >
+        <RegionFlag className="w-5 shrink-0" region={PIPELINE_REGION.code} />
+        <span className="min-w-0 truncate text-foreground">{PIPELINE_REGION.displayName}</span>
+        <span className="shrink-0 font-mono text-xs text-foreground-lighter">
+          {PIPELINE_REGION.code}
+        </span>
+      </div>
+    </FormItemLayout>
+  )
+}

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/index.test.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/index.test.tsx
@@ -71,6 +71,7 @@ vi.mock('ui', () => ({
       {children}
     </button>
   ),
+  cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
   DialogSectionSeparator: () => null,
   Form: ({ children }: PropsWithChildren) => children,
   Select: ({ children }: PropsWithChildren) => <div>{children}</div>,

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/index.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/index.tsx
@@ -5,25 +5,9 @@ import { AnimatePresence, motion } from 'framer-motion'
 import { Loader2 } from 'lucide-react'
 import { RefObject, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { useForm, useWatch } from 'react-hook-form'
-import { AWS_REGIONS } from 'shared-data'
 import { toast } from 'sonner'
-import {
-  Button,
-  DialogSectionSeparator,
-  Form,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-  SheetFooter,
-  SheetSection,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from 'ui'
+import { Button, DialogSectionSeparator, Form, SheetFooter, SheetSection } from 'ui'
 import { Admonition } from 'ui-patterns/Admonition'
-import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import * as z from 'zod'
 
 import {
@@ -54,6 +38,7 @@ import { DuckLakeFields } from './DuckLake/Fields'
 import { NewPublicationPanel } from './NewPublicationPanel'
 import { NoDestinationsAvailable } from './NoDestinationsAvailable'
 import { PipelineCostDialog } from './PipelineCostDialog'
+import { PipelineRegionField } from './PipelineRegionField'
 import { PublicationSelection } from './PublicationSelection'
 import { SnowflakeFields } from './Snowflake/Fields'
 import { getSnowflakeValidationIssues } from './Snowflake/Snowflake.utils'
@@ -62,8 +47,6 @@ import { useDestinationForm } from './useDestinationForm'
 import { ValidationFailuresSection } from './ValidationFailuresSection'
 import { ValidationWarningsDialog } from './ValidationWarningsDialog'
 import { CreateAnalyticsBucketSheet } from '@/components/interfaces/Storage/AnalyticsBuckets/CreateAnalyticsBucketSheet'
-import { InlineLinkClassName } from '@/components/ui/InlineLink'
-import { RegionFlag } from '@/components/ui/RegionFlag'
 import { useAPIKeys } from '@/data/api-keys/api-keys-query'
 import { useProjectSettingsV2Query } from '@/data/config/project-settings-v2-query'
 import { useReplicationDestinationByIdQuery } from '@/data/replication/destination-by-id-query'
@@ -71,13 +54,8 @@ import { useReplicationPipelineByIdQuery } from '@/data/replication/pipeline-by-
 import { useReplicationPublicationsQuery } from '@/data/replication/publications-query'
 import { useReplicationSourceId } from '@/data/replication/sources-query'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
-import { IS_STAGING_OR_LOCAL } from '@/lib/constants'
 
 const formId = 'destination-editor'
-
-// Pipelines always run out of a single fixed region per environment, regardless of the source
-// project's region.
-const PIPELINE_REGION = IS_STAGING_OR_LOCAL ? AWS_REGIONS.SOUTHEAST_ASIA : AWS_REGIONS.CENTRAL_EU
 
 interface DestinationFormProps {
   selectedType: DestinationType
@@ -469,42 +447,7 @@ export const DestinationForm = ({
                       onSelectNewPublication={() => setPublicationPanelVisible(true)}
                     />
                     <TableCopySelection form={form} editMode={editMode} />
-                    <FormItemLayout
-                      isReactForm={false}
-                      layout="horizontal"
-                      label="Region"
-                      description={
-                        <span className="text-foreground-lighter">
-                          Pipelines run in{' '}
-                          <Tooltip>
-                            <TooltipTrigger className={InlineLinkClassName}>
-                              {PIPELINE_REGION.displayName}
-                            </TooltipTrigger>
-                            <TooltipContent side="bottom">{PIPELINE_REGION.code}</TooltipContent>
-                          </Tooltip>
-                          . In your destination provider, choose the closest available region.
-                        </span>
-                      }
-                    >
-                      <Select disabled value={PIPELINE_REGION.code}>
-                        <SelectTrigger>
-                          <SelectValue placeholder="Select a region" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value={PIPELINE_REGION.code}>
-                            <div className="flex gap-x-3 items-center">
-                              <RegionFlag className="w-5" region={PIPELINE_REGION.code} />
-                              <p className="flex items-center gap-x-2">
-                                <span>{PIPELINE_REGION.displayName}</span>
-                                <span className="text-xs text-foreground-lighter font-mono">
-                                  {PIPELINE_REGION.code}
-                                </span>
-                              </p>
-                            </div>
-                          </SelectItem>
-                        </SelectContent>
-                      </Select>
-                    </FormItemLayout>
+                    <PipelineRegionField destinationType={selectedType} />
                   </div>
                 </div>
 

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/index.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/index.tsx
@@ -21,7 +21,10 @@ import { type DestinationType, type ExistingDestination } from '../DestinationPa
 import { AdvancedSettings } from './AdvancedSettings'
 import { getAnalyticsBucketValidationIssues } from './AnalyticsBucket/AnalyticsBucket.utils'
 import { AnalyticsBucketFields } from './AnalyticsBucket/Fields'
-import { getBigQueryValidationIssues } from './BigQuery/BigQuery.utils'
+import {
+  BIGQUERY_SERVICE_ACCOUNT_JSON_MESSAGE,
+  getBigQueryValidationIssues,
+} from './BigQuery/BigQuery.utils'
 import { BigQueryFields } from './BigQuery/Fields'
 import { getClickHouseValidationIssues } from './ClickHouse/ClickHouse.utils'
 import { ClickHouseFields } from './ClickHouse/Fields'
@@ -210,11 +213,12 @@ export const DestinationForm = ({
         }
 
         if (selectedType === 'BigQuery') {
-          getBigQueryValidationIssues(data, { secretsOptional: editMode }).forEach(
-            ({ path, message }) => {
-              addRequiredFieldError(path, message)
-            }
-          )
+          getBigQueryValidationIssues(data, {
+            secretsOptional: editMode,
+            validateJson: false,
+          }).forEach(({ path, message }) => {
+            addRequiredFieldError(path, message)
+          })
         } else if (selectedType === 'Analytics Bucket') {
           getAnalyticsBucketValidationIssues(data, {
             secretsOptional: editMode,
@@ -318,6 +322,16 @@ export const DestinationForm = ({
         publications,
         publicationName: rawData.publicationName,
       }),
+    }
+
+    if (selectedType === 'BigQuery') {
+      const jsonIssue = getBigQueryValidationIssues(data, { secretsOptional: editMode }).find(
+        (issue) => issue.message === BIGQUERY_SERVICE_ACCOUNT_JSON_MESSAGE
+      )
+      if (jsonIssue) {
+        form.setError(jsonIssue.path, { message: jsonIssue.message })
+        return
+      }
     }
 
     // Pipeline prerequisite validation models a new pipeline and cannot


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (sheet polish, no wizard).

## What is the current behavior?

Edit destination sheet uses a disabled region Select, weaker BigQuery JSON validation messaging, and a name field that password managers may fill.

## What is the new behavior?

- Read-only pipeline region field with flag, display name, region code, and destination-specific hint
- Clearer BigQuery service-account JSON validation
- Destination name ignores password managers (`data-1p-ignore` and related attrs)
- Advanced settings can optionally group fields (defaults keep full accordion for the sheet)

Independent of the [create-pipeline wizard](https://github.com/supabase/supabase/pull/49243). Safe to merge on its own.

| Before | After |
| --- | --- |
| <img width="1024" height="759" alt="Replication  Database  Chisel  Toolshed  Supabase" src="https://github.com/user-attachments/assets/98360d10-3efd-4f77-9645-2f054bb8caab" /> | <img width="1024" height="759" alt="Replication  Database  Chisel  Toolshed  Supabase" src="https://github.com/user-attachments/assets/fdb55904-44f5-4fdf-a750-d4b7f1602b4e" /> |
| <img width="1024" height="759" alt="Replication  Database  Chisel  Toolshed  Supabase" src="https://github.com/user-attachments/assets/cd40e4c3-5653-467b-a3b6-c0c497f9c500" /> | <img width="1024" height="759" alt="Replication  Database  Chisel  Toolshed  Supabase" src="https://github.com/user-attachments/assets/d4115dab-fd94-411c-bbc4-ee69e22436d6" /> |

## To test

1. Open a project → Database → Replication
2. Edit an existing destination
3. Confirm **Pipeline region** is read-only (not a combobox) and shows flag + region name/code
4. Open Advanced settings and confirm fields still appear
5. For BigQuery: paste invalid service-account JSON and confirm a clear validation message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added grouped advanced settings for connection and data configuration.
  - Added a read-only pipeline region display with destination-specific guidance.
  - Destination names now receive focus automatically when forms open.

- **Bug Fixes**
  - Improved BigQuery credential validation, including malformed or missing service-account keys.
  - Password-manager autofill is now suppressed for destination name fields.

- **Tests**
  - Added coverage for BigQuery validation and pipeline-region display behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->