### PR TITLE
feat(studio): polish account recovery request form UI

### DIFF
--- a/apps/studio/components/interfaces/SignIn/AccountRecovery.constants.ts
+++ b/apps/studio/components/interfaces/SignIn/AccountRecovery.constants.ts
@@ -1,0 +1,1 @@
+export const ACCOUNT_RECOVERY_HEADER_TITLE = 'Account recovery'

--- a/apps/studio/components/interfaces/SignIn/LostAccountAccessForm.tsx
+++ b/apps/studio/components/interfaces/SignIn/LostAccountAccessForm.tsx
@@ -176,6 +176,19 @@ const LostAccountAccessForm = ({ onSuccess }: { onSuccess: (email: string) => vo
         className="flex flex-col"
         onSubmit={form.handleSubmit(onRequestAccountRecovery)}
       >
+        <div className="h-0 overflow-hidden" aria-hidden="true">
+          <HCaptcha
+            ref={captchaRef}
+            sitekey={process.env.NEXT_PUBLIC_HCAPTCHA_SITE_KEY!}
+            size="invisible"
+            onVerify={(token) => {
+              setCaptchaToken(token)
+            }}
+            onExpire={() => {
+              setCaptchaToken(null)
+            }}
+          />
+        </div>
         <StandaloneFormCard>
           <StandaloneFormCardContent className="flex flex-col gap-y-6">
             <div className="px-6 flex flex-col gap-y-2">
@@ -327,19 +340,6 @@ const LostAccountAccessForm = ({ onSuccess }: { onSuccess: (email: string) => vo
           </StandaloneFormCardContent>
 
           <StandaloneFormCardFooter>
-            <div className="hidden" aria-hidden="true">
-              <HCaptcha
-                ref={captchaRef}
-                sitekey={process.env.NEXT_PUBLIC_HCAPTCHA_SITE_KEY!}
-                size="invisible"
-                onVerify={(token) => {
-                  setCaptchaToken(token)
-                }}
-                onExpire={() => {
-                  setCaptchaToken(null)
-                }}
-              />
-            </div>
             <Button block type="submit" size="medium" disabled={isPending} loading={isPending}>
               Submit recovery request
             </Button>

--- a/apps/studio/components/interfaces/SignIn/LostAccountAccessForm.tsx
+++ b/apps/studio/components/interfaces/SignIn/LostAccountAccessForm.tsx
@@ -1,11 +1,19 @@
 import HCaptcha from '@hcaptcha/react-hcaptcha'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { format } from 'date-fns'
-import Link from 'next/link'
 import { useRef, useState } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 import { toast } from 'sonner'
-import { Button, Calendar, Form, FormControl, FormField, Input, Separator, Textarea } from 'ui'
+import {
+  Button,
+  Calendar,
+  DialogSectionSeparator,
+  Form,
+  FormControl,
+  FormField,
+  Input,
+  Textarea,
+} from 'ui'
 import { Admonition } from 'ui-patterns/Admonition'
 import {
   DatePicker,
@@ -17,10 +25,22 @@ import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { SingleValueFieldArray } from 'ui-patterns/form/SingleValueFieldArray/SingleValueFieldArray'
 import * as z from 'zod'
 
+import {
+  StandaloneFormCard,
+  StandaloneFormCardContent,
+  StandaloneFormCardFooter,
+  StandaloneFormPanelHeading,
+} from '@/components/layouts/StandaloneFormPageLayout'
+import { DiscardChangesConfirmationDialog } from '@/components/ui-patterns/Dialogs/DiscardChangesConfirmationDialog'
+import { InlineLink } from '@/components/ui/InlineLink'
 import { useCreateAccountRecoveryRequestMutation } from '@/data/account-recovery/create-account-recovery-request-mutation'
+import { usePreventNavigationOnUnsavedChanges } from '@/hooks/ui/usePreventNavigationOnUnsavedChanges'
 
 const lostAccountSchema = z.object({
-  email: z.string().min(1, 'Please provide an email address').email('Must be a valid email'),
+  email: z
+    .string()
+    .min(1, 'Please provide an email address.')
+    .email('Must be a valid email address.'),
   organization: z.string(),
   projectRefs: z.array(
     z.object({
@@ -36,7 +56,7 @@ const lostAccountSchema = z.object({
   ),
   members: z.array(
     z.object({
-      value: z.union([z.literal(''), z.string().email('Must be a valid email')]),
+      value: z.union([z.literal(''), z.string().email('Must be a valid email address.')]),
     })
   ),
   notes: z.string().optional(),
@@ -48,7 +68,16 @@ export const LostAccountAccessFormWizard = () => {
   const [email, setEmail] = useState('')
 
   if (email) {
-    return <ConfirmAccountRecoveryRequest email={email} />
+    return (
+      <div className="flex flex-col gap-y-6">
+        <StandaloneFormCard>
+          <StandaloneFormCardContent>
+            <ConfirmAccountRecoveryRequest email={email} />
+          </StandaloneFormCardContent>
+        </StandaloneFormCard>
+        <AccountRecoverySecurityNote />
+      </div>
+    )
   }
 
   return <LostAccountAccessForm onSuccess={(email) => setEmail(email)} />
@@ -56,17 +85,28 @@ export const LostAccountAccessFormWizard = () => {
 
 const ConfirmAccountRecoveryRequest = ({ email }: { email: string }) => {
   return (
-    <Admonition type="default" title={`Check your email (${email}) for a reset code`}>
-      <p>
-        If elligible, you'll get an email with next steps. This can take a little while — there's
-        nothing else to do here right now
+    <div className="px-6 flex flex-col gap-y-2">
+      <StandaloneFormPanelHeading>Check your email</StandaloneFormPanelHeading>
+      <p className="text-sm text-foreground-light">
+        We sent a reset code to <span className="text-foreground">{email}</span>. If you’re
+        eligible, you’ll receive an email with next steps. This can take a little while.
       </p>
-      <p>
-        Supabase will never ask you for your password, a token, an API key, or a database connection
-        string during account recovery — by email, in this flow, or anywhere else.{' '}
-        <Link href="">What we will and won't ask for.</Link>
-      </p>
-    </Admonition>
+    </div>
+  )
+}
+
+const AccountRecoverySecurityNote = () => {
+  return (
+    <Admonition
+      type="note"
+      description={
+        <>
+          Supabase will never ask you for your password, a token, an API key, or a database
+          connection string during account recovery, by email, in this flow, or anywhere else.{' '}
+          <InlineLink href="/docs/security/account-recovery">Learn more</InlineLink>
+        </>
+      }
+    />
   )
 }
 
@@ -96,6 +136,14 @@ const LostAccountAccessForm = ({ onSuccess }: { onSuccess: (email: string) => vo
       },
     })
 
+  const { isDirty } = form.formState
+  const hasUnsavedChanges = isDirty && !isPending
+
+  const { handleCancelNavigation, handleConfirmNavigation, shouldConfirmNavigation } =
+    usePreventNavigationOnUnsavedChanges({
+      hasChanges: hasUnsavedChanges,
+    })
+
   const onRequestAccountRecovery: SubmitHandler<LostAccountAccessFormData> = async (data) => {
     let token = captchaToken
     if (!token) {
@@ -110,7 +158,7 @@ const LostAccountAccessForm = ({ onSuccess }: { onSuccess: (email: string) => vo
       email: data.email,
       organization: data.organization,
       projectRefs,
-      invoices: data.invoices.map((i) => ({
+      invoices: (data.invoices ?? []).map((i) => ({
         amount: i.amount != '' ? i.amount : undefined,
         number: i.number,
         issueDate: i.issueDate != null ? format(i.issueDate, 'yyyy-MM-dd') : undefined,
@@ -125,245 +173,252 @@ const LostAccountAccessForm = ({ onSuccess }: { onSuccess: (email: string) => vo
     <Form {...form}>
       <form
         method="POST"
-        className="flex flex-col pt-4 space-y-4"
+        className="flex flex-col"
         onSubmit={form.handleSubmit(onRequestAccountRecovery)}
       >
-        <Admonition
-          type="default"
-          title="Fill in what you can. Fields that don't apply to your account can be left blank — that's expected and won't count against you"
-        />
-        <FormField
-          control={form.control}
-          name="email"
-          render={({ field }) => (
-            <FormItemLayout label="Email" description="How we find your account">
-              <FormControl>
-                <Input
-                  {...field}
-                  type="email"
-                  placeholder="you@example.com"
-                  disabled={isPending}
-                  autoComplete="email"
-                />
-              </FormControl>
-            </FormItemLayout>
-          )}
-        />
-        <Separator />
-        <FormField
-          control={form.control}
-          name="organization"
-          render={({ field }) => (
-            <FormItemLayout label="Organization name and/or ID">
-              <FormControl>
-                <Input {...field} type="text" placeholder="" disabled={isPending} />
-              </FormControl>
-            </FormItemLayout>
-          )}
-        />
-        <Separator />
+        <StandaloneFormCard>
+          <StandaloneFormCardContent className="flex flex-col gap-y-6">
+            <div className="px-6 flex flex-col gap-y-2">
+              <StandaloneFormPanelHeading>Can’t access your account?</StandaloneFormPanelHeading>
+              <p className="text-sm text-foreground-light">
+                Fill in what you can. Leave blank any fields that don’t apply to your account.
+              </p>
+            </div>
 
-        <FormField
-          control={form.control}
-          name="projectRefs"
-          render={() => (
-            <FormItemLayout
-              label="Project IDs"
-              description="Leave blank if you're not sure — guessing a project ID that doesn't exist is an immediate fail."
-            >
-              <SingleValueFieldArray
+            <div className="px-6 flex flex-col gap-y-6">
+              <FormField
+                control={form.control}
+                name="email"
+                render={({ field }) => (
+                  <FormItemLayout label="Email" description="How we find your account.">
+                    <FormControl>
+                      <Input
+                        {...field}
+                        type="email"
+                        placeholder="you@example.com"
+                        disabled={isPending}
+                        autoComplete="email"
+                      />
+                    </FormControl>
+                  </FormItemLayout>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="organization"
+                render={({ field }) => (
+                  <FormItemLayout
+                    label="Organization name or slug"
+                    labelOptional="Optional"
+                    description="From your organization settings. Either is fine."
+                  >
+                    <FormControl>
+                      <Input
+                        {...field}
+                        type="text"
+                        placeholder="Acme"
+                        disabled={isPending}
+                        autoComplete="off"
+                        data-1p-ignore
+                        data-lpignore="true"
+                        data-form-type="other"
+                        data-bwignore
+                      />
+                    </FormControl>
+                  </FormItemLayout>
+                )}
+              />
+              <FormField
                 control={form.control}
                 name="projectRefs"
-                valueFieldName="value"
-                createEmptyRow={() => ({ value: '' })}
-                placeholder="hpjxqfdtriqhiwoqrdyz"
-                addLabel="Add another project"
-                removeLabel="Remove project"
+                render={() => (
+                  <FormItemLayout
+                    label="Project IDs"
+                    labelOptional="Optional"
+                    description="Leave blank if you’re not sure. Only include project IDs you’re confident about."
+                  >
+                    <SingleValueFieldArray
+                      control={form.control}
+                      name="projectRefs"
+                      valueFieldName="value"
+                      createEmptyRow={() => ({ value: '' })}
+                      placeholder="abcdefghijklmnopqrst"
+                      addLabel="Add another project"
+                      removeLabel="Remove project"
+                      minimumRows={1}
+                    />
+                  </FormItemLayout>
+                )}
               />
-            </FormItemLayout>
-          )}
-        />
-        <Separator />
+            </div>
 
-        <div>
-          <div className="flex gap-1 mb-4">
-            <span className="text-sm text-foreground flex gap-2 items-center wrap-break-word leading-normal">
-              Last two invoices
-            </span>
-            <span className="text-sm text-lighter items-center wrap-break-word leading-normal">
-              (Paid plans only).
-            </span>
-          </div>
+            <DialogSectionSeparator />
 
-          <div className="grid grid-cols-2 gap-x-4">
-            <div className="text-sm text-light">Most recent invoice</div>
-            <div className="text-sm text-light">Previous invoice</div>
-            <FormField
-              control={form.control}
-              name="invoices.0.number"
-              render={({ field }) => (
-                <FormItemLayout label={<span className="sr-only">Invoice number</span>}>
-                  <FormControl>
-                    <Input
-                      {...field}
-                      type="text"
-                      placeholder="Invoice number"
-                      disabled={isPending}
-                    />
-                  </FormControl>
-                </FormItemLayout>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name="invoices.1.number"
-              render={({ field }) => (
-                <FormItemLayout label={<span className="sr-only">Invoice number</span>}>
-                  <FormControl>
-                    <Input
-                      {...field}
-                      type="text"
-                      placeholder="Invoice number"
-                      disabled={isPending}
-                    />
-                  </FormControl>
-                </FormItemLayout>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name="invoices.0.amount"
-              render={({ field }) => (
-                <FormItemLayout label={<span className="sr-only">Amount</span>}>
-                  <FormControl>
-                    <Input {...field} type="number" placeholder="Amount" disabled={isPending} />
-                  </FormControl>
-                </FormItemLayout>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name="invoices.1.amount"
-              render={({ field }) => (
-                <FormItemLayout label={<span className="sr-only">Amount</span>}>
-                  <FormControl>
-                    <Input {...field} type="number" placeholder="Amount" disabled={isPending} />
-                  </FormControl>
-                </FormItemLayout>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name="invoices.0.issueDate"
-              render={({ field, fieldState }) => (
-                <FormItemLayout label={<span className="sr-only">Date</span>}>
-                  <FormControl>
-                    <DatePicker>
-                      <DatePickerTrigger asChild>
-                        <DatePickerButton block isInvalid={fieldState.invalid}>
-                          {field.value ? format(field.value, 'PPP') : 'Pick a date'}
-                        </DatePickerButton>
-                      </DatePickerTrigger>
-                      <DatePickerContent>
-                        <Calendar
-                          mode="single"
-                          selected={field.value}
-                          onSelect={field.onChange}
-                          initialFocus
-                        />
-                      </DatePickerContent>
-                    </DatePicker>
-                  </FormControl>
-                </FormItemLayout>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name="invoices.1.issueDate"
-              render={({ field, fieldState }) => (
-                <FormItemLayout label={<span className="sr-only">Date</span>}>
-                  <FormControl>
-                    <DatePicker>
-                      <DatePickerTrigger asChild>
-                        <DatePickerButton block isInvalid={fieldState.invalid}>
-                          {field.value ? format(field.value, 'PPP') : 'Pick a date'}
-                        </DatePickerButton>
-                      </DatePickerTrigger>
-                      <DatePickerContent>
-                        <Calendar
-                          mode="single"
-                          selected={field.value}
-                          onSelect={field.onChange}
-                          initialFocus
-                        />
-                      </DatePickerContent>
-                    </DatePicker>
-                  </FormControl>
-                </FormItemLayout>
-              )}
-            />
-          </div>
-        </div>
-        <Separator />
+            <div className="px-6">
+              <FormItemLayout
+                label="Last two invoices"
+                labelOptional="Optional"
+                description="Paid plans only."
+              >
+                <div className="flex flex-col gap-y-8">
+                  <InvoiceFields
+                    index={0}
+                    label="Most recent invoice"
+                    control={form.control}
+                    disabled={isPending}
+                  />
+                  <InvoiceFields
+                    index={1}
+                    label="Previous invoice"
+                    control={form.control}
+                    disabled={isPending}
+                  />
+                </div>
+              </FormItemLayout>
+            </div>
 
-        <FormField
-          control={form.control}
-          name="members"
-          render={() => (
-            <FormItemLayout
-              label="Other members' email addresses"
-              description="Team orgs. Corroborating only — this can't carry your request on its own."
-              hideMessage
-            >
-              <SingleValueFieldArray
+            <DialogSectionSeparator />
+
+            <div className="px-6">
+              <FormField
                 control={form.control}
                 name="members"
-                valueFieldName="value"
-                createEmptyRow={() => ({ value: '' })}
-                placeholder="teammate@example.com"
-                addLabel="Add another teammate"
-                removeLabel="Remove teammate"
+                render={() => (
+                  <FormItemLayout
+                    label="Other members’ email addresses"
+                    labelOptional="Optional"
+                    description="If your organization has other members, list their email addresses. We use these to corroborate your identity, not as the only proof we need."
+                    hideMessage
+                  >
+                    <SingleValueFieldArray
+                      control={form.control}
+                      name="members"
+                      valueFieldName="value"
+                      createEmptyRow={() => ({ value: '' })}
+                      placeholder="teammate@example.com"
+                      addLabel="Add another teammate"
+                      removeLabel="Remove teammate"
+                      minimumRows={1}
+                    />
+                  </FormItemLayout>
+                )}
               />
-            </FormItemLayout>
-          )}
-        />
+            </div>
 
+            <DialogSectionSeparator />
+
+            <div className="px-6">
+              <FormField
+                control={form.control}
+                name="notes"
+                render={({ field }) => (
+                  <FormItemLayout
+                    label="Notes"
+                    labelOptional="Optional"
+                    description="Include any other information that can help us recover your account."
+                  >
+                    <FormControl>
+                      <Textarea {...field} rows={4} className="max-h-48 resize-y" />
+                    </FormControl>
+                  </FormItemLayout>
+                )}
+              />
+            </div>
+          </StandaloneFormCardContent>
+
+          <StandaloneFormCardFooter>
+            <div className="hidden" aria-hidden="true">
+              <HCaptcha
+                ref={captchaRef}
+                sitekey={process.env.NEXT_PUBLIC_HCAPTCHA_SITE_KEY!}
+                size="invisible"
+                onVerify={(token) => {
+                  setCaptchaToken(token)
+                }}
+                onExpire={() => {
+                  setCaptchaToken(null)
+                }}
+              />
+            </div>
+            <Button block type="submit" size="medium" disabled={isPending} loading={isPending}>
+              Submit recovery request
+            </Button>
+          </StandaloneFormCardFooter>
+        </StandaloneFormCard>
+      </form>
+      <DiscardChangesConfirmationDialog
+        visible={shouldConfirmNavigation}
+        onCancel={handleCancelNavigation}
+        onClose={handleConfirmNavigation}
+      />
+    </Form>
+  )
+}
+
+const InvoiceFields = ({
+  index,
+  label,
+  control,
+  disabled,
+}: {
+  index: number
+  label: string
+  control: ReturnType<typeof useForm<LostAccountAccessFormData>>['control']
+  disabled: boolean
+}) => {
+  return (
+    <div className="flex flex-col gap-y-2">
+      <p className="text-sm text-foreground-light">{label}</p>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
         <FormField
-          control={form.control}
-          name="notes"
+          control={control}
+          name={`invoices.${index}.number`}
           render={({ field }) => (
-            <FormItemLayout
-              label="Notes"
-              description="Anything that can help us recover your account"
-            >
+            <FormItemLayout label="Invoice number">
               <FormControl>
-                <Textarea {...field} rows={4} className="resize-none" />
+                <Input {...field} type="text" placeholder="INV-001" disabled={disabled} />
               </FormControl>
             </FormItemLayout>
           )}
         />
-
-        <div className="self-center">
-          <HCaptcha
-            ref={captchaRef}
-            sitekey={process.env.NEXT_PUBLIC_HCAPTCHA_SITE_KEY!}
-            size="invisible"
-            onVerify={(token) => {
-              setCaptchaToken(token)
-            }}
-            onExpire={() => {
-              setCaptchaToken(null)
-            }}
-          />
-        </div>
-
-        <div className="border-t border-overlay-border" />
-
-        <Button block type="submit" size="medium" disabled={isPending} loading={isPending}>
-          Submit recovery request
-        </Button>
-      </form>
-    </Form>
+        <FormField
+          control={control}
+          name={`invoices.${index}.amount`}
+          render={({ field }) => (
+            <FormItemLayout label="Amount">
+              <FormControl>
+                <Input {...field} type="number" placeholder="25.00" disabled={disabled} />
+              </FormControl>
+            </FormItemLayout>
+          )}
+        />
+        <FormField
+          control={control}
+          name={`invoices.${index}.issueDate`}
+          render={({ field, fieldState }) => (
+            <FormItemLayout label="Date">
+              <FormControl>
+                <DatePicker>
+                  <DatePickerTrigger asChild>
+                    <DatePickerButton className="w-full" isInvalid={fieldState.invalid}>
+                      {field.value ? format(field.value, 'PPP') : 'Invoice payment date'}
+                    </DatePickerButton>
+                  </DatePickerTrigger>
+                  <DatePickerContent>
+                    <Calendar
+                      mode="single"
+                      selected={field.value}
+                      onSelect={field.onChange}
+                      initialFocus
+                    />
+                  </DatePickerContent>
+                </DatePicker>
+              </FormControl>
+            </FormItemLayout>
+          )}
+        />
+      </div>
+    </div>
   )
 }
 

--- a/apps/studio/components/layouts/StandaloneFormPageLayout.tsx
+++ b/apps/studio/components/layouts/StandaloneFormPageLayout.tsx
@@ -1,0 +1,106 @@
+import Link from 'next/link'
+import { type PropsWithChildren, type ReactNode } from 'react'
+import SVG from 'react-inlinesvg'
+import { Card, CardContent, CardFooter, cn, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
+
+import { BASE_PATH } from '@/lib/constants'
+
+type StandaloneFormPanelHeadingProps = {
+  children: ReactNode
+  className?: string
+}
+
+export function StandaloneFormPanelHeading({
+  children,
+  className,
+}: StandaloneFormPanelHeadingProps) {
+  return <h2 className={cn('text-xl m-0', className)}>{children}</h2>
+}
+
+type StandaloneFormCardProps = PropsWithChildren<{
+  className?: string
+}>
+
+export function StandaloneFormCard({ children, className }: StandaloneFormCardProps) {
+  return <Card className={cn('min-w-full w-full', className)}>{children}</Card>
+}
+
+type StandaloneFormCardContentProps = PropsWithChildren<{
+  className?: string
+}>
+
+export function StandaloneFormCardContent({ children, className }: StandaloneFormCardContentProps) {
+  return <CardContent className={cn('border-none py-8 px-0', className)}>{children}</CardContent>
+}
+
+type StandaloneFormCardFooterProps = PropsWithChildren<{
+  className?: string
+}>
+
+export function StandaloneFormCardFooter({ children, className }: StandaloneFormCardFooterProps) {
+  return (
+    <CardFooter className={cn('flex-col items-stretch border-t px-6 py-4', className)}>
+      {children}
+    </CardFooter>
+  )
+}
+
+type StandaloneFormPageHeaderProps = {
+  title: string
+  logoHref?: string
+  logoTooltip?: string
+}
+
+export function StandaloneFormPageHeader({
+  title,
+  logoHref = '/sign-in',
+  logoTooltip = 'Back to sign in',
+}: StandaloneFormPageHeaderProps) {
+  const logo = <SVG src={`${BASE_PATH}/img/supabase-logo.svg`} className="h-4 w-4" />
+
+  return (
+    <div className="flex items-center space-x-3">
+      {logoHref ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Link
+              href={logoHref}
+              className="rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground-muted"
+            >
+              {logo}
+              <span className="sr-only">{logoTooltip}</span>
+            </Link>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">{logoTooltip}</TooltipContent>
+        </Tooltip>
+      ) : (
+        logo
+      )}
+      <h1 className="m-0 text-lg">{title}</h1>
+    </div>
+  )
+}
+
+type StandaloneFormPageLayoutProps = PropsWithChildren<{
+  title: string
+  logoHref?: string
+  logoTooltip?: string
+}>
+
+export function StandaloneFormPageLayout({
+  title,
+  children,
+  logoHref,
+  logoTooltip,
+}: StandaloneFormPageLayoutProps) {
+  return (
+    <div className="relative min-h-screen overflow-y-auto overflow-x-hidden bg-studio">
+      <div className="mx-auto my-16 max-w-2xl w-full px-4 lg:px-6">
+        <div className="flex flex-col gap-y-8">
+          <StandaloneFormPageHeader title={title} logoHref={logoHref} logoTooltip={logoTooltip} />
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/studio/pages/lost-account-access.tsx
+++ b/apps/studio/pages/lost-account-access.tsx
@@ -1,17 +1,31 @@
+import Head from 'next/head'
+
+import { ACCOUNT_RECOVERY_HEADER_TITLE } from '@/components/interfaces/SignIn/AccountRecovery.constants'
 import { LostAccountAccessFormWizard } from '@/components/interfaces/SignIn/LostAccountAccessForm'
-import { ForgotPasswordLayout } from '@/components/layouts/SignInLayout/ForgotPasswordLayout'
+import { StandaloneFormPageLayout } from '@/components/layouts/StandaloneFormPageLayout'
+import { useCustomContent } from '@/hooks/custom-content/useCustomContent'
+import { buildStudioPageTitle } from '@/lib/page-title'
 import type { NextPageWithLayout } from '@/types'
 
 const LostAccountAccess: NextPageWithLayout = () => {
+  const { appTitle } = useCustomContent(['app:title'])
+  const pageTitle = buildStudioPageTitle({
+    section: 'Request Account Recovery',
+    brand: appTitle || 'Supabase',
+  })
+
   return (
-    <div className="flex flex-col gap-4">
+    <>
+      <Head>
+        <title>{pageTitle}</title>
+      </Head>
       <LostAccountAccessFormWizard />
-    </div>
+    </>
   )
 }
 
 LostAccountAccess.getLayout = (page) => (
-  <ForgotPasswordLayout heading="Recover your account">{page}</ForgotPasswordLayout>
+  <StandaloneFormPageLayout title={ACCOUNT_RECOVERY_HEADER_TITLE}>{page}</StandaloneFormPageLayout>
 )
 
 export default LostAccountAccess

--- a/apps/studio/routes/_auth/lost-account-access.tsx
+++ b/apps/studio/routes/_auth/lost-account-access.tsx
@@ -1,7 +1,8 @@
 import { createFileRoute } from '@tanstack/react-router'
 
-import { ForgotPasswordLayout } from '@/components/layouts/SignInLayout/ForgotPasswordLayout'
-import LostAccountAccessForm from '@/pages/lost-account-access'
+import { ACCOUNT_RECOVERY_HEADER_TITLE } from '@/components/interfaces/SignIn/AccountRecovery.constants'
+import { StandaloneFormPageLayout } from '@/components/layouts/StandaloneFormPageLayout'
+import LostAccountAccessPage from '@/pages/lost-account-access'
 
 export const Route = createFileRoute('/_auth/lost-account-access')({
   component: LostAccountAccess,
@@ -9,8 +10,8 @@ export const Route = createFileRoute('/_auth/lost-account-access')({
 
 function LostAccountAccess() {
   return (
-    <ForgotPasswordLayout heading="Recover your account">
-      <LostAccountAccessForm dehydratedState={undefined} />
-    </ForgotPasswordLayout>
+    <StandaloneFormPageLayout title={ACCOUNT_RECOVERY_HEADER_TITLE}>
+      <LostAccountAccessPage dehydratedState={undefined} />
+    </StandaloneFormPageLayout>
   )
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature polish for the account recovery request form (AUTH-1469), stacked on #49479.

## What is the current behavior?

The lost account access page uses the forgot-password layout shell, panel-style card markup, and minimal UX guardrails.

## What is the new behavior?

- Standalone form layout aligned with `/support/new` (header + `Card` compound components)
- Copy, spacing, and optional field labelling improvements
- Card footer for submit, dirty-form navigation guard, and `minimumRows={1}` on repeatable fields
- Success confirmation stays in-card; security note sits below the card
- 1Password ignore attributes on the organisation field

| After: Form | After: Success |
| --- | --- |
| <img width="1024" height="759" alt="Request Account Recovery  Supabase" src="https://github.com/user-attachments/assets/c2089189-1b65-48ce-a1f6-65a56ee7c20b" /> | <img width="1024" height="759" alt="Request Account Recovery  Supabase" src="https://github.com/user-attachments/assets/b4cb5ff9-ea2b-410c-911e-25c64aeed959" /> |

## To test

1. Open `/lost-account-access` while signed out
2. Confirm the page header shows **Account recovery** with a logo link back to sign-in
3. Fill in a few fields, then try leaving via the logo or closing the tab: you should get an unsaved-changes prompt
4. Submit the form (requires platform account recovery API): confirm the in-card **Check your email** state and the security note below the card
5. Confirm project ID and teammate rows cannot delete the last empty row

Depends on #49479.