### PR TITLE
feat(studio): add SteppedFlow component

### DIFF
--- a/apps/studio/components/ui/SteppedFlow/SteppedFlow.test.tsx
+++ b/apps/studio/components/ui/SteppedFlow/SteppedFlow.test.tsx
@@ -1,0 +1,129 @@
+import { fireEvent, screen } from '@testing-library/react'
+import { describe, expect, test, vi } from 'vitest'
+
+import { SteppedFlow, SteppedFlowHeader } from './SteppedFlow'
+import { customRender } from '@/tests/lib/custom-render'
+
+const steps = [
+  { id: 'destination', label: 'Destination' },
+  { id: 'connection', label: 'Connection' },
+  { id: 'review', label: 'Review' },
+]
+
+describe('SteppedFlow', () => {
+  test('does not show Back on the first step', () => {
+    customRender(
+      <SteppedFlow steps={steps} currentStep="destination" onStepChange={vi.fn()}>
+        Step body
+      </SteppedFlow>
+    )
+
+    expect(screen.queryByRole('button', { name: 'Back' })).not.toBeInTheDocument()
+  })
+
+  test('shows Cancel on the first step when onCancel is provided', () => {
+    const onCancel = vi.fn()
+
+    customRender(
+      <SteppedFlow
+        steps={steps}
+        currentStep="destination"
+        onStepChange={vi.fn()}
+        onCancel={onCancel}
+      >
+        Step body
+      </SteppedFlow>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(onCancel).toHaveBeenCalledOnce()
+  })
+
+  test('does not show Cancel after the first step', () => {
+    customRender(
+      <SteppedFlow steps={steps} currentStep="connection" onStepChange={vi.fn()} onCancel={vi.fn()}>
+        Step body
+      </SteppedFlow>
+    )
+
+    expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument()
+  })
+
+  test('shows Back after the first step', () => {
+    const onStepChange = vi.fn()
+
+    customRender(
+      <SteppedFlow steps={steps} currentStep="connection" onStepChange={onStepChange}>
+        Step body
+      </SteppedFlow>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }))
+    expect(onStepChange).toHaveBeenCalledWith('destination')
+  })
+
+  test('shows the final action on the last step instead of Next', () => {
+    const onFinal = vi.fn()
+
+    customRender(
+      <SteppedFlow
+        steps={steps}
+        currentStep="review"
+        onStepChange={vi.fn()}
+        onNext={vi.fn()}
+        finalAction={{ label: 'Create and start pipeline', onClick: onFinal }}
+      >
+        Step body
+      </SteppedFlow>
+    )
+
+    expect(screen.queryByRole('button', { name: /Next/ })).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Create and start pipeline' }))
+    expect(onFinal).toHaveBeenCalledOnce()
+  })
+
+  test('renders a step header heading', () => {
+    customRender(
+      <SteppedFlow steps={steps} currentStep="destination" onStepChange={vi.fn()}>
+        <SteppedFlowHeader title="Choose a destination" description="Where should data go?" />
+      </SteppedFlow>
+    )
+
+    expect(screen.getByRole('heading', { name: 'Choose a destination' })).toBeInTheDocument()
+    expect(screen.getByText('Where should data go?')).toBeInTheDocument()
+  })
+
+  test('renders optional header actions', () => {
+    customRender(
+      <SteppedFlow steps={steps} currentStep="connection" onStepChange={vi.fn()}>
+        <SteppedFlowHeader
+          title="Authorize the destination"
+          description="Name this pipeline."
+          actions={
+            <button type="button" tabIndex={0}>
+              Docs
+            </button>
+          }
+        />
+      </SteppedFlow>
+    )
+
+    expect(screen.getByRole('button', { name: 'Docs' })).toBeInTheDocument()
+  })
+
+  test('disables Back while navigation is locked', () => {
+    customRender(
+      <SteppedFlow
+        steps={steps}
+        currentStep="review"
+        onStepChange={vi.fn()}
+        navigationDisabled
+        finalAction={{ label: 'Create and start pipeline', loading: true }}
+      >
+        Step body
+      </SteppedFlow>
+    )
+
+    expect(screen.getByRole('button', { name: 'Back' })).toBeDisabled()
+  })
+})

--- a/apps/studio/components/ui/SteppedFlow/SteppedFlow.test.tsx
+++ b/apps/studio/components/ui/SteppedFlow/SteppedFlow.test.tsx
@@ -139,4 +139,35 @@ describe('SteppedFlow', () => {
 
     expect(screen.getByRole('button', { name: 'Back' })).toBeDisabled()
   })
+
+  test('disables Next while navigation is locked', () => {
+    customRender(
+      <SteppedFlow
+        steps={steps}
+        currentStep="destination"
+        onStepChange={vi.fn()}
+        navigationDisabled
+      >
+        Step body
+      </SteppedFlow>
+    )
+
+    expect(screen.getByRole('button', { name: 'Next' })).toBeDisabled()
+  })
+
+  test('disables the final action while navigation is locked', () => {
+    customRender(
+      <SteppedFlow
+        steps={steps}
+        currentStep="review"
+        onStepChange={vi.fn()}
+        navigationDisabled
+        finalAction={{ label: 'Create and start pipeline' }}
+      >
+        Step body
+      </SteppedFlow>
+    )
+
+    expect(screen.getByRole('button', { name: 'Create and start pipeline' })).toBeDisabled()
+  })
 })

--- a/apps/studio/components/ui/SteppedFlow/SteppedFlow.test.tsx
+++ b/apps/studio/components/ui/SteppedFlow/SteppedFlow.test.tsx
@@ -62,6 +62,19 @@ describe('SteppedFlow', () => {
     expect(onStepChange).toHaveBeenCalledWith('destination')
   })
 
+  test('advances to the next step when onNext is omitted', () => {
+    const onStepChange = vi.fn()
+
+    customRender(
+      <SteppedFlow steps={steps} currentStep="destination" onStepChange={onStepChange}>
+        Step body
+      </SteppedFlow>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    expect(onStepChange).toHaveBeenCalledWith('connection')
+  })
+
   test('shows the final action on the last step instead of Next', () => {
     const onFinal = vi.fn()
 

--- a/apps/studio/components/ui/SteppedFlow/SteppedFlow.tsx
+++ b/apps/studio/components/ui/SteppedFlow/SteppedFlow.tsx
@@ -75,7 +75,8 @@ export const SteppedFlow = ({
     0,
     steps.findIndex((step) => step.id === currentStep)
   )
-  const isLastStep = currentIndex === steps.length - 1
+  const stepCount = steps.length
+  const isLastStep = stepCount > 0 && currentIndex === stepCount - 1
   const isFirstStep = currentIndex === 0
   const currentStepLabel = steps[currentIndex]?.label
   const showCancel = isFirstStep && !!onCancel
@@ -92,11 +93,15 @@ export const SteppedFlow = ({
     }
   }
 
+  if (stepCount === 0) {
+    return null
+  }
+
   return (
     <div className="flex min-h-full flex-col">
       <div className="mx-auto w-full max-w-[760px] flex-1 px-6 pt-8 pb-10">
         <p className="mb-4 text-xs text-foreground-lighter" role="status">
-          Step {currentIndex + 1} of {steps.length}
+          Step {currentIndex + 1} of {stepCount}
           {currentStepLabel ? ` · ${currentStepLabel}` : ''}
         </p>
         <Card
@@ -134,7 +139,7 @@ export const SteppedFlow = ({
                   form={finalAction.form}
                   variant="primary"
                   loading={finalAction.loading}
-                  disabled={finalAction.disabled}
+                  disabled={navigationDisabled || finalAction.disabled}
                   onClick={finalAction.onClick}
                 >
                   {finalAction.label}
@@ -143,7 +148,7 @@ export const SteppedFlow = ({
                 <Button
                   type="button"
                   variant="primary"
-                  disabled={nextDisabled || !nextStepId}
+                  disabled={navigationDisabled || nextDisabled || !nextStepId}
                   loading={nextLoading}
                   onClick={handleNext}
                 >

--- a/apps/studio/components/ui/SteppedFlow/SteppedFlow.tsx
+++ b/apps/studio/components/ui/SteppedFlow/SteppedFlow.tsx
@@ -1,0 +1,143 @@
+import { type ReactNode } from 'react'
+import { Button, Card, CardFooter, CardHeader, cn } from 'ui'
+
+export type SteppedFlowStep = {
+  id: string
+  label: string
+}
+
+export type SteppedFlowFinalAction = {
+  label: string
+  onClick?: () => void
+  loading?: boolean
+  disabled?: boolean
+  form?: string
+  type?: 'button' | 'submit'
+}
+
+export const SteppedFlowHeader = ({
+  title,
+  description,
+  actions,
+  children,
+}: {
+  title: string
+  description?: ReactNode
+  actions?: ReactNode
+  children?: ReactNode
+}) => {
+  return (
+    <CardHeader>
+      <header className="flex flex-col space-y-1">
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0 flex-1 space-y-1">
+            <h2 className="text-lg text-foreground">{title}</h2>
+            {description ? <p className="text-sm text-foreground-light">{description}</p> : null}
+          </div>
+          {actions ? <div className="shrink-0">{actions}</div> : null}
+        </div>
+        {children}
+      </header>
+    </CardHeader>
+  )
+}
+
+export interface SteppedFlowProps {
+  steps: SteppedFlowStep[]
+  currentStep: string
+  onStepChange: (stepId: string) => void
+  nextDisabled?: boolean
+  nextLabel?: string
+  onNext?: () => void
+  nextLoading?: boolean
+  navigationDisabled?: boolean
+  onCancel?: () => void
+  cancelLabel?: string
+  finalAction?: SteppedFlowFinalAction
+  children: ReactNode
+}
+
+export const SteppedFlow = ({
+  steps,
+  currentStep,
+  onStepChange,
+  nextDisabled = false,
+  nextLabel = 'Next',
+  onNext,
+  nextLoading = false,
+  navigationDisabled = false,
+  onCancel,
+  cancelLabel = 'Cancel',
+  finalAction,
+  children,
+}: SteppedFlowProps) => {
+  const currentIndex = Math.max(
+    0,
+    steps.findIndex((step) => step.id === currentStep)
+  )
+  const isLastStep = currentIndex === steps.length - 1
+  const isFirstStep = currentIndex === 0
+  const currentStepLabel = steps[currentIndex]?.label
+  const showCancel = isFirstStep && !!onCancel
+
+  return (
+    <div className="flex min-h-full flex-col">
+      <div className="mx-auto w-full max-w-[760px] flex-1 px-6 pt-8 pb-10">
+        <p className="mb-4 text-xs text-foreground-lighter">
+          Step {currentIndex + 1} of {steps.length}
+          {currentStepLabel ? ` · ${currentStepLabel}` : ''}
+        </p>
+        <Card key={currentStep} className="animate-in fade-in-0 duration-200">
+          {children}
+          <CardFooter
+            className={cn(currentIndex > 0 || showCancel ? 'justify-between' : 'justify-end')}
+          >
+            {currentIndex > 0 ? (
+              <Button
+                type="button"
+                variant="default"
+                disabled={navigationDisabled}
+                onClick={() => onStepChange(steps[currentIndex - 1].id)}
+              >
+                Back
+              </Button>
+            ) : showCancel ? (
+              <Button
+                type="button"
+                variant="default"
+                disabled={navigationDisabled}
+                onClick={onCancel}
+              >
+                {cancelLabel}
+              </Button>
+            ) : null}
+            <div className="flex items-center gap-2">
+              {isLastStep && finalAction ? (
+                <Button
+                  type={finalAction.type ?? (finalAction.form ? 'submit' : 'button')}
+                  form={finalAction.form}
+                  variant="primary"
+                  loading={finalAction.loading}
+                  disabled={finalAction.disabled}
+                  onClick={finalAction.onClick}
+                >
+                  {finalAction.label}
+                </Button>
+              ) : (
+                <Button
+                  type="button"
+                  variant="primary"
+                  disabled={nextDisabled}
+                  loading={nextLoading}
+                  onClick={onNext}
+                >
+                  {nextLabel}
+                </Button>
+              )}
+            </div>
+          </CardFooter>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/apps/studio/components/ui/SteppedFlow/SteppedFlow.tsx
+++ b/apps/studio/components/ui/SteppedFlow/SteppedFlow.tsx
@@ -79,15 +79,30 @@ export const SteppedFlow = ({
   const isFirstStep = currentIndex === 0
   const currentStepLabel = steps[currentIndex]?.label
   const showCancel = isFirstStep && !!onCancel
+  const nextStepId = steps[currentIndex + 1]?.id
+
+  const handleNext = () => {
+    if (onNext) {
+      onNext()
+      return
+    }
+
+    if (nextStepId) {
+      onStepChange(nextStepId)
+    }
+  }
 
   return (
     <div className="flex min-h-full flex-col">
       <div className="mx-auto w-full max-w-[760px] flex-1 px-6 pt-8 pb-10">
-        <p className="mb-4 text-xs text-foreground-lighter">
+        <p className="mb-4 text-xs text-foreground-lighter" role="status">
           Step {currentIndex + 1} of {steps.length}
           {currentStepLabel ? ` · ${currentStepLabel}` : ''}
         </p>
-        <Card key={currentStep} className="animate-in fade-in-0 duration-200">
+        <Card
+          key={currentStep}
+          className="animate-in fade-in-0 duration-200 motion-reduce:animate-none"
+        >
           {children}
           <CardFooter
             className={cn(currentIndex > 0 || showCancel ? 'justify-between' : 'justify-end')}
@@ -101,7 +116,8 @@ export const SteppedFlow = ({
               >
                 Back
               </Button>
-            ) : showCancel ? (
+            ) : null}
+            {currentIndex === 0 && showCancel ? (
               <Button
                 type="button"
                 variant="default"
@@ -127,9 +143,9 @@ export const SteppedFlow = ({
                 <Button
                   type="button"
                   variant="primary"
-                  disabled={nextDisabled}
+                  disabled={nextDisabled || !nextStepId}
                   loading={nextLoading}
-                  onClick={onNext}
+                  onClick={handleNext}
                 >
                   {nextLabel}
                 </Button>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (shared UI primitive).

## What is the current behavior?

No shared stepped wizard shell in Studio. Upcoming create-pipeline work needs a reusable step container with header, progress, and primary/secondary actions.

## What is the new behavior?

Adds `SteppedFlow` and `SteppedFlowHeader` with unit tests: step list, current step content, next/back, optional first-step cancel, and header actions slot.

No product callsite yet. Safe to merge on its own; the create-pipeline wizard PR will consume it.

## To test

Code review + vitest:

```sh
cd apps/studio && pnpm exec vitest run components/ui/SteppedFlow/SteppedFlow.test.tsx
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable stepped-flow interface with progress indicators and step-specific content.
  * Supports optional headers, actions, loading and disabled states, forms, and configurable button types.
  * Added navigation controls for moving forward, going back, cancelling, and completing the flow.
  * Supports customizable final actions.

* **Tests**
  * Added coverage for navigation, cancellation, headers, optional actions, final actions, and disabled states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->