### PR TITLE
fix(ui-patterns): let keyboard users scroll a wide code block

### DIFF
--- a/packages/ui-patterns/src/CodeBlock/CodeBlock.tsx
+++ b/packages/ui-patterns/src/CodeBlock/CodeBlock.tsx
@@ -195,9 +195,14 @@ export const CodeBlock = ({
         </div>
       )}
       {className ? (
+        // `tabIndex` because this scrolls: without it a keyboard user cannot reach the
+        // overflowing part of a wide snippet at all. Mirrors the same fix made to the docs
+        // code block in #49562.
         <div
+          tabIndex={0}
           className={cn(
             'group relative max-w-[90vw] md:max-w-none overflow-auto',
+            'focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring',
             wrapperClassName
           )}
         >


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Accessibility bug fix, following #49562.

## What is the current behavior?

`packages/ui-patterns/src/CodeBlock/CodeBlock.tsx:200` renders the snippet inside a scrolling wrapper:

```tsx
<div className={cn('group relative max-w-[90vw] md:max-w-none overflow-auto', wrapperClassName)}>
```

`overflow-auto` with nothing focusable inside it. I checked the whole file: no `tabIndex`, no `PreTag`, no `codeTagProps`, so nothing in that subtree can take focus. A snippet wider than its container scrolls fine with a mouse or trackpad, and a keyboard user cannot reach the overflowing part at all.

That is WCAG 2.1.1. A scrollable region has to be operable by keyboard, and the usual way to do that is to make the scroll container itself focusable.

#49562 fixed exactly this on the docs code block yesterday, adding `tabIndex={0}` plus a focus ring. This is the shared component, so the same gap is live in roughly 67 places across studio, including the AI assistant panel, the editor panel, `QueryBlock` and `EdgeFunctionBlock`.

Worth noting the file already anticipates focus: the highlighter carries `outline-hidden focus:border-foreground-lighter/50`. Nothing could ever match it, because nothing was focusable.

## What is the new behavior?

The scroll container takes `tabIndex={0}` and shows a focus ring, so it lands in the tab order and a keyboard user can scroll it with the arrow keys.

I used `focus-visible:ring-2 focus-visible:ring-ring`, which is the ring pattern already used in `packages/ui` (`radio-group-card.tsx`, `radio-group-stacked.tsx`, `resizable.tsx`) and the one #49562 used, rather than inventing a style.

## Deliberately not changed

I did not copy the `role="group"` / `aria-roledescription` / `aria-label` part of #49562. That labelling depends on `getCodeBlockLabel` in `apps/docs/features/ui/CodeBlock/CodeBlock.utils.ts`, which a package cannot import from an app, so mirroring it here would mean duplicating a helper across the boundary and picking the announced wording. Naming is your design call, and the keyboard trap is fixable without it. Happy to add it in the same shape if you want it.

I also left the second render branch alone. When `className` is absent the component renders a short inline `<code>` with no scroll container, so it has nothing to fix.

`apps/www/components/CodeBlock/CodeBlock.tsx` is a separate implementation and uses `overflow-hidden`, so it is not affected either.

## Additional context

Root cause at `packages/ui-patterns/src/CodeBlock/CodeBlock.tsx:200`.

No test. There is no existing test for this component, and asserting "a div has tabIndex" restates the diff rather than pinning behavior. The real check is tabbing to a wide snippet and pressing an arrow key.

Gates: `test:prettier` clean repo wide, `typecheck --force` 16/16 across every consumer, run three times after one first-run blip that turned out to be my own deletion of `content.generated.ts` immediately before the run, and clean master gives the same 16/16. `ui-patterns` tests 247/247.

Freshman contributor, and I use Claude Code as an assistant. I found this by checking whether the sibling code block implementations had the same gap #49562 had just closed in docs.
