### PR TITLE
feat(studio): add leave feedback on replication list

### DIFF
--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationTypeSelection.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationTypeSelection.tsx
@@ -121,9 +121,7 @@ export const DestinationTypeSelection = () => {
     Deprecated: 'This destination type is deprecated.',
   }
 
-  const stageDescription = selectedOption?.stage
-    ? STAGE_DESCRIPTIONS[selectedOption.stage]
-    : null
+  const stageDescription = selectedOption?.stage ? STAGE_DESCRIPTIONS[selectedOption.stage] : null
 
   const typeDescription =
     !editMode || stageDescription ? (

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationTypeSelection.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationTypeSelection.tsx
@@ -21,7 +21,6 @@ import {
 } from '../useIsETLPrivateAlpha'
 import { DestinationType } from './DestinationPanel.types'
 import { ReadReplicasMovedCallout } from './ReadReplicasMovedCallout'
-import { InlineLink } from '@/components/ui/InlineLink'
 
 interface DestinationTypeOption {
   value: DestinationType
@@ -117,23 +116,13 @@ export const DestinationTypeSelection = () => {
   const selectedOption = options.find((option) => option.value === destinationType)
 
   const stageDescription =
-    selectedOption?.stage === 'Public Alpha' ? (
-      <>
-        In public alpha and may change.{' '}
-        <InlineLink href="https://github.com/orgs/supabase/discussions/39416">
-          Leave feedback
-        </InlineLink>
-      </>
-    ) : selectedOption?.stage === 'Early Access' ? (
-      <>
-        In early access and may change.{' '}
-        <InlineLink href="https://github.com/orgs/supabase/discussions/39416">
-          Leave feedback
-        </InlineLink>
-      </>
-    ) : selectedOption?.stage === 'Deprecated' ? (
-      'This destination type is deprecated.'
-    ) : null
+    selectedOption?.stage === 'Public Alpha'
+      ? 'In public alpha and may change.'
+      : selectedOption?.stage === 'Early Access'
+        ? 'In early access and may change.'
+        : selectedOption?.stage === 'Deprecated'
+          ? 'This destination type is deprecated.'
+          : null
 
   const typeDescription =
     !editMode || stageDescription ? (

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationTypeSelection.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationTypeSelection.tsx
@@ -115,14 +115,15 @@ export const DestinationTypeSelection = () => {
 
   const selectedOption = options.find((option) => option.value === destinationType)
 
-  const stageDescription =
-    selectedOption?.stage === 'Public Alpha'
-      ? 'In public alpha and may change.'
-      : selectedOption?.stage === 'Early Access'
-        ? 'In early access and may change.'
-        : selectedOption?.stage === 'Deprecated'
-          ? 'This destination type is deprecated.'
-          : null
+  const STAGE_DESCRIPTIONS: Record<NonNullable<DestinationTypeOption['stage']>, string> = {
+    'Public Alpha': 'In public alpha and may change.',
+    'Early Access': 'In early access and may change.',
+    Deprecated: 'This destination type is deprecated.',
+  }
+
+  const stageDescription = selectedOption?.stage
+    ? STAGE_DESCRIPTIONS[selectedOption.stage]
+    : null
 
   const typeDescription =
     !editMode || stageDescription ? (

--- a/apps/studio/components/interfaces/Database/Replication/Destinations.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/Destinations.tsx
@@ -1,6 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query'
 import { useParams } from 'common'
-import { MoreVertical, Plus, Search, Workflow, X } from 'lucide-react'
+import { MessageSquare, MoreVertical, Plus, Search, Workflow, X } from 'lucide-react'
 import Link from 'next/link'
 import { parseAsStringEnum, useQueryState } from 'nuqs'
 import { useEffect, useMemo, useRef, useState } from 'react'

--- a/apps/studio/components/interfaces/Database/Replication/Destinations.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/Destinations.tsx
@@ -29,6 +29,7 @@ import { DestinationType } from './DestinationPanel/DestinationPanel.types'
 import { DestinationRow } from './DestinationRow'
 import { DisablePipelinesDialog } from './DisablePipelinesDialog'
 import { EnablePipelinesModal } from './EnablePipelinesCallout'
+import { PIPELINES_FEEDBACK_URL } from './Replication.constants'
 import {
   useIsETLBigQueryPrivateAlpha,
   useIsETLClickHousePrivateAlpha,
@@ -243,6 +244,11 @@ export const Destinations = () => {
             </DropdownMenuContent>
           </DropdownMenu>
 
+          <Button asChild variant="default" icon={<MessageSquare />}>
+            <a href={PIPELINES_FEEDBACK_URL} target="_blank" rel="noreferrer noopener">
+              Leave feedback
+            </a>
+          </Button>
           <DocsButton href={`${DOCS_URL}/guides/database/replication`} />
 
           <Shortcut

--- a/apps/studio/components/interfaces/Database/Replication/Replication.constants.ts
+++ b/apps/studio/components/interfaces/Database/Replication/Replication.constants.ts
@@ -8,3 +8,5 @@ export enum PipelineStatusName {
   STOPPING = 'stopping',
   UNKNOWN = 'unknown',
 }
+
+export const PIPELINES_FEEDBACK_URL = 'https://github.com/orgs/supabase/discussions/39416'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature.

## What is the current behavior?

Replication destinations list has docs and add-destination actions, but no clear path to leave pipelines feedback.

## What is the new behavior?

Adds a **Leave feedback** button that opens the pipelines GitHub discussion. Create destination still opens the existing sheet (no wizard redirect in this PR).

| Before | After |
| --- | --- |
| <img width="1024" height="759" alt="Replication  Database  ETL BigTable  ETL Team  Supabase" src="https://github.com/user-attachments/assets/9a18a90b-3041-49f6-a65c-adb5c07ef0fe" /> | <img width="1024" height="759" alt="47954" src="https://github.com/user-attachments/assets/675d0137-9acb-436a-a3aa-741efeaf74bb" /> |
| <img width="1024" height="759" alt="49523" src="https://github.com/user-attachments/assets/1f8f5cd6-315f-45b1-a1e0-0b02a83d9780" /> | <img width="1024" height="759" alt="Replication  Database  ETL BigTable  ETL Team  Supabase" src="https://github.com/user-attachments/assets/d61e0db9-e28f-4384-8206-4dedbf7ecc74" /> |

## To test

1. Open a project → Database → Replication
2. Click **Leave feedback** in the list toolbar
3. Confirm it opens the pipelines discussion in a new tab
4. Confirm **Add destination** still opens the sheet as today

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Added a feedback button to the replication destinations toolbar.
- Feedback opens the relevant discussion forum in a new browser tab.

## Improvements

- Simplified destination status descriptions for clearer presentation.
- Removed inline discussion links from individual destination descriptions.
- Centralized feedback access in the replication destinations interface for easier discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->