### PR TITLE
Update pricing page: BYO Cloud → AWS PrivateLink

### DIFF
--- a/packages/shared-data/plans.ts
+++ b/packages/shared-data/plans.ts
@@ -99,7 +99,7 @@ export const plans: PricingInformation[] = [
     features: [
       'Designated Support manager',
       'Uptime SLAs',
-      'BYO Cloud supported',
+      'Supports AWS PrivateLink',
       '24×7×365 premium enterprise support',
       'Private Slack channel',
       'Custom Security Questionnaires',

--- a/packages/shared-data/pricing.ts
+++ b/packages/shared-data/pricing.ts
@@ -70,7 +70,6 @@ export type FeatureKey =
   | 'realtime.maxMessageSize'
   | 'dashboard.teamMembers'
   | 'security.platformAuditLogs'
-  | 'security.byoc'
   | 'security.logRetention'
   | 'security.logDrain'
   | 'security.metricsEndpoint'
@@ -572,17 +571,6 @@ export const pricing: Pricing = {
     title: 'Platform Security and Compliance',
     icon: 'M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z',
     features: [
-      {
-        key: 'security.byoc',
-        title: 'BYO cloud',
-        plans: {
-          free: false,
-          pro: false,
-          team: false,
-          enterprise: true,
-        },
-        usage_based: false,
-      },
       {
         key: 'security.logRetention',
         title: 'Log retention (API & Database)',


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Content update to /pricing.

## What is the current behavior?

- The Enterprise plan card lists "BYO Cloud supported" as a feature.
- The Platform Security and Compliance comparison table has a separate "BYO cloud" row (Enterprise-only), alongside an existing "AWS PrivateLink" row.

## What is the new behavior?

- Enterprise plan card bullet changed to "Supports AWS PrivateLink".
- Removed the "BYO cloud" row entirely from the Platform Security and Compliance comparison table (the AWS PrivateLink row already covers this).

## Additional context

Data-only change in `packages/shared-data/plans.ts` and `packages/shared-data/pricing.ts`. No component logic changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Enterprise plan details now highlight AWS PrivateLink support.
  * Removed the BYO Cloud feature from the security feature listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->