### PR TITLE
fix(studio): stop Explain Code sending an empty snippet

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/MonacoEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/MonacoEditor.tsx
@@ -137,15 +137,21 @@ export const MonacoEditor = ({
       contextMenuGroupId: 'operation',
       contextMenuOrder: 1,
       run: () => {
-        const selection = editorRef?.current?.getSelection()
-        if (!selection) return
+        const currentEditor = editorRef?.current
+        if (!currentEditor) return
 
-        const selectedValue = editorRef?.current?.getModel()?.getValueInRange(selection)
+        const selection = currentEditor.getSelection()
+        const selectedValue = selection
+          ? currentEditor.getModel()?.getValueInRange(selection)
+          : undefined
+        // A collapsed cursor is still a Selection, so `getValueInRange` returns ''. Fall back to
+        // the whole editor the way `getEditorSql` does for run and explain actions.
+        const valueToExplain = selectedValue || currentEditor.getValue()
 
         openSidebar(SIDEBAR_KEYS.AI_ASSISTANT)
         aiSnap.newChat({
           name: 'Explain code section',
-          sqlSnippets: [selectedValue ?? ''],
+          sqlSnippets: [valueToExplain],
           initialInput: 'Can you explain this section to me in more detail?',
         })
       },


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix in the SQL editor's Explain Code context menu action.

## What is the current behavior?

```ts
const selection = editorRef?.current?.getSelection()
if (!selection) return

const selectedValue = editorRef?.current?.getModel()?.getValueInRange(selection)

openSidebar(SIDEBAR_KEYS.AI_ASSISTANT)
aiSnap.newChat({
  name: 'Explain code section',
  sqlSnippets: [selectedValue ?? ''],
  initialInput: 'Can you explain this section to me in more detail?',
})
```

The guard reads as "bail out if nothing is selected", but that is not what it does. `getSelection(): Selection | null` returns null only when the editor has no state; a collapsed cursor is still a `Selection`, just an empty range (monaco-editor 0.52.2 `editor.api.d.ts:2710`, and `Range.isEmpty()` at `:681` exists precisely because empty ranges are normal).

So right clicking without selecting anything passes the guard, `getValueInRange` returns `''`, and `?? ''` keeps it, because `??` only catches null and undefined. The assistant opens with an empty snippet and asks "Can you explain this section to me in more detail?".

## What is the new behavior?

It falls back to the full editor contents when the selection is empty.

That is not a judgement call I made. `getEditorSql` in `SQLEditor.utils.ts:397` already does exactly this with `selectedValue || editor.getValue()`, and its docstring describes the promotion as happening "inside an explicit run/explain user action", so explain is in scope for that behavior. `getEditorValueOrSelection`, added to `CodeEditor.utils.ts` yesterday in #49651, is the same shape again, with the comment "the current selection if there is one ... otherwise the full editor value". This action was the odd one out.

The operative difference is `||` rather than `??`, since the empty string is the value that needs replacing:

```
selectedValue ?? ''    -> ""                       (today)
selectedValue || full  -> "select * from users;"   (this PR)
```

## The alternative I did not pick

The other reasonable fix is to bail out when the selection is empty, `if (!selection || selection.isEmpty()) return`. I went with the fallback because two existing helpers in this codebase already define what a run or explain gesture acts on, and matching them seemed better than adding a third behavior. Happy to switch it to the guard if you would rather Explain Code did nothing without a selection.

## Deliberately not changed

I did not refactor this to call `getEditorSql`. That returns an `UntrustedSqlFragment` for the execution path, whereas `sqlSnippets` takes plain strings and goes to the assistant rather than to `executeSql`, so pulling the branded helper in here would mean unwrapping it again for no benefit. Nothing in this diff crosses the SQL execution boundary.

I also left `getEditorValueOrSelection` alone rather than moving this file onto it. That helper lives in `components/ui/CodeEditor` and is currently used only by the Explorer's QueryEditor; wiring the SQL editor onto it is a consolidation worth doing deliberately, not as a side effect of a bug fix.

## Additional context

Root cause at `apps/studio/components/interfaces/SQLEditor/MonacoEditor.tsx:140`.

No test. There is no existing test file for `MonacoEditor.tsx`, and the meaningful assertion needs a real monaco instance to produce a collapsed selection, which is well beyond what a unit test here would justify. The check that matters is right clicking in the SQL editor with nothing selected.

Gates: `test:prettier` clean repo wide, `typecheck --filter=studio --force` 9/9, `lint:ratchet` reports rules improved.

Freshman contributor, and I use Claude Code as an assistant. I found this by comparing the selection handling #49651 introduced against the other places in Studio that read a selection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * “Explain Code” now works when no text is selected by explaining the full editor contents.
  * Added safer handling when the editor is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->