### PR TITLE
Set default opt in for explorer to be false

### DIFF
--- a/apps/studio/components/interfaces/App/FeaturePreview/useFeaturePreviews.ts
+++ b/apps/studio/components/interfaces/App/FeaturePreview/useFeaturePreviews.ts
@@ -50,7 +50,7 @@ export const useFeaturePreviews = (): FeaturePreview[] => {
         enabled: isExplorerEnabled,
         isNew: true,
         isPlatformOnly: true,
-        isDefaultOptIn: true,
+        isDefaultOptIn: false,
         getRoute: (ref?: string) => `/project/${ref}/explorer`,
       },
       {


### PR DESCRIPTION
## Context

As per PR title - default opt in for explorer preview should be false

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Feature Preview**
  - Explorer & Notebooks is no longer enabled by default for users who have not previously opted in.
  - Existing preference selections remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->