### PR TITLE
feat(studio): add a Secrets section to Workers (FE-4280)

### DIFF
--- a/apps/studio/TANSTACK_MIGRATION.md
+++ b/apps/studio/TANSTACK_MIGRATION.md
@@ -232,6 +232,7 @@ These are the layout-only TanStack files. Most hold a single product layout comp
 
 - [x] A `routes/project/$ref/workers/index.tsx` ← `pages/project/[ref]/workers/index.tsx`
 - [x] A `routes/project/$ref/workers/$name.tsx` ← `pages/project/[ref]/workers/[name].tsx`
+- [x] A `routes/project/$ref/workers/secrets.tsx` ← `pages/project/[ref]/workers/secrets.tsx`
 
 ### Project shell — `/functions/*`
 

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/EdgeFunctionSecrets.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/EdgeFunctionSecrets.tsx
@@ -1,5 +1,5 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { useParams } from 'common'
+import { useFlag, useParams } from 'common'
 import { Search } from 'lucide-react'
 import { parseAsString, useQueryState } from 'nuqs'
 import { useEffect, useMemo, useState } from 'react'
@@ -27,6 +27,7 @@ import { DOCS_URL } from '@/lib/constants'
 
 export const EdgeFunctionSecrets = () => {
   const { ref: projectRef } = useParams()
+  const workersEnabled = useFlag('workers')
   const [searchString, setSearchString] = useState('')
 
   const { can: canReadSecrets, isLoading: isLoadingSecretsPermissions } = useAsyncCheckPermissions(
@@ -231,10 +232,18 @@ export const EdgeFunctionSecrets = () => {
           }
         }}
       >
-        <p className="text-sm">
-          Ensure none of your edge functions are actively using this secret before deleting it. This
-          action cannot be undone.
-        </p>
+        {workersEnabled ? (
+          <p className="text-sm">
+            Ensure none of your <span className="font-medium">edge functions</span> or{' '}
+            <span className="font-medium">workers</span> are actively using this secret before
+            deleting it. This action cannot be undone.
+          </p>
+        ) : (
+          <p className="text-sm">
+            Ensure none of your edge functions are actively using this secret before deleting it.
+            This action cannot be undone.
+          </p>
+        )}
       </ConfirmationModal>
     </>
   )

--- a/apps/studio/components/layouts/WorkersLayout/WorkersLayout.tsx
+++ b/apps/studio/components/layouts/WorkersLayout/WorkersLayout.tsx
@@ -26,6 +26,12 @@ const useGenerateWorkersMenu = (): ProductMenuGroup[] => {
             url: `/project/${projectRef}/workers`,
             items: [],
           },
+          {
+            name: 'Secrets',
+            key: 'secrets',
+            url: `/project/${projectRef}/workers/secrets`,
+            items: [],
+          },
         ],
       },
     ],

--- a/apps/studio/pages/project/[ref]/workers/secrets.tsx
+++ b/apps/studio/pages/project/[ref]/workers/secrets.tsx
@@ -1,0 +1,104 @@
+import type { PropsWithChildren } from 'react'
+import { Admonition } from 'ui-patterns/Admonition'
+import { PageContainer } from 'ui-patterns/PageContainer'
+import {
+  PageHeader,
+  PageHeaderDescription,
+  PageHeaderMeta,
+  PageHeaderSummary,
+  PageHeaderTitle,
+} from 'ui-patterns/PageHeader'
+import { PageSection, PageSectionContent } from 'ui-patterns/PageSection'
+
+import { DefaultEdgeFunctionSecrets } from '@/components/interfaces/Functions/EdgeFunctionSecrets/DefaultEdgeFunctionSecrets'
+import { DEFAULT_EDGE_FUNCTION_SECRETS } from '@/components/interfaces/Functions/EdgeFunctionSecrets/DefaultEdgeFunctionSecrets.utils'
+// Secrets are project-level, so workers read the same values as Edge Functions; this page
+// is a separate entry point into that shared list, not a separate store.
+import { EdgeFunctionSecrets } from '@/components/interfaces/Functions/EdgeFunctionSecrets/EdgeFunctionSecrets'
+import { DefaultLayout } from '@/components/layouts/DefaultLayout'
+import { WorkersLayout } from '@/components/layouts/WorkersLayout/WorkersLayout'
+import { DocsButton } from '@/components/ui/DocsButton'
+import { useDeploymentMode } from '@/hooks/misc/useDeploymentMode'
+import { DOCS_URL, IS_PLATFORM } from '@/lib/constants'
+import type { NextPageWithLayout } from '@/types'
+
+const WorkerSecretsPage: NextPageWithLayout = () => {
+  const { isCli, isSelfHosted } = useDeploymentMode()
+
+  if (!IS_PLATFORM) {
+    return (
+      <PageContainer size="large">
+        <PageSection>
+          <PageSectionContent className="space-y-4 md:space-y-8">
+            {isCli && (
+              <Admonition
+                type="default"
+                title="Local development with the Supabase CLI"
+                description={<p>Add custom secrets from the Supabase CLI.</p>}
+              />
+            )}
+            {isSelfHosted && (
+              <Admonition
+                type="default"
+                title="Self-hosted Supabase"
+                description={<p>Set custom secrets via environment variables.</p>}
+              />
+            )}
+            <section className="space-y-4">
+              <div className="flex flex-col md:flex-row md:items-center justify-between gap-2">
+                <div className="space-y-1">
+                  <h3 className="text-foreground text-base">Default secrets</h3>
+                  <p className="text-sm text-foreground-light">
+                    Reserved secrets available in every project
+                  </p>
+                </div>
+                <DocsButton href={`${DOCS_URL}/guides/functions/secrets#default-secrets`} />
+              </div>
+              <DefaultEdgeFunctionSecrets
+                secrets={DEFAULT_EDGE_FUNCTION_SECRETS.filter((secret) => !secret.isRuntime)}
+              />
+            </section>
+          </PageSectionContent>
+        </PageSection>
+      </PageContainer>
+    )
+  }
+
+  return (
+    <PageContainer size="large">
+      <PageSection>
+        <PageSectionContent className="space-y-4 md:space-y-8">
+          <EdgeFunctionSecrets />
+        </PageSectionContent>
+      </PageSection>
+    </PageContainer>
+  )
+}
+
+// Hoisted out of `getLayout` so the TanStack route can import it directly.
+export const WorkerSecretsPageWrapper = ({ children }: PropsWithChildren) => (
+  <div className="w-full min-h-full flex flex-col items-stretch">
+    <PageHeader size="large">
+      <PageHeaderMeta>
+        <PageHeaderSummary>
+          <PageHeaderTitle>Secrets</PageHeaderTitle>
+          <PageHeaderDescription>
+            Environment variables loaded into every worker at start-up
+          </PageHeaderDescription>
+        </PageHeaderSummary>
+      </PageHeaderMeta>
+    </PageHeader>
+
+    {children}
+  </div>
+)
+
+WorkerSecretsPage.getLayout = (page) => (
+  <DefaultLayout>
+    <WorkersLayout title="Secrets">
+      <WorkerSecretsPageWrapper>{page}</WorkerSecretsPageWrapper>
+    </WorkersLayout>
+  </DefaultLayout>
+)
+
+export default WorkerSecretsPage

--- a/apps/studio/pages/project/[ref]/workers/secrets.tsx
+++ b/apps/studio/pages/project/[ref]/workers/secrets.tsx
@@ -68,6 +68,10 @@ const WorkerSecretsPage: NextPageWithLayout = () => {
     <PageContainer size="large">
       <PageSection>
         <PageSectionContent className="space-y-4 md:space-y-8">
+          <Admonition
+            type="default"
+            title="Secrets are shared between Edge Functions and Workers"
+          />
           <EdgeFunctionSecrets />
         </PageSectionContent>
       </PageSection>

--- a/apps/studio/routeTree.gen.ts
+++ b/apps/studio/routeTree.gen.ts
@@ -100,6 +100,7 @@ import { Route as ApiPlatformProfileIndexRouteImport } from './routes/api/platfo
 import { Route as ApiPlatformOrganizationsIndexRouteImport } from './routes/api/platform/organizations/index'
 import { Route as AppOrgSlugIndexRouteImport } from './routes/_app/org/$slug/index'
 import { Route as AppAccountTokensIndexRouteImport } from './routes/_app/account/tokens/index'
+import { Route as ProjectRefWorkersSecretsRouteImport } from './routes/project/$ref/workers/secrets'
 import { Route as ProjectRefWorkersNameRouteImport } from './routes/project/$ref/workers/$name'
 import { Route as ProjectRefStorageS3RouteImport } from './routes/project/$ref/storage/s3'
 import { Route as ProjectRefSqlTemplatesRouteImport } from './routes/project/$ref/sql/templates'
@@ -794,6 +795,12 @@ const AppAccountTokensIndexRoute = AppAccountTokensIndexRouteImport.update({
   path: '/tokens/',
   getParentRoute: () => AppAccountRoute,
 } as any)
+const ProjectRefWorkersSecretsRoute =
+  ProjectRefWorkersSecretsRouteImport.update({
+    id: '/secrets',
+    path: '/secrets',
+    getParentRoute: () => ProjectRefWorkersRoute,
+  } as any)
 const ProjectRefWorkersNameRoute = ProjectRefWorkersNameRouteImport.update({
   id: '/$name',
   path: '/$name',
@@ -2277,6 +2284,7 @@ export interface FileRoutesByFullPath {
   '/project/$ref/sql/templates': typeof ProjectRefSqlTemplatesRoute
   '/project/$ref/storage/s3': typeof ProjectRefStorageS3Route
   '/project/$ref/workers/$name': typeof ProjectRefWorkersNameRoute
+  '/project/$ref/workers/secrets': typeof ProjectRefWorkersSecretsRoute
   '/account/tokens/': typeof AppAccountTokensIndexRoute
   '/org/$slug/': typeof AppOrgSlugIndexRoute
   '/api/platform/organizations/': typeof ApiPlatformOrganizationsIndexRoute
@@ -2580,6 +2588,7 @@ export interface FileRoutesByTo {
   '/project/$ref/sql/templates': typeof ProjectRefSqlTemplatesRoute
   '/project/$ref/storage/s3': typeof ProjectRefStorageS3Route
   '/project/$ref/workers/$name': typeof ProjectRefWorkersNameRoute
+  '/project/$ref/workers/secrets': typeof ProjectRefWorkersSecretsRoute
   '/account/tokens': typeof AppAccountTokensIndexRoute
   '/org/$slug': typeof AppOrgSlugIndexRoute
   '/api/platform/organizations': typeof ApiPlatformOrganizationsIndexRoute
@@ -2900,6 +2909,7 @@ export interface FileRoutesById {
   '/project/$ref/sql/templates': typeof ProjectRefSqlTemplatesRoute
   '/project/$ref/storage/s3': typeof ProjectRefStorageS3Route
   '/project/$ref/workers/$name': typeof ProjectRefWorkersNameRoute
+  '/project/$ref/workers/secrets': typeof ProjectRefWorkersSecretsRoute
   '/_app/account/tokens/': typeof AppAccountTokensIndexRoute
   '/_app/org/$slug/': typeof AppOrgSlugIndexRoute
   '/api/platform/organizations/': typeof ApiPlatformOrganizationsIndexRoute
@@ -3219,6 +3229,7 @@ export interface FileRouteTypes {
     | '/project/$ref/sql/templates'
     | '/project/$ref/storage/s3'
     | '/project/$ref/workers/$name'
+    | '/project/$ref/workers/secrets'
     | '/account/tokens/'
     | '/org/$slug/'
     | '/api/platform/organizations/'
@@ -3522,6 +3533,7 @@ export interface FileRouteTypes {
     | '/project/$ref/sql/templates'
     | '/project/$ref/storage/s3'
     | '/project/$ref/workers/$name'
+    | '/project/$ref/workers/secrets'
     | '/account/tokens'
     | '/org/$slug'
     | '/api/platform/organizations'
@@ -3841,6 +3853,7 @@ export interface FileRouteTypes {
     | '/project/$ref/sql/templates'
     | '/project/$ref/storage/s3'
     | '/project/$ref/workers/$name'
+    | '/project/$ref/workers/secrets'
     | '/_app/account/tokens/'
     | '/_app/org/$slug/'
     | '/api/platform/organizations/'
@@ -4743,6 +4756,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/account/tokens/'
       preLoaderRoute: typeof AppAccountTokensIndexRouteImport
       parentRoute: typeof AppAccountRoute
+    }
+    '/project/$ref/workers/secrets': {
+      id: '/project/$ref/workers/secrets'
+      path: '/secrets'
+      fullPath: '/project/$ref/workers/secrets'
+      preLoaderRoute: typeof ProjectRefWorkersSecretsRouteImport
+      parentRoute: typeof ProjectRefWorkersRoute
     }
     '/project/$ref/workers/$name': {
       id: '/project/$ref/workers/$name'
@@ -6948,11 +6968,13 @@ const ProjectRefStorageRouteWithChildren =
 
 interface ProjectRefWorkersRouteChildren {
   ProjectRefWorkersNameRoute: typeof ProjectRefWorkersNameRoute
+  ProjectRefWorkersSecretsRoute: typeof ProjectRefWorkersSecretsRoute
   ProjectRefWorkersIndexRoute: typeof ProjectRefWorkersIndexRoute
 }
 
 const ProjectRefWorkersRouteChildren: ProjectRefWorkersRouteChildren = {
   ProjectRefWorkersNameRoute: ProjectRefWorkersNameRoute,
+  ProjectRefWorkersSecretsRoute: ProjectRefWorkersSecretsRoute,
   ProjectRefWorkersIndexRoute: ProjectRefWorkersIndexRoute,
 }
 

--- a/apps/studio/routes/project/$ref/workers/secrets.tsx
+++ b/apps/studio/routes/project/$ref/workers/secrets.tsx
@@ -1,0 +1,18 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import WorkerSecretsPage, { WorkerSecretsPageWrapper } from '@/pages/project/[ref]/workers/secrets'
+
+export const Route = createFileRoute('/project/$ref/workers/secrets')({
+  component: WorkerSecretsRoute,
+  staticData: {
+    workersLayoutTitle: 'Secrets',
+  },
+})
+
+function WorkerSecretsRoute() {
+  return (
+    <WorkerSecretsPageWrapper>
+      <WorkerSecretsPage dehydratedState={undefined} />
+    </WorkerSecretsPageWrapper>
+  )
+}


### PR DESCRIPTION
## What

A Secrets section for Workers (FE-4280), so secrets are viewable without detouring to Edge Functions. Base: #49242.

- **Nav** — a "Secrets" item under the Workers product menu, next to the worker list
- **Page** at `/project/[ref]/workers/secrets`, header copy "Environment variables loaded into every worker at start-up"
- **Route** + `routeTree.gen.ts` regenerated, plus the `TANSTACK_MIGRATION.md` entry

Gated by `WorkersLayout` (flag + permission), same as the rest of the product.

## Duplicated page, shared data

Per the ticket, this is the duplicated-page approach — a second entry point, not a second store. Secrets are project-level (`/v1/projects/{ref}/secrets`), so the page reuses the existing `EdgeFunctionSecrets` / `DefaultEdgeFunctionSecrets` components rather than forking ~400 lines of secret CRUD. Workers and Edge Functions read and write the same list. The longer-term direction (a shared Compute-level Secrets section) is out of scope here.

## How to test

Needs the `workers` flag on.

1. Project with the flag → **Workers** in the sidebar → **Secrets** appears under it
2. Open it → default secrets table + custom secrets, identical to Edge Functions → Secrets
3. Add/edit/delete a secret here; confirm it shows on the Edge Functions Secrets page too (same project secrets)

## Note

Two strings inside the reused `EdgeFunctionSecrets` component still say "edge function secrets" (the no-permission messages). Left as-is to avoid refactoring shared Edge Functions code in a private-alpha duplicated page; they'd be resolved by the eventual shared Compute-level section. Flagging in case reviewers want them parameterized now.

No new tests: the page composes already-tested components and the nav is a data literal, matching how the Edge Functions Secrets page itself is covered.

Closes FE-4280
