### PR TITLE
chore: allow triggering of restarts for v3 projects

### DIFF
--- a/apps/studio/components/interfaces/Settings/General/Infrastructure/RestartServerButton.tsx
+++ b/apps/studio/components/interfaces/Settings/General/Infrastructure/RestartServerButton.tsx
@@ -20,11 +20,7 @@ import { useProjectRestartMutation } from '@/data/projects/project-restart-mutat
 import { useProjectRestartServicesMutation } from '@/data/projects/project-restart-services-mutation'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
-import {
-  useIsAwsK8sCloudProvider,
-  useIsProjectActive,
-  useSelectedProjectQuery,
-} from '@/hooks/misc/useSelectedProject'
+import { useIsProjectActive, useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { PROJECT_STATUS } from '@/lib/constants'
 import { type ResponseError } from '@/types'
 
@@ -37,7 +33,6 @@ export const RestartServerButton = () => {
   const entityLabel = isBranch ? 'branch' : 'project'
   const entityLabelCapitalized = entityLabel.charAt(0).toUpperCase() + entityLabel.slice(1)
   const canRestart = isProjectActive || project?.status === PROJECT_STATUS.ACTIVE_UNHEALTHY
-  const isAwsK8s = useIsAwsK8sCloudProvider()
   const { setProjectStatus } = useSetProjectStatus()
 
   const [serviceToRestart, setServiceToRestart] = useState<'project' | 'branch' | 'database'>()
@@ -113,11 +108,7 @@ export const RestartServerButton = () => {
               canRestartProject && canRestart ? 'rounded-r-none focus-visible:rounded-r-sm' : ''
             )}
             disabled={
-              project === undefined ||
-              !canRestartProject ||
-              !canRestart ||
-              projectRestartDisabled ||
-              isAwsK8s
+              project === undefined || !canRestartProject || !canRestart || projectRestartDisabled
             }
             onClick={() => setServiceToRestart(entityLabel)}
             tooltip={{
@@ -129,9 +120,7 @@ export const RestartServerButton = () => {
                     ? `You need additional permissions to restart this ${entityLabel}`
                     : !canRestart
                       ? `Unable to restart ${entityLabel} as ${entityLabel} is not active`
-                      : isAwsK8s
-                        ? `${entityLabelCapitalized} restart is not supported for AWS (Revamped) projects`
-                        : undefined,
+                      : undefined,
               },
             }}
           >


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Allowing v3 projects to be restarted.

## What is the current behavior?

The current behaviour greys out the `Restart Project`

## What is the new behavior?

It allows the restart the project:
<img width="675" height="158" alt="Screenshot 2026-08-26 at 12 49 35 PM" src="https://github.com/user-attachments/assets/a80f64d3-9e4d-4b8e-bca2-ec0a6717496c" />



## Additional context
Tested with: https://github.com/supabase/platform/pull/37561

Part of: KUBE-1285

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled server restarts for AWS (Revamped) projects.
  * Updated the restart control so it is no longer disabled or restricted for these projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->