### PR TITLE
fix(studio): make menu links reliable

### DIFF
--- a/apps/studio/components/interfaces/Integrations/VercelGithub/ProjectLinkerComponents.tsx
+++ b/apps/studio/components/interfaces/Integrations/VercelGithub/ProjectLinkerComponents.tsx
@@ -1,7 +1,6 @@
 import { useParams } from 'common'
 import { Check, ChevronDown, Plus, PlusIcon } from 'lucide-react'
 import Link from 'next/link'
-import { useRouter } from 'next/router'
 import { HTMLAttributes } from 'react'
 import {
   Badge,
@@ -20,6 +19,7 @@ import {
 } from 'ui'
 
 import { Project, type ForeignProject, type ProjectLinkerProps } from './VercelGithub.types'
+import { CommandItemLink } from '@/components/ui/CommandItemLink'
 import { OrganizationProjectSelector } from '@/components/ui/OrganizationProjectSelector'
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
@@ -161,7 +161,6 @@ export const SupabaseProjectSelector = ({
   setOpen: (val: boolean) => void
   setSelectedSupabaseProject: (project: Project) => void
 } & Pick<ProjectLinkerProps, 'slug' | 'variant' | 'defaultSupabaseProject'>) => {
-  const router = useRouter()
   const { data: selectedOrganization } = useSelectedOrganizationQuery()
   const projectCreationEnabled = useIsFeatureEnabled('projects:create')
 
@@ -226,23 +225,14 @@ export const SupabaseProjectSelector = ({
         return (
           projectCreationEnabled && (
             <CommandGroup>
-              <CommandItem
-                className="cursor-pointer w-full"
-                onSelect={() => {
-                  setOpen(false)
-                  router.push(`/new/${selectedOrganization?.slug}`)
-                }}
-                onClick={() => setOpen(false)}
+              <CommandItemLink
+                href={`/new/${selectedOrganization?.slug}`}
+                className="cursor-pointer w-full gap-2"
+                onSelect={() => setOpen(false)}
               >
-                <Link
-                  href={`/new/${selectedOrganization?.slug}`}
-                  className="w-full flex items-center gap-2"
-                  onClick={() => setOpen(false)}
-                >
-                  <Plus size={14} strokeWidth={1.5} />
-                  <p>Create a new project</p>
-                </Link>
-              </CommandItem>
+                <Plus size={14} strokeWidth={1.5} />
+                <p>Create a new project</p>
+              </CommandItemLink>
             </CommandGroup>
           )
         )

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceNode.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceNode.tsx
@@ -413,7 +413,7 @@ export const ReplicaNode = ({ data }: NodeProps<Node<ReplicaNodeData>>) => {
               View connection string
             </DropdownMenuItem>
             <DropdownMenuSeparator />
-            <DropdownMenuItem className="gap-x-2">
+            <DropdownMenuItem className="gap-x-2" asChild>
               <Link href={getReadReplicaPath(ref, id)}>Manage replica</Link>
             </DropdownMenuItem>
           </DropdownMenuContent>

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/MapView.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/MapView.tsx
@@ -295,7 +295,7 @@ const MapView = () => {
 
                             <DropdownMenuSeparator />
 
-                            <DropdownMenuItem className="gap-x-2">
+                            <DropdownMenuItem className="gap-x-2" asChild>
                               <Link href={getReadReplicaPath(ref, database.identifier)}>
                                 Manage replica
                               </Link>

--- a/apps/studio/components/layouts/AppLayout/BranchDropdownCommandContent.tsx
+++ b/apps/studio/components/layouts/AppLayout/BranchDropdownCommandContent.tsx
@@ -14,6 +14,7 @@ import {
 } from 'ui'
 
 import { BranchLink } from './BranchLink'
+import { CommandItemLink } from '@/components/ui/CommandItemLink'
 import type { Branch } from '@/data/branches/branches-query'
 import { useTrack } from '@/lib/telemetry/track'
 
@@ -149,48 +150,34 @@ export function BranchDropdownCommandContent({
               <p>Create branch</p>
             </div>
           </CommandItem>
-          <CommandItem
-            className="cursor-pointer w-full"
+          <CommandItemLink
+            href={`/project/${projectRef}/branches`}
+            className="cursor-pointer w-full gap-2"
             onSelect={() => {
               track('branch_selector_manage_clicked')
               onClose()
             }}
           >
-            <Link
-              href={`/project/${projectRef}/branches`}
-              className="w-full flex items-center gap-2"
-            >
-              <ListTree size={14} strokeWidth={1.5} />
-              <p>Manage branches</p>
-            </Link>
-          </CommandItem>
+            <ListTree size={14} strokeWidth={1.5} />
+            <p>Manage branches</p>
+          </CommandItemLink>
         </CommandGroup>
 
         <CommandSeparator />
 
         <CommandGroup>
-          <CommandItem
-            className="cursor-pointer w-full"
-            onSelect={() => {
-              onClose()
-              window?.open(BRANCHING_GITHUB_DISCUSSION_LINK, '_blank')?.focus()
-            }}
-            onClick={onClose}
+          <CommandItemLink
+            href={BRANCHING_GITHUB_DISCUSSION_LINK}
+            linkProps={{ target: '_blank', rel: 'noreferrer noopener' }}
+            className="cursor-pointer w-full gap-2"
+            onSelect={onClose}
           >
-            <a
-              target="_blank"
-              rel="noreferrer noopener"
-              href={BRANCHING_GITHUB_DISCUSSION_LINK}
-              onClick={onClose}
-              className="w-full flex gap-2"
-            >
-              <MessageCircle size={14} strokeWidth={1} className="mt-0.5" />
-              <div>
-                <p>Branching feedback</p>
-                <p className="text-lighter">Join GitHub Discussion</p>
-              </div>
-            </a>
-          </CommandItem>
+            <MessageCircle size={14} strokeWidth={1} className="mt-0.5" />
+            <div>
+              <p>Branching feedback</p>
+              <p className="text-lighter">Join GitHub Discussion</p>
+            </div>
+          </CommandItemLink>
         </CommandGroup>
       </CommandList>
     </Command>

--- a/apps/studio/components/layouts/AppLayout/BranchLink.tsx
+++ b/apps/studio/components/layouts/AppLayout/BranchLink.tsx
@@ -1,9 +1,8 @@
 import { Check, Shield } from 'lucide-react'
-import Link from 'next/link'
 import { useRouter } from 'next/router'
-import { CommandItem } from 'ui'
 
 import { sanitizeRoute } from './ProjectDropdown.utils'
+import { CommandItemLink } from '@/components/ui/CommandItemLink'
 import type { Branch } from '@/data/branches/branches-query'
 import { useTrack } from '@/lib/telemetry/track'
 
@@ -21,24 +20,23 @@ export function BranchLink({ branch, isSelected, onClose }: BranchLinkProps) {
     sanitizedRoute?.replace('[ref]', branch.project_ref) ?? `/project/${branch.project_ref}`
 
   return (
-    <Link passHref href={href}>
-      <CommandItem
-        value={branch.name.replaceAll('"', '')}
-        className="cursor-pointer w-full flex items-center justify-between text-sm md:text-xs p-2 md:py-1.5 md:px-2"
-        onSelect={() => {
-          track('branch_selector_branch_clicked', {
-            branchId: branch.id,
-            branchName: branch.name,
-          })
-          onClose()
-        }}
-      >
-        <p className="truncate w-60 flex items-center gap-1" title={branch.name}>
-          {branch.is_default && <Shield size={14} className="text-amber-900" />}
-          {branch.name}
-        </p>
-        {isSelected && <Check size={14} strokeWidth={1.5} />}
-      </CommandItem>
-    </Link>
+    <CommandItemLink
+      href={href}
+      value={branch.name.replaceAll('"', '')}
+      className="cursor-pointer w-full flex items-center justify-between text-sm md:text-xs p-2 md:py-1.5 md:px-2"
+      onSelect={() => {
+        track('branch_selector_branch_clicked', {
+          branchId: branch.id,
+          branchName: branch.name,
+        })
+        onClose()
+      }}
+    >
+      <p className="truncate w-60 flex items-center gap-1" title={branch.name}>
+        {branch.is_default && <Shield size={14} className="text-amber-900" />}
+        {branch.name}
+      </p>
+      {isSelected && <Check size={14} strokeWidth={1.5} />}
+    </CommandItemLink>
   )
 }

--- a/apps/studio/components/layouts/AppLayout/OrgCommandItem.tsx
+++ b/apps/studio/components/layouts/AppLayout/OrgCommandItem.tsx
@@ -1,7 +1,7 @@
 import { Check } from 'lucide-react'
-import Link from 'next/link'
-import { cn, CommandItem } from 'ui'
+import { cn } from 'ui'
 
+import { CommandItemLink } from '@/components/ui/CommandItemLink'
 import PartnerIcon from '@/components/ui/PartnerIcon'
 import type { Organization } from '@/types'
 
@@ -25,22 +25,21 @@ export function OrgCommandItem({
   const href = hasRouteSlug ? routePathname.replace('[slug]', org.slug) : `/org/${org.slug}`
 
   return (
-    <Link passHref href={href}>
-      <CommandItem
-        key={org.slug}
-        value={`${org.name.replaceAll('"', '')} - ${org.slug}`}
-        className={cn(
-          'cursor-pointer w-full flex items-center justify-between text-sm md:text-xs',
-          !compactPadding && 'p-0.5'
-        )}
-        onSelect={onClose}
-      >
-        <div className="flex items-center gap-2">
-          <span>{org.name}</span>
-          <PartnerIcon organization={org} />
-        </div>
-        {org.slug === selectedSlug && <Check size={16} />}
-      </CommandItem>
-    </Link>
+    <CommandItemLink
+      key={org.slug}
+      href={href}
+      value={`${org.name.replaceAll('"', '')} - ${org.slug}`}
+      className={cn(
+        'cursor-pointer w-full flex items-center justify-between text-sm md:text-xs',
+        !compactPadding && 'p-0.5'
+      )}
+      onSelect={onClose}
+    >
+      <div className="flex items-center gap-2">
+        <span>{org.name}</span>
+        <PartnerIcon organization={org} />
+      </div>
+      {org.slug === selectedSlug && <Check size={16} />}
+    </CommandItemLink>
   )
 }

--- a/apps/studio/components/layouts/AppLayout/OrgCommandItem.tsx
+++ b/apps/studio/components/layouts/AppLayout/OrgCommandItem.tsx
@@ -25,25 +25,22 @@ export function OrgCommandItem({
   const href = hasRouteSlug ? routePathname.replace('[slug]', org.slug) : `/org/${org.slug}`
 
   return (
-    <CommandItem
-      key={org.slug}
-      value={`${org.name.replaceAll('"', '')} - ${org.slug}`}
-      className="cursor-pointer w-full"
-      onSelect={() => onClose()}
-    >
-      <Link
-        href={href}
+    <Link passHref href={href}>
+      <CommandItem
+        key={org.slug}
+        value={`${org.name.replaceAll('"', '')} - ${org.slug}`}
         className={cn(
-          'w-full flex items-center justify-between text-sm md:text-xs',
+          'cursor-pointer w-full flex items-center justify-between text-sm md:text-xs',
           !compactPadding && 'p-0.5'
         )}
+        onSelect={onClose}
       >
         <div className="flex items-center gap-2">
           <span>{org.name}</span>
           <PartnerIcon organization={org} />
         </div>
         {org.slug === selectedSlug && <Check size={16} />}
-      </Link>
-    </CommandItem>
+      </CommandItem>
+    </Link>
   )
 }

--- a/apps/studio/components/layouts/AppLayout/OrganizationDropdown.test.tsx
+++ b/apps/studio/components/layouts/AppLayout/OrganizationDropdown.test.tsx
@@ -72,4 +72,16 @@ describe('OrganizationDropdown', () => {
     const selectedLink = screen.getByRole('link', { name: /org one/i })
     expect(within(selectedLink).queryByTestId('partner-icon')).toBeNull()
   })
+
+  it('renders organization command items as links', () => {
+    mockUseSelectedOrganizationQuery.mockReturnValue({
+      data: createMockOrganization({ slug: 'org-one', name: 'Org One' }),
+    })
+
+    render(<OrganizationDropdown embedded />)
+
+    const organizationLink = screen.getByRole('link', { name: /org two/i })
+    expect(within(organizationLink).getByRole('option')).toBeInTheDocument()
+    expect(organizationLink).toHaveAttribute('href', '/org/org-two')
+  })
 })

--- a/apps/studio/components/layouts/AppLayout/OrganizationDropdownCommandContent.tsx
+++ b/apps/studio/components/layouts/AppLayout/OrganizationDropdownCommandContent.tsx
@@ -7,13 +7,13 @@ import {
   CommandEmpty,
   CommandGroup,
   CommandInput,
-  CommandItem,
   CommandList,
   CommandSeparator,
   ScrollArea,
 } from 'ui'
 
 import { OrgCommandItem } from './OrgCommandItem'
+import { CommandItemLink } from '@/components/ui/CommandItemLink'
 import type { Organization } from '@/types'
 
 export interface OrganizationDropdownCommandContentProps {
@@ -109,22 +109,26 @@ export function OrganizationDropdownCommandContent({
         </CommandGroup>
         <CommandSeparator />
         <CommandGroup>
-          <CommandItem className="cursor-pointer w-full" onSelect={() => onClose()}>
-            <Link href="/organizations" className="flex items-center gap-2 w-full">
-              All Organizations
-            </Link>
-          </CommandItem>
+          <CommandItemLink
+            href="/organizations"
+            className="cursor-pointer w-full gap-2"
+            onSelect={onClose}
+          >
+            All Organizations
+          </CommandItemLink>
         </CommandGroup>
         {organizationCreationEnabled && (
           <>
             <CommandSeparator />
             <CommandGroup>
-              <CommandItem className="cursor-pointer w-full" onSelect={() => onClose()}>
-                <Link href="/new" className="flex items-center gap-2 w-full">
-                  <Plus size={14} strokeWidth={1.5} />
-                  <p>New organization</p>
-                </Link>
-              </CommandItem>
+              <CommandItemLink
+                href="/new"
+                className="cursor-pointer w-full gap-2"
+                onSelect={onClose}
+              >
+                <Plus size={14} strokeWidth={1.5} />
+                <p>New organization</p>
+              </CommandItemLink>
             </CommandGroup>
           </>
         )}

--- a/apps/studio/components/layouts/AppLayout/ProjectDropdown.test.tsx
+++ b/apps/studio/components/layouts/AppLayout/ProjectDropdown.test.tsx
@@ -1,9 +1,13 @@
 import { screen } from '@testing-library/react'
+import type { ComponentProps } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ProjectDropdown } from './ProjectDropdown'
+import type { OrganizationProjectSelector } from '@/components/ui/OrganizationProjectSelector'
 import { MANAGED_BY } from '@/lib/constants/infrastructure'
 import { createMockOrganization, render } from '@/tests/helpers'
+
+type OrganizationProjectSelectorProps = ComponentProps<typeof OrganizationProjectSelector>
 
 const { mockSelectedOrganization, mockSelectedProject, mockSelectorProject, mockSelectorProps } =
   vi.hoisted(() => ({
@@ -56,11 +60,18 @@ vi.mock('@/hooks/misc/useIsFeatureEnabled', () => ({
 }))
 
 vi.mock('@/components/ui/OrganizationProjectSelector', () => ({
-  OrganizationProjectSelector: (props: any) => {
+  OrganizationProjectSelector: (props: OrganizationProjectSelectorProps) => {
     mockSelectorProps(props)
     return (
       <div>
-        <div data-testid="project-selector-trigger">{props.renderTrigger?.({})}</div>
+        <div data-testid="project-selector-trigger">
+          {props.renderTrigger?.({
+            isLoading: false,
+            project: mockSelectorProject(),
+            listboxId: 'project-selector-listbox',
+            open: false,
+          })}
+        </div>
         <div data-testid="project-selector-row">{props.renderRow?.(mockSelectorProject())}</div>
       </div>
     )

--- a/apps/studio/components/layouts/AppLayout/ProjectDropdown.test.tsx
+++ b/apps/studio/components/layouts/AppLayout/ProjectDropdown.test.tsx
@@ -5,11 +5,13 @@ import { ProjectDropdown } from './ProjectDropdown'
 import { MANAGED_BY } from '@/lib/constants/infrastructure'
 import { createMockOrganization, render } from '@/tests/helpers'
 
-const { mockSelectedOrganization, mockSelectedProject, mockSelectorProject } = vi.hoisted(() => ({
-  mockSelectedOrganization: vi.fn(),
-  mockSelectedProject: vi.fn(),
-  mockSelectorProject: vi.fn(),
-}))
+const { mockSelectedOrganization, mockSelectedProject, mockSelectorProject, mockSelectorProps } =
+  vi.hoisted(() => ({
+    mockSelectedOrganization: vi.fn(),
+    mockSelectedProject: vi.fn(),
+    mockSelectorProject: vi.fn(),
+    mockSelectorProps: vi.fn(),
+  }))
 
 const mockPush = vi.hoisted(() => vi.fn())
 
@@ -54,12 +56,15 @@ vi.mock('@/hooks/misc/useIsFeatureEnabled', () => ({
 }))
 
 vi.mock('@/components/ui/OrganizationProjectSelector', () => ({
-  OrganizationProjectSelector: ({ renderRow, renderTrigger }: any) => (
-    <div>
-      <div data-testid="project-selector-trigger">{renderTrigger?.({})}</div>
-      <div data-testid="project-selector-row">{renderRow?.(mockSelectorProject())}</div>
-    </div>
-  ),
+  OrganizationProjectSelector: (props: any) => {
+    mockSelectorProps(props)
+    return (
+      <div>
+        <div data-testid="project-selector-trigger">{props.renderTrigger?.({})}</div>
+        <div data-testid="project-selector-row">{props.renderRow?.(mockSelectorProject())}</div>
+      </div>
+    )
+  },
 }))
 
 vi.mock('@/components/ui/PartnerIcon', () => ({
@@ -165,5 +170,13 @@ describe('ProjectDropdown', () => {
       'data-managed-by',
       MANAGED_BY.VERCEL_MARKETPLACE
     )
+  })
+
+  it('provides project command items with links that preserve the current route', () => {
+    render(<ProjectDropdown />)
+
+    const selectorProps = mockSelectorProps.mock.lastCall?.[0]
+    expect(selectorProps.getItemHref({ ref: 'proj_2' })).toBe('/project/proj_2/settings')
+    expect(selectorProps.onSelect).toBeUndefined()
   })
 })

--- a/apps/studio/components/layouts/AppLayout/ProjectDropdown.tsx
+++ b/apps/studio/components/layouts/AppLayout/ProjectDropdown.tsx
@@ -4,13 +4,14 @@ import Link from 'next/link'
 import { useRouter } from 'next/router'
 import type { ComponentProps } from 'react'
 import { useState } from 'react'
-import { Button, CommandGroup, CommandItem } from 'ui'
+import { Button, CommandGroup } from 'ui'
 import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 
 import { AppLayoutDropdownTriggerButton } from './AppLayoutDropdown'
 import { sanitizeRoute } from './ProjectDropdown.utils'
 import { ProjectRowLink } from './ProjectRowLink'
 import { useEmbeddedCloseHandler } from './useEmbeddedCloseHandler'
+import { CommandItemLink } from '@/components/ui/CommandItemLink'
 import { OrganizationProjectSelector } from '@/components/ui/OrganizationProjectSelector'
 import PartnerIcon from '@/components/ui/PartnerIcon'
 import { getManagedByFromOrganizationPartner } from '@/data/organizations/managed-by-utils'
@@ -29,14 +30,12 @@ interface ProjectDropdownNewProjectActionsProps {
   organizationSlug: string | undefined
   embedded: boolean
   onClose: () => void
-  onNavigate: (href: string) => void
 }
 
 function ProjectDropdownNewProjectActions({
   organizationSlug,
   embedded,
   onClose,
-  onNavigate,
 }: ProjectDropdownNewProjectActionsProps) {
   const href = `/new/${organizationSlug}`
 
@@ -62,19 +61,10 @@ function ProjectDropdownNewProjectActions({
 
   return (
     <CommandGroup>
-      <CommandItem
-        className="cursor-pointer w-full"
-        onSelect={() => {
-          onClose()
-          onNavigate(href)
-        }}
-        onClick={onClose}
-      >
-        <Link href={href} onClick={onClose} className="w-full flex items-center gap-2">
-          <Plus size={14} strokeWidth={1.5} />
-          <p>New project</p>
-        </Link>
-      </CommandItem>
+      <CommandItemLink href={href} className="cursor-pointer w-full gap-2" onSelect={onClose}>
+        <Plus size={14} strokeWidth={1.5} />
+        <p>New project</p>
+      </CommandItemLink>
     </CommandGroup>
   )
 }
@@ -186,7 +176,6 @@ export const ProjectDropdown = ({
           organizationSlug={selectedOrganization?.slug}
           embedded={options?.embedded ?? false}
           onClose={close}
-          onNavigate={(href) => router.push(href)}
         />
       ) : null,
   }

--- a/apps/studio/components/layouts/AppLayout/ProjectDropdown.tsx
+++ b/apps/studio/components/layouts/AppLayout/ProjectDropdown.tsx
@@ -173,19 +173,12 @@ export const ProjectDropdown = ({
     open,
     setOpen: handleSetOpen,
     selectedRef: ref,
-    onSelect: (project: { ref: string }) => {
+    getItemHref: (project: { ref: string }) => {
       const sanitizedRoute = sanitizeRoute(router.route, router.query)
-      const href = sanitizedRoute?.replace('[ref]', project.ref) ?? `/project/${project.ref}`
-      close()
-      router.push(href)
+      return sanitizedRoute?.replace('[ref]', project.ref) ?? `/project/${project.ref}`
     },
     renderRow: (project: Pick<OrgProject, 'ref' | 'name' | 'status' | 'integration_source'>) => (
-      <ProjectRowLink
-        project={project}
-        selectedRef={ref}
-        route={router.route}
-        routerQueries={router.query}
-      />
+      <ProjectRowLink project={project} selectedRef={ref} />
     ),
     renderActions: (_setOpen: (value: boolean) => void, options?: { embedded?: boolean }) =>
       projectCreationEnabled ? (

--- a/apps/studio/components/layouts/AppLayout/ProjectRowLink.tsx
+++ b/apps/studio/components/layouts/AppLayout/ProjectRowLink.tsx
@@ -1,9 +1,6 @@
-import { ParsedUrlQuery } from 'querystring'
 import { Check } from 'lucide-react'
-import Link from 'next/link'
 import { Badge, cn } from 'ui'
 
-import { sanitizeRoute } from './ProjectDropdown.utils'
 import PartnerIcon from '@/components/ui/PartnerIcon'
 import { getManagedByFromOrganizationPartner } from '@/data/organizations/managed-by-utils'
 
@@ -15,27 +12,15 @@ export interface ProjectRowLinkProps {
     integration_source?: string | null
   }
   selectedRef: string | undefined
-  route: string
-  routerQueries: ParsedUrlQuery
 }
 
-export function ProjectRowLink({
-  project,
-  selectedRef,
-  route,
-  routerQueries,
-}: ProjectRowLinkProps) {
-  const sanitizedRoute = sanitizeRoute(route, routerQueries)
-  const href = sanitizedRoute?.replace('[ref]', project.ref) ?? `/project/${project.ref}`
+export function ProjectRowLink({ project, selectedRef }: ProjectRowLinkProps) {
   const isSelected = project.ref === selectedRef
   const isPaused = project.status === 'INACTIVE'
   const managedBy = getManagedByFromOrganizationPartner(undefined, project.integration_source)
 
   return (
-    <Link
-      href={href}
-      className="w-full flex items-center justify-between p-0.5 md:p-0 text-sm md:text-xs"
-    >
+    <div className="w-full flex items-center justify-between p-0.5 md:p-0 text-sm md:text-xs">
       <span
         className={cn(
           'flex items-center gap-2 min-w-0',
@@ -47,6 +32,6 @@ export function ProjectRowLink({
         <PartnerIcon organization={{ managed_by: managedBy }} />
       </span>
       {isSelected && <Check size={16} />}
-    </Link>
+    </div>
   )
 }

--- a/apps/studio/components/layouts/Navigation/NavigationBar/OrgSelector.tsx
+++ b/apps/studio/components/layouts/Navigation/NavigationBar/OrgSelector.tsx
@@ -1,6 +1,5 @@
 import { useBreakpoint, useParams } from 'common'
 import { Boxes, ChevronsUpDown, Plus } from 'lucide-react'
-import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useState } from 'react'
 import {
@@ -8,7 +7,6 @@ import {
   CommandEmpty,
   CommandGroup,
   CommandInput,
-  CommandItem,
   CommandList,
   CommandSeparator,
   Popover,
@@ -23,6 +21,7 @@ import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 
 import { OrgSelectorSheet } from './OrgSelectorSheet'
 import { OrgCommandItem } from '@/components/layouts/AppLayout/OrgCommandItem'
+import { CommandItemLink } from '@/components/ui/CommandItemLink'
 import { useOrganizationsQuery } from '@/data/organizations/organizations-query'
 import { useOrgProjectsInfiniteQuery } from '@/data/projects/org-projects-infinite-query'
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
@@ -129,36 +128,26 @@ export function OrgSelector() {
                 </CommandGroup>
                 <CommandSeparator />
                 <CommandGroup>
-                  <CommandItem
-                    className="cursor-pointer w-full"
-                    onSelect={() => {
-                      setOpen(false)
-                      router.push('/organizations')
-                    }}
-                    onClick={() => setOpen(false)}
+                  <CommandItemLink
+                    href="/organizations"
+                    className="cursor-pointer w-full gap-2"
+                    onSelect={() => setOpen(false)}
                   >
-                    <Link href="/organizations" className="flex items-center gap-2 w-full">
-                      <p>All Organizations</p>
-                    </Link>
-                  </CommandItem>
+                    <p>All Organizations</p>
+                  </CommandItemLink>
                 </CommandGroup>
                 {organizationCreationEnabled && (
                   <>
                     <CommandSeparator />
                     <CommandGroup>
-                      <CommandItem
-                        className="cursor-pointer w-full"
-                        onSelect={() => {
-                          setOpen(false)
-                          router.push('/new')
-                        }}
-                        onClick={() => setOpen(false)}
+                      <CommandItemLink
+                        href="/new"
+                        className="cursor-pointer w-full gap-2"
+                        onSelect={() => setOpen(false)}
                       >
-                        <Link href="/new" className="flex items-center gap-2 w-full">
-                          <Plus size={14} strokeWidth={1.5} />
-                          <p>New organization</p>
-                        </Link>
-                      </CommandItem>
+                        <Plus size={14} strokeWidth={1.5} />
+                        <p>New organization</p>
+                      </CommandItemLink>
                     </CommandGroup>
                   </>
                 )}

--- a/apps/studio/components/ui/CommandItemLink.test.tsx
+++ b/apps/studio/components/ui/CommandItemLink.test.tsx
@@ -1,0 +1,36 @@
+import { screen, within } from '@testing-library/react'
+import { Command } from 'ui'
+import { describe, expect, it } from 'vitest'
+
+import { CommandItemLink } from './CommandItemLink'
+import { render } from '@/tests/helpers'
+
+describe('CommandItemLink', () => {
+  it('wraps the command item in a link', () => {
+    render(
+      <Command>
+        <CommandItemLink href="/destination">Destination</CommandItemLink>
+      </Command>
+    )
+
+    const link = screen.getByRole('link', { name: 'Destination' })
+    expect(within(link).getByRole('option')).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', '/destination')
+  })
+
+  it('does not render disabled command items as links', () => {
+    render(
+      <Command>
+        <CommandItemLink href="/destination" disabled>
+          Destination
+        </CommandItemLink>
+      </Command>
+    )
+
+    expect(screen.queryByRole('link', { name: 'Destination' })).not.toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Destination' })).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    )
+  })
+})

--- a/apps/studio/components/ui/CommandItemLink.test.tsx
+++ b/apps/studio/components/ui/CommandItemLink.test.tsx
@@ -3,11 +3,11 @@ import { Command } from 'ui'
 import { describe, expect, it } from 'vitest'
 
 import { CommandItemLink } from './CommandItemLink'
-import { render } from '@/tests/helpers'
+import { customRender } from '@/tests/lib/custom-render'
 
 describe('CommandItemLink', () => {
   it('wraps the command item in a link', () => {
-    render(
+    customRender(
       <Command>
         <CommandItemLink href="/destination">Destination</CommandItemLink>
       </Command>
@@ -19,7 +19,7 @@ describe('CommandItemLink', () => {
   })
 
   it('does not render disabled command items as links', () => {
-    render(
+    customRender(
       <Command>
         <CommandItemLink href="/destination" disabled>
           Destination

--- a/apps/studio/components/ui/CommandItemLink.tsx
+++ b/apps/studio/components/ui/CommandItemLink.tsx
@@ -1,0 +1,37 @@
+import Link from 'next/link'
+import type { ComponentProps, ReactNode } from 'react'
+import { cn, CommandItem } from 'ui'
+
+export interface CommandItemLinkProps extends Omit<ComponentProps<typeof CommandItem>, 'children'> {
+  href: ComponentProps<typeof Link>['href']
+  linkProps?: Omit<ComponentProps<typeof Link>, 'children' | 'href'>
+  children: ReactNode
+}
+
+/**
+ * A command item that navigates with native link behaviour.
+ *
+ * The link must wrap the command item. Nesting a link inside a command item can
+ * unmount the link when selection closes its menu before navigation completes.
+ */
+export function CommandItemLink({
+  href,
+  linkProps,
+  children,
+  disabled,
+  ...commandItemProps
+}: CommandItemLinkProps) {
+  const commandItem = (
+    <CommandItem disabled={disabled} {...commandItemProps}>
+      {children}
+    </CommandItem>
+  )
+
+  return disabled ? (
+    commandItem
+  ) : (
+    <Link {...linkProps} href={href} className={cn('block', linkProps?.className)}>
+      {commandItem}
+    </Link>
+  )
+}

--- a/apps/studio/components/ui/DatabaseSelector.tsx
+++ b/apps/studio/components/ui/DatabaseSelector.tsx
@@ -1,8 +1,6 @@
 import { useParams } from 'common'
 import { noop } from 'lodash'
 import { Check, ChevronDown, Loader2, Plus } from 'lucide-react'
-import Link from 'next/link'
-import { useRouter } from 'next/router'
 import { parseAsBoolean, useQueryState } from 'nuqs'
 import { useEffect, useState } from 'react'
 import {
@@ -28,6 +26,7 @@ import {
   getInfrastructurePath,
 } from '@/components/interfaces/Settings/Infrastructure/Infrastructure.utils'
 import { REPLICA_STATUS } from '@/components/interfaces/Settings/Infrastructure/ReadReplicas/ReadReplicas.constants'
+import { CommandItemLink } from '@/components/ui/CommandItemLink'
 import { useReadReplicasQuery } from '@/data/read-replicas/replicas-query'
 import { formatDatabaseID, formatDatabaseRegion } from '@/data/read-replicas/replicas.utils'
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
@@ -55,7 +54,6 @@ export const DatabaseSelector = ({
   className,
   isForm = false,
 }: DatabaseSelectorProps) => {
-  const router = useRouter()
   const { ref: projectRef } = useParams()
   const [open, setOpen] = useState(false)
   const [, setShowConnect] = useQueryState('showConnect', parseAsBoolean.withDefault(false))
@@ -220,27 +218,17 @@ export const DatabaseSelector = ({
 
             {IS_PLATFORM && infrastructureReadReplicas && (
               <CommandGroup className="border-t">
-                <CommandItem
-                  className="cursor-pointer w-full"
+                <CommandItemLink
+                  href={newReplicaURL}
+                  className="cursor-pointer w-full gap-2"
                   onSelect={() => {
                     setOpen(false)
-                    router.push(newReplicaURL)
+                    setShowConnect(false)
                   }}
-                  onClick={() => setOpen(false)}
                 >
-                  <Link
-                    href={newReplicaURL}
-                    onClick={async () => {
-                      setOpen(false)
-                      // [Joshen] This is used in the Connect UI which is available across all pages
-                      setShowConnect(false)
-                    }}
-                    className="w-full flex items-center gap-2"
-                  >
-                    <Plus size={14} strokeWidth={1.5} />
-                    <p>Create a new read replica</p>
-                  </Link>
-                </CommandItem>
+                  <Plus size={14} strokeWidth={1.5} />
+                  <p>Create a new read replica</p>
+                </CommandItemLink>
               </CommandGroup>
             )}
           </CommandList>

--- a/apps/studio/components/ui/FunctionSelector.tsx
+++ b/apps/studio/components/ui/FunctionSelector.tsx
@@ -1,8 +1,6 @@
 import { useParams } from 'common'
 import { uniqBy } from 'lodash'
 import { Check, ChevronsUpDown, Plus } from 'lucide-react'
-import Link from 'next/link'
-import { useRouter } from 'next/router'
 import { useState } from 'react'
 import {
   Alert,
@@ -22,6 +20,7 @@ import {
   ScrollArea,
 } from 'ui'
 
+import { CommandItemLink } from '@/components/ui/CommandItemLink'
 import {
   DatabaseFunctionsData,
   useDatabaseFunctionsQuery,
@@ -56,7 +55,6 @@ const FunctionSelector = ({
   filterFunction = () => true,
   noResultsLabel = <span>No functions found in this schema.</span>,
 }: FunctionSelectorProps) => {
-  const router = useRouter()
   const { ref } = useParams()
   const { data: project } = useSelectedProjectQuery()
   const [open, setOpen] = useState(false)
@@ -164,25 +162,14 @@ const FunctionSelector = ({
                 </CommandGroup>
                 <CommandSeparator />
                 <CommandGroup>
-                  <CommandItem
-                    className="cursor-pointer w-full"
-                    onSelect={() => {
-                      setOpen(false)
-                      router.push(`/project/${ref}/database/functions`)
-                    }}
-                    onClick={() => setOpen(false)}
+                  <CommandItemLink
+                    href={`/project/${ref}/database/functions`}
+                    className="cursor-pointer w-full gap-2"
+                    onSelect={() => setOpen(false)}
                   >
-                    <Link
-                      href={`/project/${ref}/database/functions`}
-                      onClick={() => {
-                        setOpen(false)
-                      }}
-                      className="w-full flex items-center gap-2"
-                    >
-                      <Plus size={14} strokeWidth={1.5} />
-                      <p>New function</p>
-                    </Link>
-                  </CommandItem>
+                    <Plus size={14} strokeWidth={1.5} />
+                    <p>New function</p>
+                  </CommandItemLink>
                 </CommandGroup>
               </CommandList>
             </Command>

--- a/apps/studio/components/ui/OrganizationProjectSelector.tsx
+++ b/apps/studio/components/ui/OrganizationProjectSelector.tsx
@@ -49,6 +49,7 @@ interface OrganizationProjectSelectorSelectorProps {
   }) => ReactNode
   renderActions?: (setOpen: (value: boolean) => void, options?: { embedded?: boolean }) => ReactNode
   onSelect?: (project: OrgProject) => void
+  getItemHref?: (project: OrgProject) => string
   onInitialLoad?: (projects: OrgProject[]) => void
   isOptionDisabled?: (project: OrgProject) => boolean
   fetchOnMount?: boolean
@@ -70,6 +71,7 @@ export const OrganizationProjectSelector = ({
   renderTrigger,
   renderActions,
   onSelect,
+  getItemHref,
   onInitialLoad,
   isOptionDisabled,
   fetchOnMount = false,
@@ -184,6 +186,7 @@ export const OrganizationProjectSelector = ({
           selectedRef={selectedRef ?? undefined}
           onSelect={onSelect}
           onClose={() => setOpen(false)}
+          getItemHref={getItemHref}
           renderRow={renderRow}
           checkPosition={checkPosition}
           isOptionDisabled={isOptionDisabled}
@@ -201,6 +204,7 @@ export const OrganizationProjectSelector = ({
             selectedRef={selectedRef ?? undefined}
             onSelect={onSelect}
             onClose={() => setOpen(false)}
+            href={getItemHref?.(project)}
             renderRow={renderRow}
             checkPosition={checkPosition}
             isOptionDisabled={isOptionDisabled}

--- a/apps/studio/components/ui/OrganizationProjectSelector/EmbeddedProjectList.tsx
+++ b/apps/studio/components/ui/OrganizationProjectSelector/EmbeddedProjectList.tsx
@@ -9,6 +9,7 @@ export interface EmbeddedProjectListProps {
   selectedRef: string | undefined
   onSelect?: (project: OrgProject) => void
   onClose: () => void
+  getItemHref?: (project: OrgProject) => string
   renderRow?: (project: OrgProject) => ReactNode
   checkPosition?: 'right' | 'left'
   isOptionDisabled?: (project: OrgProject) => boolean
@@ -21,6 +22,7 @@ export function EmbeddedProjectList({
   selectedRef,
   onSelect,
   onClose,
+  getItemHref,
   renderRow,
   checkPosition,
   isOptionDisabled,
@@ -36,6 +38,7 @@ export function EmbeddedProjectList({
           selectedRef={selectedRef}
           onSelect={onSelect}
           onClose={onClose}
+          href={getItemHref?.(project)}
           renderRow={renderRow}
           checkPosition={checkPosition}
           isOptionDisabled={isOptionDisabled}

--- a/apps/studio/components/ui/OrganizationProjectSelector/ProjectCommandItem.test.tsx
+++ b/apps/studio/components/ui/OrganizationProjectSelector/ProjectCommandItem.test.tsx
@@ -1,0 +1,32 @@
+import { screen, within } from '@testing-library/react'
+import { Command } from 'ui'
+import { describe, expect, it, vi } from 'vitest'
+
+import { ProjectCommandItem } from './ProjectCommandItem'
+import type { OrgProject } from '@/data/projects/org-projects-infinite-query'
+import { render } from '@/tests/helpers'
+
+const project = {
+  ref: 'project-ref',
+  name: 'Project name',
+  status: 'ACTIVE_HEALTHY',
+} as OrgProject
+
+describe('ProjectCommandItem', () => {
+  it('wraps navigable command items in a link', () => {
+    render(
+      <Command>
+        <ProjectCommandItem
+          project={project}
+          selectedRef={undefined}
+          onClose={vi.fn()}
+          href="/project/project-ref"
+        />
+      </Command>
+    )
+
+    const projectLink = screen.getByRole('link', { name: 'Project name' })
+    expect(within(projectLink).getByRole('option')).toBeInTheDocument()
+    expect(projectLink).toHaveAttribute('href', '/project/project-ref')
+  })
+})

--- a/apps/studio/components/ui/OrganizationProjectSelector/ProjectCommandItem.test.tsx
+++ b/apps/studio/components/ui/OrganizationProjectSelector/ProjectCommandItem.test.tsx
@@ -7,10 +7,16 @@ import type { OrgProject } from '@/data/projects/org-projects-infinite-query'
 import { render } from '@/tests/helpers'
 
 const project = {
+  cloud_provider: 'AWS',
+  databases: [],
+  inserted_at: '2026-08-26T00:00:00.000Z',
+  integration_source: null,
+  is_branch: false,
   ref: 'project-ref',
   name: 'Project name',
+  region: 'ap-southeast-2',
   status: 'ACTIVE_HEALTHY',
-} as OrgProject
+} satisfies OrgProject
 
 describe('ProjectCommandItem', () => {
   it('wraps navigable command items in a link', () => {

--- a/apps/studio/components/ui/OrganizationProjectSelector/ProjectCommandItem.tsx
+++ b/apps/studio/components/ui/OrganizationProjectSelector/ProjectCommandItem.tsx
@@ -1,4 +1,5 @@
 import { Check } from 'lucide-react'
+import Link from 'next/link'
 import { ReactNode } from 'react'
 import { cn, CommandItem } from 'ui'
 
@@ -9,6 +10,7 @@ export interface ProjectCommandItemProps {
   selectedRef: string | undefined
   onSelect?: (project: OrgProject) => void
   onClose: () => void
+  href?: string
   renderRow?: (project: OrgProject) => ReactNode
   checkPosition?: 'right' | 'left'
   isOptionDisabled?: (project: OrgProject) => boolean
@@ -19,6 +21,7 @@ export function ProjectCommandItem({
   selectedRef,
   onSelect,
   onClose,
+  href,
   renderRow,
   checkPosition = 'right',
   isOptionDisabled,
@@ -30,7 +33,7 @@ export function ProjectCommandItem({
 
   const disabled = isOptionDisabled?.(project) ?? false
 
-  return (
+  const item = (
     <CommandItem
       key={project.ref}
       value={`${project.name.replaceAll('"', '')}-${project.ref}`}
@@ -54,5 +57,13 @@ export function ProjectCommandItem({
         </div>
       )}
     </CommandItem>
+  )
+
+  return href && !disabled ? (
+    <Link passHref href={href}>
+      {item}
+    </Link>
+  ) : (
+    item
   )
 }

--- a/apps/studio/components/ui/OrganizationProjectSelector/ProjectCommandItem.tsx
+++ b/apps/studio/components/ui/OrganizationProjectSelector/ProjectCommandItem.tsx
@@ -1,8 +1,8 @@
 import { Check } from 'lucide-react'
-import Link from 'next/link'
 import { ReactNode } from 'react'
 import { cn, CommandItem } from 'ui'
 
+import { CommandItemLink } from '@/components/ui/CommandItemLink'
 import type { OrgProject } from '@/data/projects/org-projects-infinite-query'
 
 export interface ProjectCommandItemProps {
@@ -33,14 +33,8 @@ export function ProjectCommandItem({
 
   const disabled = isOptionDisabled?.(project) ?? false
 
-  const item = (
-    <CommandItem
-      key={project.ref}
-      value={`${project.name.replaceAll('"', '')}-${project.ref}`}
-      className="cursor-pointer w-full"
-      onSelect={handleSelect}
-      disabled={disabled}
-    >
+  const content = (
+    <>
       {renderRow ? (
         renderRow(project)
       ) : (
@@ -56,14 +50,21 @@ export function ProjectCommandItem({
           {checkPosition === 'right' && project.ref === selectedRef && <Check size={16} />}
         </div>
       )}
-    </CommandItem>
+    </>
   )
 
-  return href && !disabled ? (
-    <Link passHref href={href}>
-      {item}
-    </Link>
+  const commandItemProps = {
+    value: `${project.name.replaceAll('"', '')}-${project.ref}`,
+    className: 'cursor-pointer w-full',
+    onSelect: handleSelect,
+    disabled,
+  }
+
+  return href ? (
+    <CommandItemLink href={href} {...commandItemProps}>
+      {content}
+    </CommandItemLink>
   ) : (
-    item
+    <CommandItem {...commandItemProps}>{content}</CommandItem>
   )
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix. Resolves [FE-4192](https://linear.app/supabase/issue/FE-4192/org-and-project-selectors-sometimes-dont-register-selections).

## What is the current behavior?

Navigation actions sometimes nest links inside command or dropdown menu items. Closing the menu during selection can prevent the nested link navigation from registering.

## What is the new behavior?

- Adds a documented Studio CommandItemLink composition that wraps command items with their navigation link.
- Migrates all Studio command-item links, including organisation, project, function, database, branch, and integration actions.
- Uses the dropdown menu asChild composition for both infrastructure-diagram Manage replica actions.
- Preserves native link behaviour and leaves disabled command items non-navigable.

## To test

- [ ] [Organisation and project selectors](https://studio-staging-git-dnywh-fe-4192-selector-links-supabase.vercel.app/dashboard/org): open the organisation selector and try an organisation, All Organizations, and New organization. Open a project, then use the project selector to switch projects and open New project. Confirm every action navigates on the first click.
- [ ] [Branch selector](https://studio-staging-git-dnywh-fe-4192-selector-links-supabase.vercel.app/dashboard/project/_): in a project with branching enabled, open the branch selector. Switch branches and select Manage branches. Confirm both navigate on the first click.
- [ ] [Database selector](https://studio-staging-git-dnywh-fe-4192-selector-links-supabase.vercel.app/dashboard/project/_/observability/query-performance): open the Source selector. Switch between the primary database and a read replica if available, then select Create a new read replica. Confirm selections apply and the footer action navigates on the first click.
- [ ] [Function selector](https://studio-staging-git-dnywh-fe-4192-selector-links-supabase.vercel.app/dashboard/project/_/auth/hooks): select Add a new hook, choose a hook, select Postgres, then open the Postgres function selector and select New function. Confirm it navigates on the first click.
- [ ] [Infrastructure diagram](https://studio-staging-git-dnywh-fe-4192-selector-links-supabase.vercel.app/dashboard/project/_/settings/infrastructure): for a project with a read replica, select Manage replica from both diagram variants. Confirm the replica settings open on the first click.
- [ ] On any navigational row above, modifier-click and confirm native link behaviour is preserved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent link navigation across organization, project, branch, function, replica, and integration menus.
  * Added project-specific destinations to organization and project selectors.
  * Preserved disabled-item behavior while improving accessible command-menu link semantics.

* **Bug Fixes**
  * Improved navigation and menu-closing behavior for command items and dropdown actions.

* **Tests**
  * Added coverage for link destinations, accessibility roles, disabled states, and route preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->