### PR TITLE
fix(studio): let the assistant dropdown's link item render as its link

### DIFF
--- a/apps/studio/components/ui/AiAssistantDropdown.tsx
+++ b/apps/studio/components/ui/AiAssistantDropdown.tsx
@@ -180,7 +180,15 @@ export function AiAssistantDropdown({
             <>
               <DropdownMenuSeparator />
               {additionalDropdownItems.map((item, i) => (
-                <DropdownMenuItem key={i} onClick={item.onClick} className="gap-2">
+                // `asChild` only when there is an href: the item then renders as the Link, so
+                // selecting it with the keyboard follows the link. Without an href the child is
+                // a fragment, which Slot cannot merge into, so the default rendering stays.
+                <DropdownMenuItem
+                  key={i}
+                  onClick={item.onClick}
+                  className="gap-2"
+                  asChild={!!item.href}
+                >
                   {item.href ? (
                     <Link href={item.href} target="_blank" rel="noreferrer">
                       {item.icon}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix, following #49584.

## What is the current behavior?

#49584 made menu links reliable by giving the `DropdownMenuItem` that wraps a `Link` an `asChild`, in `InstanceNode.tsx` and `MapView.tsx`:

```diff
-<DropdownMenuItem className="gap-x-2">
+<DropdownMenuItem className="gap-x-2" asChild>
```

`AiAssistantDropdown.tsx:183` has the same shape and was not converted. Its `additionalDropdownItems` render as:

```tsx
<DropdownMenuItem key={i} onClick={item.onClick} className="gap-2">
  {item.href ? (
    <Link href={item.href} target="_blank" rel="noreferrer">
```

so the anchor sits inside the menu item rather than being it. Selecting the item with the keyboard, which is how a Radix menu item is normally activated, runs the item's own select handling and never activates the anchor, so the link does not open. A mouse click only navigates when the pointer happens to be over the anchor text rather than the item's padding.

This is reachable rather than theoretical. `ErrorCodeTooltip.tsx:117` is a live caller and passes an href:

```tsx
additionalDropdownItems={[
  { label: 'Go to Docs', icon: <ExternalLink size={14} />, href: docsUrl },
]}
```

The other two callers, `EdgeFunctionRecentErrors.tsx` and `useQueryInsightsTableColumns.tsx`, pass `onClick` instead of `href`, so they are unaffected either way.

## How I found it

I scanned every `DropdownMenuItem` in `apps/studio` whose first child is a `Link` or `a` and which has no `asChild`, using a brace-aware parse rather than a regex, since a regex cannot handle JSX attributes containing `{}`. Canaried against the commit before #49584 so I could tell the scan actually detects the pattern:

```
before #49584   3 hits   MapView, InstanceNode, AiAssistantDropdown
on master       1 hit    AiAssistantDropdown
with this fix   0 hits
```

## What is the new behavior?

The item renders as its link when it has one, so keyboard selection follows it.

`asChild` is conditional rather than unconditional here, which is the one way this differs from the two sites in #49584. When there is no href the child is a fragment, and Slot needs a single element to merge into, so `asChild={!!item.href}` keeps the existing rendering for the `onClick` callers.

## Deliberately not changed

No test. The two equivalent `asChild` fixes in #49584 shipped without one, and the test files that PR did add cover the larger `ProjectDropdown` and `OrganizationDropdown` rewrites rather than the one-prop changes. There is no existing component test for `AiAssistantDropdown` to extend, only `ErrorCodeTooltip.utils.test.ts` which tests utils. Happy to add one if you would rather have it.

I also left the `CommandItem` to `CommandItemLink` conversion from #49584 alone. Nothing outside the files that PR already touched still wraps a `Link` in a bare `CommandItem`.

## Additional context

Root cause at `apps/studio/components/ui/AiAssistantDropdown.tsx:183`.

Gates: `test:prettier` clean repo wide, `typecheck --filter=studio --force` 9/9, `lint:ratchet` reports rules improved.

Freshman contributor, and I use Claude Code as an assistant. I found this by scanning for the pattern #49584 fixed and checking which callsites it had not reached.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dropdown navigation so linked options behave correctly as keyboard-activated links.
  * Preserved standard menu-item behavior for options without links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->