### PR TITLE
chore(studio): update edge functions detail page to use PageBreadcrumbs ui pattern

### DIFF
--- a/apps/studio/components/layouts/EdgeFunctionsLayout/EdgeFunctionDetailsLayout.tsx
+++ b/apps/studio/components/layouts/EdgeFunctionsLayout/EdgeFunctionDetailsLayout.tsx
@@ -26,10 +26,9 @@ import {
   Separator,
 } from 'ui'
 import { Input } from 'ui-patterns/DataInputs/Input'
+import { PageBreadcrumbs, PageBreadcrumbsActions } from 'ui-patterns/PageBreadcrumbs'
 import {
   PageHeader,
-  PageHeaderAside,
-  PageHeaderBreadcrumb,
   PageHeaderDescription,
   PageHeaderMeta,
   PageHeaderNavigationTabs,
@@ -273,9 +272,67 @@ const EdgeFunctionDetailsLayout = ({
   return (
     <EdgeFunctionsLayout title={title} browserTitle={browserTitle}>
       <div className="w-full min-h-full flex flex-col items-stretch">
-        <PageHeader size="full" className="sticky top-0 z-10 bg-surface-75">
+        <div className="sticky top-0 z-10">
           {breadcrumbItems.length > 0 && (
-            <PageHeaderBreadcrumb>
+            <PageBreadcrumbs
+              slotClassName="bg-sidebar"
+              actions={
+                <PageBreadcrumbsActions>
+                  <DocsButton href={`${DOCS_URL}/guides/functions`} />
+                  <Popover open={isDownloadOpen} onOpenChange={setIsDownloadOpen}>
+                    <ShortcutTooltip
+                      shortcutId={SHORTCUT_IDS.FUNCTION_DETAIL_OPEN_DOWNLOAD}
+                      side="bottom"
+                      open={isDownloadOpen ? false : undefined}
+                    >
+                      <PopoverTrigger asChild>
+                        <Button variant="default" icon={<Download />}>
+                          Download
+                        </Button>
+                      </PopoverTrigger>
+                    </ShortcutTooltip>
+                    <PopoverContent align="end" className="p-0">
+                      {IS_PLATFORM && (
+                        <>
+                          <div className="p-3 flex flex-col gap-y-2">
+                            <p className="text-xs text-foreground-light">Download via CLI</p>
+                            <Input
+                              copy
+                              showCopyOnHover
+                              readOnly
+                              containerClassName=""
+                              className="text-xs font-mono tracking-tighter"
+                              value={`supabase functions download ${functionSlug}`}
+                            />
+                          </div>
+                          <Separator className="bg-border-overlay!" />
+                        </>
+                      )}
+                      <div className="py-2 px-1">
+                        <Button
+                          variant="text"
+                          className="w-min hover:bg-transparent"
+                          icon={<FileArchive />}
+                          onClick={downloadFunction}
+                        >
+                          Download as ZIP
+                        </Button>
+                      </div>
+                    </PopoverContent>
+                  </Popover>
+                  {!!functionSlug && (
+                    <ShortcutTooltip
+                      shortcutId={SHORTCUT_IDS.FUNCTION_DETAIL_OPEN_TEST}
+                      side="bottom"
+                    >
+                      <Button variant="default" icon={<Send />} onClick={openTestSheet}>
+                        Test
+                      </Button>
+                    </ShortcutTooltip>
+                  )}
+                </PageBreadcrumbsActions>
+              }
+            >
               <BreadcrumbList>
                 {breadcrumbItems.map((item, index) => (
                   <React.Fragment key={item.label || `breadcrumb-${index}`}>
@@ -292,143 +349,91 @@ const EdgeFunctionDetailsLayout = ({
                   </React.Fragment>
                 ))}
               </BreadcrumbList>
-            </PageHeaderBreadcrumb>
+            </PageBreadcrumbs>
           )}
 
-          <PageHeaderMeta>
-            <PageHeaderSummary>
-              <PageHeaderTitle>{functionSlug ? name : 'Edge Functions'}</PageHeaderTitle>
-              <PageHeaderDescription className="flex flex-row flex-wrap items-center gap-x-4 gap-y-1 text-sm!">
-                <div className="flex items-center gap-x-2">
-                  <span className="flex items-center gap-2">{functionUrl}</span>
-                  <ShortcutTooltip shortcutId={SHORTCUT_IDS.FUNCTION_DETAIL_COPY_URL} side="bottom">
-                    <CopyButton iconOnly variant="text" text={functionUrl} />
-                  </ShortcutTooltip>
-                </div>
+          <PageHeader size="full" className="bg-surface-75">
+            <PageHeaderMeta>
+              <PageHeaderSummary>
+                <PageHeaderTitle>{functionSlug ? name : 'Edge Functions'}</PageHeaderTitle>
+                <PageHeaderDescription className="flex flex-row flex-wrap items-center gap-x-4 gap-y-1 text-sm!">
+                  <div className="flex items-center gap-x-2">
+                    <span className="flex items-center gap-2">{functionUrl}</span>
+                    <ShortcutTooltip
+                      shortcutId={SHORTCUT_IDS.FUNCTION_DETAIL_COPY_URL}
+                      side="bottom"
+                    >
+                      <CopyButton iconOnly variant="text" text={functionUrl} />
+                    </ShortcutTooltip>
+                  </div>
 
-                <HoverCard
-                  openDelay={250}
-                  closeDelay={100}
-                  open={isTimestampHoverCardOpen}
-                  onOpenChange={setIsTimestampHoverCardOpen}
-                >
-                  <HoverCardTrigger asChild>
-                    <button type="button" tabIndex={0} className="flex items-center gap-2 group">
-                      <Clock size={16} strokeWidth={1.5} className="text-foreground-lighter" />
-                      <span className="transition text-foreground-light group-hover:text-foreground underline decoration-dotted decoration-foreground-muted underline-offset-4">
-                        {updatedRelative ?? 'Deploy status unavailable'}
-                      </span>
-                    </button>
-                  </HoverCardTrigger>
-                  <HoverCardContent side="bottom" align="start" className="w-40 p-0">
-                    {createdRelative && (
-                      <div className="px-4 py-2 space-y-1">
-                        <h3 className="heading-meta text-foreground-light">Created</h3>
-                        {!!selectedFunction && (
-                          <TimestampInfo
-                            className="text-sm"
-                            label={createdRelative}
-                            utcTimestamp={selectedFunction.created_at}
-                          />
-                        )}
-                      </div>
-                    )}
-                    {updatedRelative && (
-                      <div className="px-4 py-2 space-y-1">
-                        <h3 className="heading-meta text-foreground-light">Last deployed</h3>
-                        {!!selectedFunction && (
-                          <TimestampInfo
-                            className="text-sm"
-                            label={updatedRelative}
-                            utcTimestamp={selectedFunction.updated_at}
-                          />
-                        )}
-                      </div>
-                    )}
-                    {selectedFunction?.version !== undefined && (
-                      <div className="px-4 py-2 space-y-1">
-                        <h3 className="heading-meta text-foreground-light">Deployments</h3>
-                        <p className="text-sm text-foreground">{selectedFunction.version}</p>
-                      </div>
-                    )}
-                  </HoverCardContent>
-                </HoverCard>
-              </PageHeaderDescription>
-            </PageHeaderSummary>
-
-            <PageHeaderAside>
-              <div className="flex items-center space-x-2">
-                <DocsButton href={`${DOCS_URL}/guides/functions`} />
-                <Popover open={isDownloadOpen} onOpenChange={setIsDownloadOpen}>
-                  <ShortcutTooltip
-                    shortcutId={SHORTCUT_IDS.FUNCTION_DETAIL_OPEN_DOWNLOAD}
-                    side="bottom"
-                    open={isDownloadOpen ? false : undefined}
+                  <HoverCard
+                    openDelay={250}
+                    closeDelay={100}
+                    open={isTimestampHoverCardOpen}
+                    onOpenChange={setIsTimestampHoverCardOpen}
                   >
-                    <PopoverTrigger asChild>
-                      <Button variant="default" icon={<Download />}>
-                        Download
-                      </Button>
-                    </PopoverTrigger>
-                  </ShortcutTooltip>
-                  <PopoverContent align="end" className="p-0">
-                    {IS_PLATFORM && (
-                      <>
-                        <div className="p-3 flex flex-col gap-y-2">
-                          <p className="text-xs text-foreground-light">Download via CLI</p>
-                          <Input
-                            copy
-                            showCopyOnHover
-                            readOnly
-                            containerClassName=""
-                            className="text-xs font-mono tracking-tighter"
-                            value={`supabase functions download ${functionSlug}`}
-                          />
+                    <HoverCardTrigger asChild>
+                      <button type="button" tabIndex={0} className="flex items-center gap-2 group">
+                        <Clock size={16} strokeWidth={1.5} className="text-foreground-lighter" />
+                        <span className="transition text-foreground-light group-hover:text-foreground underline decoration-dotted decoration-foreground-muted underline-offset-4">
+                          {updatedRelative ?? 'Deploy status unavailable'}
+                        </span>
+                      </button>
+                    </HoverCardTrigger>
+                    <HoverCardContent side="bottom" align="start" className="w-40 p-0">
+                      {createdRelative && (
+                        <div className="px-4 py-2 space-y-1">
+                          <h3 className="heading-meta text-foreground-light">Created</h3>
+                          {!!selectedFunction && (
+                            <TimestampInfo
+                              className="text-sm"
+                              label={createdRelative}
+                              utcTimestamp={selectedFunction.created_at}
+                            />
+                          )}
                         </div>
-                        <Separator className="bg-border-overlay!" />
-                      </>
-                    )}
-                    <div className="py-2 px-1">
-                      <Button
-                        variant="text"
-                        className="w-min hover:bg-transparent"
-                        icon={<FileArchive />}
-                        onClick={downloadFunction}
-                      >
-                        Download as ZIP
-                      </Button>
-                    </div>
-                  </PopoverContent>
-                </Popover>
-                {!!functionSlug && (
-                  <ShortcutTooltip
-                    shortcutId={SHORTCUT_IDS.FUNCTION_DETAIL_OPEN_TEST}
-                    side="bottom"
-                  >
-                    <Button variant="default" icon={<Send />} onClick={openTestSheet}>
-                      Test
-                    </Button>
-                  </ShortcutTooltip>
-                )}
-              </div>
-            </PageHeaderAside>
-          </PageHeaderMeta>
+                      )}
+                      {updatedRelative && (
+                        <div className="px-4 py-2 space-y-1">
+                          <h3 className="heading-meta text-foreground-light">Last deployed</h3>
+                          {!!selectedFunction && (
+                            <TimestampInfo
+                              className="text-sm"
+                              label={updatedRelative}
+                              utcTimestamp={selectedFunction.updated_at}
+                            />
+                          )}
+                        </div>
+                      )}
+                      {selectedFunction?.version !== undefined && (
+                        <div className="px-4 py-2 space-y-1">
+                          <h3 className="heading-meta text-foreground-light">Deployments</h3>
+                          <p className="text-sm text-foreground">{selectedFunction.version}</p>
+                        </div>
+                      )}
+                    </HoverCardContent>
+                  </HoverCard>
+                </PageHeaderDescription>
+              </PageHeaderSummary>
+            </PageHeaderMeta>
 
-          {navigationItems.length > 0 && (
-            <PageHeaderNavigationTabs>
-              <NavMenu>
-                {navigationItems.map((item) => {
-                  const isActive = router.asPath.split('?')[0] === item.href
-                  return (
-                    <NavMenuItem key={item.label} active={isActive}>
-                      <Link href={item.href}>{item.label}</Link>
-                    </NavMenuItem>
-                  )
-                })}
-              </NavMenu>
-            </PageHeaderNavigationTabs>
-          )}
-        </PageHeader>
+            {navigationItems.length > 0 && (
+              <PageHeaderNavigationTabs>
+                <NavMenu>
+                  {navigationItems.map((item) => {
+                    const isActive = router.asPath.split('?')[0] === item.href
+                    return (
+                      <NavMenuItem key={item.label} active={isActive}>
+                        <Link href={item.href}>{item.label}</Link>
+                      </NavMenuItem>
+                    )
+                  })}
+                </NavMenu>
+              </PageHeaderNavigationTabs>
+            )}
+          </PageHeader>
+        </div>
 
         {children}
         <EdgeFunctionTesterSheet visible={isOpen} onClose={() => setIsOpen(false)} />


### PR DESCRIPTION
| Before | After |
|--|--|
| <img width="1227" height="656" alt="Screenshot 2026-08-27 at 17 30 58" src="https://github.com/user-attachments/assets/2c523708-d816-41c0-a401-a9502bb2d8e2" /> | <img width="1227" height="654" alt="Screenshot 2026-08-27 at 17 29 45" src="https://github.com/user-attachments/assets/0169faa3-5bf9-43c3-ad71-1b2343e95053" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Restructured the edge function details header for a cleaner layout.
  * Improved placement and behavior of breadcrumbs and actions, including Docs, Download, and Test.
  * Preserved existing navigation, download, testing, URL copying, and timestamp functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->