### PR TITLE
Revert "fix: FormItemLayout does not apply item id correctly"

### DIFF
--- a/packages/ui-patterns/src/form/Layout/FormLayout.tsx
+++ b/packages/ui-patterns/src/form/Layout/FormLayout.tsx
@@ -398,6 +398,7 @@ export const FormLayout = React.forwardRef<
                 <FormLabel
                   className="text-foreground flex gap-2 items-center wrap-break-word"
                   data-formlayout-id="formLabel"
+                  htmlFor={props.name || id}
                 >
                   <LabelContents />
                 </FormLabel>


### PR DESCRIPTION
Reverts supabase/supabase#49593 because we currently provide `id` manually in some places and that breaks many tests. We didn't see the failures because the PR only modified `ui-patterns` which isn't in the paths checked to actually run the tests (this must be fixed too).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form accessibility by correctly associating labels with their corresponding fields in React form layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->