### PR TITLE
feat(www): publish machine-readable pricing.json

### DIFF
--- a/.github/workflows/www-tests.yml
+++ b/.github/workflows/www-tests.yml
@@ -10,6 +10,8 @@ on:
       - 'apps/www/lib/**/*.js'
       - 'apps/www/content/md/**'
       - 'apps/www/scripts/**/*.mjs'
+      - 'apps/www/data/**'
+      - 'packages/shared-data/**'
 
 # Cancel old builds on new commit for same workflow + branch/PR
 concurrency:

--- a/apps/www/app/llms.txt/route.ts
+++ b/apps/www/app/llms.txt/route.ts
@@ -93,6 +93,7 @@ export async function GET() {
     '## Pricing',
     '',
     '- [Supabase Pricing](https://supabase.com/pricing.md)',
+    '- [Supabase Pricing (structured JSON)](https://supabase.com/pricing.json)',
   ].join('\n')
 
   return new Response(content, {

--- a/apps/www/app/pricing.json/route.ts
+++ b/apps/www/app/pricing.json/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server'
+
+import { buildPricingJson } from '@/lib/pricing-json'
+
+export const dynamic = 'force-dynamic'
+
+const PRICING_JSON_HEADERS = {
+  'Content-Type': 'application/json; charset=utf-8',
+  'X-Content-Type-Options': 'nosniff',
+  'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
+}
+
+export async function GET() {
+  return NextResponse.json(buildPricingJson(), { headers: PRICING_JSON_HEADERS })
+}

--- a/apps/www/components/Pricing/PricingAddons.tsx
+++ b/apps/www/components/Pricing/PricingAddons.tsx
@@ -5,6 +5,7 @@ import { useTheme } from 'next-themes'
 import Image from 'next/image'
 import Link from 'next/link'
 import { FC } from 'react'
+import { ADDONS, usd } from 'shared-data/pricing-catalog'
 import { Button, cn } from 'ui'
 
 import CostControlAnimation from './CostControlAnimation'
@@ -26,7 +27,7 @@ const addons = [
     name: 'Custom Domain',
     heroImg: 'custom-domain-on',
     icon: 'custom-domain-upgrade',
-    price: 'Flat fee $10/month',
+    price: `Flat fee ${usd(ADDONS.customDomain.priceMonthlyPerDomain)}/month`,
     description:
       'Use your own domain for your Supabase project to present a branded experience to your users.',
     ctaText: 'Documentation',
@@ -38,7 +39,7 @@ const addons = [
     name: 'Point in Time Recovery',
     heroImg: 'pitr-on',
     icon: 'pitr-upgrade',
-    price: 'Starts from $100/month',
+    price: `Starts from ${usd(ADDONS.pitr.priceMonthlyPer7DaysRetention)}/month`,
     description: 'Roll back to any specific point in time, down to the second.',
     ctaText: 'Documentation',
     ctaLink: 'https://supabase.com/docs/guides/platform/backups',

--- a/apps/www/components/Pricing/PricingComputeSection.tsx
+++ b/apps/www/components/Pricing/PricingComputeSection.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import React, { useEffect, useRef, useState } from 'react'
 import { useWindowSize } from 'react-use'
 import { plans as allPlans } from 'shared-data/plans'
+import { PLAN_BILLING, usd } from 'shared-data/pricing-catalog'
 import { Button, cn } from 'ui'
 import { ToggleGroup, ToggleGroupItem } from 'ui/src/components/shadcn/ui/toggle-group'
 
@@ -98,7 +99,7 @@ const PricingComputeSection = () => {
                 </>
               )}
               <p className="text-foreground-lighter text-xs mt-2">
-                Paid plans include $10/mo in compute credits, enough to cover one Micro instance.
+                {`Paid plans include ${usd(PLAN_BILLING.pro.computeCreditsMonthly)}/mo in compute credits, enough to cover one Micro instance.`}
               </p>
             </div>
           </div>

--- a/apps/www/components/Pricing/PricingDiskSection.tsx
+++ b/apps/www/components/Pricing/PricingDiskSection.tsx
@@ -1,28 +1,26 @@
-import { Button } from 'ui'
-import Panel from '../Panel'
-import Link from 'next/link'
 import { ArrowUpRight } from 'lucide-react'
+import Link from 'next/link'
+import { DISK_PRICING, qty, usd } from 'shared-data/pricing-catalog'
+import { Button } from 'ui'
 
-const diskTypes = [
-  {
-    name: 'General Purpose',
-    tagline: 'Balance between price and performance',
-    maxSize: '16 TB',
-    size: '8 GB included\nthen $0.125 per GB',
-    iops: '3,000 IOPS included\nthen $0.024 per IOPS',
-    throughput: '125 MB/s included\nthen $0.095 per MB/s',
-    durability: '99.9%',
-  },
-  {
-    name: 'High Performance',
-    tagline: 'For mission critical applications',
-    maxSize: '60 TB',
-    size: '$0.195 per GB',
-    iops: '$0.119 per IOPS',
-    throughput: 'Scales automatically with IOPS',
-    durability: '99.999%',
-  },
-]
+import Panel from '../Panel'
+
+const diskTypes = Object.values(DISK_PRICING).map((disk) => ({
+  name: disk.displayName,
+  tagline: disk.tagline,
+  maxSize: `${disk.maxSizeTb} TB`,
+  size: disk.includedPerProject
+    ? `${disk.includedPerProject.sizeGb} GB included\nthen ${usd(disk.perUnitMonth.sizeGb)} per GB`
+    : `${usd(disk.perUnitMonth.sizeGb)} per GB`,
+  iops: disk.includedPerProject
+    ? `${qty(disk.includedPerProject.iops, 'comma')} IOPS included\nthen ${usd(disk.perUnitMonth.iops)} per IOPS`
+    : `${usd(disk.perUnitMonth.iops)} per IOPS`,
+  throughput:
+    disk.includedPerProject && disk.perUnitMonth.throughputMBps !== null
+      ? `${disk.includedPerProject.throughputMBps} MB/s included\nthen ${usd(disk.perUnitMonth.throughputMBps)} per MB/s`
+      : (disk.throughputNote ?? ''),
+  durability: `${disk.durabilityPercent}%`,
+}))
 
 const PricingDiskSection = () => (
   <div>

--- a/apps/www/components/Pricing/PricingDiskSection.tsx
+++ b/apps/www/components/Pricing/PricingDiskSection.tsx
@@ -18,7 +18,9 @@ const diskTypes = Object.values(DISK_PRICING).map((disk) => ({
   throughput:
     disk.includedPerProject && disk.perUnitMonth.throughputMBps !== null
       ? `${disk.includedPerProject.throughputMBps} MB/s included\nthen ${usd(disk.perUnitMonth.throughputMBps)} per MB/s`
-      : (disk.throughputNote ?? ''),
+      : 'throughputNote' in disk
+        ? disk.throughputNote
+        : '',
   durability: `${disk.durabilityPercent}%`,
 }))
 

--- a/apps/www/lib/llms.test.ts
+++ b/apps/www/lib/llms.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+
+import { generatePricingContent } from './llms'
+
+describe('generatePricingContent', () => {
+  it('builds without throwing and carries the derived billing example', () => {
+    let content = ''
+    expect(() => {
+      content = generatePricingContent()
+    }).not.toThrow()
+    expect(content).toContain('in compute credits')
+    expect(content).toContain('## Disk Storage')
+    expect(content).toContain('Structured pricing data (JSON): https://supabase.com/pricing.json')
+  })
+})

--- a/apps/www/lib/llms.ts
+++ b/apps/www/lib/llms.ts
@@ -1,8 +1,10 @@
 import { plans } from 'shared-data/plans'
 import { pricing } from 'shared-data/pricing'
+import { DISK_PRICING, PLAN_BILLING, qty, usd } from 'shared-data/pricing-catalog'
 
 import addOnTable from '@/data/PricingAddOnTable.json'
 import pricingFaq from '@/data/PricingFAQ.json'
+import { getColumnValue, parseUsdString } from '@/lib/pricing-json'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -27,12 +29,6 @@ function formatPlanValue(val: boolean | string | string[]): string {
 
 function pad(str: string, len: number): string {
   return str.padEnd(len)
-}
-
-function getColumnValue(row: { columns: { key: string; value: unknown }[] }, key: string): unknown {
-  const col = row.columns.find((c) => c.key === key)
-  if (!col) throw new Error(`Missing column "${key}"`)
-  return col.value
 }
 
 // ---------------------------------------------------------------------------
@@ -118,7 +114,7 @@ function buildComputeSection(): string {
     separator,
     ...bodyRows,
     '',
-    'Compute is billed hourly. Each project runs its own instance. Pro and Team plans include $10/month in compute credits (covers one Micro instance). Additional projects add their full compute cost.',
+    `Compute is billed hourly. Each project runs its own instance. Pro and Team plans include ${usd(PLAN_BILLING.pro.computeCreditsMonthly)}/month in compute credits (covers one Micro instance). Additional projects add their full compute cost.`,
     '',
   ].join('\n')
 }
@@ -127,39 +123,39 @@ function buildComputeSection(): string {
 // Disk Storage
 // ---------------------------------------------------------------------------
 
-const DISK_TYPES = [
-  {
-    name: 'General Purpose',
-    maxSize: '16 TB',
-    size: '8 GB included, then $0.125 per GB',
-    iops: '3,000 IOPS included, then $0.024 per IOPS',
-    throughput: '125 MB/s included, then $0.095 per MB/s',
-    durability: '99.9%',
-  },
-  {
-    name: 'High Performance',
-    maxSize: '60 TB',
-    size: '$0.195 per GB',
-    iops: '$0.119 per IOPS',
-    throughput: 'Scales automatically with IOPS',
-    durability: '99.999%',
-  },
-]
-
 function buildDiskSection(): string {
-  const lines: string[] = ['## Disk Storage', '']
+  const headers = ['Disk type', 'Max size', 'Size', 'IOPS', 'Throughput', 'Durability']
 
-  for (const disk of DISK_TYPES) {
-    lines.push(`### ${disk.name}`)
-    lines.push(`- Max size: ${disk.maxSize}`)
-    lines.push(`- Size: ${disk.size}`)
-    lines.push(`- IOPS: ${disk.iops}`)
-    lines.push(`- Throughput: ${disk.throughput}`)
-    lines.push(`- Durability: ${disk.durability}`)
-    lines.push('')
-  }
+  const dataRows = Object.values(DISK_PRICING).map((disk) => {
+    const size = disk.includedPerProject
+      ? `${disk.includedPerProject.sizeGb} GB included, then ${usd(disk.perUnitMonth.sizeGb)} per GB`
+      : `${usd(disk.perUnitMonth.sizeGb)} per GB`
+    const iops = disk.includedPerProject
+      ? `${qty(disk.includedPerProject.iops, 'comma')} IOPS included, then ${usd(disk.perUnitMonth.iops)} per IOPS`
+      : `${usd(disk.perUnitMonth.iops)} per IOPS`
+    const throughput =
+      disk.includedPerProject && disk.perUnitMonth.throughputMBps !== null
+        ? `${qty(disk.includedPerProject.throughputMBps)} MB/s included, then ${usd(disk.perUnitMonth.throughputMBps)} per MB/s`
+        : (disk.throughputNote ?? '')
 
-  return lines.join('\n')
+    return [
+      `${disk.displayName} (${disk.type})`,
+      `${disk.maxSizeTb} TB`,
+      size,
+      iops,
+      throughput,
+      `${disk.durabilityPercent}%`,
+    ]
+  })
+
+  const widths = headers.map((h, i) => Math.max(h.length, ...dataRows.map((r) => r[i].length)))
+  const headerRow = `| ${headers.map((h, i) => pad(h, widths[i])).join(' | ')} |`
+  const separator = `| ${widths.map((w) => '-'.repeat(w)).join(' | ')} |`
+  const bodyRows = dataRows.map(
+    (cells) => `| ${cells.map((c, i) => pad(c, widths[i])).join(' | ')} |`
+  )
+
+  return ['## Disk Storage', '', headerRow, separator, ...bodyRows, ''].join('\n')
 }
 
 // ---------------------------------------------------------------------------
@@ -259,6 +255,17 @@ function buildFAQSection(): string {
   return lines.join('\n')
 }
 
+function buildBillingExample(): string {
+  const proPrice = PLAN_BILLING.pro.priceMonthly
+  const credits = PLAN_BILLING.pro.computeCreditsMonthly
+  const microRow = addOnTable.database.rows.find((row) => getColumnValue(row, 'plan') === 'Micro')
+  if (!microRow) throw new Error('Missing Micro row in PricingAddOnTable')
+  const microPrice = parseUsdString(String(getColumnValue(microRow, 'pricing')))
+  const exampleTotal = proPrice + 2 * microPrice - credits
+
+  return `Pro and Team plans include ${usd(credits)}/month in compute credits, which covers one Micro instance. Additional projects each add their own compute cost. For example, a Pro org with 2 projects on Micro compute costs: ${usd(proPrice)} (plan) + ${usd(microPrice)} (project 1) + ${usd(microPrice)} (project 2) - ${usd(credits)} (credits) = ${usd(exampleTotal)}/month.`
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -275,9 +282,11 @@ export function generatePricingContent(): string {
     '',
     'Supabase uses organization-based billing. You choose a plan (Pro, Team, or Enterprise) for your organization, then each project within it runs on its own compute instance. The plan subscription covers platform features and usage quotas. Compute is billed separately per project.',
     '',
-    'Pro and Team plans include $10/month in compute credits, which covers one Micro instance. Additional projects each add their own compute cost. For example, a Pro org with 2 projects on Micro compute costs: $25 (plan) + $10 (project 1) + $10 (project 2) - $10 (credits) = $35/month.',
+    buildBillingExample(),
     '',
     'For current pricing, visit https://supabase.com/pricing.',
+    '',
+    'Structured pricing data (JSON): https://supabase.com/pricing.json',
     '',
     buildPlanTiersSection(),
     buildComputeSection(),

--- a/apps/www/lib/llms.ts
+++ b/apps/www/lib/llms.ts
@@ -136,7 +136,9 @@ function buildDiskSection(): string {
     const throughput =
       disk.includedPerProject && disk.perUnitMonth.throughputMBps !== null
         ? `${qty(disk.includedPerProject.throughputMBps)} MB/s included, then ${usd(disk.perUnitMonth.throughputMBps)} per MB/s`
-        : (disk.throughputNote ?? '')
+        : 'throughputNote' in disk
+          ? disk.throughputNote
+          : ''
 
     return [
       `${disk.displayName} (${type})`,

--- a/apps/www/lib/llms.ts
+++ b/apps/www/lib/llms.ts
@@ -31,6 +31,16 @@ function pad(str: string, len: number): string {
   return str.padEnd(len)
 }
 
+function buildMarkdownTable(headers: string[], dataRows: string[][]): string[] {
+  const widths = headers.map((h, i) => Math.max(h.length, ...dataRows.map((r) => r[i].length)))
+  const headerRow = `| ${headers.map((h, i) => pad(h, widths[i])).join(' | ')} |`
+  const separator = `| ${widths.map((w) => '-'.repeat(w)).join(' | ')} |`
+  const bodyRows = dataRows.map(
+    (cells) => `| ${cells.map((c, i) => pad(c, widths[i])).join(' | ')} |`
+  )
+  return [headerRow, separator, ...bodyRows]
+}
+
 // ---------------------------------------------------------------------------
 // Plan Tiers
 // ---------------------------------------------------------------------------
@@ -97,22 +107,12 @@ function buildComputeSection(): string {
     })
   )
 
-  const widths = headers.map((h, i) => Math.max(h.length, ...dataRows.map((r) => r[i].length)))
-
-  const headerRow = `| ${headers.map((h, i) => pad(h, widths[i])).join(' | ')} |`
-  const separator = `| ${widths.map((w) => '-'.repeat(w)).join(' | ')} |`
-  const bodyRows = dataRows.map(
-    (cells) => `| ${cells.map((c, i) => pad(c, widths[i])).join(' | ')} |`
-  )
-
   return [
     '## Compute Add-Ons',
     '',
     'All projects run on a compute instance. Pro and Team plans include Micro compute in the base price.',
     '',
-    headerRow,
-    separator,
-    ...bodyRows,
+    ...buildMarkdownTable(headers, dataRows),
     '',
     `Compute is billed hourly. Each project runs its own instance. Pro and Team plans include ${usd(PLAN_BILLING.pro.computeCreditsMonthly)}/month in compute credits (covers one Micro instance). Additional projects add their full compute cost.`,
     '',
@@ -126,7 +126,7 @@ function buildComputeSection(): string {
 function buildDiskSection(): string {
   const headers = ['Disk type', 'Max size', 'Size', 'IOPS', 'Throughput', 'Durability']
 
-  const dataRows = Object.values(DISK_PRICING).map((disk) => {
+  const dataRows = Object.entries(DISK_PRICING).map(([type, disk]) => {
     const size = disk.includedPerProject
       ? `${disk.includedPerProject.sizeGb} GB included, then ${usd(disk.perUnitMonth.sizeGb)} per GB`
       : `${usd(disk.perUnitMonth.sizeGb)} per GB`
@@ -139,7 +139,7 @@ function buildDiskSection(): string {
         : (disk.throughputNote ?? '')
 
     return [
-      `${disk.displayName} (${disk.type})`,
+      `${disk.displayName} (${type})`,
       `${disk.maxSizeTb} TB`,
       size,
       iops,
@@ -148,14 +148,7 @@ function buildDiskSection(): string {
     ]
   })
 
-  const widths = headers.map((h, i) => Math.max(h.length, ...dataRows.map((r) => r[i].length)))
-  const headerRow = `| ${headers.map((h, i) => pad(h, widths[i])).join(' | ')} |`
-  const separator = `| ${widths.map((w) => '-'.repeat(w)).join(' | ')} |`
-  const bodyRows = dataRows.map(
-    (cells) => `| ${cells.map((c, i) => pad(c, widths[i])).join(' | ')} |`
-  )
-
-  return ['## Disk Storage', '', headerRow, separator, ...bodyRows, ''].join('\n')
+  return ['## Disk Storage', '', ...buildMarkdownTable(headers, dataRows), ''].join('\n')
 }
 
 // ---------------------------------------------------------------------------
@@ -192,16 +185,7 @@ function buildAddOnsSection(): string {
     ],
   ]
 
-  const nameWidth = Math.max('Add-on'.length, ...addOns.map(([n]) => n.length))
-  const priceWidth = Math.max('Price'.length, ...addOns.map(([, p]) => p.length))
-
-  const header = `| ${pad('Add-on', nameWidth)} | ${pad('Price', priceWidth)} |`
-  const separator = `| ${'-'.repeat(nameWidth)} | ${'-'.repeat(priceWidth)} |`
-  const rows = addOns.map(
-    ([name, price]) => `| ${pad(name, nameWidth)} | ${pad(price, priceWidth)} |`
-  )
-
-  return ['## Add-Ons', '', header, separator, ...rows, ''].join('\n')
+  return ['## Add-Ons', '', ...buildMarkdownTable(['Add-on', 'Price'], addOns), ''].join('\n')
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/www/lib/pricing-json.test.ts
+++ b/apps/www/lib/pricing-json.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildPricingJson, parseUsdString } from './pricing-json'
+
+describe('parseUsdString', () => {
+  it('parses plain dollar amounts', () => {
+    expect(parseUsdString('$10')).toBe(10)
+    expect(parseUsdString('$1,870')).toBe(1870)
+    expect(parseUsdString('$0.024')).toBe(0.024)
+  })
+
+  it('throws on anything that is not a bare dollar amount', () => {
+    expect(() => parseUsdString('Contact Us')).toThrow('Unparseable price')
+    expect(() => parseUsdString('10')).toThrow('Unparseable price')
+    expect(() => parseUsdString('$10/mo')).toThrow('Unparseable price')
+    expect(() => parseUsdString('')).toThrow('Unparseable price')
+  })
+})
+
+describe('buildPricingJson', () => {
+  const payload = buildPricingJson()
+  const planKeys = ['free', 'pro', 'team', 'enterprise']
+
+  it('declares itself informational', () => {
+    expect(payload.description).toContain('not a billing API')
+    expect(payload.source).toBe('https://supabase.com/pricing')
+    expect(payload.currency).toBe('USD')
+  })
+
+  it('covers all four plans with billing semantics', () => {
+    expect(payload.plans.map((p) => p.id)).toEqual(planKeys)
+    for (const plan of payload.plans) {
+      expect(typeof plan.spendCapAvailable).toBe('boolean')
+      if (plan.id === 'enterprise') {
+        expect(plan.priceMonthly).toBeNull()
+        expect(plan.contactSales).toBe(true)
+      } else {
+        expect(Number.isFinite(plan.priceMonthly)).toBe(true)
+      }
+    }
+  })
+
+  it('parses every compute tier with numeric prices', () => {
+    expect(payload.compute.tiers.length).toBeGreaterThanOrEqual(10)
+    const contactTiers = payload.compute.tiers.filter((t) => t.contactSales)
+    expect(contactTiers).toHaveLength(1)
+    for (const tier of payload.compute.tiers) {
+      if (tier.contactSales) {
+        expect(tier.priceMonthly).toBeNull()
+        continue
+      }
+      expect(Number.isFinite(tier.priceMonthly)).toBe(true)
+      expect(tier.priceMonthly!).toBeGreaterThan(0)
+      expect(Number.isFinite(tier.memoryGb)).toBe(true)
+      expect(Number.isFinite(tier.connectionsDirect)).toBe(true)
+      expect(Number.isFinite(tier.connectionsPooler)).toBe(true)
+    }
+  })
+
+  it('carries exactly the gp3 and io2 disk types with numeric rates', () => {
+    expect(payload.disk.types.map((d) => d.type)).toEqual(['gp3', 'io2'])
+    const gp3 = payload.disk.types[0]
+    expect(gp3.includedPerProject).toEqual({ sizeGb: 8, iops: 3000, throughputMBps: 125 })
+    expect(gp3.perUnitMonth.iops).toBeGreaterThan(0)
+    expect(gp3.perUnitMonth.throughputMBps).toBeGreaterThan(0)
+    const io2 = payload.disk.types[1]
+    expect(io2.includedPerProject).toBeNull()
+    expect(io2.perUnitMonth.throughputMBps).toBeNull()
+  })
+
+  it('gives every meter a scope, positive price, and complete includedByPlan', () => {
+    expect(payload.meters.length).toBeGreaterThanOrEqual(15)
+    for (const meter of payload.meters) {
+      expect(meter.scope).toMatch(/^per-/)
+      expect(meter.pricePerUnitQuantity).toBeGreaterThan(0)
+      expect(meter.unitQuantity).toBeGreaterThan(0)
+      expect(Object.keys(meter.includedByPlan).sort()).toEqual([...planKeys].sort())
+    }
+  })
+
+  it('keeps unified egress out of any product bucket', () => {
+    const egress = payload.meters.find((m) => m.id === 'egress')
+    expect(egress?.unified).toBe(true)
+    expect(egress?.product).toBeNull()
+  })
+
+  it('lists every addon with per-project scope and availability', () => {
+    expect(payload.addons.map((a) => a.id).sort()).toEqual([
+      'advancedMfaPhone',
+      'customDomain',
+      'logDrain',
+      'pitr',
+    ])
+    for (const addon of payload.addons) {
+      expect(addon.scope).toBe('per-project')
+      expect(Object.keys(addon.availability).sort()).toEqual([...planKeys].sort())
+    }
+  })
+})

--- a/apps/www/lib/pricing-json.ts
+++ b/apps/www/lib/pricing-json.ts
@@ -1,0 +1,118 @@
+import { plans } from 'shared-data/plans'
+import { ADDONS, DISK_PRICING, METERS, PLAN_BILLING, usd } from 'shared-data/pricing-catalog'
+
+import addOnTable from '@/data/PricingAddOnTable.json'
+
+export function getColumnValue(
+  row: { columns: { key: string; value: unknown }[] },
+  key: string
+): unknown {
+  const col = row.columns.find((c) => c.key === key)
+  if (!col) throw new Error(`Missing column "${key}"`)
+  return col.value
+}
+
+export function parseUsdString(value: string): number {
+  const match = /^\$([\d,]+(?:\.\d+)?)$/.exec(value)
+  if (!match) throw new Error(`Unparseable price: ${value}`)
+  return Number(match[1].replace(/,/g, ''))
+}
+
+function parseGbString(value: string): number {
+  const match = /^([\d.]+)[  ]GB$/.exec(value)
+  if (!match) throw new Error(`Unparseable size: ${value}`)
+  return Number(match[1])
+}
+
+function parseCountString(value: string): number {
+  const match = /^[\d,]+$/.exec(value)
+  if (!match) throw new Error(`Unparseable count: ${value}`)
+  return Number(value.replace(/,/g, ''))
+}
+
+interface ComputeTier {
+  name: string
+  priceMonthly: number | null
+  contactSales?: true
+  cpu?: string
+  dedicated?: boolean
+  memoryGb?: number
+  connectionsDirect?: number
+  connectionsPooler?: number
+}
+
+function buildComputeTiers(): ComputeTier[] {
+  return addOnTable.database.rows.map((row) => {
+    const name = String(getColumnValue(row, 'plan'))
+    const pricing = String(getColumnValue(row, 'pricing'))
+
+    if (pricing === 'Contact Us') {
+      return { name, priceMonthly: null, contactSales: true as const }
+    }
+
+    return {
+      name,
+      priceMonthly: parseUsdString(pricing),
+      cpu: String(getColumnValue(row, 'cpu')),
+      dedicated: Boolean(getColumnValue(row, 'dedicated')),
+      memoryGb: parseGbString(String(getColumnValue(row, 'memory'))),
+      connectionsDirect: parseCountString(String(getColumnValue(row, 'directConnections'))),
+      connectionsPooler: parseCountString(String(getColumnValue(row, 'poolerConnections'))),
+    }
+  })
+}
+
+export function buildPricingJson() {
+  return {
+    description:
+      'Machine-readable pricing for https://supabase.com/pricing. Informational, not a billing API. Monthly totals depend on plan quotas, compute credits, and the spend cap encoded below; metered prices apply only beyond includedByPlan quotas.',
+    source: 'https://supabase.com/pricing',
+    docs: 'https://supabase.com/docs/guides/platform/org-based-billing',
+    currency: 'USD',
+    plans: plans.map((plan) => {
+      const billing = PLAN_BILLING[plan.planId]
+      return {
+        id: plan.planId,
+        name: plan.name,
+        priceMonthly: billing.priceMonthly,
+        ...(plan.planId === 'enterprise' ? { contactSales: true as const } : {}),
+        computeCreditsMonthly: billing.computeCreditsMonthly,
+        spendCapAvailable: billing.spendCapAvailable,
+      }
+    }),
+    compute: {
+      scope: 'per-project',
+      note: `Every project runs on its own compute instance, billed hourly. Pro and Team plans include ${usd(PLAN_BILLING.pro.computeCreditsMonthly)}/month in compute credits, which covers one Micro instance.`,
+      tiers: buildComputeTiers(),
+    },
+    disk: {
+      scope: 'per-project',
+      types: Object.values(DISK_PRICING).map((disk) => ({
+        type: disk.type,
+        name: disk.displayName,
+        maxSizeTb: disk.maxSizeTb,
+        durabilityPercent: disk.durabilityPercent,
+        includedPerProject: disk.includedPerProject,
+        perUnitMonth: disk.perUnitMonth,
+        ...(disk.throughputNote ? { throughputNote: disk.throughputNote } : {}),
+      })),
+    },
+    meters: Object.entries(METERS).map(([id, meter]) => ({
+      id,
+      product: meter.product,
+      ...('unified' in meter && meter.unified ? { unified: true as const } : {}),
+      scope: `per-${meter.scope}`,
+      unit: meter.unit,
+      unitQuantity: meter.per,
+      pricePerUnitQuantity: meter.price,
+      includedByPlan: meter.includedByPlan,
+      ...('billingNote' in meter && meter.billingNote ? { billingNote: meter.billingNote } : {}),
+    })),
+    addons: Object.entries(ADDONS).map(([id, addon]) => {
+      const { scope, availability, ...prices } = addon
+      return { id, scope: `per-${scope}`, ...prices, availability }
+    }),
+  }
+}
+
+export type PricingJson = ReturnType<typeof buildPricingJson>

--- a/apps/www/lib/pricing-json.ts
+++ b/apps/www/lib/pricing-json.ts
@@ -65,7 +65,7 @@ function buildComputeTiers(): ComputeTier[] {
 export function buildPricingJson() {
   return {
     description:
-      'Machine-readable pricing for https://supabase.com/pricing. Informational, not a billing API. Monthly totals depend on plan quotas, compute credits, and the spend cap encoded below; metered prices apply only beyond includedByPlan quotas.',
+      "Machine-readable pricing for https://supabase.com/pricing. Informational, not a billing API. Monthly totals depend on plan quotas, compute credits, and the spend cap encoded below; metered prices apply only beyond includedByPlan quotas. In includedByPlan: null means the metric is not available on that plan, 0 means available with no included quota, 'custom' means negotiated.",
     source: 'https://supabase.com/pricing',
     docs: 'https://supabase.com/docs/guides/platform/org-based-billing',
     currency: 'USD',
@@ -94,7 +94,7 @@ export function buildPricingJson() {
         durabilityPercent: disk.durabilityPercent,
         includedPerProject: disk.includedPerProject,
         perUnitMonth: disk.perUnitMonth,
-        ...(disk.throughputNote ? { throughputNote: disk.throughputNote } : {}),
+        ...('throughputNote' in disk ? { throughputNote: disk.throughputNote } : {}),
       })),
     },
     meters: Object.entries(METERS).map(([id, meter]) => ({

--- a/apps/www/lib/pricing-json.ts
+++ b/apps/www/lib/pricing-json.ts
@@ -87,8 +87,8 @@ export function buildPricingJson() {
     },
     disk: {
       scope: 'per-project',
-      types: Object.values(DISK_PRICING).map((disk) => ({
-        type: disk.type,
+      types: Object.entries(DISK_PRICING).map(([type, disk]) => ({
+        type,
         name: disk.displayName,
         maxSizeTb: disk.maxSizeTb,
         durabilityPercent: disk.durabilityPercent,

--- a/packages/shared-data/index.ts
+++ b/packages/shared-data/index.ts
@@ -13,6 +13,7 @@ import extensions from './extensions.json'
 import logConstants from './log-constants'
 import { plans, PricingInformation } from './plans'
 import { pricing } from './pricing'
+import { ADDONS, DISK_PRICING, METERS, PLAN_BILLING } from './pricing-catalog'
 import { PRODUCT_MODULES, products } from './products'
 import questions from './questions'
 import type { AWS_REGIONS_KEYS, CloudProvider, Region } from './regions'
@@ -20,6 +21,7 @@ import { AWS_REGIONS } from './regions'
 import tweets, { topTweets } from './tweets'
 
 export {
+  ADDONS,
   AWS_REGIONS,
   COMPUTE_BASELINE_IOPS,
   COMPUTE_BASELINE_THROUGHPUT,
@@ -28,11 +30,14 @@ export {
   COMPUTE_MAX_THROUGHPUT,
   computeInstanceAddonVariantIdSchema,
   config,
+  DISK_PRICING,
   ERROR_CODE_DOCS_URLS,
   ERROR_CODES,
   HTTP_ERROR_CODES,
   extensions,
   logConstants,
+  METERS,
+  PLAN_BILLING,
   plans,
   pricing,
   PRODUCT_MODULES,

--- a/packages/shared-data/plans.ts
+++ b/packages/shared-data/plans.ts
@@ -1,6 +1,7 @@
 import { ADDONS, gbDisplay, METERS, PLAN_BILLING, qty, usd, withUnit } from './pricing-catalog'
+import type { PlanKey } from './pricing-catalog'
 
-export type PlanId = 'free' | 'pro' | 'team' | 'enterprise'
+export type PlanId = PlanKey
 
 export interface PricingInformation {
   id: 'tier_free' | 'tier_pro' | 'tier_team' | 'tier_enterprise'

--- a/packages/shared-data/plans.ts
+++ b/packages/shared-data/plans.ts
@@ -1,3 +1,5 @@
+import { ADDONS, gbDisplay, METERS, PLAN_BILLING, qty, usd, withUnit } from './pricing-catalog'
+
 export type PlanId = 'free' | 'pro' | 'team' | 'enterprise'
 
 export interface PricingInformation {
@@ -27,16 +29,19 @@ export const plans: PricingInformation[] = [
     costUnit: '/ month',
     href: 'https://supabase.com/dashboard/new?plan=free',
     priceLabel: '',
-    priceMonthly: 0,
+    priceMonthly: PLAN_BILLING.free.priceMonthly,
     description: 'Perfect for passion projects & simple websites.',
     preface: 'Get started with:',
     features: [
       'Unlimited API requests',
-      '50,000 monthly active users',
-      ['500 MB database size', 'Shared CPU • 500 MB RAM'],
-      ['5 GB egress'],
-      ['5 GB cached egress'],
-      '1 GB file storage',
+      `${qty(METERS.maus.includedByPlan.free, 'comma')} monthly active users`,
+      [
+        `${gbDisplay(METERS.databaseDiskSize.includedByPlan.free)} database size`,
+        'Shared CPU • 500 MB RAM',
+      ],
+      [`${qty(METERS.egress.includedByPlan.free)} GB egress`],
+      [`${qty(METERS.cachedEgress.includedByPlan.free)} GB cached egress`],
+      `${qty(METERS.storageSize.includedByPlan.free)} GB file storage`,
       'Community support',
     ],
     footer: 'Free projects are paused after 1 week of inactivity. Limit of 2 active projects.',
@@ -51,18 +56,36 @@ export const plans: PricingInformation[] = [
     href: 'https://supabase.com/dashboard/new?plan=pro',
     priceLabel: 'From',
     warning: 'Includes one project running on Micro compute.',
-    priceMonthly: 25,
+    priceMonthly: PLAN_BILLING.pro.priceMonthly,
     description: 'For production applications with the power to scale.',
     features: [
-      ['100,000 monthly active users', 'then $0.00325 per MAU'],
-      ['8 GB disk size per project', 'then $0.125 per GB'],
-      ['250 GB egress', 'then $0.09 per GB'],
-      ['250 GB cached egress', 'then $0.03 per GB'],
-      ['100 GB file storage', 'then $0.0213 per GB'],
+      [
+        `${qty(METERS.maus.includedByPlan.pro, 'comma')} monthly active users`,
+        `then ${usd(METERS.maus.price)} per MAU`,
+      ],
+      [
+        `${gbDisplay(METERS.databaseDiskSize.includedByPlan.pro)} disk size per project`,
+        `then ${usd(METERS.databaseDiskSize.price)} per GB`,
+      ],
+      [
+        `${withUnit(METERS.egress.includedByPlan.pro, 'GB')} egress`,
+        `then ${usd(METERS.egress.price)} per GB`,
+      ],
+      [
+        `${withUnit(METERS.cachedEgress.includedByPlan.pro, 'GB')} cached egress`,
+        `then ${usd(METERS.cachedEgress.price)} per GB`,
+      ],
+      [
+        `${withUnit(METERS.storageSize.includedByPlan.pro, 'GB')} file storage`,
+        `then ${usd(METERS.storageSize.price)} per GB`,
+      ],
       'Email support',
       'Daily backups stored for 7 days',
       '7-day log retention',
-      ['Add Log Drains', 'additional $60 per drain, per project'],
+      [
+        'Add Log Drains',
+        `additional ${usd(ADDONS.logDrain.priceMonthlyPerDrain)} per drain, per project`,
+      ],
     ],
     preface: 'Everything in the Free Plan, plus:',
     cta: 'Get Started',
@@ -76,7 +99,7 @@ export const plans: PricingInformation[] = [
     href: 'https://supabase.com/dashboard/new?plan=team',
     priceLabel: 'From',
     warning: 'Includes one project running on Micro compute.',
-    priceMonthly: 599,
+    priceMonthly: PLAN_BILLING.team.priceMonthly,
     description: 'Add features such as SSO, control over backups, and industry certifications.',
     features: [
       'SOC2 & ISO 27001',

--- a/packages/shared-data/pricing-catalog.ts
+++ b/packages/shared-data/pricing-catalog.ts
@@ -26,7 +26,6 @@ export interface DiskAllowance {
 }
 
 export interface DiskTypeEntry {
-  type: 'gp3' | 'io2'
   displayName: string
   tagline: string
   maxSizeTb: number
@@ -34,13 +33,6 @@ export interface DiskTypeEntry {
   includedPerProject: DiskAllowance | null
   perUnitMonth: { sizeGb: number; iops: number; throughputMBps: number | null }
   throughputNote?: string
-}
-
-export interface AddonAvailability {
-  free: boolean
-  pro: boolean
-  team: boolean
-  enterprise: boolean
 }
 
 export function usd(amount: number, decimals?: number): string {
@@ -72,9 +64,8 @@ export const PLAN_BILLING = {
   enterprise: { priceMonthly: null, computeCreditsMonthly: null, spendCapAvailable: false },
 } as const satisfies Record<PlanKey, PlanBillingEntry>
 
-export const DISK_PRICING: Record<'gp3' | 'io2', DiskTypeEntry> = {
+export const DISK_PRICING = {
   gp3: {
-    type: 'gp3',
     displayName: 'General Purpose',
     tagline: 'Balance between price and performance',
     maxSizeTb: 16,
@@ -83,7 +74,6 @@ export const DISK_PRICING: Record<'gp3' | 'io2', DiskTypeEntry> = {
     perUnitMonth: { sizeGb: GP3_PER_GB_MONTH, iops: 0.024, throughputMBps: 0.095 },
   },
   io2: {
-    type: 'io2',
     displayName: 'High Performance',
     tagline: 'For mission critical applications',
     maxSizeTb: 60,
@@ -92,7 +82,7 @@ export const DISK_PRICING: Record<'gp3' | 'io2', DiskTypeEntry> = {
     perUnitMonth: { sizeGb: 0.195, iops: 0.119, throughputMBps: null },
     throughputNote: 'Scales automatically with IOPS',
   },
-}
+} as const satisfies Record<'gp3' | 'io2', DiskTypeEntry>
 
 export const METERS = {
   egress: {

--- a/packages/shared-data/pricing-catalog.ts
+++ b/packages/shared-data/pricing-catalog.ts
@@ -53,18 +53,24 @@ export function qty(n: number, style?: 'comma' | 'millionWord'): string {
   return String(n)
 }
 
+const THIN_SPACE = ' '
+
+export function withUnit(n: number, unit: string, style?: 'comma' | 'millionWord'): string {
+  return `${qty(n, style)}${THIN_SPACE}${unit}`
+}
+
 export function gbDisplay(sizeGb: number): string {
-  return sizeGb < 1 ? `${sizeGb * 1000} MB` : `${sizeGb} GB`
+  return sizeGb < 1 ? withUnit(sizeGb * 1000, 'MB') : withUnit(sizeGb, 'GB')
 }
 
 const GP3_PER_GB_MONTH = 0.125
 
-export const PLAN_BILLING: Record<PlanKey, PlanBillingEntry> = {
+export const PLAN_BILLING = {
   free: { priceMonthly: 0, computeCreditsMonthly: null, spendCapAvailable: false },
   pro: { priceMonthly: 25, computeCreditsMonthly: 10, spendCapAvailable: true },
   team: { priceMonthly: 599, computeCreditsMonthly: 10, spendCapAvailable: false },
   enterprise: { priceMonthly: null, computeCreditsMonthly: null, spendCapAvailable: false },
-}
+} as const satisfies Record<PlanKey, PlanBillingEntry>
 
 export const DISK_PRICING: Record<'gp3' | 'io2', DiskTypeEntry> = {
   gp3: {

--- a/packages/shared-data/pricing-catalog.ts
+++ b/packages/shared-data/pricing-catalog.ts
@@ -1,0 +1,241 @@
+export type PlanKey = 'free' | 'pro' | 'team' | 'enterprise'
+export type IncludedQuota = number | 'custom' | null
+export type IncludedByPlan = Record<PlanKey, IncludedQuota>
+
+export interface PlanBillingEntry {
+  priceMonthly: number | null
+  computeCreditsMonthly: number | null
+  spendCapAvailable: boolean
+}
+
+export interface MeterEntry {
+  product: 'database' | 'auth' | 'storage' | 'functions' | 'realtime' | null
+  unified?: true
+  scope: 'organization' | 'project' | 'branch' | 'pipeline'
+  unit: string
+  per: number
+  price: number
+  includedByPlan: IncludedByPlan
+  billingNote?: string
+}
+
+export interface DiskAllowance {
+  sizeGb: number
+  iops: number
+  throughputMBps: number
+}
+
+export interface DiskTypeEntry {
+  type: 'gp3' | 'io2'
+  displayName: string
+  tagline: string
+  maxSizeTb: number
+  durabilityPercent: number
+  includedPerProject: DiskAllowance | null
+  perUnitMonth: { sizeGb: number; iops: number; throughputMBps: number | null }
+  throughputNote?: string
+}
+
+export interface AddonAvailability {
+  free: boolean
+  pro: boolean
+  team: boolean
+  enterprise: boolean
+}
+
+export function usd(amount: number, decimals?: number): string {
+  return `$${decimals === undefined ? String(amount) : amount.toFixed(decimals)}`
+}
+
+export function qty(n: number, style?: 'comma' | 'millionWord'): string {
+  if (style === 'comma') return n.toLocaleString('en-US')
+  if (style === 'millionWord') return `${n / 1_000_000} Million`
+  return String(n)
+}
+
+export function gbDisplay(sizeGb: number): string {
+  return sizeGb < 1 ? `${sizeGb * 1000} MB` : `${sizeGb} GB`
+}
+
+const GP3_PER_GB_MONTH = 0.125
+
+export const PLAN_BILLING: Record<PlanKey, PlanBillingEntry> = {
+  free: { priceMonthly: 0, computeCreditsMonthly: null, spendCapAvailable: false },
+  pro: { priceMonthly: 25, computeCreditsMonthly: 10, spendCapAvailable: true },
+  team: { priceMonthly: 599, computeCreditsMonthly: 10, spendCapAvailable: false },
+  enterprise: { priceMonthly: null, computeCreditsMonthly: null, spendCapAvailable: false },
+}
+
+export const DISK_PRICING: Record<'gp3' | 'io2', DiskTypeEntry> = {
+  gp3: {
+    type: 'gp3',
+    displayName: 'General Purpose',
+    tagline: 'Balance between price and performance',
+    maxSizeTb: 16,
+    durabilityPercent: 99.9,
+    includedPerProject: { sizeGb: 8, iops: 3000, throughputMBps: 125 },
+    perUnitMonth: { sizeGb: GP3_PER_GB_MONTH, iops: 0.024, throughputMBps: 0.095 },
+  },
+  io2: {
+    type: 'io2',
+    displayName: 'High Performance',
+    tagline: 'For mission critical applications',
+    maxSizeTb: 60,
+    durabilityPercent: 99.999,
+    includedPerProject: null,
+    perUnitMonth: { sizeGb: 0.195, iops: 0.119, throughputMBps: null },
+    throughputNote: 'Scales automatically with IOPS',
+  },
+}
+
+export const METERS = {
+  egress: {
+    product: null,
+    unified: true,
+    scope: 'organization',
+    unit: 'GB',
+    per: 1,
+    price: 0.09,
+    includedByPlan: { free: 5, pro: 250, team: 250, enterprise: 'custom' },
+    billingNote: 'unified across all products',
+  },
+  cachedEgress: {
+    product: 'storage',
+    scope: 'organization',
+    unit: 'GB',
+    per: 1,
+    price: 0.03,
+    includedByPlan: { free: 5, pro: 250, team: 250, enterprise: 'custom' },
+  },
+  databaseDiskSize: {
+    product: 'database',
+    scope: 'project',
+    unit: 'GB',
+    per: 1,
+    price: GP3_PER_GB_MONTH,
+    includedByPlan: { free: 0.5, pro: 8, team: 8, enterprise: 'custom' },
+    billingNote: 'general-purpose (gp3) disk rate',
+  },
+  storageSize: {
+    product: 'storage',
+    scope: 'organization',
+    unit: 'GB',
+    per: 1,
+    price: 0.0213,
+    includedByPlan: { free: 1, pro: 100, team: 100, enterprise: 'custom' },
+  },
+  maus: {
+    product: 'auth',
+    scope: 'organization',
+    unit: 'MAU',
+    per: 1,
+    price: 0.00325,
+    includedByPlan: { free: 50_000, pro: 100_000, team: 100_000, enterprise: 'custom' },
+  },
+  thirdPartyMaus: {
+    product: 'auth',
+    scope: 'organization',
+    unit: 'MAU',
+    per: 1,
+    price: 0.00325,
+    includedByPlan: { free: 50_000, pro: 100_000, team: 100_000, enterprise: 'custom' },
+  },
+  ssoMaus: {
+    product: 'auth',
+    scope: 'organization',
+    unit: 'MAU',
+    per: 1,
+    price: 0.015,
+    includedByPlan: { free: null, pro: 50, team: 50, enterprise: 'custom' },
+  },
+  imageTransformations: {
+    product: 'storage',
+    scope: 'organization',
+    unit: 'origin images',
+    per: 1000,
+    price: 5,
+    includedByPlan: { free: null, pro: 100, team: 100, enterprise: 'custom' },
+  },
+  functionsInvocations: {
+    product: 'functions',
+    scope: 'organization',
+    unit: 'invocations',
+    per: 1_000_000,
+    price: 2,
+    includedByPlan: { free: 500_000, pro: 2_000_000, team: 2_000_000, enterprise: 'custom' },
+  },
+  realtimeConnections: {
+    product: 'realtime',
+    scope: 'organization',
+    unit: 'concurrent peak connections',
+    per: 1000,
+    price: 10,
+    includedByPlan: { free: 200, pro: 500, team: 500, enterprise: 'custom' },
+  },
+  realtimeMessages: {
+    product: 'realtime',
+    scope: 'organization',
+    unit: 'messages',
+    per: 1_000_000,
+    price: 2.5,
+    includedByPlan: { free: 2_000_000, pro: 5_000_000, team: 5_000_000, enterprise: 'custom' },
+  },
+  branching: {
+    product: 'database',
+    scope: 'branch',
+    unit: 'branch-hours',
+    per: 1,
+    price: 0.01344,
+    includedByPlan: { free: null, pro: 0, team: 0, enterprise: 'custom' },
+  },
+  replicationPipelineHours: {
+    product: 'database',
+    scope: 'pipeline',
+    unit: 'pipeline-hours',
+    per: 1,
+    price: 0.053,
+    includedByPlan: { free: null, pro: 0, team: 0, enterprise: 'custom' },
+  },
+  replicationOngoingGb: {
+    product: 'database',
+    scope: 'pipeline',
+    unit: 'GB processed during ongoing replication',
+    per: 1,
+    price: 3,
+    includedByPlan: { free: null, pro: 0, team: 0, enterprise: 'custom' },
+  },
+  replicationInitialSyncGb: {
+    product: 'database',
+    scope: 'pipeline',
+    unit: 'GB processed during initial sync',
+    per: 1,
+    price: 0.6,
+    includedByPlan: { free: null, pro: 0, team: 0, enterprise: 'custom' },
+  },
+} satisfies Record<string, MeterEntry>
+
+export const ADDONS = {
+  pitr: {
+    scope: 'project',
+    priceMonthlyPer7DaysRetention: 100,
+    availability: { free: false, pro: true, team: true, enterprise: true },
+  },
+  customDomain: {
+    scope: 'project',
+    priceMonthlyPerDomain: 10,
+    availability: { free: false, pro: true, team: true, enterprise: true },
+  },
+  advancedMfaPhone: {
+    scope: 'project',
+    priceMonthlyFirstProject: 75,
+    priceMonthlyAdditionalProject: 10,
+    availability: { free: false, pro: true, team: true, enterprise: true },
+  },
+  logDrain: {
+    scope: 'project',
+    priceMonthlyPerDrain: 60,
+    perMillionEvents: 0.2,
+    perGbEgress: 0.09,
+    availability: { free: false, pro: true, team: true, enterprise: true },
+  },
+} as const

--- a/packages/shared-data/pricing.ts
+++ b/packages/shared-data/pricing.ts
@@ -1,3 +1,5 @@
+import { ADDONS, gbDisplay, METERS, qty, usd, withUnit } from './pricing-catalog'
+
 type Pricing = {
   database: PricingCategory
   auth: PricingCategory
@@ -122,9 +124,15 @@ export const pricing: Pricing = {
         key: 'database.size',
         title: 'Database size',
         plans: {
-          free: '500 MB database size per project included',
-          pro: ['8 GB disk size per project included', 'then $0.125 per GB'],
-          team: ['8 GB disk size per project included', 'then $0.125 per GB'],
+          free: `${gbDisplay(METERS.databaseDiskSize.includedByPlan.free)} database size per project included`,
+          pro: [
+            `${gbDisplay(METERS.databaseDiskSize.includedByPlan.pro)} disk size per project included`,
+            `then ${usd(METERS.databaseDiskSize.price)} per GB`,
+          ],
+          team: [
+            `${gbDisplay(METERS.databaseDiskSize.includedByPlan.team)} disk size per project included`,
+            `then ${usd(METERS.databaseDiskSize.price)} per GB`,
+          ],
           enterprise: 'Custom',
         },
         usage_based: true,
@@ -156,9 +164,9 @@ export const pricing: Pricing = {
         title: 'Point in time recovery',
         plans: {
           free: false,
-          pro: '$100 per month per 7 days retention',
-          team: '$100 per month per 7 days retention',
-          enterprise: '$100 per month per 7 days retention, >28 days retention available',
+          pro: `${usd(ADDONS.pitr.priceMonthlyPer7DaysRetention)} per month per 7 days retention`,
+          team: `${usd(ADDONS.pitr.priceMonthlyPer7DaysRetention)} per month per 7 days retention`,
+          enterprise: `${usd(ADDONS.pitr.priceMonthlyPer7DaysRetention)} per month per 7 days retention, >28 days retention available`,
         },
         usage_based: false,
       },
@@ -178,8 +186,8 @@ export const pricing: Pricing = {
         title: 'Branching',
         plans: {
           free: false,
-          pro: '$0.01344 per branch, per hour',
-          team: '$0.01344 per branch, per hour',
+          pro: `${usd(METERS.branching.price)} per branch, per hour`,
+          team: `${usd(METERS.branching.price)} per branch, per hour`,
           enterprise: 'Custom',
         },
         usage_based: true,
@@ -188,9 +196,15 @@ export const pricing: Pricing = {
         key: 'database.egress',
         title: 'Egress',
         plans: {
-          free: '5 GB included',
-          pro: ['250 GB included', 'then $0.09 per GB'],
-          team: ['250 GB included', 'then $0.09 per GB'],
+          free: `${withUnit(METERS.egress.includedByPlan.free, 'GB')} included`,
+          pro: [
+            `${withUnit(METERS.egress.includedByPlan.pro, 'GB')} included`,
+            `then ${usd(METERS.egress.price)} per GB`,
+          ],
+          team: [
+            `${withUnit(METERS.egress.includedByPlan.team, 'GB')} included`,
+            `then ${usd(METERS.egress.price)} per GB`,
+          ],
           enterprise: 'Custom',
         },
         usage_based: true,
@@ -201,14 +215,14 @@ export const pricing: Pricing = {
         plans: {
           free: false,
           pro: [
-            '$0.053 per pipeline per hour',
-            '$3.00 per GB processed during ongoing replication',
-            '$0.60 per GB processed during initial sync',
+            `${usd(METERS.replicationPipelineHours.price)} per pipeline per hour`,
+            `${usd(METERS.replicationOngoingGb.price, 2)} per GB processed during ongoing replication`,
+            `${usd(METERS.replicationInitialSyncGb.price, 2)} per GB processed during initial sync`,
           ],
           team: [
-            '$0.053 per pipeline per hour',
-            '$3.00 per GB processed during ongoing replication',
-            '$0.60 per GB processed during initial sync',
+            `${usd(METERS.replicationPipelineHours.price)} per pipeline per hour`,
+            `${usd(METERS.replicationOngoingGb.price, 2)} per GB processed during ongoing replication`,
+            `${usd(METERS.replicationInitialSyncGb.price, 2)} per GB processed during initial sync`,
           ],
           enterprise: 'Custom',
         },
@@ -235,9 +249,15 @@ export const pricing: Pricing = {
         key: 'auth.maus',
         title: 'MAUs',
         plans: {
-          free: '50,000 included',
-          pro: ['100,000 included', 'then $0.00325 per MAU'],
-          team: ['100,000 included', 'then $0.00325 per MAU'],
+          free: `${qty(METERS.maus.includedByPlan.free, 'comma')} included`,
+          pro: [
+            `${qty(METERS.maus.includedByPlan.pro, 'comma')} included`,
+            `then ${usd(METERS.maus.price)} per MAU`,
+          ],
+          team: [
+            `${qty(METERS.maus.includedByPlan.team, 'comma')} included`,
+            `then ${usd(METERS.maus.price)} per MAU`,
+          ],
           enterprise: 'Custom',
         },
         usage_based: true,
@@ -325,8 +345,14 @@ export const pricing: Pricing = {
         title: 'Advanced Multi-Factor Auth - Phone',
         plans: {
           free: false,
-          pro: ['$75 per month for first project', 'then $10 per month per additional projects'],
-          team: ['$75 per month for first project', 'then $10 per month per additional projects'],
+          pro: [
+            `${usd(ADDONS.advancedMfaPhone.priceMonthlyFirstProject)} per month for first project`,
+            `then ${usd(ADDONS.advancedMfaPhone.priceMonthlyAdditionalProject)} per month per additional projects`,
+          ],
+          team: [
+            `${usd(ADDONS.advancedMfaPhone.priceMonthlyFirstProject)} per month for first project`,
+            `then ${usd(ADDONS.advancedMfaPhone.priceMonthlyAdditionalProject)} per month per additional projects`,
+          ],
           enterprise: 'Custom',
         },
         usage_based: false,
@@ -335,9 +361,15 @@ export const pricing: Pricing = {
         key: 'auth.thirdPartyMAUs',
         title: 'Third-Party MAUs',
         plans: {
-          free: '50,000 included',
-          pro: ['100,000 included', 'then $0.00325 per MAU'],
-          team: ['100,000 included', 'then $0.00325 per MAU'],
+          free: `${qty(METERS.thirdPartyMaus.includedByPlan.free, 'comma')} included`,
+          pro: [
+            `${qty(METERS.thirdPartyMaus.includedByPlan.pro, 'comma')} included`,
+            `then ${usd(METERS.thirdPartyMaus.price)} per MAU`,
+          ],
+          team: [
+            `${qty(METERS.thirdPartyMaus.includedByPlan.team, 'comma')} included`,
+            `then ${usd(METERS.thirdPartyMaus.price)} per MAU`,
+          ],
           enterprise: 'Custom',
         },
         usage_based: true,
@@ -347,8 +379,14 @@ export const pricing: Pricing = {
         title: 'Single Sign-On (SAML 2.0)',
         plans: {
           free: false,
-          pro: ['50 included', 'then $0.015 per MAU'],
-          team: ['50 included', 'then $0.015 per MAU'],
+          pro: [
+            `${qty(METERS.ssoMaus.includedByPlan.pro)} included`,
+            `then ${usd(METERS.ssoMaus.price)} per MAU`,
+          ],
+          team: [
+            `${qty(METERS.ssoMaus.includedByPlan.team)} included`,
+            `then ${usd(METERS.ssoMaus.price)} per MAU`,
+          ],
           enterprise: 'Contact Us',
         },
 
@@ -420,9 +458,15 @@ export const pricing: Pricing = {
         key: 'storage.size',
         title: 'Storage',
         plans: {
-          free: '1 GB included',
-          pro: ['100 GB included', 'then $0.0213 per GB'],
-          team: ['100 GB included', 'then $0.0213 per GB'],
+          free: `${withUnit(METERS.storageSize.includedByPlan.free, 'GB')} included`,
+          pro: [
+            `${withUnit(METERS.storageSize.includedByPlan.pro, 'GB')} included`,
+            `then ${usd(METERS.storageSize.price)} per GB`,
+          ],
+          team: [
+            `${withUnit(METERS.storageSize.includedByPlan.team, 'GB')} included`,
+            `then ${usd(METERS.storageSize.price)} per GB`,
+          ],
           enterprise: 'Custom',
         },
         usage_based: true,
@@ -431,9 +475,15 @@ export const pricing: Pricing = {
         key: 'storage.cachedEgress',
         title: 'Cached Egress',
         plans: {
-          free: '5 GB included',
-          pro: ['250 GB included', 'then $0.03 per GB'],
-          team: ['250 GB included', 'then $0.03 per GB'],
+          free: `${withUnit(METERS.cachedEgress.includedByPlan.free, 'GB')} included`,
+          pro: [
+            `${withUnit(METERS.cachedEgress.includedByPlan.pro, 'GB')} included`,
+            `then ${usd(METERS.cachedEgress.price)} per GB`,
+          ],
+          team: [
+            `${withUnit(METERS.cachedEgress.includedByPlan.team, 'GB')} included`,
+            `then ${usd(METERS.cachedEgress.price)} per GB`,
+          ],
           enterprise: 'Custom',
         },
         usage_based: true,
@@ -476,8 +526,14 @@ export const pricing: Pricing = {
         title: 'Image Transformations',
         plans: {
           free: false,
-          pro: ['100 origin images included', 'then $5 per 1000 origin images'],
-          team: ['100 origin images included', 'then $5 per 1000 origin images'],
+          pro: [
+            `${qty(METERS.imageTransformations.includedByPlan.pro)} origin images included`,
+            `then ${usd(METERS.imageTransformations.price)} per ${qty(METERS.imageTransformations.per)} origin images`,
+          ],
+          team: [
+            `${qty(METERS.imageTransformations.includedByPlan.team)} origin images included`,
+            `then ${usd(METERS.imageTransformations.price)} per ${qty(METERS.imageTransformations.per)} origin images`,
+          ],
           enterprise: 'Custom',
         },
         usage_based: true,
@@ -492,9 +548,15 @@ export const pricing: Pricing = {
         key: 'functions.invocations',
         title: 'Invocations',
         plans: {
-          free: '500,000 included',
-          pro: ['2 Million included', 'then $2 per 1 Million'],
-          team: ['2 Million included', 'then $2 per 1 Million'],
+          free: `${qty(METERS.functionsInvocations.includedByPlan.free, 'comma')} included`,
+          pro: [
+            `${qty(METERS.functionsInvocations.includedByPlan.pro, 'millionWord')} included`,
+            `then ${usd(METERS.functionsInvocations.price)} per ${qty(METERS.functionsInvocations.per, 'millionWord')}`,
+          ],
+          team: [
+            `${qty(METERS.functionsInvocations.includedByPlan.team, 'millionWord')} included`,
+            `then ${usd(METERS.functionsInvocations.price)} per ${qty(METERS.functionsInvocations.per, 'millionWord')}`,
+          ],
           enterprise: 'Custom',
         },
         usage_based: true,
@@ -520,9 +582,15 @@ export const pricing: Pricing = {
         key: 'realtime.concurrentConnections',
         title: 'Concurrent Peak Connections',
         plans: {
-          free: '200 included',
-          pro: ['500 included', 'then $10 per 1000'],
-          team: ['500 included', 'then $10 per 1000'],
+          free: `${qty(METERS.realtimeConnections.includedByPlan.free)} included`,
+          pro: [
+            `${qty(METERS.realtimeConnections.includedByPlan.pro)} included`,
+            `then ${usd(METERS.realtimeConnections.price)} per ${qty(METERS.realtimeConnections.per)}`,
+          ],
+          team: [
+            `${qty(METERS.realtimeConnections.includedByPlan.team)} included`,
+            `then ${usd(METERS.realtimeConnections.price)} per ${qty(METERS.realtimeConnections.per)}`,
+          ],
           enterprise: 'Custom concurrent connections and volume discount',
         },
         usage_based: true,
@@ -531,9 +599,15 @@ export const pricing: Pricing = {
         key: 'realtime.messagesPerMonth',
         title: 'Messages Per Month',
         plans: {
-          free: '2 Million included',
-          pro: ['5 Million included', 'then $2.50 per Million'],
-          team: ['5 Million included', 'then $2.50 per Million'],
+          free: `${qty(METERS.realtimeMessages.includedByPlan.free, 'millionWord')} included`,
+          pro: [
+            `${qty(METERS.realtimeMessages.includedByPlan.pro, 'millionWord')} included`,
+            `then ${usd(METERS.realtimeMessages.price, 2)} per Million`,
+          ],
+          team: [
+            `${qty(METERS.realtimeMessages.includedByPlan.team, 'millionWord')} included`,
+            `then ${usd(METERS.realtimeMessages.price, 2)} per Million`,
+          ],
           enterprise: 'Volume discounts on messages',
         },
         usage_based: true,
@@ -599,8 +673,16 @@ export const pricing: Pricing = {
         title: 'Log Drain',
         plans: {
           free: false,
-          pro: ['$60 per drain per month', '+ $0.20 per million events', '+ $0.09 per GB egress'],
-          team: ['$60 per drain per month', '+ $0.20 per million events', '+ $0.09 per GB egress'],
+          pro: [
+            `${usd(ADDONS.logDrain.priceMonthlyPerDrain)} per drain per month`,
+            `+ ${usd(ADDONS.logDrain.perMillionEvents, 2)} per million events`,
+            `+ ${usd(ADDONS.logDrain.perGbEgress)} per GB egress`,
+          ],
+          team: [
+            `${usd(ADDONS.logDrain.priceMonthlyPerDrain)} per drain per month`,
+            `+ ${usd(ADDONS.logDrain.perMillionEvents, 2)} per million events`,
+            `+ ${usd(ADDONS.logDrain.perGbEgress)} per GB egress`,
+          ],
           enterprise: 'Custom',
         },
         usage_based: true,
@@ -720,9 +802,9 @@ export const pricing: Pricing = {
         title: 'Custom Domains',
         plans: {
           free: false,
-          pro: '$10 per domain per month per project add on',
-          team: '$10 per domain per month per project add on',
-          enterprise: '1, additional $10/domain/month',
+          pro: `${usd(ADDONS.customDomain.priceMonthlyPerDomain)} per domain per month per project add on`,
+          team: `${usd(ADDONS.customDomain.priceMonthlyPerDomain)} per domain per month per project add on`,
+          enterprise: `1, additional ${usd(ADDONS.customDomain.priceMonthlyPerDomain)}/domain/month`,
         },
         usage_based: false,
       },


### PR DESCRIPTION
Public price-performance benchmarks need database pricing that a plain HTTP client can fetch deterministically; pricing.md is semi-structured and error-prone to parse, and no machine-shaped pricing source existed anywhere (disk prices lived only as hardcoded prose in two independent copies). I added a pricing catalog in shared-data holding every dollar figure as numbers, published supabase.com/pricing.json derived from it per-request, and made every pricing display string derive from the same catalog.

**Changed:**
- **supabase.com/pricing.json**: new route handler serving structured pricing: plans with compute-credit and spend-cap semantics, per-project compute tiers and disk types with gp3/io2 rates, a flat meters list with per-plan included quotas, and add-ons. Same per-request + 1h edge cache pattern as pricing.md. Advertised in llms.txt and inside pricing.md.
- **Single source for every dollar figure**: new `shared-data/pricing-catalog.ts`; the price strings in plans.ts/pricing.ts and the previously hardcoded copies in PricingDiskSection/PricingAddons/llms.ts now derive from it, so the page, pricing.md, and pricing.json cannot drift. Rendered output is byte-identical (curl diff against production, including the U+2009 thin spaces some quota strings use).
- **pricing.md disk section**: prose bullets became a markdown table like Compute Add-Ons, with disk types named (gp3/io2).

**Note:** the JSON field names are a public contract once consumed, so renames are breaking. Freshness/version fields were deliberately left out (issue non-goal: git history of the sources plus benchmark-side input snapshotting cover reproducibility).

## To test
Tested on Vercel preview:
- [x] GET /pricing.json, expect valid JSON with application/json content type and plans/compute/disk/meters/addons sections carrying numeric prices, disk types gp3 and io2 — verified: 11 compute tiers (one contactSales), 15 meters, 4 addons, includedByPlan semantics stated in the description field. Client-facing cache-control shows `public` because the Vercel edge consumes s-maxage; prod pricing.md behaves identically.
- [x] GET /pricing.md, expect the disk section as a table naming gp3/io2, a "Structured pricing data (JSON)" pointer near the top, and every price unchanged vs production — verified: diff against prod shows exactly the two intended changes (pointer line, disk table), zero price changes.
- [x] Open /pricing, expect disk table, add-on cards, and comparison table strings identical to production — verified in the browser: exact-string match on disk rows, add-on card prices, compute-credits line, and Pro-column comparison cells; no new console errors; no template artifacts in rendered text.
- [x] GET /llms.txt, expect the Pricing section to list both pricing.md and pricing.json — verified.

## Linear
- fixes GROWTH-1136
