### PR TITLE
fix(www): career page apply button sizing

### DIFF
--- a/apps/www/pages/careers.tsx
+++ b/apps/www/pages/careers.tsx
@@ -485,11 +485,11 @@ const JobItem = ({ job }: { job: JobItemProps }) => {
       <h4 className="text-base min-w-[240px] lg:min-w-[316px] grow sm:truncate mr-6">
         {job.title}
       </h4>
-      <div className="flex justify-between justify-[normal] pt-2 md:pt-0 lg:w-1/3 items-center">
-        <div className="flex items-center gap-4">
+      <div className="flex justify-between justify-[normal] pt-2 md:pt-0 items-center">
+        <div className="flex items-center gap-4 min-w-0">
           <Badge>
-            <GlobeAltIcon className="w-3 h-3" />
-            <span>{job.location}</span>
+            <GlobeAltIcon className="w-3 h-3 shrink-0" />
+            <span className="truncate">{job.location}</span>
           </Badge>
           <span className="hidden md:block">{job.employment}</span>
         </div>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Noticed this by accident, simplified the apply button area sizing on large screens. 

| Before | After |
|--------|--------|
| <img width="390" height="228" alt="Screenshot 2026-08-27 at 15 25 36" src="https://github.com/user-attachments/assets/7f49021c-1332-4a00-b19c-5544537c1cb4" /> | <img width="491" height="274" alt="Screenshot 2026-08-27 at 15 45 11" src="https://github.com/user-attachments/assets/846faff8-bd72-4141-b8d4-01d7ddd97b6d" /> | 






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved job listing badge layout and responsiveness.
  * Long location names now truncate cleanly instead of overflowing.
  * Reduced location icon size for a more balanced presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->