### PR TITLE
fix(docs): resolve a composite schema given as a single object in the API reference

### DIFF
--- a/apps/docs/features/docs/Reference.api.utils.test.ts
+++ b/apps/docs/features/docs/Reference.api.utils.test.ts
@@ -5,20 +5,21 @@ import { getTypeDisplayFromSchema, type ISchema } from './Reference.api.utils'
 describe('getTypeDisplayFromSchema', () => {
   it('resolves a composite given as a single schema object', () => {
     // The shape analytics_v0 and functions_v0 actually ship, e.g.
-    // Notification.properties.team_user_ids_for_email
-    const schema = { allOf: { type: 'string' }, type: 'array' } as unknown as ISchema
+    // Notification.properties.team_user_ids_for_email. `type` sits alongside `allOf`
+    // there, which no single union member models, hence the assertion.
+    const schema = { allOf: { type: 'string' }, type: 'array' } as ISchema
 
     expect(getTypeDisplayFromSchema(schema)?.displayName).toBe('string')
   })
 
   it('resolves a composite given as a single element array', () => {
-    const schema = { allOf: [{ type: 'string' }] } as unknown as ISchema
+    const schema: ISchema = { allOf: [{ type: 'string' }] }
 
     expect(getTypeDisplayFromSchema(schema)?.displayName).toBe('string')
   })
 
   it('still reports a composite when there is more than one option', () => {
-    const schema = { allOf: [{ type: 'string' }, { type: 'integer' }] } as unknown as ISchema
+    const schema: ISchema = { allOf: [{ type: 'string' }, { type: 'integer' }] }
 
     expect(getTypeDisplayFromSchema(schema)?.displayName).toBe('all of the following options')
   })

--- a/apps/docs/features/docs/Reference.api.utils.test.ts
+++ b/apps/docs/features/docs/Reference.api.utils.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import { getTypeDisplayFromSchema, type ISchema } from './Reference.api.utils'
+
+describe('getTypeDisplayFromSchema', () => {
+  it('resolves a composite given as a single schema object', () => {
+    // The shape analytics_v0 and functions_v0 actually ship, e.g.
+    // Notification.properties.team_user_ids_for_email
+    const schema = { allOf: { type: 'string' }, type: 'array' } as unknown as ISchema
+
+    expect(getTypeDisplayFromSchema(schema)?.displayName).toBe('string')
+  })
+
+  it('resolves a composite given as a single element array', () => {
+    const schema = { allOf: [{ type: 'string' }] } as unknown as ISchema
+
+    expect(getTypeDisplayFromSchema(schema)?.displayName).toBe('string')
+  })
+
+  it('still reports a composite when there is more than one option', () => {
+    const schema = { allOf: [{ type: 'string' }, { type: 'integer' }] } as unknown as ISchema
+
+    expect(getTypeDisplayFromSchema(schema)?.displayName).toBe('all of the following options')
+  })
+})

--- a/apps/docs/features/docs/Reference.api.utils.ts
+++ b/apps/docs/features/docs/Reference.api.utils.ts
@@ -95,15 +95,21 @@ interface ISchemaEnum extends ISchemaBase {
 }
 
 interface ISchemaAllOf extends ISchemaBase {
-  allOf: Array<ISchema>
+  // Object form as well as array: some specs write a single schema here rather than a
+  // one element list. Normalise with `asSchemaArray` before iterating.
+  allOf: ISchema | Array<ISchema>
 }
 
 interface ISchemaAnyOf extends ISchemaBase {
-  anyOf: Array<ISchema>
+  // Object form as well as array: some specs write a single schema here rather than a
+  // one element list. Normalise with `asSchemaArray` before iterating.
+  anyOf: ISchema | Array<ISchema>
 }
 
 interface ISchemaOneOf extends ISchemaBase {
-  oneOf: Array<ISchema>
+  // Object form as well as array: some specs write a single schema here rather than a
+  // one element list. Normalise with `asSchemaArray` before iterating.
+  oneOf: ISchema | Array<ISchema>
 }
 
 interface IApiRequestBody extends IApiJsonDTO, IApiFormUrlEncodedDTO {}

--- a/apps/docs/features/docs/Reference.api.utils.ts
+++ b/apps/docs/features/docs/Reference.api.utils.ts
@@ -134,26 +134,37 @@ interface IFgaSecurity {
   fga_permissions: string[]
 }
 
+// Some specs have allOf/anyOf/oneOf as a single schema object instead of an
+// array. Wrap it so callers can treat both shapes the same way.
+export function asSchemaArray(value: unknown): Array<any> {
+  if (Array.isArray(value)) return value
+  if (value && typeof value === 'object') return [value]
+  return []
+}
+
 export function getTypeDisplayFromSchema(schema: ISchema) {
   if ('allOf' in schema) {
-    if (schema.allOf.length === 1) {
-      return getTypeDisplayFromSchema(schema.allOf[0])
+    const options = asSchemaArray(schema.allOf)
+    if (options.length === 1) {
+      return getTypeDisplayFromSchema(options[0])
     } else {
       return {
         displayName: 'all of the following options',
       }
     }
   } else if ('oneOf' in schema) {
-    if (schema.oneOf.length === 1) {
-      return getTypeDisplayFromSchema(schema.oneOf[0])
+    const options = asSchemaArray(schema.oneOf)
+    if (options.length === 1) {
+      return getTypeDisplayFromSchema(options[0])
     } else {
       return {
         displayName: 'one of the following options',
       }
     }
   } else if ('anyOf' in schema) {
-    if (schema.anyOf.length === 1) {
-      return getTypeDisplayFromSchema(schema.anyOf[0])
+    const options = asSchemaArray(schema.anyOf)
+    if (options.length === 1) {
+      return getTypeDisplayFromSchema(options[0])
     } else {
       return {
         displayName: 'any of the following options',

--- a/apps/docs/features/docs/Reference.ui.tsx
+++ b/apps/docs/features/docs/Reference.ui.tsx
@@ -16,7 +16,12 @@ import type { HTMLAttributes, PropsWithChildren } from 'react'
 import ReactMarkdown from 'react-markdown'
 import { Badge, cn, Collapsible, CollapsibleContent, CollapsibleTrigger } from 'ui'
 
-import { getTypeDisplayFromSchema, IApiEndPoint, type ISchema } from './Reference.api.utils'
+import {
+  asSchemaArray,
+  getTypeDisplayFromSchema,
+  IApiEndPoint,
+  type ISchema,
+} from './Reference.api.utils'
 import { API_REFERENCE_REQUEST_BODY_SCHEMA_DATA_ATTRIBUTES } from './Reference.ui.shared'
 
 interface SectionProps extends PropsWithChildren {
@@ -379,14 +384,6 @@ export function ApiOperationRequestBodyDetails({
 
 interface ApiOperationRequestBodyDetailsInternalProps extends HTMLAttributes<HTMLUListElement> {
   schema: ISchema
-}
-
-// Some specs have allOf/anyOf/oneOf as a single schema object instead of an
-// array. Wrap it so it still renders instead of crashing or disappearing.
-function asSchemaArray(value: unknown): Array<any> {
-  if (Array.isArray(value)) return value
-  if (value && typeof value === 'object') return [value]
-  return []
 }
 
 function ApiOperationRequestBodyDetailsInternal({


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix, following #49575.

## What is the current behavior?

#49575 added `asSchemaArray` with this reasoning:

> Some specs have allOf/anyOf/oneOf as a single schema object instead of an array.

and applied it throughout `Reference.ui.tsx`. `getTypeDisplayFromSchema` in `Reference.api.utils.ts` rests on the same assumption and was not changed:

```ts
if ('allOf' in schema) {
  if (schema.allOf.length === 1) {
    return getTypeDisplayFromSchema(schema.allOf[0])
  } else {
    return { displayName: 'all of the following options' }
  }
}
```

When `allOf` is an object, `.length` is `undefined`, `undefined === 1` is false, and it silently falls into the composite label. Same for `oneOf` and `anyOf`.

That shape is really in the specs you render, not just hypothetical. Scanning `spec/transforms/*_deparsed.json`, which is what `Reference.generated.script.ts` imports, finds **30** non-array `allOf` occurrences across `analytics_v0_openapi_deparsed.json` and `functions_v0_openapi_deparsed.json`. For example `Notification.properties.team_user_ids_for_email`:

```json
{ "allOf": { "type": "string" }, "type": "array" }
```

so those fields currently display **"all of the following options"** where there is exactly one option and the type is knowable.

## What is the new behavior?

`getTypeDisplayFromSchema` normalises through the same helper first, so a single-option composite collapses to its real type, which is what the surrounding `length === 1` branch was already trying to do.

I moved `asSchemaArray` into `Reference.api.utils.ts` and imported it into `Reference.ui.tsx` rather than writing a second copy. `Reference.ui.tsx` already imported from that file, so the direction was there.

## What I checked and did not change

No crash exists here, and I want to be precise since it looked like there might be. `Reference.api.utils.ts:188` calls `getTypeDisplayFromSchema(schema.items)` with no guard, and 60 schemas in those specs have `type: 'array'` with no `items`. It never throws, because every one of those 60 also has `allOf`, and both the util and `ApiOperationRequestBodyDetailsInternal` test the composite keys before reaching the array branch. I counted: zero schemas with `type: 'array'`, no `items`, and no `allOf`/`anyOf`/`oneOf`/`enum`. So I left that line alone rather than adding a guard for a state the data cannot produce.

I also left the `border-fault` to `border-default` change from #49575 alone. `border-fault` appears nowhere else in the monorepo, so there was no second instance to fix.

## Test

One new colocated file, `Reference.api.utils.test.ts`, in the pattern already used elsewhere in `apps/docs`. Reverting only the source and keeping the test gives:

```
FAIL  getTypeDisplayFromSchema > resolves a composite given as a single schema object
AssertionError: expected 'all of the following options' to be 'string'
Tests  1 failed | 2 passed (3)
```

The other two cases pass either way on purpose: they pin the array shape and the genuine multi-option case, so the fix cannot quietly over-normalise and start collapsing composites that really do have several options.

## Additional context

Root cause at `apps/docs/features/docs/Reference.api.utils.ts:139`, `:148`, `:157`.

Gates: `test:prettier` clean repo wide, `typecheck --filter=docs --force` 8/8, new test 3/3.

Freshman contributor, and I use Claude Code as an assistant. I found this by taking the premise stated in #49575's own comment and checking which other code made the same assumption.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API reference type displays for schemas using `allOf`, `oneOf`, or `anyOf` when defined as a single object or an array.
  * Standardized schema handling across request-body and parameter details.

* **Tests**
  * Added coverage for composite schema type display behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->