### PR TITLE
fix(studio): preserve search filter when refetching storage explorer objects

### DIFF
--- a/apps/studio/components/interfaces/Storage/StorageExplorer/StorageExplorer.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/StorageExplorer.tsx
@@ -41,6 +41,7 @@ export const StorageExplorer = () => {
     setSelectedFilePreview,
     setSelectedItemsToMove,
     setIsSearching,
+    setSearchString,
   } = useStorageExplorerStateSnapshot()
   const { view } = useStoragePreference(projectRef)
 
@@ -58,12 +59,14 @@ export const StorageExplorer = () => {
 
   const handleClearSearch = useCallback(() => {
     setIsSearching(false)
+    setSearchString('')
     setItemSearchString('')
-  }, [setIsSearching])
+  }, [setIsSearching, setSearchString])
 
   useStorageExplorerShortcuts({ onClearSearch: handleClearSearch })
 
   const fetchContents = useEffectEvent(async (bucket: Bucket) => {
+    setSearchString(debouncedSearchString)
     if (view === STORAGE_VIEWS.LIST) {
       const currentFolderIdx = openedFolders.length - 1
       const currentFolder = openedFolders[currentFolderIdx]

--- a/apps/studio/state/storage-explorer.tsx
+++ b/apps/studio/state/storage-explorer.tsx
@@ -162,6 +162,12 @@ function createStorageExplorerState({
       })
     },
 
+    searchString: '',
+    setSearchString: (value: string) => {
+      state.searchString = value
+      state.isSearching = value.length > 0
+    },
+
     isSearching: false,
     setIsSearching: (value: boolean) => (state.isSearching = value),
 
@@ -268,7 +274,7 @@ function createStorageExplorerState({
       folderId,
       folderName,
       index,
-      searchString,
+      searchString = state.searchString,
     }: {
       bucketId: string
       folderId: string | null
@@ -349,7 +355,7 @@ function createStorageExplorerState({
     fetchMoreFolderContents: async ({
       index,
       column,
-      searchString = '',
+      searchString = state.searchString,
     }: {
       index: number
       column: StorageColumn
@@ -395,9 +401,9 @@ function createStorageExplorerState({
       }
     },
 
-    refetchAllOpenedFolders: async () => {
+    refetchAllOpenedFolders: async (searchString = state.searchString) => {
       const paths = state.openedFolders.map((folder) => folder.name)
-      await state.fetchFoldersByPath({ paths })
+      await state.fetchFoldersByPath({ paths, searchString })
     },
 
     refreshAll: async () => {
@@ -411,7 +417,7 @@ function createStorageExplorerState({
 
     fetchFoldersByPath: async ({
       paths,
-      searchString = '',
+      searchString = state.searchString,
       showLoading = false,
     }: {
       paths: string[]


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Closes #49625

In the Storage Explorer, filtering objects by entering search text and then deleting one or more filtered objects causes `refetchAllOpenedFolders` to refetch bucket contents with `search: ''`. This resets the file list view to display full/unfiltered bucket contents, even though the search input box still contains the typed filter string.

## What is the new behavior?

- Added `searchString` and `setSearchString` to the `storage-explorer` state proxy.
- Defaulted `searchString` in `refetchAllOpenedFolders`, `fetchFoldersByPath`, `fetchFolderContents`, and `fetchMoreFolderContents` to `state.searchString`.
- Synchronized `debouncedSearchString` to `state.searchString` in `StorageExplorer`.

After deleting, moving, or renaming items while a search filter is active, the file list now refetches using the active search filter, keeping the list and search box in 100% agreement.

## Additional context

Verified UI search input sync and refetch behaviors across list and column views.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search terms now remain applied when refreshing, paginating, or navigating between folders in the storage explorer.
  * Clearing the search consistently resets the active filter.
  * Search input and displayed storage results now stay synchronized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->