### PR TITLE
joshenlim/fe 4285 explorer missing prettify in query toolbar actions

### DIFF
--- a/apps/studio/components/interfaces/Explorer/ExplorerNotebookTab.tsx
+++ b/apps/studio/components/interfaces/Explorer/ExplorerNotebookTab.tsx
@@ -447,6 +447,7 @@ export const ExplorerNotebookTab = () => {
                           key={cell._id}
                           cell={cell}
                           onEdit={persistNotebookTab}
+                          onPrettifyQuery={() => queryCellRefs.current.get(cell._id)?.prettify()}
                           ref={(instance) => {
                             if (instance) queryCellRefs.current.set(cell._id, instance)
                             else queryCellRefs.current.delete(cell._id)

--- a/apps/studio/components/interfaces/Explorer/ExplorerQueryTab.tsx
+++ b/apps/studio/components/interfaces/Explorer/ExplorerQueryTab.tsx
@@ -1,8 +1,9 @@
+import { type Hotkey } from '@tanstack/react-hotkeys'
 import { useDebounce } from '@uidotdev/usehooks'
 import { LOCAL_STORAGE_KEYS, useParams } from 'common'
-import { Check, Keyboard, Loader2, MoreVertical, Save, SquareCode } from 'lucide-react'
+import { AlignLeft, Check, Keyboard, Loader2, MoreVertical, Save, SquareCode } from 'lucide-react'
 import { useRouter } from 'next/router'
-import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import {
   Button,
@@ -14,16 +15,18 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
+  KeyboardShortcut,
 } from 'ui'
 import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 
 import { ExplorerToolbarAction } from './ExplorerToolbar'
 import { useCreateNotebook } from './hooks'
-import { QueryEditor, type ExplorerQueryModel } from './QueryEditor'
+import { QueryEditor, type ExplorerQueryModel, type QueryEditorHandle } from './QueryEditor'
 import { type QueryDisplay, type QueryResult } from './types'
 import { createQueryCellSkeleton } from './utils'
 import { getNotebook } from '@/data/content/notebooks/notebook-query'
@@ -33,6 +36,8 @@ import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
 import { explorerQueryState, useExplorerQueryStateSnapshot } from '@/state/explorer-query'
 import { useNotebooksStateSnapshot } from '@/state/notebooks/notebooks-state'
 import { useControlledRoleImpersonationState } from '@/state/role-impersonation-state'
+import { hotkeyToKeys } from '@/state/shortcuts/formatShortcut'
+import { SHORTCUT_DEFINITIONS, SHORTCUT_IDS } from '@/state/shortcuts/registry'
 import { createTabId, TabsStateContext } from '@/state/tabs'
 
 /** Query-tab lifecycle adapter around the shared QueryEditor. */
@@ -49,6 +54,12 @@ export const ExplorerQueryTab = () => {
     LOCAL_STORAGE_KEYS.SQL_EDITOR_INTELLISENSE,
     true
   )
+
+  const queryEditorRef = useRef<QueryEditorHandle>(null)
+
+  const hotkeySequnece: Hotkey | undefined =
+    SHORTCUT_DEFINITIONS[SHORTCUT_IDS.SQL_EDITOR_FORMAT].sequence[0]
+  const formatKeys = hotkeySequnece ? hotkeyToKeys(hotkeySequnece) : undefined
 
   const [restoredQueryKey, setRestoredQueryKey] = useState<string>()
   const [showQuery, setShowQuery] = useState(true)
@@ -166,6 +177,7 @@ export const ExplorerQueryTab = () => {
 
   return (
     <QueryEditor
+      ref={queryEditorRef}
       id={id}
       variant="viewport"
       title={draft.name}
@@ -252,7 +264,7 @@ export const ExplorerQueryTab = () => {
             <DropdownMenuTrigger asChild>
               <ExplorerToolbarAction icon={<MoreVertical />} />
             </DropdownMenuTrigger>
-            <DropdownMenuContent>
+            <DropdownMenuContent className="w-48" align="end">
               <DropdownMenuItem
                 className="justify-between"
                 onClick={() => setIsIntellisenseEnabled(!isIntellisenseEnabled)}
@@ -262,6 +274,17 @@ export const ExplorerQueryTab = () => {
                   <span>Intellisense enabled</span>
                 </div>
                 {isIntellisenseEnabled && <Check className="text-brand" size={16} />}
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                className="justify-between"
+                onClick={() => queryEditorRef.current?.prettify()}
+              >
+                <span className="flex items-center gap-x-2">
+                  <AlignLeft size={14} />
+                  Prettify SQL
+                </span>
+                {formatKeys && <KeyboardShortcut keys={formatKeys} />}
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>

--- a/apps/studio/components/interfaces/Explorer/ExplorerToolbar.tsx
+++ b/apps/studio/components/interfaces/Explorer/ExplorerToolbar.tsx
@@ -133,7 +133,7 @@ export type ExplorerToolbarActionProps = Omit<
   React.ComponentPropsWithRef<typeof Button>,
   'size' | 'variant'
 > & {
-  tooltip?: string
+  tooltip?: React.ReactNode
 }
 
 /**

--- a/apps/studio/components/interfaces/Explorer/QueryCell/index.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryCell/index.tsx
@@ -1,5 +1,6 @@
 import { AlignLeft } from 'lucide-react'
 import { forwardRef, useState } from 'react'
+import { KeyboardShortcut } from 'ui'
 import { type Snapshot } from 'valtio'
 
 import { AddCellDropdown } from '../AddCellDropdown'
@@ -24,6 +25,12 @@ import {
 import { type QuerySourceBinding } from '@/data/query-sources/query-source-registry'
 import { useCurrentNotebook, useNotebooksStateSnapshot } from '@/state/notebooks/notebooks-state'
 import { useLocalRoleImpersonationState } from '@/state/role-impersonation-state'
+import { hotkeyToKeys } from '@/state/shortcuts/formatShortcut'
+import { SHORTCUT_DEFINITIONS, SHORTCUT_IDS } from '@/state/shortcuts/registry'
+
+const PRETTIFY_SHORTCUT_KEYS = hotkeyToKeys(
+  SHORTCUT_DEFINITIONS[SHORTCUT_IDS.SQL_EDITOR_FORMAT].sequence[0]
+)
 
 interface QueryCellProps {
   cell: Snapshot<QueryCellSchema>
@@ -130,7 +137,12 @@ export const QueryCell = forwardRef<QueryEditorHandle, QueryCellProps>(function 
         toolbarActions={
           <ExplorerToolbarAction
             icon={<AlignLeft />}
-            tooltip="Prettify SQL"
+            tooltip={
+              <div className="flex items-center gap-2.5">
+                <span>Prettify SQL</span>
+                <KeyboardShortcut keys={PRETTIFY_SHORTCUT_KEYS} />
+              </div>
+            }
             onClick={onPrettifyQuery}
           />
         }

--- a/apps/studio/components/interfaces/Explorer/QueryCell/index.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryCell/index.tsx
@@ -1,7 +1,9 @@
+import { AlignLeft } from 'lucide-react'
 import { forwardRef, useState } from 'react'
 import { type Snapshot } from 'valtio'
 
 import { AddCellDropdown } from '../AddCellDropdown'
+import { ExplorerToolbarAction } from '../ExplorerToolbar'
 import { MoveCellDropdownContent } from '../MoveCellDropdownContent'
 import { QueryEditor, type QueryEditorHandle } from '../QueryEditor'
 import { type QueryDisplay, type QueryResult } from '../types'
@@ -26,11 +28,12 @@ import { useLocalRoleImpersonationState } from '@/state/role-impersonation-state
 interface QueryCellProps {
   cell: Snapshot<QueryCellSchema>
   onEdit?: () => void
+  onPrettifyQuery?: () => void
 }
 
 /** Notebook adapter around the shared QueryEditor. */
 export const QueryCell = forwardRef<QueryEditorHandle, QueryCellProps>(function QueryCell(
-  { cell, onEdit },
+  { cell, onEdit, onPrettifyQuery },
   ref
 ) {
   const snap = useNotebooksStateSnapshot()
@@ -124,6 +127,13 @@ export const QueryCell = forwardRef<QueryEditorHandle, QueryCellProps>(function 
         onResultChange={setResult}
         onRowLimitChange={handleRowLimitChange}
         onDisplayChange={handleDisplayChange}
+        toolbarActions={
+          <ExplorerToolbarAction
+            icon={<AlignLeft />}
+            tooltip="Prettify SQL"
+            onClick={onPrettifyQuery}
+          />
+        }
       />
     </SortableSection>
   )

--- a/apps/studio/components/interfaces/Explorer/QueryEditor/index.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryEditor/index.tsx
@@ -76,8 +76,6 @@ import {
   isRoleImpersonationEnabled,
   type RoleImpersonationController,
 } from '@/state/role-impersonation-state'
-import { hotkeyToKeys } from '@/state/shortcuts/formatShortcut'
-import { SHORTCUT_DEFINITIONS, SHORTCUT_IDS } from '@/state/shortcuts/registry'
 
 const generatePlaceholder = (os: string | undefined) =>
   `Hit ${os === 'macos' ? 'CMD+SHIFT+K' : 'CTRL+SHIFT+K'} to generate query or just start typing`

--- a/apps/studio/components/interfaces/Explorer/QueryEditor/index.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryEditor/index.tsx
@@ -353,6 +353,8 @@ export const QueryEditor = forwardRef<QueryEditorHandle, QueryEditorProps>(funct
   const Shell = variant === 'viewport' ? ExplorerQueryViewport : ExplorerQuery
 
   const handlePrettify = async () => {
+    if (pendingProposalRef.current) return
+
     const editor = editorInstanceRef.current
     if (!editor) return
     await editor.getAction('editor.action.formatDocument')?.run()

--- a/apps/studio/components/interfaces/Explorer/QueryEditor/index.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryEditor/index.tsx
@@ -12,7 +12,7 @@ import {
   useState,
   type ReactNode,
 } from 'react'
-import { Button, cn } from 'ui'
+import { Button, cn, KeyboardShortcut } from 'ui'
 
 import { resolveLogTimeRange } from '../../QuerySources/LogTimeRange.utils'
 import {
@@ -76,6 +76,8 @@ import {
   isRoleImpersonationEnabled,
   type RoleImpersonationController,
 } from '@/state/role-impersonation-state'
+import { hotkeyToKeys } from '@/state/shortcuts/formatShortcut'
+import { SHORTCUT_DEFINITIONS, SHORTCUT_IDS } from '@/state/shortcuts/registry'
 
 const generatePlaceholder = (os: string | undefined) =>
   `Hit ${os === 'macos' ? 'CMD+SHIFT+K' : 'CTRL+SHIFT+K'} to generate query or just start typing`
@@ -417,7 +419,12 @@ export const QueryEditor = forwardRef<QueryEditorHandle, QueryEditorProps>(funct
             <ExplorerToolbarAction
               icon={<Play />}
               loading={isExecuting}
-              tooltip={hasSelection ? 'Run selected query' : 'Run query'}
+              tooltip={
+                <div className="flex items-center gap-2.5">
+                  <span>{hasSelection ? 'Run selected query' : 'Run query'}</span>
+                  <KeyboardShortcut keys={['Meta', 'Enter']} />
+                </div>
+              }
               disabled={
                 isBusy || pendingProposal !== null || isRunDisabled || sql.trim().length === 0
               }

--- a/apps/studio/components/interfaces/Explorer/QueryEditor/index.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryEditor/index.tsx
@@ -502,6 +502,16 @@ export const QueryEditor = forwardRef<QueryEditorHandle, QueryEditorProps>(funct
                       if (selectionParts) setPromptState({ isOpen: true, ...selectionParts })
                     },
                   })
+
+                  editor.addAction({
+                    id: 'prettify-query',
+                    label: 'Prettify SQL',
+                    keybindings: [monaco.KeyMod.Alt | monaco.KeyMod.Shift | monaco.KeyCode.KeyF],
+                    contextMenuGroupId: 'operation',
+                    run: () => {
+                      handlePrettify()
+                    },
+                  })
                 }}
               />
 

--- a/apps/studio/components/interfaces/Explorer/QueryEditor/index.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryEditor/index.tsx
@@ -113,6 +113,8 @@ export type QueryEditorHandle = {
   run: (force?: boolean) => Promise<void>
   /** The editor's live text buffer, ahead of any blur-triggered commit to the store. */
   getSql: () => string
+  /** Formats the editor's SQL in place and commits the result, same as the SQL Editor's Prettify SQL action. */
+  prettify: () => Promise<void>
 }
 
 type QueryEditorProps = {
@@ -350,9 +352,17 @@ export const QueryEditor = forwardRef<QueryEditorHandle, QueryEditorProps>(funct
 
   const Shell = variant === 'viewport' ? ExplorerQueryViewport : ExplorerQuery
 
+  const handlePrettify = async () => {
+    const editor = editorInstanceRef.current
+    if (!editor) return
+    await editor.getAction('editor.action.formatDocument')?.run()
+    onSqlCommitRef.current?.(editor.getValue())
+  }
+
   useImperativeHandle(ref, () => ({
     run: (force = false) => handleRunQuery({ shouldForce: force }),
     getSql: () => sqlRef.current,
+    prettify: handlePrettify,
   }))
 
   useEffect(() => {


### PR DESCRIPTION
## Context

Adds the prettify SQL CTA to Explorer Notebook and Query Tab

Query tab: Prettify CTA is within the dropdown menu here
<img width="1092" height="272" alt="image" src="https://github.com/user-attachments/assets/3b4f3514-69cc-4c24-a127-da1555ee905e" />

Query cell: Prettify CTA sits between the buttons in the toolbar
<img width="1085" height="306" alt="image" src="https://github.com/user-attachments/assets/e503ad6c-5dda-4c2b-a824-8c1049d5e9fb" />

Also added shortcut tooltip for the run button
<img width="183" height="103" alt="image" src="https://github.com/user-attachments/assets/729055b8-8e2c-4cf7-8f2e-c5726e828644" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SQL prettification to Explorer query editors through the overflow menu, query toolbar, editor action, and keyboard shortcut.
  * Displays the configured formatting shortcut alongside the prettify action.
  * Prevents formatting while an AI proposal is pending.
  * Added a keyboard shortcut hint to the query run action.
  * Enhanced toolbar tooltips to support richer formatted content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->