### PR TITLE
feat(studio): add Health Advisor page

### DIFF
--- a/apps/studio/TANSTACK_MIGRATION.md
+++ b/apps/studio/TANSTACK_MIGRATION.md
@@ -290,6 +290,7 @@ These are the layout-only TanStack files. Most hold a single product layout comp
 
 ### Project shell — `/advisors/*`
 
+- [x] A `routes/project/$ref/advisors/health.tsx` ← `pages/project/[ref]/advisors/health.tsx`
 - [x] A `routes/project/$ref/advisors/performance.tsx` ← `pages/project/[ref]/advisors/performance.tsx`
 - [x] A `routes/project/$ref/advisors/security.tsx` ← `pages/project/[ref]/advisors/security.tsx`
 - [x] A `routes/project/$ref/advisors/rules/performance.tsx` ← `pages/project/[ref]/advisors/rules/performance.tsx`

--- a/apps/studio/components/interfaces/Linter/Linter.utils.test.tsx
+++ b/apps/studio/components/interfaces/Linter/Linter.utils.test.tsx
@@ -2,7 +2,8 @@ import { Ruler } from 'lucide-react'
 import { isValidElement } from 'react'
 import { describe, expect, it } from 'vitest'
 
-import { lintInfoMap } from './Linter.utils'
+import { lintInfoMap, parseLinterLevel } from './Linter.utils'
+import { LINTER_LEVELS } from '@/components/interfaces/Linter/Linter.constants'
 import { Lint } from '@/data/lint/lint-query'
 
 const projectRef = 'abc'
@@ -81,5 +82,19 @@ describe('Linter.utils lintInfoMap pitr_archiving_stale entry', () => {
     // metadata is unused by this entry's link(), and every field on Lint['metadata'] is optional, so {} needs no cast
     expect(info!.link({ projectRef, metadata: {} })).toBe('/project/abc/database/backups/pitr')
     expect(info!.docsLink).toContain('/guides/platform/backups#point-in-time-recovery')
+  })
+})
+
+describe('parseLinterLevel', () => {
+  it('returns the matching level', () => {
+    expect(parseLinterLevel('ERROR')).toBe(LINTER_LEVELS.ERROR)
+    expect(parseLinterLevel('WARN')).toBe(LINTER_LEVELS.WARN)
+    expect(parseLinterLevel('INFO')).toBe(LINTER_LEVELS.INFO)
+  })
+
+  it('returns undefined for values that are not a level', () => {
+    expect(parseLinterLevel('error')).toBeUndefined()
+    expect(parseLinterLevel('SOMETHING_ELSE')).toBeUndefined()
+    expect(parseLinterLevel(undefined)).toBeUndefined()
   })
 })

--- a/apps/studio/components/interfaces/Linter/Linter.utils.tsx
+++ b/apps/studio/components/interfaces/Linter/Linter.utils.tsx
@@ -571,6 +571,15 @@ Issue Details: ${issue}
 Description: ${description}`
 }
 
+const LINTER_LEVEL_VALUES = Object.values(LINTER_LEVELS)
+
+/**
+ * The `preset` query param is user controlled, so match it against the known levels
+ * instead of trusting it to be one.
+ */
+export const parseLinterLevel = (value?: string) =>
+  LINTER_LEVEL_VALUES.find((level) => level === value)
+
 export const getLintEntityString = (metadata: Lint['metadata']) => {
   if (!metadata) {
     return undefined

--- a/apps/studio/components/interfaces/Linter/useAdvisorPageShortcuts.ts
+++ b/apps/studio/components/interfaces/Linter/useAdvisorPageShortcuts.ts
@@ -12,8 +12,8 @@ interface UseAdvisorPageShortcutsParams {
 }
 
 /**
- * Registers shortcuts that apply across the Security and Performance Advisor
- * pages:
+ * Registers shortcuts that apply across the Health, Security, and Performance
+ * Advisor pages:
  *   - 1 / 2 / 3: switch to Errors / Warnings / Info tab
  *   - Shift+R: rerun the linter
  *   - Escape: close the lint detail panel (only when a lint is selected)

--- a/apps/studio/components/layouts/AdvisorsLayout/Advisors.Commands.tsx
+++ b/apps/studio/components/layouts/AdvisorsLayout/Advisors.Commands.tsx
@@ -1,6 +1,7 @@
 import { useParams } from 'common'
 import type { CommandOptions } from 'ui-patterns/CommandMenu'
 import { useRegisterCommands } from 'ui-patterns/CommandMenu'
+import type { IRouteCommand } from 'ui-patterns/CommandMenu/internal/types'
 
 import { COMMAND_MENU_SECTIONS } from '@/components/interfaces/App/CommandMenu/CommandMenu.utils'
 import { IS_PLATFORM } from '@/lib/constants'
@@ -19,7 +20,7 @@ export function useAdvisorsGoToCommands(options?: CommandOptions) {
               name: 'Health Advisor',
               route: `/project/${ref}/advisors/health`,
               defaultHidden: true,
-            },
+            } satisfies IRouteCommand,
           ]
         : []),
       {

--- a/apps/studio/components/layouts/AdvisorsLayout/Advisors.Commands.tsx
+++ b/apps/studio/components/layouts/AdvisorsLayout/Advisors.Commands.tsx
@@ -3,6 +3,7 @@ import type { CommandOptions } from 'ui-patterns/CommandMenu'
 import { useRegisterCommands } from 'ui-patterns/CommandMenu'
 
 import { COMMAND_MENU_SECTIONS } from '@/components/interfaces/App/CommandMenu/CommandMenu.utils'
+import { IS_PLATFORM } from '@/lib/constants'
 
 export function useAdvisorsGoToCommands(options?: CommandOptions) {
   let { ref } = useParams()
@@ -11,6 +12,16 @@ export function useAdvisorsGoToCommands(options?: CommandOptions) {
   useRegisterCommands(
     COMMAND_MENU_SECTIONS.NAVIGATE,
     [
+      ...(IS_PLATFORM
+        ? [
+            {
+              id: 'nav-advisors-health',
+              name: 'Health Advisor',
+              route: `/project/${ref}/advisors/health`,
+              defaultHidden: true,
+            },
+          ]
+        : []),
       {
         id: 'nav-advisors-security',
         name: 'Security Advisor',

--- a/apps/studio/components/layouts/AdvisorsLayout/AdvisorsMenu.utils.test.ts
+++ b/apps/studio/components/layouts/AdvisorsLayout/AdvisorsMenu.utils.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { generateAdvisorsMenu } from './AdvisorsMenu.utils'
+
+describe('generateAdvisorsMenu', () => {
+  it('puts Health Advisor first on platform', () => {
+    const [advisors] = generateAdvisorsMenu({
+      ref: 'abc',
+      isAdvisorRulesEnabled: false,
+      isPlatform: true,
+    })
+
+    expect(advisors.items.map((item) => item.key)).toEqual([
+      'health',
+      'security',
+      'performance',
+      'query-performance',
+    ])
+    expect(advisors.items[0].url).toBe('/project/abc/advisors/health')
+  })
+
+  it('omits Health Advisor when not on platform', () => {
+    const [advisors] = generateAdvisorsMenu({
+      ref: 'abc',
+      isAdvisorRulesEnabled: false,
+      isPlatform: false,
+    })
+
+    expect(advisors.items.map((item) => item.key)).toEqual([
+      'security',
+      'performance',
+      'query-performance',
+    ])
+  })
+})

--- a/apps/studio/components/layouts/AdvisorsLayout/AdvisorsMenu.utils.tsx
+++ b/apps/studio/components/layouts/AdvisorsLayout/AdvisorsMenu.utils.tsx
@@ -2,42 +2,63 @@ import { useParams } from 'common'
 import { ArrowUpRight } from 'lucide-react'
 
 import { useIsAdvisorRulesEnabled } from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
-import type { ProductMenuGroup } from '@/components/ui/ProductMenu/ProductMenu.types'
+import type {
+  ProductMenuGroup,
+  ProductMenuGroupItem,
+} from '@/components/ui/ProductMenu/ProductMenu.types'
 import { IS_PLATFORM } from '@/lib/constants'
 import { SHORTCUT_IDS } from '@/state/shortcuts/registry'
 
-export const useGenerateAdvisorsMenu = (): ProductMenuGroup[] => {
-  const { ref } = useParams()
-  const isAdvisorRulesEnabled = useIsAdvisorRulesEnabled()
+export const generateAdvisorsMenu = ({
+  ref,
+  isAdvisorRulesEnabled,
+  isPlatform,
+}: {
+  ref: string | undefined
+  isAdvisorRulesEnabled: boolean
+  isPlatform: boolean
+}): ProductMenuGroup[] => {
+  const advisorItems: ProductMenuGroupItem[] = [
+    ...(isPlatform
+      ? [
+          {
+            name: 'Health Advisor',
+            key: 'health',
+            url: `/project/${ref}/advisors/health`,
+            items: [],
+            shortcutId: SHORTCUT_IDS.NAV_ADVISORS_HEALTH,
+          },
+        ]
+      : []),
+    {
+      name: 'Security Advisor',
+      key: 'security',
+      url: `/project/${ref}/advisors/security`,
+      items: [],
+      shortcutId: SHORTCUT_IDS.NAV_ADVISORS_SECURITY,
+    },
+    {
+      name: 'Performance Advisor',
+      key: 'performance',
+      url: `/project/${ref}/advisors/performance`,
+      items: [],
+      shortcutId: SHORTCUT_IDS.NAV_ADVISORS_PERFORMANCE,
+    },
+    {
+      name: 'Query Performance',
+      key: 'query-performance',
+      url: `/project/${ref}/observability/query-performance`,
+      items: [],
+      rightIcon: <ArrowUpRight size={14} strokeWidth={1.5} className="h-4 w-4" />,
+    },
+  ]
 
   return [
     {
       title: 'Advisors',
-      items: [
-        {
-          name: 'Security Advisor',
-          key: 'security',
-          url: `/project/${ref}/advisors/security`,
-          items: [],
-          shortcutId: SHORTCUT_IDS.NAV_ADVISORS_SECURITY,
-        },
-        {
-          name: 'Performance Advisor',
-          key: 'performance',
-          url: `/project/${ref}/advisors/performance`,
-          items: [],
-          shortcutId: SHORTCUT_IDS.NAV_ADVISORS_PERFORMANCE,
-        },
-        {
-          name: 'Query Performance',
-          key: 'query-performance',
-          url: `/project/${ref}/observability/query-performance`,
-          items: [],
-          rightIcon: <ArrowUpRight size={14} strokeWidth={1.5} className="h-4 w-4" />,
-        },
-      ],
+      items: advisorItems,
     },
-    ...(IS_PLATFORM && isAdvisorRulesEnabled
+    ...(isPlatform && isAdvisorRulesEnabled
       ? [
           {
             title: 'Configuration',
@@ -54,4 +75,15 @@ export const useGenerateAdvisorsMenu = (): ProductMenuGroup[] => {
         ]
       : []),
   ]
+}
+
+export const useGenerateAdvisorsMenu = (): ProductMenuGroup[] => {
+  const { ref } = useParams()
+  const isAdvisorRulesEnabled = useIsAdvisorRulesEnabled()
+
+  return generateAdvisorsMenu({
+    ref,
+    isAdvisorRulesEnabled,
+    isPlatform: IS_PLATFORM,
+  })
 }

--- a/apps/studio/pages/project/[ref]/advisors/health.tsx
+++ b/apps/studio/pages/project/[ref]/advisors/health.tsx
@@ -3,7 +3,7 @@ import { useMemo, useState } from 'react'
 import { LoadingLine } from 'ui'
 
 import { LINTER_LEVELS } from '@/components/interfaces/Linter/Linter.constants'
-import { lintInfoMap } from '@/components/interfaces/Linter/Linter.utils'
+import { lintInfoMap, parseLinterLevel } from '@/components/interfaces/Linter/Linter.utils'
 import { LinterDataGrid } from '@/components/interfaces/Linter/LinterDataGrid'
 import LinterFilters from '@/components/interfaces/Linter/LinterFilters'
 import LintPageTabs from '@/components/interfaces/Linter/LintPageTabs'
@@ -27,7 +27,7 @@ const ProjectHealthLints: NextPageWithLayout = () => {
     { level: LINTER_LEVELS.INFO, filters: [] },
   ])
   const [currentTab, setCurrentTab] = useState<LINTER_LEVELS>(
-    (preset as LINTER_LEVELS) ?? LINTER_LEVELS.ERROR
+    parseLinterLevel(preset) ?? LINTER_LEVELS.ERROR
   )
   const { data, isPending, isRefetching, refetch } = useProjectHealthLintsQuery({
     projectRef: project?.ref,
@@ -38,8 +38,7 @@ const ProjectHealthLints: NextPageWithLayout = () => {
   const isLoading = IS_PLATFORM && isPending
 
   const activeLints = (data ?? []).filter((lint) => lint.categories.includes('HEALTH'))
-  const currentTabFilters = (filters.find((filter) => filter.level === currentTab)?.filters ||
-    []) as string[]
+  const currentTabFilters = filters.find((filter) => filter.level === currentTab)?.filters ?? []
   const filteredLints = activeLints
     .filter((x) => x.level === currentTab)
     .filter((x) => (currentTabFilters.length > 0 ? currentTabFilters.includes(x.name) : x))

--- a/apps/studio/pages/project/[ref]/advisors/health.tsx
+++ b/apps/studio/pages/project/[ref]/advisors/health.tsx
@@ -1,0 +1,102 @@
+import { useParams } from 'common'
+import { useMemo, useState } from 'react'
+import { LoadingLine } from 'ui'
+
+import { LINTER_LEVELS } from '@/components/interfaces/Linter/Linter.constants'
+import { lintInfoMap } from '@/components/interfaces/Linter/Linter.utils'
+import { LinterDataGrid } from '@/components/interfaces/Linter/LinterDataGrid'
+import LinterFilters from '@/components/interfaces/Linter/LinterFilters'
+import LintPageTabs from '@/components/interfaces/Linter/LintPageTabs'
+import { useAdvisorPageShortcuts } from '@/components/interfaces/Linter/useAdvisorPageShortcuts'
+import AdvisorsLayout from '@/components/layouts/AdvisorsLayout/AdvisorsLayout'
+import { DefaultLayout } from '@/components/layouts/DefaultLayout'
+import { FormHeader } from '@/components/ui/Forms/FormHeader'
+import { useProjectHealthLintsQuery } from '@/data/lint/health-lints-query'
+import { Lint } from '@/data/lint/lint-query'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { IS_PLATFORM } from '@/lib/constants'
+import type { NextPageWithLayout } from '@/types'
+
+const ProjectHealthLints: NextPageWithLayout = () => {
+  const { preset, id } = useParams()
+  const { data: project } = useSelectedProjectQuery()
+
+  const [filters, setFilters] = useState<{ level: LINTER_LEVELS; filters: string[] }[]>([
+    { level: LINTER_LEVELS.ERROR, filters: [] },
+    { level: LINTER_LEVELS.WARN, filters: [] },
+    { level: LINTER_LEVELS.INFO, filters: [] },
+  ])
+  const [currentTab, setCurrentTab] = useState<LINTER_LEVELS>(
+    (preset as LINTER_LEVELS) ?? LINTER_LEVELS.ERROR
+  )
+  const { data, isPending, isRefetching, refetch } = useProjectHealthLintsQuery({
+    projectRef: project?.ref,
+  })
+
+  // Health checks are platform-only. If this page is opened self-hosted the query stays
+  // disabled, and `isPending` would otherwise spin forever.
+  const isLoading = IS_PLATFORM && isPending
+
+  const activeLints = (data ?? []).filter((lint) => lint.categories.includes('HEALTH'))
+  const currentTabFilters = (filters.find((filter) => filter.level === currentTab)?.filters ||
+    []) as string[]
+  const filteredLints = activeLints
+    .filter((x) => x.level === currentTab)
+    .filter((x) => (currentTabFilters.length > 0 ? currentTabFilters.includes(x.name) : x))
+  const filterOptions = lintInfoMap
+    .filter((item) =>
+      activeLints.some((lint) => lint.name === item.name && lint.level === currentTab)
+    )
+    .map((type) => ({
+      name: type.title,
+      value: type.name,
+    }))
+
+  const selectedLint: Lint | null = useMemo(() => {
+    return activeLints.find((lint) => lint.cache_key === id) ?? null
+  }, [id, activeLints])
+
+  useAdvisorPageShortcuts({
+    setCurrentTab,
+    refetch,
+    hasSelectedLint: selectedLint !== null,
+    isRefreshDisabled: isLoading || isRefetching,
+  })
+
+  return (
+    <div className="h-full flex flex-col">
+      <FormHeader className="py-4 px-6 -mb-px!" title="Health Advisor" />
+      <LintPageTabs
+        activeLints={activeLints}
+        isLoading={isLoading}
+        currentTab={currentTab}
+        setCurrentTab={setCurrentTab}
+      />
+      <LinterFilters
+        filterOptions={filterOptions}
+        filteredLints={filteredLints}
+        activeLints={activeLints}
+        currentTab={currentTab}
+        filters={filters}
+        isLoading={isLoading || isRefetching}
+        setFilters={setFilters}
+        onClickRefresh={refetch}
+      />
+      <LoadingLine loading={isRefetching} />
+      <LinterDataGrid
+        filteredLints={filteredLints}
+        currentTab={currentTab}
+        selectedLint={selectedLint}
+        isLoading={isLoading}
+      />
+    </div>
+  )
+}
+
+ProjectHealthLints.getLayout = (page) => (
+  <DefaultLayout>
+    <AdvisorsLayout title="Linter">{page}</AdvisorsLayout>
+  </DefaultLayout>
+)
+
+export default ProjectHealthLints

--- a/apps/studio/routeTree.gen.ts
+++ b/apps/studio/routeTree.gen.ts
@@ -178,6 +178,7 @@ import { Route as ProjectRefAuthAuditLogsRouteImport } from './routes/project/$r
 import { Route as ProjectRefAdvisorsSecurityRouteImport } from './routes/project/$ref/advisors/security'
 import { Route as ProjectRefAdvisorsRulesRouteImport } from './routes/project/$ref/advisors/rules'
 import { Route as ProjectRefAdvisorsPerformanceRouteImport } from './routes/project/$ref/advisors/performance'
+import { Route as ProjectRefAdvisorsHealthRouteImport } from './routes/project/$ref/advisors/health'
 import { Route as ApiPlatformTelemetryEventRouteImport } from './routes/api/platform/telemetry/event'
 import { Route as ApiPlatformIntegrationsSlugRouteImport } from './routes/api/platform/integrations/$slug'
 import { Route as ApiAiSqlTitleV2RouteImport } from './routes/api/ai/sql/title-v2'
@@ -1238,6 +1239,12 @@ const ProjectRefAdvisorsPerformanceRoute =
     path: '/performance',
     getParentRoute: () => ProjectRefAdvisorsRoute,
   } as any)
+const ProjectRefAdvisorsHealthRoute =
+  ProjectRefAdvisorsHealthRouteImport.update({
+    id: '/health',
+    path: '/health',
+    getParentRoute: () => ProjectRefAdvisorsRoute,
+  } as any)
 const ApiPlatformTelemetryEventRoute =
   ApiPlatformTelemetryEventRouteImport.update({
     id: '/api/platform/telemetry/event',
@@ -2207,6 +2214,7 @@ export interface FileRoutesByFullPath {
   '/api/ai/sql/title-v2': typeof ApiAiSqlTitleV2Route
   '/api/platform/integrations/$slug': typeof ApiPlatformIntegrationsSlugRoute
   '/api/platform/telemetry/event': typeof ApiPlatformTelemetryEventRoute
+  '/project/$ref/advisors/health': typeof ProjectRefAdvisorsHealthRoute
   '/project/$ref/advisors/performance': typeof ProjectRefAdvisorsPerformanceRoute
   '/project/$ref/advisors/rules': typeof ProjectRefAdvisorsRulesRouteWithChildren
   '/project/$ref/advisors/security': typeof ProjectRefAdvisorsSecurityRoute
@@ -2514,6 +2522,7 @@ export interface FileRoutesByTo {
   '/api/ai/sql/title-v2': typeof ApiAiSqlTitleV2Route
   '/api/platform/integrations/$slug': typeof ApiPlatformIntegrationsSlugRoute
   '/api/platform/telemetry/event': typeof ApiPlatformTelemetryEventRoute
+  '/project/$ref/advisors/health': typeof ProjectRefAdvisorsHealthRoute
   '/project/$ref/advisors/performance': typeof ProjectRefAdvisorsPerformanceRoute
   '/project/$ref/advisors/rules': typeof ProjectRefAdvisorsRulesRouteWithChildren
   '/project/$ref/advisors/security': typeof ProjectRefAdvisorsSecurityRoute
@@ -2832,6 +2841,7 @@ export interface FileRoutesById {
   '/api/ai/sql/title-v2': typeof ApiAiSqlTitleV2Route
   '/api/platform/integrations/$slug': typeof ApiPlatformIntegrationsSlugRoute
   '/api/platform/telemetry/event': typeof ApiPlatformTelemetryEventRoute
+  '/project/$ref/advisors/health': typeof ProjectRefAdvisorsHealthRoute
   '/project/$ref/advisors/performance': typeof ProjectRefAdvisorsPerformanceRoute
   '/project/$ref/advisors/rules': typeof ProjectRefAdvisorsRulesRouteWithChildren
   '/project/$ref/advisors/security': typeof ProjectRefAdvisorsSecurityRoute
@@ -3152,6 +3162,7 @@ export interface FileRouteTypes {
     | '/api/ai/sql/title-v2'
     | '/api/platform/integrations/$slug'
     | '/api/platform/telemetry/event'
+    | '/project/$ref/advisors/health'
     | '/project/$ref/advisors/performance'
     | '/project/$ref/advisors/rules'
     | '/project/$ref/advisors/security'
@@ -3459,6 +3470,7 @@ export interface FileRouteTypes {
     | '/api/ai/sql/title-v2'
     | '/api/platform/integrations/$slug'
     | '/api/platform/telemetry/event'
+    | '/project/$ref/advisors/health'
     | '/project/$ref/advisors/performance'
     | '/project/$ref/advisors/rules'
     | '/project/$ref/advisors/security'
@@ -3776,6 +3788,7 @@ export interface FileRouteTypes {
     | '/api/ai/sql/title-v2'
     | '/api/platform/integrations/$slug'
     | '/api/platform/telemetry/event'
+    | '/project/$ref/advisors/health'
     | '/project/$ref/advisors/performance'
     | '/project/$ref/advisors/rules'
     | '/project/$ref/advisors/security'
@@ -5303,6 +5316,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProjectRefAdvisorsPerformanceRouteImport
       parentRoute: typeof ProjectRefAdvisorsRoute
     }
+    '/project/$ref/advisors/health': {
+      id: '/project/$ref/advisors/health'
+      path: '/health'
+      fullPath: '/project/$ref/advisors/health'
+      preLoaderRoute: typeof ProjectRefAdvisorsHealthRouteImport
+      parentRoute: typeof ProjectRefAdvisorsRoute
+    }
     '/api/platform/telemetry/event': {
       id: '/api/platform/telemetry/event'
       path: '/api/platform/telemetry/event'
@@ -6504,12 +6524,14 @@ const ProjectRefAdvisorsRulesRouteWithChildren =
   )
 
 interface ProjectRefAdvisorsRouteChildren {
+  ProjectRefAdvisorsHealthRoute: typeof ProjectRefAdvisorsHealthRoute
   ProjectRefAdvisorsPerformanceRoute: typeof ProjectRefAdvisorsPerformanceRoute
   ProjectRefAdvisorsRulesRoute: typeof ProjectRefAdvisorsRulesRouteWithChildren
   ProjectRefAdvisorsSecurityRoute: typeof ProjectRefAdvisorsSecurityRoute
 }
 
 const ProjectRefAdvisorsRouteChildren: ProjectRefAdvisorsRouteChildren = {
+  ProjectRefAdvisorsHealthRoute: ProjectRefAdvisorsHealthRoute,
   ProjectRefAdvisorsPerformanceRoute: ProjectRefAdvisorsPerformanceRoute,
   ProjectRefAdvisorsRulesRoute: ProjectRefAdvisorsRulesRouteWithChildren,
   ProjectRefAdvisorsSecurityRoute: ProjectRefAdvisorsSecurityRoute,

--- a/apps/studio/routes/project/$ref/advisors/health.tsx
+++ b/apps/studio/routes/project/$ref/advisors/health.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import AdvisorsHealthPage from '@/pages/project/[ref]/advisors/health'
+
+export const Route = createFileRoute('/project/$ref/advisors/health')({
+  component: AdvisorsHealthRoute,
+  staticData: {
+    advisorsLayoutTitle: 'Linter',
+  },
+})
+
+function AdvisorsHealthRoute() {
+  return <AdvisorsHealthPage dehydratedState={undefined} />
+}

--- a/apps/studio/state/shortcuts/registry/advisors-nav.ts
+++ b/apps/studio/state/shortcuts/registry/advisors-nav.ts
@@ -10,6 +10,7 @@ import { RegistryDefinations } from '../types'
  * global key. `A` is already in use by Auth.
  */
 export const ADVISORS_NAV_SHORTCUT_IDS = {
+  NAV_ADVISORS_HEALTH: 'nav.advisors-health',
   NAV_ADVISORS_SECURITY: 'nav.advisors-security',
   NAV_ADVISORS_PERFORMANCE: 'nav.advisors-performance',
   NAV_ADVISORS_RULES: 'nav.advisors-rules',
@@ -19,6 +20,13 @@ export type AdvisorsNavShortcutId =
   (typeof ADVISORS_NAV_SHORTCUT_IDS)[keyof typeof ADVISORS_NAV_SHORTCUT_IDS]
 
 export const advisorsNavRegistry: RegistryDefinations<AdvisorsNavShortcutId> = {
+  [ADVISORS_NAV_SHORTCUT_IDS.NAV_ADVISORS_HEALTH]: {
+    id: ADVISORS_NAV_SHORTCUT_IDS.NAV_ADVISORS_HEALTH,
+    label: 'Go to Health Advisor',
+    sequence: ['V', 'H'],
+    showInSettings: false,
+    referenceGroup: SHORTCUT_REFERENCE_GROUPS.NAVIGATION_ADVISORS,
+  },
   [ADVISORS_NAV_SHORTCUT_IDS.NAV_ADVISORS_SECURITY]: {
     id: ADVISORS_NAV_SHORTCUT_IDS.NAV_ADVISORS_SECURITY,
     label: 'Go to Security Advisor',

--- a/apps/studio/state/shortcuts/registry/advisors-page.ts
+++ b/apps/studio/state/shortcuts/registry/advisors-page.ts
@@ -2,7 +2,7 @@ import { SHORTCUT_REFERENCE_GROUPS } from '../referenceGroups'
 import { RegistryDefinations } from '../types'
 
 /**
- * Shortcuts scoped to the Security and Performance Advisor pages — tab digit
+ * Shortcuts scoped to the Health, Security, and Performance Advisor pages — tab digit
  * shortcuts, refresh, and detail panel close. The tab digits mirror the
  * functions-detail-nav pattern (`ignoreInputs: true` so they don't fire from
  * inputs), and `Escape` follows the auth-users close-panel pattern with


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Feature

## Summary

- Add a Health Advisor page at `/project/[ref]/advisors/health`
- Put Health Advisor first in the Advisors left nav (above Security), platform-only
- Register `V` then `H` and a command-menu entry

Stacked on #49662. Top of the stack.

## To test

1. Open any project in Studio.
2. Click **Advisors** in the main nav (or go to `/project/<ref>/advisors/security`).
3. In the left nav, confirm the order is **Health Advisor**, then Security Advisor, then Performance Advisor, then Query Performance.
4. Click **Health Advisor**. You should land on a page titled “Health Advisor” with Errors / Warnings / Info tabs, same layout as Security Advisor.
5. If the project is healthy, Errors should say no errors were detected. If it is not, the failing checks should list here (database down, connection limit, and so on).
6. Click **Refresh** (or Shift+R) and confirm the list reloads.
7. Click a row and confirm the detail panel opens with a link through to logs, connections, or infrastructure.
8. While still in Advisors, press **V** then **H**. You should jump back to Health Advisor.
9. Open the command menu and search **Health Advisor**. Choosing it should navigate to this page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Health Advisor page for reviewing project health findings by severity and category.
  - Added Health Advisor navigation in the advisor menu and a keyboard shortcut (`V`, then `H`) on supported platforms.
  - Added refresh, filtering, selection, and lint detail navigation for health findings.

- **Bug Fixes**
  - Added validation for linter severity values, safely handling unsupported or missing inputs.

- **Documentation**
  - Updated migration and shortcut documentation to include the Health Advisor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->