### PR TITLE
Add feature preview banner toast for explorerd

### DIFF
--- a/apps/studio/components/layouts/ObservabilityLayout/ObservabilityLayout.tsx
+++ b/apps/studio/components/layouts/ObservabilityLayout/ObservabilityLayout.tsx
@@ -56,7 +56,6 @@ const ObservabilityLayoutContent = ({
     })
   }, [
     addBanner,
-    dismissBanner,
     isInitialized,
     isDatabaseConnectionsBannerDismissed,
     previouslyToggled,

--- a/apps/studio/components/layouts/ProjectLayout/index.test.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/index.test.tsx
@@ -81,6 +81,7 @@ vi.mock('common', () => ({
       `project-integration-banner-dismissed-${ref}-${integrationSource}`,
   },
   isFeatureEnabled: () => false,
+  useFlag: () => false,
 }))
 
 vi.mock('framer-motion', () => ({

--- a/apps/studio/components/layouts/ProjectLayout/index.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/index.tsx
@@ -42,6 +42,7 @@ import { UnhealthyState } from './UnhealthyState'
 import { UpgradingState } from './UpgradingState'
 import { CreateBranchModal } from '@/components/interfaces/BranchManagement/CreateBranchModal'
 import { ProjectAPIDocs } from '@/components/interfaces/ProjectAPIDocs/ProjectAPIDocs'
+import { BannerExplorer } from '@/components/ui/BannerStack/Banners/BannerExplorer'
 import { BannerFreeMicroUpgrade } from '@/components/ui/BannerStack/Banners/BannerFreeMicroUpgrade'
 import { BANNER_ID, useBannerStack } from '@/components/ui/BannerStack/BannerStackProvider'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
@@ -152,6 +153,7 @@ export const ProjectLayout = forwardRef<HTMLDivElement, PropsWithChildren<Projec
       !!projectResourceWarnings?.disk_io_exhaustion
     const isNanoCompute = selectedProject?.infra_compute_size === 'nano'
     const showUpgradeBanner = isNanoCompute && isComputeNearExhaustion
+
     const [isFreeMicroUpgradeBannerDismissed] = useLocalStorageQuery(
       LOCAL_STORAGE_KEYS.FREE_MICRO_UPGRADE_BANNER_DISMISSED(selectedProject?.ref ?? ''),
       false
@@ -164,6 +166,11 @@ export const ProjectLayout = forwardRef<HTMLDivElement, PropsWithChildren<Projec
         }),
         false
       )
+    const [isExplorerBannerDismissed, , { isSuccess: isLocalStorageReady }] = useLocalStorageQuery(
+      LOCAL_STORAGE_KEYS.EXPLORER_BANNER_DISMISSED,
+      false
+    )
+
     const { showSidebar } = useAppStateSnapshot()
     const { setContent: setMobileSheetContent, registerOpenMenu } = useMobileSheet()
 
@@ -232,6 +239,17 @@ export const ProjectLayout = forwardRef<HTMLDivElement, PropsWithChildren<Projec
       addBanner,
       dismissBanner,
     ])
+
+    useEffect(() => {
+      if (!isLocalStorageReady || isExplorerBannerDismissed) return
+
+      addBanner({
+        id: 'explorer-banner',
+        priority: 2,
+        isDismissed: false,
+        content: <BannerExplorer />,
+      })
+    }, [addBanner, isExplorerBannerDismissed, isLocalStorageReady])
 
     useLayoutEffect(() => {
       const unregister = registerOpenMenu(() => {

--- a/apps/studio/components/layouts/ProjectLayout/index.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/index.tsx
@@ -1,4 +1,4 @@
-import { LOCAL_STORAGE_KEYS, mergeRefs, useParams } from 'common'
+import { LOCAL_STORAGE_KEYS, mergeRefs, useFlag, useParams } from 'common'
 import { AnimatePresence, motion } from 'framer-motion'
 import { XIcon } from 'lucide-react'
 import Head from 'next/head'
@@ -154,6 +154,8 @@ export const ProjectLayout = forwardRef<HTMLDivElement, PropsWithChildren<Projec
     const isNanoCompute = selectedProject?.infra_compute_size === 'nano'
     const showUpgradeBanner = isNanoCompute && isComputeNearExhaustion
 
+    const isExplorerEnabled = useFlag('explorer')
+
     const [isFreeMicroUpgradeBannerDismissed] = useLocalStorageQuery(
       LOCAL_STORAGE_KEYS.FREE_MICRO_UPGRADE_BANNER_DISMISSED(selectedProject?.ref ?? ''),
       false
@@ -241,7 +243,7 @@ export const ProjectLayout = forwardRef<HTMLDivElement, PropsWithChildren<Projec
     ])
 
     useEffect(() => {
-      if (!isLocalStorageReady || isExplorerBannerDismissed) return
+      if (!isExplorerEnabled || !isLocalStorageReady || isExplorerBannerDismissed) return
 
       addBanner({
         id: 'explorer-banner',
@@ -249,7 +251,7 @@ export const ProjectLayout = forwardRef<HTMLDivElement, PropsWithChildren<Projec
         isDismissed: false,
         content: <BannerExplorer />,
       })
-    }, [addBanner, isExplorerBannerDismissed, isLocalStorageReady])
+    }, [addBanner, isExplorerEnabled, isExplorerBannerDismissed, isLocalStorageReady])
 
     useLayoutEffect(() => {
       const unregister = registerOpenMenu(() => {

--- a/apps/studio/components/ui/BannerStack/BannerStackProvider.tsx
+++ b/apps/studio/components/ui/BannerStack/BannerStackProvider.tsx
@@ -9,6 +9,7 @@ export const BANNER_ID = {
   TOS_UPDATE: 'tos-update-banner',
   LOGS_ALL_DEPRECATION: 'logs-all-deprecation-banner',
   SELECT_26: 'select-2026-banner',
+  EXPLORER: 'explorer-banner',
 } as const
 
 export type BannerId = (typeof BANNER_ID)[keyof typeof BANNER_ID]

--- a/apps/studio/components/ui/BannerStack/Banners/BannerExplorer.tsx
+++ b/apps/studio/components/ui/BannerStack/Banners/BannerExplorer.tsx
@@ -1,0 +1,86 @@
+import { LOCAL_STORAGE_KEYS } from 'common'
+import { useParams } from 'common/hooks'
+import { AnimatePresence, motion } from 'framer-motion'
+import { Badge, Button } from 'ui'
+
+import { BannerCard } from '../BannerCard'
+import { useBannerStack } from '../BannerStackProvider'
+import { useFeaturePreviewModal } from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
+import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
+import { useTrack } from '@/lib/telemetry/track'
+
+export const BannerExplorer = () => {
+  const track = useTrack()
+  const { ref } = useParams()
+  const { dismissBanner } = useBannerStack()
+  const { selectFeaturePreview } = useFeaturePreviewModal()
+
+  const [, setIsDismissed] = useLocalStorageQuery(
+    LOCAL_STORAGE_KEYS.DATABASE_CONNECTIONS_BANNER_DISMISSED(ref ?? ''),
+    false
+  )
+
+  return (
+    <BannerCard
+      onDismiss={() => {
+        setIsDismissed(true)
+        dismissBanner('explorer-banner')
+        track('explorer_banner_dismiss_button_clicked')
+      }}
+    >
+      <div className="flex flex-col gap-y-4">
+        <div className="flex flex-col gap-y-2 items-start w-full">
+          <Badge variant="success" className="-ml-0.5 uppercase inline-flex items-center">
+            Preview
+          </Badge>
+          <AnimatePresence>
+            <div className="border h-27 w-full rounded-t-md mt-2 bg-surface-100 py-4 px-2 pb-0">
+              <motion.div
+                initial={{ opacity: 0, top: 10 }}
+                animate={{ opacity: 1, top: 0 }}
+                transition={{ delay: 0.5, duration: 0.2, ease: 'easeOut' }}
+                className="w-[90%] mx-auto"
+              >
+                <p className="text-[10px]">User growth</p>
+                <p className="text-[9px] text-foreground-lighter">
+                  Track how your user base is trending.
+                </p>
+              </motion.div>
+              <motion.div
+                initial={{ opacity: 0, top: 10 }}
+                animate={{ opacity: 1, top: 0 }}
+                transition={{ delay: 1, duration: 0.2, ease: 'easeOut' }}
+                className="w-full h-13.5 border border-b-0 mt-2 rounded-t bg-surface-200 overflow-hidden"
+              >
+                <div className="h-3 w-full border-b" />
+                <p className="px-2 py-1 text-[8px] font-mono tracking-tighter flex flex-col">
+                  <span className="text-code_block-1">select</span>
+                  <span className="pl-2">date_trunc('week', last_sign_in_at) as week,</span>
+                  <span className="pl-2">count(distinct id) as active_users</span>
+                </p>
+              </motion.div>
+            </div>
+          </AnimatePresence>
+        </div>
+        <div className="flex flex-col gap-y-1 mb-2">
+          <p className="text-sm font-medium">Explorer & Notebooks</p>
+          <p className="text-xs text-foreground-lighter text-balance">
+            New unified workspace for querying data and chatting with Assistant.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button
+            variant="default"
+            size="tiny"
+            onClick={() => {
+              selectFeaturePreview(LOCAL_STORAGE_KEYS.UI_PREVIEW_EXPLORER)
+              track('explorer_banner_cta_button_clicked')
+            }}
+          >
+            Enable Explorer
+          </Button>
+        </div>
+      </div>
+    </BannerCard>
+  )
+}

--- a/apps/studio/components/ui/BannerStack/Banners/BannerExplorer.tsx
+++ b/apps/studio/components/ui/BannerStack/Banners/BannerExplorer.tsx
@@ -1,5 +1,4 @@
 import { LOCAL_STORAGE_KEYS } from 'common'
-import { useParams } from 'common/hooks'
 import { AnimatePresence, motion } from 'framer-motion'
 import { Badge, Button } from 'ui'
 
@@ -11,12 +10,11 @@ import { useTrack } from '@/lib/telemetry/track'
 
 export const BannerExplorer = () => {
   const track = useTrack()
-  const { ref } = useParams()
   const { dismissBanner } = useBannerStack()
   const { selectFeaturePreview } = useFeaturePreviewModal()
 
   const [, setIsDismissed] = useLocalStorageQuery(
-    LOCAL_STORAGE_KEYS.DATABASE_CONNECTIONS_BANNER_DISMISSED(ref ?? ''),
+    LOCAL_STORAGE_KEYS.EXPLORER_BANNER_DISMISSED,
     false
   )
 

--- a/packages/common/constants/local-storage.ts
+++ b/packages/common/constants/local-storage.ts
@@ -116,6 +116,7 @@ export const LOCAL_STORAGE_KEYS = {
     `organization-marketplace-banner-dismissed-${orgSlug}-${managedBy}`,
   PROJECT_INTEGRATION_BANNER_DISMISSED: (ref: string, integrationSource: string) =>
     `project-integration-banner-dismissed-${ref}-${integrationSource}`,
+  EXPLORER_BANNER_DISMISSED: `explorer-banner-dismissed`,
 
   TABLE_EDITOR_QUEUE_OPERATIONS_BANNER_DISMISSED: (ref: string) =>
     `table-editor-queue-operations-banner-dismissed-${ref}`,

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -1531,6 +1531,28 @@ export interface DatabaseConnectionsBannerCtaButtonClickedEvent {
 }
 
 /**
+ * User clicked the dismiss button on the Explorer feature preview banner in studio project pages.
+ *
+ * @group Events
+ * @source studio
+ */
+export interface ExplorerBannerDismissButtonClickedEvent {
+  action: 'explorer_banner_dismiss_button_clicked'
+  groups: TelemetryGroups
+}
+
+/**
+ * User clicked the CTA button on the Explorer feature preview banner in studio project pages.
+ *
+ * @group Events
+ * @source studio
+ */
+export interface ExplorerBannerCtaButtonClickedEvent {
+  action: 'explorer_banner_cta_button_clicked'
+  groups: TelemetryGroups
+}
+
+/**
  * User clicked a metric card PID in the Overview panel of the Database Connections observability page, selecting it in the activity table below.
  *
  * @group Events
@@ -3810,6 +3832,8 @@ export type TelemetryEvent =
   | DatabaseConnectionsBlockerViewClickedEvent
   | DatabaseConnectionsBannerDismissButtonClickedEvent
   | DatabaseConnectionsBannerCtaButtonClickedEvent
+  | ExplorerBannerDismissButtonClickedEvent
+  | ExplorerBannerCtaButtonClickedEvent
   | SessionTerminateButtonClickedEvent
   | SessionTerminateSubmittedEvent
   | QueryCancelButtonClickedEvent


### PR DESCRIPTION
## Context

Adds a feature preview banner toast for the explorer - flagged behind the configcat flag
<img width="315" height="342" alt="image" src="https://github.com/user-attachments/assets/9dbd7ffd-02c6-4083-9ca0-266b862e1b5d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an Explorer preview banner to project layouts when the feature is enabled.
  - Added an “Enable Explorer” call-to-action that opens the feature preview.
  - Banner dismissal is remembered and persists across sessions.
  - Added telemetry tracking for banner dismissal and CTA interactions.

- **Bug Fixes**
  - Improved banner behavior and stability when displaying database connection notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->