### PR TITLE
fix(studio): clarify pipeline form guidance

### DIFF
--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/AdvancedSettings.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/AdvancedSettings.tsx
@@ -28,6 +28,11 @@ import {
 } from './DestinationForm.constants'
 import { type DestinationPanelSchemaType } from './DestinationForm.schema'
 
+const INVALIDATED_SLOT_BEHAVIOR_LABELS = {
+  error: 'Block startup',
+  recreate: 'Recreate slot',
+} as const
+
 export const AdvancedSettings = ({
   type,
   form,
@@ -153,16 +158,18 @@ export const AdvancedSettings = ({
                 >
                   <FormControl>
                     <Select value={field.value ?? 'error'} onValueChange={field.onChange}>
-                      <SelectTrigger className="capitalize">{field.value ?? 'error'}</SelectTrigger>
+                      <SelectTrigger>
+                        {INVALIDATED_SLOT_BEHAVIOR_LABELS[field.value ?? 'error']}
+                      </SelectTrigger>
                       <SelectContent>
                         <SelectItem value="error" className="[&>span]:top-2.5">
-                          <p>Error</p>
+                          <p>Block startup</p>
                           <p className="text-foreground-lighter">
                             Blocks startup for manual recovery.
                           </p>
                         </SelectItem>
                         <SelectItem value="recreate" className="[&>span]:top-2.5">
-                          <p>Recreate</p>
+                          <p>Recreate slot</p>
                           <p className="text-foreground-lighter">
                             Replaces destination tables and runs a new, billable initial sync.
                           </p>
@@ -222,7 +229,7 @@ export const AdvancedSettings = ({
                         </div>
                       }
                       layout="horizontal"
-                      description="How old query results can be while BigQuery applies ongoing changes."
+                      description="Leave blank for freshest results. When set, the maximum age of query results while BigQuery applies ongoing changes."
                     >
                       <FormControl>
                         <InputGroup>
@@ -233,7 +240,6 @@ export const AdvancedSettings = ({
                             step={1}
                             value={field.value ?? ''}
                             onChange={handleNumberChange(field)}
-                            placeholder="Default: None (Freshest results)"
                           />
                           <InputGroupAddon align="inline-end">
                             <InputGroupText>minutes</InputGroupText>

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/AdvancedSettings.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/AdvancedSettings.tsx
@@ -31,7 +31,7 @@ import { type DestinationPanelSchemaType } from './DestinationForm.schema'
 const INVALIDATED_SLOT_BEHAVIOR_LABELS = {
   error: 'Block startup',
   recreate: 'Recreate slot',
-} as const
+}
 
 export const AdvancedSettings = ({
   type,
@@ -229,7 +229,7 @@ export const AdvancedSettings = ({
                         </div>
                       }
                       layout="horizontal"
-                      description="Leave blank for freshest results. When set, the maximum age of query results while BigQuery applies ongoing changes."
+                      description="Set the maximum age of query results while BigQuery applies ongoing changes, or leave blank for the freshest results."
                     >
                       <FormControl>
                         <InputGroup>

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/AnalyticsBucket/AnalyticsBucket.utils.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/AnalyticsBucket/AnalyticsBucket.utils.ts
@@ -21,9 +21,9 @@ type AnalyticsBucketValidationOptions = {
 
 // Fields that are always required regardless of the namespace / access key selections.
 const ANALYTICS_BUCKET_REQUIRED_FIELDS: AnalyticsBucketValidationIssue[] = [
-  { path: 'warehouseName', message: 'Bucket is required' },
-  { path: 's3Region', message: 'S3 region is required' },
-  { path: 's3AccessKeyId', message: 'S3 access key ID is required' },
+  { path: 'warehouseName', message: 'Bucket is required.' },
+  { path: 's3Region', message: 'S3 region is required.' },
+  { path: 's3AccessKeyId', message: 'S3 access key ID is required.' },
 ]
 
 export const getAnalyticsBucketValidationIssues = (
@@ -43,8 +43,8 @@ export const getAnalyticsBucketValidationIssues = (
   if (!hasValidNamespace) {
     issues.push(
       isCreatingNewNamespace
-        ? { path: 'newNamespaceName', message: 'Namespace name is required' }
-        : { path: 'namespace', message: 'Namespace is required' }
+        ? { path: 'newNamespaceName', message: 'Namespace name is required.' }
+        : { path: 'namespace', message: 'Namespace is required.' }
     )
   }
 
@@ -53,7 +53,7 @@ export const getAnalyticsBucketValidationIssues = (
     data.s3SecretAccessKey?.trim().length &&
     !data.s3AccessKeyId?.trim().length
   ) {
-    issues.push({ path: 's3AccessKeyId', message: 'S3 access key ID is required' })
+    issues.push({ path: 's3AccessKeyId', message: 'S3 access key ID is required.' })
   }
 
   const currentS3AccessKeyId = data.s3AccessKeyId?.trim()
@@ -69,7 +69,7 @@ export const getAnalyticsBucketValidationIssues = (
     (!options.secretsOptional || hasChangedStoredS3AccessKey) &&
     !data.s3SecretAccessKey?.trim().length
   ) {
-    issues.push({ path: 's3SecretAccessKey', message: 'S3 secret access key is required' })
+    issues.push({ path: 's3SecretAccessKey', message: 'S3 secret access key is required.' })
   }
 
   return issues

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/BigQuery/BigQuery.schema.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/BigQuery/BigQuery.schema.ts
@@ -7,11 +7,11 @@ export const BigQueryFormSchema = z.object({
   connectionPoolSize: z
     .number()
     .int()
-    .min(1, 'Connection pool size must be greater than 0')
+    .min(1, 'Connection pool size must be greater than 0.')
     .optional(),
   maxStalenessMins: z
     .number()
-    .int('Maximum staleness must be a whole number of minutes')
-    .min(0, 'Maximum staleness must be 0 or greater')
+    .int('Maximum staleness must be a whole number of minutes.')
+    .min(0, 'Maximum staleness must be 0 or greater.')
     .optional(),
 })

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/BigQuery/BigQuery.utils.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/BigQuery/BigQuery.utils.ts
@@ -7,14 +7,14 @@ export type BigQueryValidationIssue = {
   message: string
 }
 
-export const BIGQUERY_SERVICE_ACCOUNT_JSON_MESSAGE = 'Service account key must be valid JSON'
+export const BIGQUERY_SERVICE_ACCOUNT_JSON_MESSAGE = 'Service account key must be valid JSON.'
 
 const BIGQUERY_REQUIRED_FIELDS: {
   path: Exclude<BigQueryFieldPath, 'serviceAccountKey'>
   message: string
 }[] = [
-  { path: 'projectId', message: 'Project ID is required' },
-  { path: 'datasetId', message: 'Dataset ID is required' },
+  { path: 'projectId', message: 'Project ID is required.' },
+  { path: 'datasetId', message: 'Dataset ID is required.' },
 ]
 
 const isValidJsonString = (value: string) => {
@@ -39,7 +39,7 @@ export const getBigQueryValidationIssues = (
 
   if (!serviceAccountKey) {
     if (!secretsOptional) {
-      issues.push({ path: 'serviceAccountKey', message: 'Service account key is required' })
+      issues.push({ path: 'serviceAccountKey', message: 'Service account key is required.' })
     }
     return issues
   }

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/ClickHouse/ClickHouse.utils.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/ClickHouse/ClickHouse.utils.ts
@@ -64,26 +64,26 @@ export const getClickHouseValidationIssues = (
   const issues: ClickHouseValidationIssue[] = []
 
   if (!data.clickhouseUrl?.length) {
-    issues.push({ path: 'clickhouseUrl', message: 'URL is required' })
+    issues.push({ path: 'clickhouseUrl', message: 'URL is required.' })
   } else {
     let parsed: URL | undefined
 
     try {
       parsed = new URL(data.clickhouseUrl)
     } catch {
-      issues.push({ path: 'clickhouseUrl', message: 'ClickHouse URL must be a valid URL' })
+      issues.push({ path: 'clickhouseUrl', message: 'ClickHouse URL must be a valid URL.' })
     }
 
     if (parsed) {
       if (parsed.protocol !== 'https:') {
-        issues.push({ path: 'clickhouseUrl', message: 'ClickHouse URL must use https://' })
+        issues.push({ path: 'clickhouseUrl', message: 'ClickHouse URL must use HTTPS.' })
       } else {
         const host = parsed.hostname.replace(/^\[|\]$/g, '')
 
         if (isClickHouseHostInternal(host)) {
           issues.push({
             path: 'clickhouseUrl',
-            message: 'ClickHouse URL must not target an internal address',
+            message: 'ClickHouse URL must not target an internal address.',
           })
         }
       }
@@ -91,11 +91,11 @@ export const getClickHouseValidationIssues = (
   }
 
   if (!data.clickhouseUser?.length) {
-    issues.push({ path: 'clickhouseUser', message: 'User is required' })
+    issues.push({ path: 'clickhouseUser', message: 'User is required.' })
   }
 
   if (!data.clickhouseDatabase?.length) {
-    issues.push({ path: 'clickhouseDatabase', message: 'Database is required' })
+    issues.push({ path: 'clickhouseDatabase', message: 'Database is required.' })
   }
 
   return issues

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationForm.schema.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationForm.schema.ts
@@ -7,8 +7,8 @@ import { DuckLakeFormSchema } from './DuckLake/DuckLake.schema'
 import { SnowflakeFormSchema } from './Snowflake/Snowflake.schema'
 
 const CommonFormSchema = z.object({
-  name: z.string().min(1, 'Name is required'),
-  publicationName: z.string().min(1, 'Publication is required'),
+  name: z.string().min(1, 'Name is required.'),
+  publicationName: z.string().min(1, 'Publication is required.'),
   tableSyncCopyMode: z.enum([
     'include_all_tables',
     'skip_all_tables',
@@ -18,18 +18,18 @@ const CommonFormSchema = z.object({
   tableSyncCopyTableIds: z.array(z.string()),
   maxFillMs: z
     .number()
-    .int('Batch wait time must be a whole number of milliseconds')
-    .min(0, 'Batch wait time must be 0 or greater')
+    .int('Batch wait time must be a whole number of milliseconds.')
+    .min(0, 'Batch wait time must be 0 or greater.')
     .optional(),
   maxTableSyncWorkers: z
     .number()
-    .min(1, 'Max table sync workers must be greater than 0')
-    .int('Max table sync workers must be a whole number')
+    .min(1, 'Max table sync workers must be greater than 0.')
+    .int('Max table sync workers must be a whole number.')
     .optional(),
   maxCopyConnectionsPerTable: z
     .number()
     .int()
-    .min(1, 'Max copy connections per table must be greater than 0')
+    .min(1, 'Max copy connections per table must be greater than 0.')
     .optional(),
   invalidatedSlotBehavior: z.enum(['error', 'recreate']).optional(),
 })

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationForm.utils.test.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationForm.utils.test.ts
@@ -306,12 +306,12 @@ describe('DestinationForm.utils DuckLake', () => {
     })
 
     expect(issues).toEqual([
-      { path: 'ducklakeCatalogUrl', message: 'Catalog URL is required' },
-      { path: 'ducklakeDataPath', message: 'Data path is required' },
-      { path: 'ducklakeS3AccessKeyId', message: 'S3 access key ID is required' },
-      { path: 'ducklakeS3SecretAccessKey', message: 'S3 secret access key is required' },
-      { path: 'ducklakeS3Region', message: 'S3 region is required' },
-      { path: 'ducklakeS3Endpoint', message: 'S3 endpoint is required' },
+      { path: 'ducklakeCatalogUrl', message: 'Catalog URL is required.' },
+      { path: 'ducklakeDataPath', message: 'Data path is required.' },
+      { path: 'ducklakeS3AccessKeyId', message: 'S3 access key ID is required.' },
+      { path: 'ducklakeS3SecretAccessKey', message: 'S3 secret access key is required.' },
+      { path: 'ducklakeS3Region', message: 'S3 region is required.' },
+      { path: 'ducklakeS3Endpoint', message: 'S3 endpoint is required.' },
     ])
   })
 
@@ -347,7 +347,7 @@ describe('DestinationForm.utils DuckLake', () => {
     )
 
     expect(issues).toEqual([
-      { path: 'ducklakeS3SecretAccessKey', message: 'S3 secret access key is required' },
+      { path: 'ducklakeS3SecretAccessKey', message: 'S3 secret access key is required.' },
     ])
   })
 
@@ -363,12 +363,12 @@ describe('DestinationForm.utils DuckLake', () => {
     })
 
     expect(issues).toEqual([
-      { path: 'ducklakeCatalogUrl', message: 'Catalog URL is required' },
-      { path: 'ducklakeDataPath', message: 'Data path is required' },
-      { path: 'ducklakeS3AccessKeyId', message: 'S3 access key ID is required' },
-      { path: 'ducklakeS3SecretAccessKey', message: 'S3 secret access key is required' },
-      { path: 'ducklakeS3Region', message: 'S3 region is required' },
-      { path: 'ducklakeS3Endpoint', message: 'S3 endpoint is required' },
+      { path: 'ducklakeCatalogUrl', message: 'Catalog URL is required.' },
+      { path: 'ducklakeDataPath', message: 'Data path is required.' },
+      { path: 'ducklakeS3AccessKeyId', message: 'S3 access key ID is required.' },
+      { path: 'ducklakeS3SecretAccessKey', message: 'S3 secret access key is required.' },
+      { path: 'ducklakeS3Region', message: 'S3 region is required.' },
+      { path: 'ducklakeS3Endpoint', message: 'S3 endpoint is required.' },
     ])
   })
 
@@ -386,19 +386,19 @@ describe('DestinationForm.utils DuckLake', () => {
     expect(issues).toEqual([
       {
         path: 'ducklakeCatalogUrl',
-        message: 'DuckLake catalog URL must be a PostgreSQL-compatible URL',
+        message: 'DuckLake catalog URL must be a PostgreSQL-compatible URL.',
       },
       {
         path: 'ducklakeDataPath',
-        message: 'DuckLake data path must start with s3:// and cannot contain file://',
+        message: 'DuckLake data path must start with s3:// and cannot contain file://.',
       },
       {
         path: 'ducklakeS3Endpoint',
-        message: 'S3 endpoint must not contain the protocol scheme',
+        message: 'S3 endpoint must not contain the protocol scheme.',
       },
       {
         path: 'ducklakeMetadataSchema',
-        message: 'DuckLake metadata schema must contain only letters, numbers, and underscores',
+        message: 'DuckLake metadata schema must contain only letters, numbers, and underscores.',
       },
     ])
   })
@@ -487,9 +487,9 @@ describe('DestinationForm.utils DuckLake (Use Supabase)', () => {
     })
 
     expect(issues).toEqual([
-      { path: 'ducklakeCatalogProjectRef', message: 'Catalog project is required' },
-      { path: 'ducklakeStorageProjectRef', message: 'Storage project is required' },
-      { path: 'ducklakeStorageBucket', message: 'Bucket is required' },
+      { path: 'ducklakeCatalogProjectRef', message: 'Catalog project is required.' },
+      { path: 'ducklakeStorageProjectRef', message: 'Storage project is required.' },
+      { path: 'ducklakeStorageBucket', message: 'Bucket is required.' },
     ])
   })
 
@@ -574,11 +574,11 @@ describe('DestinationForm.utils Snowflake', () => {
     })
 
     expect(issues).toEqual([
-      { path: 'snowflakeAccountId', message: 'Account ID is required' },
-      { path: 'snowflakeUser', message: 'User is required' },
-      { path: 'snowflakePrivateKey', message: 'Private key is required' },
-      { path: 'snowflakeDatabase', message: 'Database is required' },
-      { path: 'snowflakeSchema', message: 'Schema is required' },
+      { path: 'snowflakeAccountId', message: 'Account ID is required.' },
+      { path: 'snowflakeUser', message: 'User is required.' },
+      { path: 'snowflakePrivateKey', message: 'Private key is required.' },
+      { path: 'snowflakeDatabase', message: 'Database is required.' },
+      { path: 'snowflakeSchema', message: 'Schema is required.' },
     ])
   })
 
@@ -653,9 +653,9 @@ describe('DestinationForm.utils ClickHouse', () => {
     })
 
     expect(issues).toEqual([
-      { path: 'clickhouseUrl', message: 'URL is required' },
-      { path: 'clickhouseUser', message: 'User is required' },
-      { path: 'clickhouseDatabase', message: 'Database is required' },
+      { path: 'clickhouseUrl', message: 'URL is required.' },
+      { path: 'clickhouseUser', message: 'User is required.' },
+      { path: 'clickhouseDatabase', message: 'Database is required.' },
     ])
   })
 
@@ -666,7 +666,7 @@ describe('DestinationForm.utils ClickHouse', () => {
         clickhouseUser: 'default',
         clickhouseDatabase: 'analytics',
       })
-    ).toEqual([{ path: 'clickhouseUrl', message: 'ClickHouse URL must use https://' }])
+    ).toEqual([{ path: 'clickhouseUrl', message: 'ClickHouse URL must use HTTPS.' }])
 
     expect(
       getClickHouseValidationIssues({
@@ -675,7 +675,7 @@ describe('DestinationForm.utils ClickHouse', () => {
         clickhouseDatabase: 'analytics',
       })
     ).toEqual([
-      { path: 'clickhouseUrl', message: 'ClickHouse URL must not target an internal address' },
+      { path: 'clickhouseUrl', message: 'ClickHouse URL must not target an internal address.' },
     ])
   })
 
@@ -711,7 +711,7 @@ describe('DestinationForm.utils ClickHouse', () => {
         clickhouseDatabase: 'analytics',
       })
     ).toEqual([
-      { path: 'clickhouseUrl', message: 'ClickHouse URL must not target an internal address' },
+      { path: 'clickhouseUrl', message: 'ClickHouse URL must not target an internal address.' },
     ])
   })
 
@@ -739,9 +739,9 @@ describe('DestinationForm.utils BigQuery', () => {
     })
 
     expect(issues).toEqual([
-      { path: 'projectId', message: 'Project ID is required' },
-      { path: 'datasetId', message: 'Dataset ID is required' },
-      { path: 'serviceAccountKey', message: 'Service account key is required' },
+      { path: 'projectId', message: 'Project ID is required.' },
+      { path: 'datasetId', message: 'Dataset ID is required.' },
+      { path: 'serviceAccountKey', message: 'Service account key is required.' },
     ])
   })
 
@@ -753,9 +753,9 @@ describe('DestinationForm.utils BigQuery', () => {
     })
 
     expect(issues).toEqual([
-      { path: 'projectId', message: 'Project ID is required' },
-      { path: 'datasetId', message: 'Dataset ID is required' },
-      { path: 'serviceAccountKey', message: 'Service account key is required' },
+      { path: 'projectId', message: 'Project ID is required.' },
+      { path: 'datasetId', message: 'Dataset ID is required.' },
+      { path: 'serviceAccountKey', message: 'Service account key is required.' },
     ])
   })
 
@@ -777,7 +777,7 @@ describe('DestinationForm.utils BigQuery', () => {
     })
 
     expect(issues).toEqual([
-      { path: 'serviceAccountKey', message: 'Service account key must be valid JSON' },
+      { path: 'serviceAccountKey', message: 'Service account key must be valid JSON.' },
     ])
   })
 
@@ -802,7 +802,7 @@ describe('DestinationForm.utils BigQuery', () => {
     })
 
     expect(issues).toEqual([
-      { path: 'serviceAccountKey', message: 'Service account key must be valid JSON' },
+      { path: 'serviceAccountKey', message: 'Service account key must be valid JSON.' },
     ])
   })
 
@@ -817,7 +817,7 @@ describe('DestinationForm.utils BigQuery', () => {
     )
 
     expect(issues).toEqual([
-      { path: 'serviceAccountKey', message: 'Service account key must be valid JSON' },
+      { path: 'serviceAccountKey', message: 'Service account key must be valid JSON.' },
     ])
   })
 
@@ -847,11 +847,11 @@ describe('DestinationForm.utils Analytics Bucket', () => {
     })
 
     expect(issues).toEqual([
-      { path: 'warehouseName', message: 'Bucket is required' },
-      { path: 's3Region', message: 'S3 region is required' },
-      { path: 's3AccessKeyId', message: 'S3 access key ID is required' },
-      { path: 'namespace', message: 'Namespace is required' },
-      { path: 's3SecretAccessKey', message: 'S3 secret access key is required' },
+      { path: 'warehouseName', message: 'Bucket is required.' },
+      { path: 's3Region', message: 'S3 region is required.' },
+      { path: 's3AccessKeyId', message: 'S3 access key ID is required.' },
+      { path: 'namespace', message: 'Namespace is required.' },
+      { path: 's3SecretAccessKey', message: 'S3 secret access key is required.' },
     ])
   })
 
@@ -866,11 +866,11 @@ describe('DestinationForm.utils Analytics Bucket', () => {
     })
 
     expect(issues).toEqual([
-      { path: 'warehouseName', message: 'Bucket is required' },
-      { path: 's3Region', message: 'S3 region is required' },
-      { path: 's3AccessKeyId', message: 'S3 access key ID is required' },
-      { path: 'namespace', message: 'Namespace is required' },
-      { path: 's3SecretAccessKey', message: 'S3 secret access key is required' },
+      { path: 'warehouseName', message: 'Bucket is required.' },
+      { path: 's3Region', message: 'S3 region is required.' },
+      { path: 's3AccessKeyId', message: 'S3 access key ID is required.' },
+      { path: 'namespace', message: 'Namespace is required.' },
+      { path: 's3SecretAccessKey', message: 'S3 secret access key is required.' },
     ])
   })
 
@@ -884,7 +884,7 @@ describe('DestinationForm.utils Analytics Bucket', () => {
       s3SecretAccessKey: 'secret',
     })
 
-    expect(issues).toEqual([{ path: 'newNamespaceName', message: 'Namespace name is required' }])
+    expect(issues).toEqual([{ path: 'newNamespaceName', message: 'Namespace name is required.' }])
   })
 
   it('skips the S3 secret when creating a new access key', () => {
@@ -946,7 +946,7 @@ describe('DestinationForm.utils Analytics Bucket', () => {
     )
 
     expect(issues).toEqual([
-      { path: 's3SecretAccessKey', message: 'S3 secret access key is required' },
+      { path: 's3SecretAccessKey', message: 'S3 secret access key is required.' },
     ])
   })
 

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationForm.utils.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationForm.utils.ts
@@ -172,7 +172,7 @@ export const buildTableSyncCopyConfig = ({
   if (mode === 'include_all_tables' || mode === 'skip_all_tables') return { type: mode }
 
   if (selectedTableIds.length === 0) {
-    throw new Error('Select at least one table for the initial sync')
+    throw new Error('Select at least one table for the initial sync.')
   }
 
   const tableIds = selectedTableIds.map(Number)
@@ -343,7 +343,7 @@ export const buildDestinationConfigForValidation = ({
   } else if (selectedType === 'ClickHouse') {
     return { clickHouse: buildClickHouseConfig(data) }
   } else {
-    throw new Error('Invalid destination type')
+    throw new Error('Invalid destination type.')
   }
 }
 

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationNameInput.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationNameInput.tsx
@@ -14,7 +14,11 @@ export const DestinationNameInput = ({ form }: DestinationNameInputProps) => {
       control={form.control}
       name="name"
       render={({ field }) => (
-        <FormItemLayout label="Name" layout="horizontal">
+        <FormItemLayout
+          label="Name"
+          layout="horizontal"
+          description="Used to identify this pipeline in Supabase."
+        >
           <FormControl>
             <Input
               {...field}

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DuckLake/DuckLake.schema.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DuckLake/DuckLake.schema.ts
@@ -14,8 +14,8 @@ export const DuckLakeFormSchema = z.object({
   ducklakePoolSize: z
     .number()
     .int()
-    .min(1, 'Pool size must be greater than 0')
-    .max(6, 'Pool size must be 6 or less')
+    .min(1, 'Pool size must be greater than 0.')
+    .max(6, 'Pool size must be 6 or less.')
     .optional(),
   ducklakeS3AccessKeyId: z.string().optional(),
   ducklakeS3SecretAccessKey: z.string().optional(),

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DuckLake/DuckLake.utils.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DuckLake/DuckLake.utils.ts
@@ -55,18 +55,18 @@ type DucklakeValidationData = Pick<
 // Required fields per mode. "Use Supabase" only needs project refs + a bucket; the catalog URL and
 // S3 credentials are resolved by the platform API.
 const DUCKLAKE_SUPABASE_REQUIRED_FIELDS: DucklakeValidationIssue[] = [
-  { path: 'ducklakeCatalogProjectRef', message: 'Catalog project is required' },
-  { path: 'ducklakeStorageProjectRef', message: 'Storage project is required' },
-  { path: 'ducklakeStorageBucket', message: 'Bucket is required' },
+  { path: 'ducklakeCatalogProjectRef', message: 'Catalog project is required.' },
+  { path: 'ducklakeStorageProjectRef', message: 'Storage project is required.' },
+  { path: 'ducklakeStorageBucket', message: 'Bucket is required.' },
 ]
 
 const DUCKLAKE_CUSTOM_REQUIRED_FIELDS: DucklakeValidationIssue[] = [
-  { path: 'ducklakeCatalogUrl', message: 'Catalog URL is required' },
-  { path: 'ducklakeDataPath', message: 'Data path is required' },
-  { path: 'ducklakeS3AccessKeyId', message: 'S3 access key ID is required' },
-  { path: 'ducklakeS3SecretAccessKey', message: 'S3 secret access key is required' },
-  { path: 'ducklakeS3Region', message: 'S3 region is required' },
-  { path: 'ducklakeS3Endpoint', message: 'S3 endpoint is required' },
+  { path: 'ducklakeCatalogUrl', message: 'Catalog URL is required.' },
+  { path: 'ducklakeDataPath', message: 'Data path is required.' },
+  { path: 'ducklakeS3AccessKeyId', message: 'S3 access key ID is required.' },
+  { path: 'ducklakeS3SecretAccessKey', message: 'S3 secret access key is required.' },
+  { path: 'ducklakeS3Region', message: 'S3 region is required.' },
+  { path: 'ducklakeS3Endpoint', message: 'S3 endpoint is required.' },
 ]
 
 const DUCKLAKE_CUSTOM_SECRET_FIELDS = new Set<DucklakeFieldPath>([
@@ -79,7 +79,7 @@ const DUCKLAKE_CUSTOM_SECRET_FIELDS = new Set<DucklakeFieldPath>([
 const METADATA_SCHEMA_PATTERN = /^[A-Za-z0-9_]+$/
 const METADATA_SCHEMA_ISSUE: DucklakeValidationIssue = {
   path: 'ducklakeMetadataSchema',
-  message: 'DuckLake metadata schema must contain only letters, numbers, and underscores',
+  message: 'DuckLake metadata schema must contain only letters, numbers, and underscores.',
 }
 
 const getMissingRequiredFieldIssues = (
@@ -113,7 +113,7 @@ export const getDucklakeValidationIssues = (
   ) {
     issues.push({
       path: 'ducklakeS3AccessKeyId',
-      message: 'S3 access key ID is required',
+      message: 'S3 access key ID is required.',
     })
   }
 
@@ -124,7 +124,7 @@ export const getDucklakeValidationIssues = (
   ) {
     issues.push({
       path: 'ducklakeS3SecretAccessKey',
-      message: 'S3 secret access key is required',
+      message: 'S3 secret access key is required.',
     })
   }
 
@@ -136,7 +136,7 @@ export const getDucklakeValidationIssues = (
   ) {
     issues.push({
       path: 'ducklakeCatalogUrl',
-      message: 'DuckLake catalog URL must be a PostgreSQL-compatible URL',
+      message: 'DuckLake catalog URL must be a PostgreSQL-compatible URL.',
     })
   }
 
@@ -146,7 +146,7 @@ export const getDucklakeValidationIssues = (
   ) {
     issues.push({
       path: 'ducklakeDataPath',
-      message: 'DuckLake data path must start with s3:// and cannot contain file://',
+      message: 'DuckLake data path must start with s3:// and cannot contain file://.',
     })
   }
 
@@ -157,7 +157,7 @@ export const getDucklakeValidationIssues = (
   ) {
     issues.push({
       path: 'ducklakeS3Endpoint',
-      message: 'S3 endpoint must not contain the protocol scheme',
+      message: 'S3 endpoint must not contain the protocol scheme.',
     })
   }
 

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DuckLake/Fields.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DuckLake/Fields.tsx
@@ -154,7 +154,7 @@ const DuckLakeSupabaseFields = ({ form }: { form: UseFormReturn<DestinationPanel
     const name = newBucketName.trim()
     if (!name || !ducklakeStorageProjectRef) return
     if (name.includes('/')) {
-      return toast.error('Bucket name cannot contain "/"')
+      return toast.error('Bucket name cannot contain "/".')
     }
 
     createBucket({

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/Snowflake/Snowflake.utils.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/Snowflake/Snowflake.utils.ts
@@ -23,11 +23,11 @@ export type SnowflakeValidationIssue = {
 }
 
 const SNOWFLAKE_REQUIRED_FIELDS: { path: SnowflakeFieldPath; message: string }[] = [
-  { path: 'snowflakeAccountId', message: 'Account ID is required' },
-  { path: 'snowflakeUser', message: 'User is required' },
-  { path: 'snowflakePrivateKey', message: 'Private key is required' },
-  { path: 'snowflakeDatabase', message: 'Database is required' },
-  { path: 'snowflakeSchema', message: 'Schema is required' },
+  { path: 'snowflakeAccountId', message: 'Account ID is required.' },
+  { path: 'snowflakeUser', message: 'User is required.' },
+  { path: 'snowflakePrivateKey', message: 'Private key is required.' },
+  { path: 'snowflakeDatabase', message: 'Database is required.' },
+  { path: 'snowflakeSchema', message: 'Schema is required.' },
 ]
 
 export const getSnowflakeValidationIssues = (

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/useDestinationForm.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/useDestinationForm.ts
@@ -85,7 +85,7 @@ export const useDestinationForm = ({ selectedType }: { selectedType: Destination
   // Helper function to handle namespace creation if needed
   const resolveNamespace = async (data: z.infer<typeof FormSchema>) => {
     if (data.namespace === CREATE_NEW_NAMESPACE) {
-      if (!data.newNamespaceName) throw new Error('New namespace name is required')
+      if (!data.newNamespaceName) throw new Error('New namespace name is required.')
 
       await createNamespace({
         projectRef,
@@ -224,7 +224,7 @@ export const useDestinationForm = ({ selectedType }: { selectedType: Destination
         resolveNamespace,
       })
 
-      if (!destinationConfig) throw new Error('Destination configuration is missing')
+      if (!destinationConfig) throw new Error('Destination configuration is missing.')
 
       const shouldSendBatch =
         !editMode || data.maxFillMs !== (existingBatch?.max_fill_ms ?? DEFAULT_MAX_FILL_MS)


### PR DESCRIPTION
## What kind of change does this PR introduce?

UI copy improvement for the current pipeline creation sheet.

## What is the current behavior?

Several pipeline fields use ambiguous labels or omit useful guidance. Validation messages also use inconsistent punctuation.

## What is the new behavior?

- Explains how the pipeline name is used
- Clarifies invalidated replication slot behaviour
- Explains that BigQuery maximum staleness is optional
- Makes pipeline validation messages consistent

## To test

1. Open a project, then go to Database → Replication and select Add destination.
2. Confirm Name explains that it identifies the pipeline in Supabase.
3. Expand Advanced settings and confirm Invalidated slot behaviour uses Block startup and Recreate slot.
4. Select BigQuery and confirm Maximum staleness explains that leaving it blank gives the freshest results.
5. Submit incomplete destination settings and confirm validation messages end with full stops.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replication slot behavior options now use clearer labels: “Block startup” and “Recreate slot.”
  * Added guidance explaining that the pipeline name identifies the pipeline in Supabase.
  * Improved the BigQuery maximum-staleness description and display.

* **Bug Fixes**
  * Standardized replication destination validation messages with consistent punctuation.
  * Clarified the ClickHouse HTTPS validation message.
  * Updated validation tests to reflect the improved error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->