### PR TITLE
feat(studio): add pipeline settings summary

### DIFF
--- a/apps/studio/components/interfaces/Database/Replication/ReplicationPipelineLayout.test.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/ReplicationPipelineLayout.test.tsx
@@ -1,0 +1,144 @@
+import { fireEvent, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { ReplicationPipelineLayout } from './ReplicationPipelineLayout'
+import { customRender } from '@/tests/lib/custom-render'
+
+const mocks = vi.hoisted(() => ({
+  status: 'started',
+  hasUpdate: false,
+  path: '/project/default/database/replication/42',
+  setRequestStatus: vi.fn(),
+}))
+
+vi.mock('common', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('common')>()),
+  useParams: () => ({ ref: 'default', pipelineId: '42' }),
+}))
+
+vi.mock('next/router', () => ({
+  useRouter: () => ({ asPath: mocks.path }),
+}))
+
+vi.mock('./PipelineStatus', () => ({
+  PipelineStatus: () => <span>Running</span>,
+}))
+
+vi.mock('./UpdateVersionModal', () => ({
+  UpdateVersionModal: ({ visible }: { visible: boolean }) =>
+    visible ? <div>Update pipeline version</div> : null,
+}))
+
+vi.mock('@/data/replication/pipeline-by-id-query', () => ({
+  useReplicationPipelineByIdQuery: () => ({
+    data: {
+      id: 42,
+      source_name: 'main-db',
+      destination_name: 'Analytics warehouse',
+      config: { publication_name: 'analytics_publication' },
+    },
+    error: null,
+  }),
+}))
+
+vi.mock('@/data/replication/pipeline-status-query', () => ({
+  useReplicationPipelineStatusQuery: () => ({
+    data: { status: { name: mocks.status } },
+    isLoading: false,
+    isError: false,
+    isSuccess: true,
+  }),
+}))
+
+vi.mock('@/data/replication/pipeline-version-query', () => ({
+  useReplicationPipelineVersionQuery: () => ({
+    data: mocks.hasUpdate ? { new_version: { id: 2 } } : undefined,
+  }),
+}))
+
+vi.mock('@/data/replication/start-pipeline-mutation', () => ({
+  useStartPipelineMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}))
+
+vi.mock('@/data/replication/stop-pipeline-mutation', () => ({
+  useStopPipelineMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}))
+
+vi.mock('@/data/replication/restart-pipeline-mutation', () => ({
+  useRestartPipelineMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}))
+
+vi.mock('@/state/replication-pipeline-request-status', () => ({
+  PipelineStatusRequestStatus: {
+    None: 'None',
+    StartRequested: 'StartRequested',
+    StopRequested: 'StopRequested',
+    RestartRequested: 'RestartRequested',
+  },
+  usePipelineRequestStatus: () => ({
+    getRequestStatus: () => 'None',
+    setRequestStatus: mocks.setRequestStatus,
+    updatePipelineStatus: vi.fn(),
+  }),
+}))
+
+describe('ReplicationPipelineLayout', () => {
+  beforeEach(() => {
+    mocks.status = 'started'
+    mocks.hasUpdate = false
+    mocks.path = '/project/default/database/replication/42'
+  })
+
+  test('renders pipeline identity, navigation, logs and lifecycle action', async () => {
+    customRender(
+      <ReplicationPipelineLayout>
+        <div>Overview content</div>
+      </ReplicationPipelineLayout>
+    )
+
+    expect(await screen.findByRole('heading', { name: 'Analytics warehouse' })).toBeVisible()
+    expect(screen.getByText('From main-db using analytics_publication')).toBeVisible()
+    expect(screen.getByRole('link', { name: 'Replication' })).toHaveAttribute(
+      'href',
+      '/project/default/database/replication'
+    )
+    expect(screen.getByRole('link', { name: 'Settings' })).toHaveAttribute(
+      'href',
+      '/project/default/database/replication/42/settings'
+    )
+    expect(screen.getByRole('link', { name: 'View logs' }).getAttribute('href')).toContain(
+      'pipeline_id'
+    )
+    expect(screen.getByRole('button', { name: 'Stop' })).toBeVisible()
+  })
+
+  test('keeps an available update visible and opens its modal', async () => {
+    mocks.hasUpdate = true
+    customRender(<ReplicationPipelineLayout />)
+
+    const updateButton = await screen.findByRole('button', { name: 'Update available' })
+    expect(updateButton).toHaveClass('bg-brand-400')
+    fireEvent.click(updateButton)
+    expect(screen.getByText('Update pipeline version')).toBeVisible()
+  })
+
+  test.each([
+    ['stopped', 'Start'],
+    ['failed', 'Restart'],
+  ])('shows the correct %s lifecycle action', async (status, action) => {
+    mocks.status = status
+    customRender(<ReplicationPipelineLayout />)
+
+    expect(await screen.findByRole('button', { name: action })).toBeVisible()
+  })
+
+  test('marks Settings active on the settings route', async () => {
+    mocks.path = '/project/default/database/replication/42/settings?edit=7'
+    customRender(<ReplicationPipelineLayout />)
+
+    expect((await screen.findByRole('link', { name: 'Settings' })).parentElement).toHaveAttribute(
+      'aria-selected',
+      'true'
+    )
+  })
+})

--- a/apps/studio/components/interfaces/Database/Replication/ReplicationPipelineLayout.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/ReplicationPipelineLayout.tsx
@@ -1,0 +1,238 @@
+import { useParams } from 'common'
+import { ArrowUpCircle, Ban, Pause, Play, RotateCcw } from 'lucide-react'
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+import { PropsWithChildren, useEffect, useState } from 'react'
+import { toast } from 'sonner'
+import {
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbSeparator,
+  Button,
+  NavMenu,
+  NavMenuItem,
+} from 'ui'
+import {
+  PageHeader,
+  PageHeaderAside,
+  PageHeaderBreadcrumb,
+  PageHeaderDescription,
+  PageHeaderMeta,
+  PageHeaderNavigationTabs,
+  PageHeaderSummary,
+  PageHeaderTitle,
+} from 'ui-patterns/PageHeader'
+
+import { getPipelineDisplayState, getStatusName, PIPELINE_ACTIONABLE_STATES } from './Pipeline.utils'
+import { PipelineStatus } from './PipelineStatus'
+import { PipelineStatusName, STATUS_REFRESH_FREQUENCY_MS } from './Replication.constants'
+import { UpdateVersionModal } from './UpdateVersionModal'
+import { useReplicationPipelineByIdQuery } from '@/data/replication/pipeline-by-id-query'
+import { useReplicationPipelineStatusQuery } from '@/data/replication/pipeline-status-query'
+import { useReplicationPipelineVersionQuery } from '@/data/replication/pipeline-version-query'
+import { useRestartPipelineMutation } from '@/data/replication/restart-pipeline-mutation'
+import { useStartPipelineMutation } from '@/data/replication/start-pipeline-mutation'
+import { useStopPipelineMutation } from '@/data/replication/stop-pipeline-mutation'
+import {
+  PipelineStatusRequestStatus,
+  usePipelineRequestStatus,
+} from '@/state/replication-pipeline-request-status'
+import { type ResponseError } from '@/types'
+
+export const ReplicationPipelineLayout = ({ children }: PropsWithChildren) => {
+  const router = useRouter()
+  const { ref: projectRef, pipelineId: pipelineIdParam } = useParams()
+  const pipelineId = Number(pipelineIdParam)
+  const [showUpdateVersionModal, setShowUpdateVersionModal] = useState(false)
+  const { getRequestStatus, setRequestStatus, updatePipelineStatus } = usePipelineRequestStatus()
+  const requestStatus = getRequestStatus(pipelineId)
+
+  const { data: pipeline, error: pipelineError } = useReplicationPipelineByIdQuery({
+    projectRef,
+    pipelineId,
+  })
+  const {
+    data: pipelineStatusData,
+    error: pipelineStatusError,
+    isLoading: isPipelineStatusLoading,
+    isError: isPipelineStatusError,
+    isSuccess: isPipelineStatusSuccess,
+  } = useReplicationPipelineStatusQuery(
+    { projectRef, pipelineId },
+    { enabled: !!pipelineId, refetchInterval: STATUS_REFRESH_FREQUENCY_MS }
+  )
+  const { data: versionData } = useReplicationPipelineVersionQuery({
+    projectRef,
+    pipelineId: pipeline?.id,
+  })
+
+  const { mutateAsync: startPipeline, isPending: isStartingPipeline } =
+    useStartPipelineMutation()
+  const { mutateAsync: stopPipeline, isPending: isStoppingPipeline } = useStopPipelineMutation()
+  const { mutateAsync: restartPipeline, isPending: isRestartingPipeline } =
+    useRestartPipelineMutation()
+
+  const statusName = getStatusName(pipelineStatusData?.status)
+  const displayState = getPipelineDisplayState(requestStatus, statusName)
+  const hasUpdate = Boolean(versionData?.new_version)
+  const isTransitioning = requestStatus !== PipelineStatusRequestStatus.None
+  const isActionable = PIPELINE_ACTIONABLE_STATES.includes(statusName as PipelineStatusName)
+
+  const lifecycleLabel = isTransitioning
+    ? displayState.label
+    : statusName === PipelineStatusName.STOPPED
+      ? 'Start'
+      : statusName === PipelineStatusName.STARTED
+        ? 'Stop'
+        : statusName === PipelineStatusName.FAILED
+          ? 'Restart'
+          : displayState.label
+
+  const lifecycleIcon =
+    statusName === PipelineStatusName.STOPPED ? (
+      <Play />
+    ) : statusName === PipelineStatusName.STARTED ? (
+      <Pause />
+    ) : statusName === PipelineStatusName.FAILED ? (
+      <RotateCcw />
+    ) : (
+      <Ban />
+    )
+
+  const onLifecycleAction = async () => {
+    if (!projectRef || !pipeline) return
+
+    const action =
+      statusName === PipelineStatusName.STOPPED
+        ? 'start'
+        : statusName === PipelineStatusName.STARTED
+          ? 'stop'
+          : 'restart'
+
+    try {
+      if (statusName === PipelineStatusName.STOPPED) {
+        setRequestStatus(pipeline.id, PipelineStatusRequestStatus.StartRequested, statusName)
+        await startPipeline({ projectRef, pipelineId: pipeline.id })
+      } else if (statusName === PipelineStatusName.STARTED) {
+        setRequestStatus(pipeline.id, PipelineStatusRequestStatus.StopRequested, statusName)
+        await stopPipeline({ projectRef, pipelineId: pipeline.id })
+      } else if (statusName === PipelineStatusName.FAILED) {
+        setRequestStatus(pipeline.id, PipelineStatusRequestStatus.RestartRequested, statusName)
+        await restartPipeline({ projectRef, pipelineId: pipeline.id })
+      }
+    } catch (error) {
+      setRequestStatus(pipeline.id, PipelineStatusRequestStatus.None)
+      toast.error(`Failed to ${action} pipeline: ${(error as ResponseError).message}`)
+    }
+  }
+
+  useEffect(() => {
+    updatePipelineStatus(pipelineId, statusName)
+  }, [pipelineId, statusName, updatePipelineStatus])
+
+  const overviewUrl = `/project/${projectRef}/database/replication/${pipelineId}`
+  const settingsUrl = `${overviewUrl}/settings`
+  const logsUrl = `/project/${projectRef}/logs/replication-logs?f=${encodeURIComponent(
+    JSON.stringify({ pipeline_id: pipelineId })
+  )}`
+  const currentPath = router.asPath.split('?')[0]
+
+  return (
+    <div className="flex min-h-full w-full flex-col items-stretch">
+      <PageHeader size="full" className="sticky top-0 z-10 bg-surface-75">
+        <PageHeaderBreadcrumb>
+          <BreadcrumbList>
+            <BreadcrumbItem>
+              <BreadcrumbLink asChild>
+                <Link href={`/project/${projectRef}/database/replication`}>Replication</Link>
+              </BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator />
+            <BreadcrumbItem>{pipeline?.destination_name ?? 'Pipeline'}</BreadcrumbItem>
+          </BreadcrumbList>
+        </PageHeaderBreadcrumb>
+
+        <PageHeaderMeta>
+          <PageHeaderSummary>
+            <div className="flex flex-wrap items-center gap-3">
+              <PageHeaderTitle>{pipeline?.destination_name ?? 'Pipeline'}</PageHeaderTitle>
+              <PipelineStatus
+                pipelineStatus={pipelineStatusData?.status}
+                error={pipelineStatusError}
+                isLoading={isPipelineStatusLoading}
+                isError={isPipelineStatusError}
+                isSuccess={isPipelineStatusSuccess}
+                requestStatus={requestStatus}
+                pipelineId={pipelineId}
+              />
+            </div>
+            {pipeline !== undefined && (
+              <PageHeaderDescription>
+                From {pipeline.source_name} using {pipeline.config.publication_name}
+              </PageHeaderDescription>
+            )}
+          </PageHeaderSummary>
+
+          <PageHeaderAside>
+            <div className="flex flex-wrap items-center justify-end gap-2">
+              {hasUpdate && (
+                <Button
+                  variant="primary"
+                  icon={<ArrowUpCircle />}
+                  onClick={() => setShowUpdateVersionModal(true)}
+                >
+                  Update available
+                </Button>
+              )}
+              <Button asChild variant="default">
+                <Link href={logsUrl}>View logs</Link>
+              </Button>
+              <Button
+                variant={!hasUpdate && statusName === PipelineStatusName.STOPPED ? 'primary' : 'default'}
+                icon={lifecycleIcon}
+                className="capitalize"
+                onClick={onLifecycleAction}
+                loading={
+                  Boolean(pipelineError) ||
+                  displayState.type === 'loading' ||
+                  isTransitioning ||
+                  isStartingPipeline ||
+                  isStoppingPipeline ||
+                  isRestartingPipeline
+                }
+                disabled={!pipeline || isTransitioning || !isActionable}
+              >
+                {lifecycleLabel}
+              </Button>
+            </div>
+          </PageHeaderAside>
+        </PageHeaderMeta>
+
+        <PageHeaderNavigationTabs>
+          <NavMenu>
+            <NavMenuItem active={currentPath === overviewUrl}>
+              <Link href={overviewUrl}>Overview</Link>
+            </NavMenuItem>
+            <NavMenuItem active={currentPath === settingsUrl}>
+              <Link href={settingsUrl}>Settings</Link>
+            </NavMenuItem>
+          </NavMenu>
+        </PageHeaderNavigationTabs>
+      </PageHeader>
+
+      {children}
+
+      <UpdateVersionModal
+        visible={showUpdateVersionModal}
+        pipeline={pipeline}
+        onClose={() => setShowUpdateVersionModal(false)}
+        confirmLabel={
+          statusName === PipelineStatusName.STARTED || statusName === PipelineStatusName.FAILED
+            ? 'Update and restart'
+            : 'Update version'
+        }
+      />
+    </div>
+  )
+}

--- a/apps/studio/components/interfaces/Database/Replication/ReplicationPipelineSettings.test.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/ReplicationPipelineSettings.test.tsx
@@ -1,0 +1,59 @@
+import { fireEvent, screen } from '@testing-library/react'
+import { useState } from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+import { ReplicationPipelineSettings } from './ReplicationPipelineSettings'
+import { customRender } from '@/tests/lib/custom-render'
+
+const setEdit = vi.hoisted(() => vi.fn())
+
+vi.mock('common', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('common')>()),
+  useParams: () => ({ ref: 'default', pipelineId: '42' }),
+}))
+
+vi.mock('nuqs', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('nuqs')>()),
+  useQueryState: () => {
+    const [value, setValue] = useState<number | null>(null)
+    return [
+      value,
+      (nextValue: number | null) => {
+        setEdit(nextValue)
+        setValue(nextValue)
+      },
+    ]
+  },
+}))
+
+vi.mock('./DestinationPanel/DestinationPanel', () => ({
+  DestinationPanel: () => <div>Destination editor</div>,
+}))
+
+vi.mock('@/data/replication/pipeline-by-id-query', () => ({
+  useReplicationPipelineByIdQuery: () => ({
+    data: {
+      id: 42,
+      destination_id: 7,
+      source_name: 'main-db',
+      destination_name: 'Analytics warehouse',
+      config: { publication_name: 'analytics_publication' },
+    },
+    isPending: false,
+    isError: false,
+  }),
+}))
+
+describe('ReplicationPipelineSettings', () => {
+  test('shows configuration and opens the existing destination editor', () => {
+    customRender(<ReplicationPipelineSettings />)
+
+    expect(screen.getByText('Analytics warehouse')).toBeVisible()
+    expect(screen.getByText('main-db')).toBeVisible()
+    expect(screen.getByText('analytics_publication')).toBeVisible()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit destination' }))
+    expect(setEdit).toHaveBeenCalledWith(7)
+    expect(screen.getByText('Destination editor')).toBeVisible()
+  })
+})

--- a/apps/studio/components/interfaces/Database/Replication/ReplicationPipelineSettings.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/ReplicationPipelineSettings.tsx
@@ -1,0 +1,84 @@
+import { useParams } from 'common'
+import { Edit } from 'lucide-react'
+import { parseAsInteger, useQueryState } from 'nuqs'
+import { Button, Card, CardContent } from 'ui'
+import { PageContainer } from 'ui-patterns/PageContainer'
+import {
+  PageSection,
+  PageSectionAside,
+  PageSectionContent,
+  PageSectionDescription,
+  PageSectionMeta,
+  PageSectionSummary,
+  PageSectionTitle,
+} from 'ui-patterns/PageSection'
+import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
+
+import { DestinationPanel } from './DestinationPanel/DestinationPanel'
+import { AlertError } from '@/components/ui/AlertError'
+import { useReplicationPipelineByIdQuery } from '@/data/replication/pipeline-by-id-query'
+
+const ConfigurationRow = ({ label, value }: { label: string; value: string }) => (
+  <div className="flex flex-col justify-between gap-1 py-4 first:pt-0 last:pb-0 sm:flex-row sm:items-center">
+    <span className="text-sm text-foreground-light">{label}</span>
+    <span className="text-sm text-foreground">{value}</span>
+  </div>
+)
+
+export const ReplicationPipelineSettings = () => {
+  const { ref: projectRef, pipelineId: pipelineIdParam } = useParams()
+  const pipelineId = Number(pipelineIdParam)
+  const [edit, setEdit] = useQueryState(
+    'edit',
+    parseAsInteger.withOptions({ history: 'push', clearOnDefault: true })
+  )
+  const {
+    data: pipeline,
+    error,
+    isPending,
+    isError,
+  } = useReplicationPipelineByIdQuery({
+    projectRef,
+    pipelineId,
+  })
+
+  return (
+    <PageContainer size="small">
+      <PageSection>
+        <PageSectionMeta>
+          <PageSectionSummary>
+            <PageSectionTitle>Pipeline configuration</PageSectionTitle>
+            <PageSectionDescription>
+              Review the source and destination used by this pipeline.
+            </PageSectionDescription>
+          </PageSectionSummary>
+          {pipeline !== undefined && (
+            <PageSectionAside>
+              <Button icon={<Edit />} onClick={() => setEdit(pipeline.destination_id)}>
+                Edit destination
+              </Button>
+            </PageSectionAside>
+          )}
+        </PageSectionMeta>
+
+        <PageSectionContent>
+          {isPending ? (
+            <GenericSkeletonLoader />
+          ) : isError ? (
+            <AlertError error={error} subject="Failed to retrieve pipeline information" />
+          ) : pipeline !== undefined ? (
+            <Card>
+              <CardContent className="divide-y divide-border py-4">
+                <ConfigurationRow label="Destination" value={pipeline.destination_name} />
+                <ConfigurationRow label="Source" value={pipeline.source_name} />
+                <ConfigurationRow label="Publication" value={pipeline.config.publication_name} />
+              </CardContent>
+            </Card>
+          ) : null}
+        </PageSectionContent>
+      </PageSection>
+
+      {edit !== null && <DestinationPanel />}
+    </PageContainer>
+  )
+}

--- a/apps/studio/components/interfaces/Database/Replication/ReplicationPipelineStatus/ReplicationPipelineStatus.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/ReplicationPipelineStatus/ReplicationPipelineStatus.tsx
@@ -1,22 +1,7 @@
 import { useParams } from 'common'
-import {
-  Activity,
-  ArrowUpCircle,
-  Ban,
-  ChevronDown,
-  ChevronLeft,
-  Info,
-  Pause,
-  Play,
-  RotateCcw,
-  Search,
-  WifiOff,
-  X,
-} from 'lucide-react'
-import Link from 'next/link'
+import { Activity, ChevronDown, Info, RotateCcw, Search, WifiOff, X } from 'lucide-react'
 import { parseAsString, useQueryState } from 'nuqs'
 import { useEffect, useMemo, useState } from 'react'
-import { toast } from 'sonner'
 import {
   Button,
   Card,
@@ -31,19 +16,14 @@ import {
   TableRow,
 } from 'ui'
 import { Input } from 'ui-patterns/DataInputs/Input'
+import { PageContainer } from 'ui-patterns/PageContainer'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 
 import { BatchRestartDialog } from '../BatchRestartDialog'
 import { ErrorDetailsDialog } from '../ErrorDetailsDialog'
-import {
-  getPipelineDisplayState,
-  getStatusName,
-  PIPELINE_ACTIONABLE_STATES,
-} from '../Pipeline.utils'
-import { PipelineStatus } from '../PipelineStatus'
+import { getStatusName, PIPELINE_ACTIONABLE_STATES } from '../Pipeline.utils'
 import { PipelineStatusName, STATUS_REFRESH_FREQUENCY_MS } from '../Replication.constants'
 import { RestartTableDialog } from '../RestartTableDialog'
-import { UpdateVersionModal } from '../UpdateVersionModal'
 import { SlotLagMetrics } from './ReplicationPipelineStatus.types'
 import { getDisabledStateConfig } from './ReplicationPipelineStatus.utils'
 import { SlotLagMetricsInline, SlotLagMetricsList } from './SlotLagMetrics'
@@ -54,15 +34,10 @@ import { DropdownMenuItemTooltip } from '@/components/ui/DropdownMenuItemTooltip
 import { useReplicationPipelineByIdQuery } from '@/data/replication/pipeline-by-id-query'
 import { useReplicationPipelineReplicationStatusQuery } from '@/data/replication/pipeline-replication-status-query'
 import { useReplicationPipelineStatusQuery } from '@/data/replication/pipeline-status-query'
-import { useReplicationPipelineVersionQuery } from '@/data/replication/pipeline-version-query'
-import { useRestartPipelineMutation } from '@/data/replication/restart-pipeline-mutation'
-import { useStartPipelineMutation } from '@/data/replication/start-pipeline-mutation'
-import { useStopPipelineMutation } from '@/data/replication/stop-pipeline-mutation'
 import {
   PipelineStatusRequestStatus,
   usePipelineRequestStatus,
 } from '@/state/replication-pipeline-request-status'
-import { type ResponseError } from '@/types'
 
 /**
  * Component for displaying replication pipeline status and table replication details.
@@ -72,7 +47,6 @@ export const ReplicationPipelineStatus = () => {
   const { ref: projectRef, pipelineId: _pipelineId } = useParams()
   const [searchString, setSearchString] = useQueryState('search', parseAsString.withDefault(''))
 
-  const [showUpdateVersionModal, setShowUpdateVersionModal] = useState(false)
   const [showErrorDialog, setShowErrorDialog] = useState(false)
   const [selectedTableError, setSelectedTableError] = useState<{
     tableName: string
@@ -90,7 +64,7 @@ export const ReplicationPipelineStatus = () => {
   const [restartingTableIds, setRestartingTableIds] = useState<Set<number>>(new Set())
 
   const pipelineId = Number(_pipelineId)
-  const { getRequestStatus, updatePipelineStatus, setRequestStatus } = usePipelineRequestStatus()
+  const { getRequestStatus, updatePipelineStatus } = usePipelineRequestStatus()
   const requestStatus = getRequestStatus(pipelineId)
 
   const {
@@ -103,13 +77,7 @@ export const ReplicationPipelineStatus = () => {
     pipelineId,
   })
 
-  const {
-    data: pipelineStatusData,
-    error: pipelineStatusError,
-    isLoading: isPipelineStatusLoading,
-    isError: isPipelineStatusError,
-    isSuccess: isPipelineStatusSuccess,
-  } = useReplicationPipelineStatusQuery(
+  const { data: pipelineStatusData } = useReplicationPipelineStatusQuery(
     { projectRef, pipelineId },
     {
       enabled: !!pipelineId,
@@ -129,19 +97,7 @@ export const ReplicationPipelineStatus = () => {
     }
   )
 
-  const { data: versionData } = useReplicationPipelineVersionQuery({
-    projectRef,
-    pipelineId: pipeline?.id,
-  })
-  const hasUpdate = Boolean(versionData?.new_version)
-
-  const { mutateAsync: startPipeline, isPending: isStartingPipeline } = useStartPipelineMutation()
-  const { mutateAsync: stopPipeline, isPending: isStoppingPipeline } = useStopPipelineMutation()
-  const { mutateAsync: restartPipeline } = useRestartPipelineMutation()
-
-  const destinationName = pipeline?.destination_name
   const statusName = getStatusName(pipelineStatusData?.status)
-  const displayState = getPipelineDisplayState(requestStatus, statusName)
   const config = getDisabledStateConfig({ requestStatus, statusName })
 
   // Sort tables by schema and name for consistent ordering (memoized)
@@ -180,16 +136,12 @@ export const ReplicationPipelineStatus = () => {
   const isAnyRestartInProgress = restartingTableIds.size > 0
 
   const hasTableData = tableStatuses.length > 0
-  const isPipelineActionable =
-    statusName === PipelineStatusName.STARTED ||
-    statusName === PipelineStatusName.STOPPED ||
-    statusName === PipelineStatusName.FAILED
+  const isPipelineActionable = PIPELINE_ACTIONABLE_STATES.includes(statusName as PipelineStatusName)
   const isEnablingDisabling =
     requestStatus === PipelineStatusRequestStatus.StartRequested ||
     requestStatus === PipelineStatusRequestStatus.StopRequested ||
     requestStatus === PipelineStatusRequestStatus.RestartRequested
-  const isPipelineBusy = isEnablingDisabling || isAnyRestartInProgress
-  const showDisabledState = isPipelineBusy || !isPipelineActionable
+  const showDisabledState = isEnablingDisabling || isAnyRestartInProgress || !isPipelineActionable
   const lastKnownStateMessage =
     statusName === PipelineStatusName.STOPPED
       ? 'Showing the last known table state before the pipeline was stopped.'
@@ -201,121 +153,13 @@ export const ReplicationPipelineStatus = () => {
       ? `${Math.round(STATUS_REFRESH_FREQUENCY_MS / 1000)}s`
       : `${STATUS_REFRESH_FREQUENCY_MS}ms`
 
-  const logsUrl = `/project/${projectRef}/logs/replication-logs${
-    pipelineId ? `?f=${encodeURIComponent(JSON.stringify({ pipeline_id: pipelineId }))}` : ''
-  }`
-
-  const label = isEnablingDisabling
-    ? displayState.label
-    : statusName === PipelineStatusName.STOPPED
-      ? 'Start'
-      : statusName === PipelineStatusName.STARTED
-        ? 'Stop'
-        : statusName === PipelineStatusName.FAILED
-          ? 'Restart'
-          : displayState.label
-
-  const icon =
-    statusName === PipelineStatusName.STOPPED ? (
-      <Play />
-    ) : statusName === PipelineStatusName.STARTED ? (
-      <Pause />
-    ) : statusName === PipelineStatusName.FAILED ? (
-      <RotateCcw />
-    ) : (
-      <Ban />
-    )
-
-  const onPrimaryAction = async () => {
-    if (!projectRef) return console.error('Project ref is required')
-    if (!pipeline) return toast.error('No pipeline found')
-
-    const action =
-      statusName === PipelineStatusName.STOPPED
-        ? 'start'
-        : statusName === PipelineStatusName.STARTED
-          ? 'stop'
-          : 'restart'
-    try {
-      if (statusName === PipelineStatusName.STOPPED) {
-        setRequestStatus(pipeline.id, PipelineStatusRequestStatus.StartRequested, statusName)
-        await startPipeline({ projectRef, pipelineId: pipeline.id })
-      } else if (statusName === PipelineStatusName.STARTED) {
-        setRequestStatus(pipeline.id, PipelineStatusRequestStatus.StopRequested, statusName)
-        await stopPipeline({ projectRef, pipelineId: pipeline.id })
-      } else if (statusName === PipelineStatusName.FAILED) {
-        setRequestStatus(pipeline.id, PipelineStatusRequestStatus.RestartRequested, statusName)
-        await restartPipeline({ projectRef, pipelineId: pipeline.id })
-      }
-    } catch (error) {
-      setRequestStatus(pipeline.id, PipelineStatusRequestStatus.None)
-      toast.error(`Failed to ${action} pipeline: ${(error as ResponseError).message}`)
-    }
-  }
-
   useEffect(() => {
     updatePipelineStatus(pipelineId, statusName)
   }, [pipelineId, statusName, updatePipelineStatus])
 
   return (
-    <>
+    <PageContainer size="large">
       <div className="flex flex-col gap-y-4">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-x-3">
-            <Button asChild variant="outline" icon={<ChevronLeft />} style={{ padding: '5px' }}>
-              <Link href={`/project/${projectRef}/database/replication`} />
-            </Button>
-            <div className="flex items-center gap-x-3">
-              <h3 className="text-xl font-semibold">{destinationName || 'Pipeline'}</h3>
-              <PipelineStatus
-                pipelineStatus={pipelineStatusData?.status}
-                error={pipelineStatusError}
-                isLoading={isPipelineStatusLoading}
-                isError={isPipelineStatusError}
-                isSuccess={isPipelineStatusSuccess}
-                requestStatus={requestStatus}
-                pipelineId={pipelineId}
-              />
-            </div>
-          </div>
-
-          <div className="flex items-center gap-x-2">
-            {hasUpdate && (
-              <Button
-                variant="primary"
-                icon={<ArrowUpCircle />}
-                onClick={() => setShowUpdateVersionModal(true)}
-              >
-                Update available
-              </Button>
-            )}
-
-            <Button asChild variant="default">
-              <Link href={logsUrl}>View logs</Link>
-            </Button>
-
-            <Button
-              variant={statusName === PipelineStatusName.STOPPED ? 'primary' : 'default'}
-              onClick={onPrimaryAction}
-              loading={
-                isPipelineError ||
-                displayState.type === 'loading' ||
-                isEnablingDisabling ||
-                isStartingPipeline ||
-                isStoppingPipeline ||
-                isAnyRestartInProgress
-              }
-              disabled={
-                isPipelineBusy ||
-                !PIPELINE_ACTIONABLE_STATES.includes(statusName as PipelineStatusName)
-              }
-              icon={icon}
-              className="capitalize"
-            >
-              {label}
-            </Button>
-          </div>
-        </div>
         {isPipelineError && (
           <AlertError error={pipelineError} subject="Failed to retrieve pipeline information" />
         )}
@@ -330,10 +174,6 @@ export const ReplicationPipelineStatus = () => {
 
         {(isPipelineLoading || isStatusLoading) && (
           <div className="space-y-3">
-            <div className="flex items-center gap-x-3">
-              <div className="h-6 w-40 rounded-sm bg-surface-200" />
-              <div className="h-5 w-24 rounded-sm bg-surface-200" />
-            </div>
             <GenericSkeletonLoader />
           </div>
         )}
@@ -562,17 +402,6 @@ export const ReplicationPipelineStatus = () => {
         )}
       </div>
 
-      <UpdateVersionModal
-        visible={showUpdateVersionModal}
-        pipeline={pipeline}
-        onClose={() => setShowUpdateVersionModal(false)}
-        confirmLabel={
-          statusName === PipelineStatusName.STARTED || statusName === PipelineStatusName.FAILED
-            ? 'Update and restart'
-            : 'Update version'
-        }
-      />
-
       {/* Restart Table Confirmation Dialog */}
       {selectedTableForRestart && (
         <RestartTableDialog
@@ -630,6 +459,6 @@ export const ReplicationPipelineStatus = () => {
           }}
         />
       )}
-    </>
+    </PageContainer>
   )
 }

--- a/apps/studio/pages/project/[ref]/database/replication/[pipelineId]/settings.tsx
+++ b/apps/studio/pages/project/[ref]/database/replication/[pipelineId]/settings.tsx
@@ -1,9 +1,9 @@
 import { FeatureFlagContext, useParams } from 'common'
 import { useRouter } from 'next/router'
 import { useContext, useEffect } from 'react'
-import { PageContainer } from 'ui-patterns/PageContainer'
 
 import { ReplicationPipelineLayout } from '@/components/interfaces/Database/Replication/ReplicationPipelineLayout'
+import { ReplicationPipelineSettings } from '@/components/interfaces/Database/Replication/ReplicationPipelineSettings'
 import { useIsETLPrivateAlpha } from '@/components/interfaces/Database/Replication/useIsETLPrivateAlpha'
 import DatabaseLayout from '@/components/layouts/DatabaseLayout/DatabaseLayout'
 import { DefaultLayout } from '@/components/layouts/DefaultLayout'
@@ -27,7 +27,7 @@ const DatabaseReplicationSettingsPage: NextPageWithLayout = () => {
       {enablePgReplicate && (
         <PipelineRequestStatusProvider>
           <ReplicationPipelineLayout>
-            <PageContainer size="small" />
+            <ReplicationPipelineSettings />
           </ReplicationPipelineLayout>
         </PipelineRequestStatusProvider>
       )}

--- a/apps/studio/pages/project/[ref]/database/replication/[pipelineId]/settings.tsx
+++ b/apps/studio/pages/project/[ref]/database/replication/[pipelineId]/settings.tsx
@@ -1,8 +1,8 @@
 import { FeatureFlagContext, useParams } from 'common'
 import { useRouter } from 'next/router'
 import { useContext, useEffect } from 'react'
+import { PageContainer } from 'ui-patterns/PageContainer'
 
-import { ReplicationPipelineStatus } from '@/components/interfaces/Database/Replication/ReplicationPipelineStatus/ReplicationPipelineStatus'
 import { ReplicationPipelineLayout } from '@/components/interfaces/Database/Replication/ReplicationPipelineLayout'
 import { useIsETLPrivateAlpha } from '@/components/interfaces/Database/Replication/useIsETLPrivateAlpha'
 import DatabaseLayout from '@/components/layouts/DatabaseLayout/DatabaseLayout'
@@ -10,7 +10,7 @@ import { DefaultLayout } from '@/components/layouts/DefaultLayout'
 import { PipelineRequestStatusProvider } from '@/state/replication-pipeline-request-status'
 import type { NextPageWithLayout } from '@/types'
 
-const DatabaseReplicationPage: NextPageWithLayout = () => {
+const DatabaseReplicationSettingsPage: NextPageWithLayout = () => {
   const router = useRouter()
   const { ref: projectRef } = useParams()
   const { hasLoaded } = useContext(FeatureFlagContext)
@@ -27,7 +27,7 @@ const DatabaseReplicationPage: NextPageWithLayout = () => {
       {enablePgReplicate && (
         <PipelineRequestStatusProvider>
           <ReplicationPipelineLayout>
-            <ReplicationPipelineStatus />
+            <PageContainer size="small" />
           </ReplicationPipelineLayout>
         </PipelineRequestStatusProvider>
       )}
@@ -35,10 +35,10 @@ const DatabaseReplicationPage: NextPageWithLayout = () => {
   )
 }
 
-DatabaseReplicationPage.getLayout = (page) => (
+DatabaseReplicationSettingsPage.getLayout = (page) => (
   <DefaultLayout>
     <DatabaseLayout title="Replication">{page}</DatabaseLayout>
   </DefaultLayout>
 )
 
-export default DatabaseReplicationPage
+export default DatabaseReplicationSettingsPage

--- a/apps/studio/routeTree.gen.ts
+++ b/apps/studio/routeTree.gen.ts
@@ -275,6 +275,7 @@ import { Route as ApiPlatformAuthRefInviteRouteImport } from './routes/api/platf
 import { Route as AuthPartnersStripeProjectsLoginRouteImport } from './routes/_auth/partners/stripe/projects/login'
 import { Route as AppOrgSlugWebhooksEndpointIdRouteImport } from './routes/_app/org/$slug/webhooks/$endpointId'
 import { Route as ProjectRefIntegrationsIdPageIdIndexRouteImport } from './routes/project/$ref/integrations/$id/$pageId/index'
+import { Route as ProjectRefDatabaseReplicationPipelineIdIndexRouteImport } from './routes/project/$ref/database/replication/$pipelineId/index'
 import { Route as ApiV1ProjectsRefFunctionsIndexRouteImport } from './routes/api/v1/projects/$ref/functions/index'
 import { Route as ApiPlatformStorageRefVectorBucketsIndexRouteImport } from './routes/api/platform/storage/$ref/vector-buckets/index'
 import { Route as ApiPlatformStorageRefBucketsIndexRouteImport } from './routes/api/platform/storage/$ref/buckets/index'
@@ -288,6 +289,7 @@ import { Route as ProjectRefStorageFilesBucketsBucketIdRouteImport } from './rou
 import { Route as ProjectRefStorageAnalyticsBucketsBucketIdRouteImport } from './routes/project/$ref/storage/analytics/buckets/$bucketId'
 import { Route as ProjectRefSettingsInfrastructureReplicaReplicaIdRouteImport } from './routes/project/$ref/settings/infrastructure/replica/$replicaId'
 import { Route as ProjectRefDatabaseReplicationReplicaReplicaIdRouteImport } from './routes/project/$ref/database/replication/replica/$replicaId'
+import { Route as ProjectRefDatabaseReplicationPipelineIdSettingsRouteImport } from './routes/project/$ref/database/replication/$pipelineId/settings'
 import { Route as ApiV1ProjectsRefTypesTypescriptRouteImport } from './routes/api/v1/projects/$ref/types/typescript'
 import { Route as ApiV1ProjectsRefDatabaseMigrationsRouteImport } from './routes/api/v1/projects/$ref/database/migrations'
 import { Route as ApiV1ProjectsRefApiKeysIdRouteImport } from './routes/api/v1/projects/$ref/api-keys/$id'
@@ -1793,6 +1795,12 @@ const ProjectRefIntegrationsIdPageIdIndexRoute =
     path: '/$id/$pageId/',
     getParentRoute: () => ProjectRefIntegrationsRoute,
   } as any)
+const ProjectRefDatabaseReplicationPipelineIdIndexRoute =
+  ProjectRefDatabaseReplicationPipelineIdIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => ProjectRefDatabaseReplicationPipelineIdRoute,
+  } as any)
 const ApiV1ProjectsRefFunctionsIndexRoute =
   ApiV1ProjectsRefFunctionsIndexRouteImport.update({
     id: '/api/v1/projects/$ref/functions/',
@@ -1870,6 +1878,12 @@ const ProjectRefDatabaseReplicationReplicaReplicaIdRoute =
     id: '/replication/replica/$replicaId',
     path: '/replication/replica/$replicaId',
     getParentRoute: () => ProjectRefDatabaseRoute,
+  } as any)
+const ProjectRefDatabaseReplicationPipelineIdSettingsRoute =
+  ProjectRefDatabaseReplicationPipelineIdSettingsRouteImport.update({
+    id: '/settings',
+    path: '/settings',
+    getParentRoute: () => ProjectRefDatabaseReplicationPipelineIdRoute,
   } as any)
 const ApiV1ProjectsRefTypesTypescriptRoute =
   ApiV1ProjectsRefTypesTypescriptRouteImport.update({
@@ -2320,7 +2334,7 @@ export interface FileRoutesByFullPath {
   '/project/$ref/database/backups/restore-to-new-project': typeof ProjectRefDatabaseBackupsRestoreToNewProjectRoute
   '/project/$ref/database/backups/scheduled': typeof ProjectRefDatabaseBackupsScheduledRoute
   '/project/$ref/database/publications/$id': typeof ProjectRefDatabasePublicationsIdRoute
-  '/project/$ref/database/replication/$pipelineId': typeof ProjectRefDatabaseReplicationPipelineIdRoute
+  '/project/$ref/database/replication/$pipelineId': typeof ProjectRefDatabaseReplicationPipelineIdRouteWithChildren
   '/project/$ref/database/tables/$id': typeof ProjectRefDatabaseTablesIdRoute
   '/project/$ref/database/triggers/data': typeof ProjectRefDatabaseTriggersDataRoute
   '/project/$ref/database/triggers/event': typeof ProjectRefDatabaseTriggersEventRoute
@@ -2370,6 +2384,7 @@ export interface FileRoutesByFullPath {
   '/api/v1/projects/$ref/api-keys/$id': typeof ApiV1ProjectsRefApiKeysIdRoute
   '/api/v1/projects/$ref/database/migrations': typeof ApiV1ProjectsRefDatabaseMigrationsRoute
   '/api/v1/projects/$ref/types/typescript': typeof ApiV1ProjectsRefTypesTypescriptRoute
+  '/project/$ref/database/replication/$pipelineId/settings': typeof ProjectRefDatabaseReplicationPipelineIdSettingsRoute
   '/project/$ref/database/replication/replica/$replicaId': typeof ProjectRefDatabaseReplicationReplicaReplicaIdRoute
   '/project/$ref/settings/infrastructure/replica/$replicaId': typeof ProjectRefSettingsInfrastructureReplicaReplicaIdRoute
   '/project/$ref/storage/analytics/buckets/$bucketId': typeof ProjectRefStorageAnalyticsBucketsBucketIdRoute
@@ -2383,6 +2398,7 @@ export interface FileRoutesByFullPath {
   '/api/platform/storage/$ref/buckets/': typeof ApiPlatformStorageRefBucketsIndexRoute
   '/api/platform/storage/$ref/vector-buckets/': typeof ApiPlatformStorageRefVectorBucketsIndexRoute
   '/api/v1/projects/$ref/functions/': typeof ApiV1ProjectsRefFunctionsIndexRoute
+  '/project/$ref/database/replication/$pipelineId/': typeof ProjectRefDatabaseReplicationPipelineIdIndexRoute
   '/project/$ref/integrations/$id/$pageId/': typeof ProjectRefIntegrationsIdPageIdIndexRoute
   '/api/platform/auth/$ref/users/$id/factors': typeof ApiPlatformAuthRefUsersIdFactorsRoute
   '/api/platform/projects/$ref/analytics/endpoints/$name': typeof ApiPlatformProjectsRefAnalyticsEndpointsNameRoute
@@ -2622,7 +2638,6 @@ export interface FileRoutesByTo {
   '/project/$ref/database/backups/restore-to-new-project': typeof ProjectRefDatabaseBackupsRestoreToNewProjectRoute
   '/project/$ref/database/backups/scheduled': typeof ProjectRefDatabaseBackupsScheduledRoute
   '/project/$ref/database/publications/$id': typeof ProjectRefDatabasePublicationsIdRoute
-  '/project/$ref/database/replication/$pipelineId': typeof ProjectRefDatabaseReplicationPipelineIdRoute
   '/project/$ref/database/tables/$id': typeof ProjectRefDatabaseTablesIdRoute
   '/project/$ref/database/triggers/data': typeof ProjectRefDatabaseTriggersDataRoute
   '/project/$ref/database/triggers/event': typeof ProjectRefDatabaseTriggersEventRoute
@@ -2672,6 +2687,7 @@ export interface FileRoutesByTo {
   '/api/v1/projects/$ref/api-keys/$id': typeof ApiV1ProjectsRefApiKeysIdRoute
   '/api/v1/projects/$ref/database/migrations': typeof ApiV1ProjectsRefDatabaseMigrationsRoute
   '/api/v1/projects/$ref/types/typescript': typeof ApiV1ProjectsRefTypesTypescriptRoute
+  '/project/$ref/database/replication/$pipelineId/settings': typeof ProjectRefDatabaseReplicationPipelineIdSettingsRoute
   '/project/$ref/database/replication/replica/$replicaId': typeof ProjectRefDatabaseReplicationReplicaReplicaIdRoute
   '/project/$ref/settings/infrastructure/replica/$replicaId': typeof ProjectRefSettingsInfrastructureReplicaReplicaIdRoute
   '/project/$ref/storage/analytics/buckets/$bucketId': typeof ProjectRefStorageAnalyticsBucketsBucketIdRoute
@@ -2685,6 +2701,7 @@ export interface FileRoutesByTo {
   '/api/platform/storage/$ref/buckets': typeof ApiPlatformStorageRefBucketsIndexRoute
   '/api/platform/storage/$ref/vector-buckets': typeof ApiPlatformStorageRefVectorBucketsIndexRoute
   '/api/v1/projects/$ref/functions': typeof ApiV1ProjectsRefFunctionsIndexRoute
+  '/project/$ref/database/replication/$pipelineId': typeof ProjectRefDatabaseReplicationPipelineIdIndexRoute
   '/project/$ref/integrations/$id/$pageId': typeof ProjectRefIntegrationsIdPageIdIndexRoute
   '/api/platform/auth/$ref/users/$id/factors': typeof ApiPlatformAuthRefUsersIdFactorsRoute
   '/api/platform/projects/$ref/analytics/endpoints/$name': typeof ApiPlatformProjectsRefAnalyticsEndpointsNameRoute
@@ -2941,7 +2958,7 @@ export interface FileRoutesById {
   '/project/$ref/database/backups/restore-to-new-project': typeof ProjectRefDatabaseBackupsRestoreToNewProjectRoute
   '/project/$ref/database/backups/scheduled': typeof ProjectRefDatabaseBackupsScheduledRoute
   '/project/$ref/database/publications/$id': typeof ProjectRefDatabasePublicationsIdRoute
-  '/project/$ref/database/replication/$pipelineId': typeof ProjectRefDatabaseReplicationPipelineIdRoute
+  '/project/$ref/database/replication/$pipelineId': typeof ProjectRefDatabaseReplicationPipelineIdRouteWithChildren
   '/project/$ref/database/tables/$id': typeof ProjectRefDatabaseTablesIdRoute
   '/project/$ref/database/triggers/data': typeof ProjectRefDatabaseTriggersDataRoute
   '/project/$ref/database/triggers/event': typeof ProjectRefDatabaseTriggersEventRoute
@@ -2991,6 +3008,7 @@ export interface FileRoutesById {
   '/api/v1/projects/$ref/api-keys/$id': typeof ApiV1ProjectsRefApiKeysIdRoute
   '/api/v1/projects/$ref/database/migrations': typeof ApiV1ProjectsRefDatabaseMigrationsRoute
   '/api/v1/projects/$ref/types/typescript': typeof ApiV1ProjectsRefTypesTypescriptRoute
+  '/project/$ref/database/replication/$pipelineId/settings': typeof ProjectRefDatabaseReplicationPipelineIdSettingsRoute
   '/project/$ref/database/replication/replica/$replicaId': typeof ProjectRefDatabaseReplicationReplicaReplicaIdRoute
   '/project/$ref/settings/infrastructure/replica/$replicaId': typeof ProjectRefSettingsInfrastructureReplicaReplicaIdRoute
   '/project/$ref/storage/analytics/buckets/$bucketId': typeof ProjectRefStorageAnalyticsBucketsBucketIdRoute
@@ -3004,6 +3022,7 @@ export interface FileRoutesById {
   '/api/platform/storage/$ref/buckets/': typeof ApiPlatformStorageRefBucketsIndexRoute
   '/api/platform/storage/$ref/vector-buckets/': typeof ApiPlatformStorageRefVectorBucketsIndexRoute
   '/api/v1/projects/$ref/functions/': typeof ApiV1ProjectsRefFunctionsIndexRoute
+  '/project/$ref/database/replication/$pipelineId/': typeof ProjectRefDatabaseReplicationPipelineIdIndexRoute
   '/project/$ref/integrations/$id/$pageId/': typeof ProjectRefIntegrationsIdPageIdIndexRoute
   '/api/platform/auth/$ref/users/$id/factors': typeof ApiPlatformAuthRefUsersIdFactorsRoute
   '/api/platform/projects/$ref/analytics/endpoints/$name': typeof ApiPlatformProjectsRefAnalyticsEndpointsNameRoute
@@ -3309,6 +3328,7 @@ export interface FileRouteTypes {
     | '/api/v1/projects/$ref/api-keys/$id'
     | '/api/v1/projects/$ref/database/migrations'
     | '/api/v1/projects/$ref/types/typescript'
+    | '/project/$ref/database/replication/$pipelineId/settings'
     | '/project/$ref/database/replication/replica/$replicaId'
     | '/project/$ref/settings/infrastructure/replica/$replicaId'
     | '/project/$ref/storage/analytics/buckets/$bucketId'
@@ -3322,6 +3342,7 @@ export interface FileRouteTypes {
     | '/api/platform/storage/$ref/buckets/'
     | '/api/platform/storage/$ref/vector-buckets/'
     | '/api/v1/projects/$ref/functions/'
+    | '/project/$ref/database/replication/$pipelineId/'
     | '/project/$ref/integrations/$id/$pageId/'
     | '/api/platform/auth/$ref/users/$id/factors'
     | '/api/platform/projects/$ref/analytics/endpoints/$name'
@@ -3561,7 +3582,6 @@ export interface FileRouteTypes {
     | '/project/$ref/database/backups/restore-to-new-project'
     | '/project/$ref/database/backups/scheduled'
     | '/project/$ref/database/publications/$id'
-    | '/project/$ref/database/replication/$pipelineId'
     | '/project/$ref/database/tables/$id'
     | '/project/$ref/database/triggers/data'
     | '/project/$ref/database/triggers/event'
@@ -3611,6 +3631,7 @@ export interface FileRouteTypes {
     | '/api/v1/projects/$ref/api-keys/$id'
     | '/api/v1/projects/$ref/database/migrations'
     | '/api/v1/projects/$ref/types/typescript'
+    | '/project/$ref/database/replication/$pipelineId/settings'
     | '/project/$ref/database/replication/replica/$replicaId'
     | '/project/$ref/settings/infrastructure/replica/$replicaId'
     | '/project/$ref/storage/analytics/buckets/$bucketId'
@@ -3624,6 +3645,7 @@ export interface FileRouteTypes {
     | '/api/platform/storage/$ref/buckets'
     | '/api/platform/storage/$ref/vector-buckets'
     | '/api/v1/projects/$ref/functions'
+    | '/project/$ref/database/replication/$pipelineId'
     | '/project/$ref/integrations/$id/$pageId'
     | '/api/platform/auth/$ref/users/$id/factors'
     | '/api/platform/projects/$ref/analytics/endpoints/$name'
@@ -3929,6 +3951,7 @@ export interface FileRouteTypes {
     | '/api/v1/projects/$ref/api-keys/$id'
     | '/api/v1/projects/$ref/database/migrations'
     | '/api/v1/projects/$ref/types/typescript'
+    | '/project/$ref/database/replication/$pipelineId/settings'
     | '/project/$ref/database/replication/replica/$replicaId'
     | '/project/$ref/settings/infrastructure/replica/$replicaId'
     | '/project/$ref/storage/analytics/buckets/$bucketId'
@@ -3942,6 +3965,7 @@ export interface FileRouteTypes {
     | '/api/platform/storage/$ref/buckets/'
     | '/api/platform/storage/$ref/vector-buckets/'
     | '/api/v1/projects/$ref/functions/'
+    | '/project/$ref/database/replication/$pipelineId/'
     | '/project/$ref/integrations/$id/$pageId/'
     | '/api/platform/auth/$ref/users/$id/factors'
     | '/api/platform/projects/$ref/analytics/endpoints/$name'
@@ -5957,6 +5981,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProjectRefIntegrationsIdPageIdIndexRouteImport
       parentRoute: typeof ProjectRefIntegrationsRoute
     }
+    '/project/$ref/database/replication/$pipelineId/': {
+      id: '/project/$ref/database/replication/$pipelineId/'
+      path: '/'
+      fullPath: '/project/$ref/database/replication/$pipelineId/'
+      preLoaderRoute: typeof ProjectRefDatabaseReplicationPipelineIdIndexRouteImport
+      parentRoute: typeof ProjectRefDatabaseReplicationPipelineIdRoute
+    }
     '/api/v1/projects/$ref/functions/': {
       id: '/api/v1/projects/$ref/functions/'
       path: '/api/v1/projects/$ref/functions'
@@ -6047,6 +6078,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/project/$ref/database/replication/replica/$replicaId'
       preLoaderRoute: typeof ProjectRefDatabaseReplicationReplicaReplicaIdRouteImport
       parentRoute: typeof ProjectRefDatabaseRoute
+    }
+    '/project/$ref/database/replication/$pipelineId/settings': {
+      id: '/project/$ref/database/replication/$pipelineId/settings'
+      path: '/settings'
+      fullPath: '/project/$ref/database/replication/$pipelineId/settings'
+      preLoaderRoute: typeof ProjectRefDatabaseReplicationPipelineIdSettingsRouteImport
+      parentRoute: typeof ProjectRefDatabaseReplicationPipelineIdRoute
     }
     '/api/v1/projects/$ref/types/typescript': {
       id: '/api/v1/projects/$ref/types/typescript'
@@ -6557,6 +6595,24 @@ const ProjectRefDatabaseTriggersRouteWithChildren =
     ProjectRefDatabaseTriggersRouteChildren,
   )
 
+interface ProjectRefDatabaseReplicationPipelineIdRouteChildren {
+  ProjectRefDatabaseReplicationPipelineIdSettingsRoute: typeof ProjectRefDatabaseReplicationPipelineIdSettingsRoute
+  ProjectRefDatabaseReplicationPipelineIdIndexRoute: typeof ProjectRefDatabaseReplicationPipelineIdIndexRoute
+}
+
+const ProjectRefDatabaseReplicationPipelineIdRouteChildren: ProjectRefDatabaseReplicationPipelineIdRouteChildren =
+  {
+    ProjectRefDatabaseReplicationPipelineIdSettingsRoute:
+      ProjectRefDatabaseReplicationPipelineIdSettingsRoute,
+    ProjectRefDatabaseReplicationPipelineIdIndexRoute:
+      ProjectRefDatabaseReplicationPipelineIdIndexRoute,
+  }
+
+const ProjectRefDatabaseReplicationPipelineIdRouteWithChildren =
+  ProjectRefDatabaseReplicationPipelineIdRoute._addFileChildren(
+    ProjectRefDatabaseReplicationPipelineIdRouteChildren,
+  )
+
 interface ProjectRefDatabaseRouteChildren {
   ProjectRefDatabaseColumnPrivilegesRoute: typeof ProjectRefDatabaseColumnPrivilegesRoute
   ProjectRefDatabaseExtensionsRoute: typeof ProjectRefDatabaseExtensionsRoute
@@ -6573,7 +6629,7 @@ interface ProjectRefDatabaseRouteChildren {
   ProjectRefDatabaseBackupsRestoreToNewProjectRoute: typeof ProjectRefDatabaseBackupsRestoreToNewProjectRoute
   ProjectRefDatabaseBackupsScheduledRoute: typeof ProjectRefDatabaseBackupsScheduledRoute
   ProjectRefDatabasePublicationsIdRoute: typeof ProjectRefDatabasePublicationsIdRoute
-  ProjectRefDatabaseReplicationPipelineIdRoute: typeof ProjectRefDatabaseReplicationPipelineIdRoute
+  ProjectRefDatabaseReplicationPipelineIdRoute: typeof ProjectRefDatabaseReplicationPipelineIdRouteWithChildren
   ProjectRefDatabaseTablesIdRoute: typeof ProjectRefDatabaseTablesIdRoute
   ProjectRefDatabasePublicationsIndexRoute: typeof ProjectRefDatabasePublicationsIndexRoute
   ProjectRefDatabaseReplicationIndexRoute: typeof ProjectRefDatabaseReplicationIndexRoute
@@ -6601,7 +6657,7 @@ const ProjectRefDatabaseRouteChildren: ProjectRefDatabaseRouteChildren = {
     ProjectRefDatabaseBackupsScheduledRoute,
   ProjectRefDatabasePublicationsIdRoute: ProjectRefDatabasePublicationsIdRoute,
   ProjectRefDatabaseReplicationPipelineIdRoute:
-    ProjectRefDatabaseReplicationPipelineIdRoute,
+    ProjectRefDatabaseReplicationPipelineIdRouteWithChildren,
   ProjectRefDatabaseTablesIdRoute: ProjectRefDatabaseTablesIdRoute,
   ProjectRefDatabasePublicationsIndexRoute:
     ProjectRefDatabasePublicationsIndexRoute,

--- a/apps/studio/routes/project/$ref/database/replication/$pipelineId.tsx
+++ b/apps/studio/routes/project/$ref/database/replication/$pipelineId.tsx
@@ -1,14 +1,8 @@
-import { createFileRoute } from '@tanstack/react-router'
-
-import DatabaseReplicationPage from '@/pages/project/[ref]/database/replication/[pipelineId]'
+import { createFileRoute, Outlet } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/project/$ref/database/replication/$pipelineId')({
-  component: DatabaseReplicationPipelineRoute,
+  component: Outlet,
   staticData: {
     databaseLayoutTitle: 'Replication',
   },
 })
-
-function DatabaseReplicationPipelineRoute() {
-  return <DatabaseReplicationPage dehydratedState={undefined} />
-}

--- a/apps/studio/routes/project/$ref/database/replication/$pipelineId/index.tsx
+++ b/apps/studio/routes/project/$ref/database/replication/$pipelineId/index.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import DatabaseReplicationPage from '@/pages/project/[ref]/database/replication/[pipelineId]'
+
+export const Route = createFileRoute('/project/$ref/database/replication/$pipelineId/')({
+  component: DatabaseReplicationPipelineRoute,
+  staticData: {
+    databaseLayoutTitle: 'Replication',
+  },
+})
+
+function DatabaseReplicationPipelineRoute() {
+  return <DatabaseReplicationPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/database/replication/$pipelineId/settings.tsx
+++ b/apps/studio/routes/project/$ref/database/replication/$pipelineId/settings.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import DatabaseReplicationSettingsPage from '@/pages/project/[ref]/database/replication/[pipelineId]/settings'
+
+export const Route = createFileRoute('/project/$ref/database/replication/$pipelineId/settings')({
+  component: DatabaseReplicationSettingsRoute,
+  staticData: {
+    databaseLayoutTitle: 'Replication',
+  },
+})
+
+function DatabaseReplicationSettingsRoute() {
+  return <DatabaseReplicationSettingsPage dehydratedState={undefined} />
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Studio feature. Adds the first useful pipeline Settings content on top of the pipeline detail navigation.

Depends on #49630.

## What is the current behavior?

The new pipeline Settings route is empty.

## What is the new behavior?

Settings shows the pipeline destination, source, and publication. `Edit destination` opens the existing editor without introducing new configuration APIs.

## To test

1. Open the Vercel preview and select a project with an existing pipeline.
2. Open `Database > Replication`, select the pipeline, then select Settings.
3. Confirm the destination, source, and publication match the pipeline.
4. Select `Edit destination` and confirm the existing destination editor opens with the saved configuration.
5. Close the editor and confirm Settings remains active.
6. Rename the destination, save it, and confirm the Settings summary and page header refresh.
