### PR TITLE
fix(pg-meta): make FDW DO blocks safe for values containing dollar quotes

### DIFF
--- a/packages/pg-meta/src/sql/studio/database/fdw.ts
+++ b/packages/pg-meta/src/sql/studio/database/fdw.ts
@@ -7,6 +7,20 @@ import {
   type SafeSqlFragment,
 } from '../../../pg-format'
 
+// DO blocks are dollar-quoted, so any user-derived value interpolated into the
+// block body could contain the closing delimiter and terminate the block early.
+// Generate a delimiter that cannot appear in any of the values instead.
+function getDoBlockDelimiter(values: string[]): SafeSqlFragment {
+  let suffix = 0
+  while (true) {
+    const delimiter = suffix === 0 ? safeSql`$pg_meta$` : safeSql`$pg_meta_${literal(suffix)}$`
+    if (values.every((value) => !value.includes(delimiter))) {
+      return delimiter
+    }
+    suffix += 1
+  }
+}
+
 type SimplifiedWrapperMeta = {
   handlerName: string
   validatorName: string
@@ -96,9 +110,10 @@ export function getCreateFDWSql({
   const createEncryptedKeysSqlArray = encryptedOptions.map((option) => {
     const key = `${formState.wrapper_name}_${option.name}`
     const quotedValue = literal(formState[option.name] || '')
+    const delimiter = getDoBlockDelimiter([key, formState[option.name] || ''])
 
     return safeSql`
-      do $$
+      do ${delimiter}
       begin
         -- Old wrappers has an implicit dependency on pgsodium. For new wrappers
         -- we use Vault directly.
@@ -147,7 +162,7 @@ export function getCreateFDWSql({
             new_name := ${literal(key)}
           );
         end if;
-      end $$;
+      end ${delimiter};
     `
   })
 
@@ -169,8 +184,19 @@ export function getCreateFDWSql({
     ','
   )
 
+  // Server/wrapper names reach format() as %s arguments (already-quoted
+  // identifiers) so quotes or backslashes in user-typed names never interact
+  // with the outer E'...' string.
+  const createServerDelimiter = getDoBlockDelimiter([
+    formState.server_name,
+    formState.wrapper_name,
+    ...encryptedOptions.map((option) => `${formState.wrapper_name}_${option.name}`),
+    ...encryptedOptions.map((option) => formState[option.name] || ''),
+    ...unencryptedOptionsFilter.map((option) => formState[option.name]),
+  ])
+
   const createServerSql = safeSql`
-    do $$
+    do ${createServerDelimiter}
     declare
       -- Old wrappers has an implicit dependency on pgsodium. For new wrappers
       -- we use Vault directly.
@@ -222,7 +248,9 @@ export function getCreateFDWSql({
       )}
     
       execute format(
-        E'create server ${ident(formState.server_name)} foreign data wrapper ${ident(formState.wrapper_name)} options (${optionsSqlArray});',
+        E'create server %s foreign data wrapper %s options (${optionsSqlArray});',
+        ${ident(formState.server_name)},
+        ${ident(formState.wrapper_name)},
         ${joinSqlFragments(
           [
             ...encryptedOptions
@@ -233,7 +261,7 @@ export function getCreateFDWSql({
           ','
         )}
       );
-    end $$;
+    end ${createServerDelimiter};
   `
 
   const createTablesSql = joinSqlFragments(
@@ -305,9 +333,10 @@ export const getDeleteFDWSql = ({
 
   const deleteEncryptedSecretsSqlArray = encryptedOptions.map((option) => {
     const key = `${wrapper.name}_${option.name}`
+    const delimiter = getDoBlockDelimiter([key])
 
     return safeSql`
-      do $$
+      do ${delimiter}
       begin
         -- Old wrappers has an implicit dependency on pgsodium. For new wrappers
         -- we use Vault directly.
@@ -345,7 +374,7 @@ export const getDeleteFDWSql = ({
         else
           delete from vault.secrets where name = ${literal(key)};
         end if;
-      end $$;
+      end ${delimiter};
     `
   })
 

--- a/packages/pg-meta/test/sql/studio/fdw.test.ts
+++ b/packages/pg-meta/test/sql/studio/fdw.test.ts
@@ -91,8 +91,17 @@ test('server and wrapper names are passed as format() arguments, not embedded in
   // never interact with the outer E'...' string.
   expect(sql).toContain(`E'create server %s foreign data wrapper %s options (`)
 
-  const quotedServer = ident("serv'er")
-  const quotedWrapper = ident("wrap'per\\x")
-  expect(sql).toContain(quotedServer)
-  expect(sql).toContain(quotedWrapper)
+  // Assert the identifiers appear as the following format() arguments, in
+  // order, and that the format template itself embeds neither identifier.
+  const formatIndex = sql.indexOf(`E'create server %s foreign data wrapper %s options (`)
+  const formatSql = sql.slice(formatIndex)
+  const serverArg = formatSql.indexOf(ident("serv'er"))
+  const wrapperArg = formatSql.indexOf(ident("wrap'per\\x"))
+  expect(formatIndex).toBeGreaterThan(-1)
+  expect(serverArg).toBeGreaterThan(-1)
+  expect(wrapperArg).toBeGreaterThan(serverArg)
+  expect(formatSql.slice(0, serverArg)).not.toContain(ident("serv'er"))
+  expect(formatSql.slice(serverArg + ident("serv'er").length, wrapperArg)).not.toContain(
+    ident("wrap'per\\x")
+  )
 })

--- a/packages/pg-meta/test/sql/studio/fdw.test.ts
+++ b/packages/pg-meta/test/sql/studio/fdw.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from 'vitest'
 
 import { getCreateFDWSql } from '../../../src'
-import { literal } from '../../../src/pg-format'
+import { ident, literal } from '../../../src/pg-format'
 
 const baseArgs = {
   mode: 'skip' as const,
@@ -53,4 +53,46 @@ test('encrypted server options still resolve their value through Vault unchanged
   // Encrypted options keep the ''%s'' placeholder filled by the vault secret id.
   expect(sql).toContain("api_secret ''%s''")
   expect(sql).toContain('vault.create_secret')
+})
+
+// A legal Postgres identifier whose spelling collides with the fixed DO-block
+// dollar-quote delimiter used before the delimiter became generated.
+const dollarWrapper = { wrapper_name: 'x$pg_meta$y', server_name: 'my_server' }
+
+test('DO-block delimiters avoid collision with user values containing dollar quotes', () => {
+  const sql = getCreateFDWSql({
+    ...baseArgs,
+    wrapperMeta: {
+      handlerName: 'wasm_fdw_handler',
+      validatorName: 'wasm_fdw_validator',
+      server: { options: [{ name: 'api_key', encrypted: false }] },
+    },
+    formState: { ...dollarWrapper, api_key: 'plain' },
+  })
+
+  // The base delimiter cannot be used when a value itself contains it.
+  expect(sql).not.toContain('do $pg_meta$')
+  // A collision-free suffix is picked instead.
+  expect(sql).toContain('do $pg_meta_1$')
+})
+
+test('server and wrapper names are passed as format() arguments, not embedded in the E-string', () => {
+  const sql = getCreateFDWSql({
+    ...baseArgs,
+    wrapperMeta: {
+      handlerName: 'wasm_fdw_handler',
+      validatorName: 'wasm_fdw_validator',
+      server: { options: [{ name: 'api_key', encrypted: false }] },
+    },
+    formState: { wrapper_name: "wrap'per\\x", server_name: "serv'er", api_key: 'plain' },
+  })
+
+  // Names reach format() as %s arguments so quotes/backslashes in the names
+  // never interact with the outer E'...' string.
+  expect(sql).toContain(`E'create server %s foreign data wrapper %s options (`)
+
+  const quotedServer = ident("serv'er")
+  const quotedWrapper = ident("wrap'per\\x")
+  expect(sql).toContain(quotedServer)
+  expect(sql).toContain(quotedWrapper)
 })


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

The three `DO $$ ... $$` blocks in `packages/pg-meta`'s FDW SQL builders (`create` encrypted-key blocks and the create-server block) use a fixed `$$` dollar-quote delimiter. Any user-derived value interpolated into the block body — vault key names built from the wrapper name, or secret values — that itself contains `$$` terminates the block early and breaks the whole statement. A wrapper named `x$$y`, for example, makes every encrypted-option create/delete fail.

The create-server block additionally embeds `ident()` output of user-typed server/wrapper names directly inside its `E'...'` format string. Legal Postgres identifier characters such as quotes or backslashes in those names corrupt the generated SQL or abort creation.

## What is the new behavior?

- Each DO block now uses a generated delimiter (`$pg_meta$`, then `$pg_meta_1$`, ...) checked against every value interpolated into that block, so no user value can terminate it early.
- Server/wrapper names are passed to `format()` as `%s` arguments (already-quoted identifiers) instead of being embedded in the outer `E'...'` string, so their content never interacts with the string literal.

## Additional context

Same bug class as #49523 (table privileges) and #49588 (column privileges); this closes out the remaining DO-block instances in pg-meta.

Verification performed:

```text
RED -> GREEN: two new unit tests fail against master, pass after the fix
  - delimiter collision (wrapper_name containing $pg_meta$ forces $pg_meta_1$)
  - server/wrapper names with quote + backslash emitted as format() arguments
packages/pg-meta full vitest suite against the harness database (32 files / 480 tests)
tsc --noEmit (pg-meta typecheck)
Prettier check on committed content
git diff --check
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when creating servers, encrypted keys, and deleting encrypted secrets.
  * Fixed handling of server and wrapper names containing quotes, backslashes, or delimiter-like content.
  * Prevented SQL execution issues caused by conflicting generated delimiters.
  * Improved safe handling of names passed into database operations.

* **Tests**
  * Added coverage for special characters, safe name handling, and collision-free SQL delimiter generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->