### PR TITLE
feat(studio): migrate support forms to Card component

### DIFF
--- a/apps/studio/components/interfaces/Support/LinkSupportTicketPage.tsx
+++ b/apps/studio/components/interfaces/Support/LinkSupportTicketPage.tsx
@@ -2,7 +2,7 @@ import { Check, Mail } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useState } from 'react'
-import { Button, cn, DialogSectionSeparator } from 'ui'
+import { Button, Card, CardContent, DialogSectionSeparator } from 'ui'
 import { Admonition } from 'ui-patterns/Admonition'
 
 import { LinkSupportTicketForm } from './LinkSupportTicketForm'
@@ -36,20 +36,18 @@ function LinkSupportTicketPageContent() {
   }
 
   return (
-    <div
-      className={cn(
-        'min-w-full w-full space-y-12 rounded-sm border bg-panel-body-light shadow-md border-default'
-      )}
-    >
-      {isSuccess ? (
-        <LinkSupportTicketSuccess />
-      ) : (
-        <LinkSupportTicketForm
-          conversationId={conversationId}
-          onSuccess={() => setIsSuccess(true)}
-        />
-      )}
-    </div>
+    <Card className="min-w-full w-full">
+      <CardContent className="space-y-12 border-none py-8 px-0">
+        {isSuccess ? (
+          <LinkSupportTicketSuccess />
+        ) : (
+          <LinkSupportTicketForm
+            conversationId={conversationId}
+            onSuccess={() => setIsSuccess(true)}
+          />
+        )}
+      </CardContent>
+    </Card>
   )
 }
 

--- a/apps/studio/components/interfaces/Support/SupportFormPage.tsx
+++ b/apps/studio/components/interfaces/Support/SupportFormPage.tsx
@@ -5,7 +5,7 @@ import { useCallback, useReducer, type Dispatch, type PropsWithChildren } from '
 import type { UseFormReturn } from 'react-hook-form'
 import SVG from 'react-inlinesvg'
 import { toast } from 'sonner'
-import { Button, cn, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
+import { Button, Card, CardContent, cn, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 import { Admonition } from 'ui-patterns/Admonition'
 
 import { AIAssistantOption } from './AIAssistantOption'
@@ -258,20 +258,22 @@ function SupportFormBody({
   const isSuccess = state.type === 'success'
 
   return (
-    <div
-      className={cn(
-        'min-w-full w-full space-y-12 rounded-sm border bg-panel-body-light shadow-md py-8',
-        'border-default'
-      )}
-    >
-      {isSuccess ? (
-        <Success
-          selectedProject={selectedProjectRef ?? undefined}
-          sentCategory={state.sentCategory}
-        />
-      ) : (
-        <SupportFormV2 form={form} initialError={initialError} state={state} dispatch={dispatch} />
-      )}
-    </div>
+    <Card className="min-w-full w-full">
+      <CardContent className="space-y-12 border-none py-8 px-0">
+        {isSuccess ? (
+          <Success
+            selectedProject={selectedProjectRef ?? undefined}
+            sentCategory={state.sentCategory}
+          />
+        ) : (
+          <SupportFormV2
+            form={form}
+            initialError={initialError}
+            state={state}
+            dispatch={dispatch}
+          />
+        )}
+      </CardContent>
+    </Card>
   )
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

UI consistency update for support forms.

## What is the current behavior?

The support form and link-ticket page use bespoke panel-style `div`s (`bg-panel-body-light`, manual border/shadow classes).

## What is the new behavior?

Both pages use the shared `Card` and `CardContent` components from `ui`.

## Should this use StandaloneFormPageLayout?

No, not the full layout.

`StandaloneFormPageLayout` (in #49627) is for unauthenticated standalone pages: full-viewport shell, small logo header, back-to-sign-in link. Account recovery uses that because it sits outside `AppLayout`.

Support pages are different:

- They run inside `AppLayout` + `DefaultLayout` (signed-in dashboard shell)
- They need a custom header (troubleshooting link, status page button), not the simple logo + title header

So support should not adopt `StandaloneFormPageLayout` wholesale. The overlap is the card shell and the `max-w-2xl` content width, not the page chrome.

## Remaining work

- [ ] **Share card wrappers on master.** #49627 introduces `StandaloneFormCard` / `StandaloneFormCardContent` / `StandaloneFormCardFooter` in `StandaloneFormPageLayout.tsx`. After that lands, switch this PR's inline `Card` classNames to those helpers so support and account recovery stay in sync.
- [ ] **Unify outer page wrapper.** `SupportFormWrapper` and `LinkSupportTicketPage`'s outer `div` both hand-roll `mx-auto my-16 max-w-2xl`. Consider a shared authenticated form page container (without the unauthenticated logo header).
- [ ] **CardFooter on support submit.** Account recovery uses `StandaloneFormCardFooter` with a divider above submit. Support still renders submit inside the form body. Optional follow-up for visual parity.
- [ ] **Link support ticket success footer.** Success state still uses a manual divider + button row inside the card, not `CardFooter`.
- [ ] **Forgot-password / reset-password / MFA flows.** Explicitly out of scope. Still on `ForgotPasswordLayout` (large wordmark, no card). Separate PR if we want recovery UX consistency later.

## To test

1. Sign in and open `/support/new`
2. Confirm the form still renders inside a card with familiar spacing
3. Submit a test ticket (or reach the success state) and confirm the success view still renders correctly inside the card
4. Open `/support/link?conversationId=<id>` with a valid conversation ID and confirm the link form and success state use the same card shell