### PR TITLE
fix(docs): actually clear project scoped keys on sign out

### DIFF
--- a/apps/docs/features/auth/auth.client.tsx
+++ b/apps/docs/features/auth/auth.client.tsx
@@ -1,9 +1,8 @@
 'use client'
 
 import { useQueryClient } from '@tanstack/react-query'
-import { AuthProvider, LOCAL_STORAGE_KEYS } from 'common'
+import { AuthProvider, clearLocalStorage } from 'common'
 import { type PropsWithChildren, useCallback } from 'react'
-import { remove } from '~/lib/storage'
 import { useOnLogout } from '~/lib/userAuth'
 
 /**
@@ -19,9 +18,7 @@ const SignOutHandler = ({ children }: PropsWithChildren) => {
     queryClient.cancelQueries()
     queryClient.clear()
 
-    Object.keys(LOCAL_STORAGE_KEYS).forEach((key) => {
-      remove('local', LOCAL_STORAGE_KEYS[key])
-    })
+    clearLocalStorage()
   }, [queryClient])
 
   useOnLogout(cleanUp)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix, on the sign out path in `apps/docs`.

## What is the current behavior?

`SignOutHandler` sits under a comment that says exactly what it is for:

```
 * !!! IMPORTANT !!!
 * Ensure data is cleared on sign out.
```

and clears storage like this:

```tsx
Object.keys(LOCAL_STORAGE_KEYS).forEach((key) => {
  remove('local', LOCAL_STORAGE_KEYS[key])
})
```

36 of the 85 entries in `LOCAL_STORAGE_KEYS` are not strings, they are functions of the form `(ref: string) => \`...-${ref}\``, because the key depends on the project. `remove` ends in `storage.removeItem(key as string)`, and that `as string` is a cast, not a conversion, so at runtime the function is coerced by `removeItem` into its own source text.

I ran it rather than reasoning about it:

```
before: [ 'dashboard-history-abcdefgh', 'supabase-report-daterange' ]
after : [ 'dashboard-history-abcdefgh' ]
key actually passed: "(ref)=>`dashboard-history-${ref}`"
```

The plain string key is removed. The project scoped one is not, because storage was asked to delete a key literally named `(ref)=>\`dashboard-history-${ref}\``, which nothing ever wrote.

So the 49 string keys are cleared and all 36 project scoped ones survive sign out. Those are the ones holding per project state: `DASHBOARD_HISTORY`, `AI_ASSISTANT_STATE`, `AUTH_USERS_FILTER`, `STORAGE_PREFERENCE` and so on. Since docs and studio share the `supabase.com` origin, that is studio's per project data still sitting in storage after someone signs out from docs.

## What is the new behavior?

It calls `clearLocalStorage()` from `common`, which enumerates the keys that are actually present and removes everything outside `LOCAL_STORAGE_KEYS_ALLOWLIST`. That is what the loop was trying to express, it works for keys whose names are only known at runtime, and it is already what studio calls on its own sign out (`packages/common/auth.tsx:162`, `apps/studio/lib/auth.tsx:50`), so the two apps now behave the same way.

Net effect is a deletion: the loop and the `remove` import go away.

## One behavior change worth calling out

`clearLocalStorage` is allowlist based rather than manifest based, so it also clears keys that are not in `LOCAL_STORAGE_KEYS` at all. In `apps/docs` there is one: `supabase.ui-patterns.ComplexTabs.withQueryParams.v0`, the remembered code tab selection in `useTabsWithQueryParams.tsx`. Today it survives sign out; after this it would not.

I left that alone rather than folding it in. If you want it preserved it is one line in the allowlist, which already holds raw strings like `'theme'` and `'graphiql:theme'`, but that is a product call about whether a UI preference should outlive a sign out, and it is a different concern from the bug. Happy to add it if you say so.

The `SAVED_ORG` / `SAVED_PROJECT` / `SAVED_BRANCH` keys that docs writes itself are plain strings, so they were already being cleared and still are.

## Additional context

Root cause at `apps/docs/features/auth/auth.client.tsx:22`.

No test. There is no existing test for `features/auth`, and the honest check here is a browser one: sign out and confirm a project scoped key is gone. Worth flagging that `clearLocalStorage` is currently a no-op under vitest for an unrelated reason (`safeLocalStorage.keys()` uses `Object.keys`, which does not enumerate the suite's storage polyfill), which is #49336 and open, so a unit test written today would pass vacuously.

Gates: `test:prettier` clean repo wide, `typecheck --force` 16/16. `~/lib/storage` is not orphaned, `retrieve` and `storeOrRemoveNull` are still used by `ProjectConfigVariables.tsx` and `remove` is still called inside `storeOrRemoveNull`.

Freshman contributor, and I use Claude Code as an assistant. I found this while checking whether some `LOCAL_STORAGE_KEYS` entries were dead, noticed this loop enumerates the whole object, and looked at what it does with the function valued half.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sign-out cleanup by reliably clearing locally stored session data.
  - Simplified the cleanup process to help ensure no stale authentication data remains after signing out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->