### PR TITLE
Disable analyze button for notebooks if notebook is empty

### DIFF
--- a/apps/studio/components/interfaces/Explorer/ExplorerNotebookTab.tsx
+++ b/apps/studio/components/interfaces/Explorer/ExplorerNotebookTab.tsx
@@ -354,6 +354,8 @@ export const ExplorerNotebookTab = () => {
           <ExplorerToolbarAction
             icon={<AiIconAnimation size={16} />}
             loading={isCreating}
+            disabled={cells.length === 0}
+            tooltip={cells.length === 0 ? 'Add a cell to the notebook to analyze it' : undefined}
             onClick={handleClickAnalyze}
           >
             Analyze


### PR DESCRIPTION
## Context

As per PR title - just disables the analyze button if the notebook is empty

<img width="1077" height="323" alt="image" src="https://github.com/user-attachments/assets/f8da8bd4-eb0c-43ae-85c7-b60c1c7dcfed" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled the Analyze action for empty notebooks.
  * Added guidance prompting users to add a cell before starting analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->