### PR TITLE
feat(storage): show archived files inline

### DIFF
--- a/apps/studio/components/interfaces/Storage/StorageExplorer/ArchivedFilesContext.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/ArchivedFilesContext.tsx
@@ -1,0 +1,98 @@
+import { useQuery } from '@tanstack/react-query'
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type PropsWithChildren,
+} from 'react'
+
+import type { ArchivedVersionRow } from './archivedVersions.utils'
+import { useStoragePreference } from './useStoragePreference'
+import { useIsStorageVersioningEnabled } from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
+import {
+  archivedObjectsQueryOptions,
+  type ArchivedObject,
+} from '@/data/storage/versioning/archived-objects-query'
+import { useStorageExplorerStateSnapshot } from '@/state/storage-explorer'
+
+interface ArchivedFilesContextValue {
+  isOverlayEnabled: boolean
+  archivedObjects: ArchivedObject[]
+  selectedArchivedObject: ArchivedObject | undefined
+  selectedArchivedVersion: ArchivedVersionRow | undefined
+  setSelectedArchivedVersion: (version?: ArchivedVersionRow) => void
+  selectArchivedObject: (archivedObjectId: string) => void
+  clearArchivedSelection: () => void
+}
+
+const ArchivedFilesContext = createContext<ArchivedFilesContextValue>({
+  isOverlayEnabled: false,
+  archivedObjects: [],
+  selectedArchivedObject: undefined,
+  selectedArchivedVersion: undefined,
+  setSelectedArchivedVersion: () => {},
+  selectArchivedObject: () => {},
+  clearArchivedSelection: () => {},
+})
+
+export const useArchivedFilesContext = () => useContext(ArchivedFilesContext)
+
+/**
+ * Fetched once here rather than per row. Not gated on the bucket's versioning
+ * state — a suspended bucket can still be retaining files.
+ */
+export const ArchivedFilesProvider = ({ children }: PropsWithChildren) => {
+  const { projectRef, selectedBucket } = useStorageExplorerStateSnapshot()
+  const { showArchivedInline } = useStoragePreference(projectRef)
+  const isStorageVersioningEnabled = useIsStorageVersioningEnabled()
+
+  const [selectedArchivedObject, setSelectedArchivedObject] = useState<ArchivedObject>()
+  const [selectedArchivedVersion, setSelectedArchivedVersion] = useState<ArchivedVersionRow>()
+
+  const bucketId = selectedBucket?.id
+  const isOverlayEnabled = isStorageVersioningEnabled && showArchivedInline
+
+  const { data: archivedObjects = [] } = useQuery({
+    ...archivedObjectsQueryOptions({ projectRef, bucketId }),
+    enabled: isOverlayEnabled && !!projectRef && !!bucketId,
+  })
+
+  const selectArchivedObject = useCallback(
+    (archivedObjectId: string) => {
+      const object = archivedObjects.find((candidate) => candidate.id === archivedObjectId)
+      if (object === undefined) return
+      setSelectedArchivedVersion(undefined)
+      setSelectedArchivedObject(object)
+    },
+    [archivedObjects]
+  )
+
+  const clearArchivedSelection = useCallback(() => {
+    setSelectedArchivedObject(undefined)
+    setSelectedArchivedVersion(undefined)
+  }, [])
+
+  const value = useMemo(
+    () => ({
+      isOverlayEnabled,
+      archivedObjects,
+      selectedArchivedObject,
+      selectedArchivedVersion,
+      setSelectedArchivedVersion,
+      selectArchivedObject,
+      clearArchivedSelection,
+    }),
+    [
+      isOverlayEnabled,
+      archivedObjects,
+      selectedArchivedObject,
+      selectedArchivedVersion,
+      selectArchivedObject,
+      clearArchivedSelection,
+    ]
+  )
+
+  return <ArchivedFilesContext.Provider value={value}>{children}</ArchivedFilesContext.Provider>
+}

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorer.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorer.tsx
@@ -1,12 +1,46 @@
 import { noop } from 'lodash'
-import { useEffect, useRef } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import { cn } from 'ui'
 
-import { STORAGE_ROW_STATUS, STORAGE_VIEWS } from '../Storage.constants'
-import type { StorageColumn, StorageItemWithColumn } from '../Storage.types'
+import {
+  STORAGE_ROW_STATUS,
+  STORAGE_SORT_BY,
+  STORAGE_SORT_BY_ORDER,
+  STORAGE_VIEWS,
+} from '../Storage.constants'
+import type { StorageColumn, StorageItem, StorageItemWithColumn } from '../Storage.types'
+import { useArchivedFilesContext } from './ArchivedFilesContext'
+import { getArchivedOverlayItems } from './archivedOverlay.utils'
 import { FileExplorerColumn } from './FileExplorerColumn'
 import { useStoragePreference } from './useStoragePreference'
 import { useStorageExplorerStateSnapshot } from '@/state/storage-explorer'
+
+/** Archived rows fall back to the archive timestamp so they don't all sink. */
+const getSortValue = (item: StorageItem, sortBy: STORAGE_SORT_BY): string | number | null => {
+  switch (sortBy) {
+    case STORAGE_SORT_BY.NAME:
+      return item.name.toLowerCase()
+    case STORAGE_SORT_BY.CREATED_AT:
+      return item.created_at ?? (item.archived ? item.updated_at : null)
+    case STORAGE_SORT_BY.UPDATED_AT:
+      return item.updated_at
+    case STORAGE_SORT_BY.LAST_ACCESSED_AT:
+      return item.last_accessed_at ?? (item.archived ? item.updated_at : null)
+  }
+}
+
+const compareItems =
+  (sortBy: STORAGE_SORT_BY, order: STORAGE_SORT_BY_ORDER) => (a: StorageItem, b: StorageItem) => {
+    const aValue = getSortValue(a, sortBy)
+    const bValue = getSortValue(b, sortBy)
+    // Nulls last either way, matching the server-side sort on the live items.
+    if (aValue === null && bValue === null) return 0
+    if (aValue === null) return 1
+    if (bValue === null) return -1
+    if (aValue < bValue) return order === STORAGE_SORT_BY_ORDER.ASC ? -1 : 1
+    if (aValue > bValue) return order === STORAGE_SORT_BY_ORDER.ASC ? 1 : -1
+    return 0
+  }
 
 export interface FileExplorerProps {
   columns: StorageColumn[]
@@ -31,7 +65,26 @@ export const FileExplorer = ({
 }: FileExplorerProps) => {
   const fileExplorerRef = useRef<any>(null)
   const snap = useStorageExplorerStateSnapshot()
-  const { view } = useStoragePreference(snap.projectRef)
+  const { view, sortBy, sortByOrder } = useStoragePreference(snap.projectRef)
+  const { isOverlayEnabled, archivedObjects } = useArchivedFilesContext()
+
+  const overlaidColumns = useMemo(() => {
+    if (!isOverlayEnabled || archivedObjects.length === 0) return columns
+    const compare = compareItems(sortBy, sortByOrder)
+
+    return columns.map((column) => {
+      const folderSegments = column.path.split('/').filter((segment) => segment !== '')
+      const archivedItems = getArchivedOverlayItems({
+        folderSegments,
+        archivedObjects,
+        existingItemNames: new Set(column.items.map((item) => item.name)),
+      })
+      if (archivedItems.length === 0) return column
+
+      // The server-side sort never saw the archived rows.
+      return { ...column, items: [...column.items, ...archivedItems].sort(compare) }
+    })
+  }, [columns, archivedObjects, isOverlayEnabled, sortBy, sortByOrder])
 
   useEffect(() => {
     if (fileExplorerRef) {
@@ -40,7 +93,7 @@ export const FileExplorer = ({
         fileExplorerRef.current.scrollLeft += scrollWidth - clientWidth
       }
     }
-  }, [columns])
+  }, [overlaidColumns])
 
   return (
     <div
@@ -56,7 +109,7 @@ export const FileExplorer = ({
         />
       ) : view === STORAGE_VIEWS.COLUMNS ? (
         <div className="flex">
-          {columns.map((column, index) => (
+          {overlaidColumns.map((column, index) => (
             <FileExplorerColumn
               key={`column-${index}`}
               index={index}
@@ -72,11 +125,11 @@ export const FileExplorer = ({
         </div>
       ) : view === STORAGE_VIEWS.LIST ? (
         <>
-          {columns.length > 0 && (
+          {overlaidColumns.length > 0 && (
             <FileExplorerColumn
               fullWidth
-              index={columns.length - 1}
-              column={columns[columns.length - 1]}
+              index={overlaidColumns.length - 1}
+              column={overlaidColumns[overlaidColumns.length - 1]}
               selectedItems={selectedItems}
               itemSearchString={itemSearchString}
               onFilesUpload={onFilesUpload}

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerHeader.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerHeader.tsx
@@ -46,6 +46,7 @@ import { STORAGE_SORT_BY, STORAGE_SORT_BY_ORDER, STORAGE_VIEWS } from '../Storag
 import { pageChromeRowClassName } from './storageExplorerChrome'
 import { useFileExplorerHeaderShortcuts } from './useFileExplorerHeaderShortcuts'
 import { useStoragePreference } from './useStoragePreference'
+import { useIsStorageVersioningEnabled } from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import { ShortcutTooltip } from '@/components/ui/ShortcutTooltip'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
@@ -174,7 +175,10 @@ export const FileExplorerHeader = ({
     setSortBy: setPreferenceSortBy,
     sortByOrder,
     setSortByOrder: setPreferenceSortByOrder,
+    showArchivedInline,
+    setShowArchivedInline,
   } = useStoragePreference(projectRef)
+  const isStorageVersioningEnabled = useIsStorageVersioningEnabled()
 
   const breadcrumbs = columns.map((column) => column.name)
   const isListView = view === STORAGE_VIEWS.LIST
@@ -416,6 +420,17 @@ export const FileExplorerHeader = ({
                       ))}
                     </DropdownMenuSubContent>
                   </DropdownMenuSub>
+                  {isStorageVersioningEnabled && (
+                    <>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem onClick={() => setShowArchivedInline(!showArchivedInline)}>
+                        <div className="flex items-center justify-between w-full">
+                          <p>Show archived</p>
+                          {showArchivedInline && <Check size={16} className="text-brand" />}
+                        </div>
+                      </DropdownMenuItem>
+                    </>
+                  )}
                 </DropdownMenuContent>
               </DropdownMenu>
             </div>

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerRow.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerRow.tsx
@@ -36,6 +36,7 @@ import {
 } from '../Storage.constants'
 import { StorageItemWithColumn, type StorageItem } from '../Storage.types'
 import { StorageRowIcon } from '../StorageRowIcon'
+import { useArchivedFilesContext } from './ArchivedFilesContext'
 import { useFileExplorerContextMenu } from './FileExplorerRowContextMenu'
 import { FileExplorerRowEditing } from './FileExplorerRowEditing'
 import { copyPathToFolder } from './StorageExplorer.utils'
@@ -43,6 +44,12 @@ import { useCopyUrl } from './useCopyUrl'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
 import { formatBytes } from '@/lib/helpers'
 import { useStorageExplorerStateSnapshot } from '@/state/storage-explorer'
+
+/** Built from `currentColor` so the stripes track the row's text color. */
+const ARCHIVED_STRIPES_STYLE: CSSProperties = {
+  backgroundImage:
+    'repeating-linear-gradient(-45deg, color-mix(in srgb, currentColor 8%, transparent) 0 1px, transparent 1px 7px)',
+}
 
 interface FileExplorerRowProps {
   index: number
@@ -82,18 +89,32 @@ export const FileExplorerRow = ({
   const { onCopyUrl } = useCopyUrl()
   const ctx = useFileExplorerContextMenu()
 
+  const { selectedArchivedObject, selectArchivedObject, clearArchivedSelection } =
+    useArchivedFilesContext()
+  const isArchived = item.archived !== undefined
+  const archivedObjectId = item.archived?.archivedObjectId
+  const isArchivedFile = archivedObjectId !== undefined && item.type === STORAGE_ROW_TYPES.FILE
+
   const isPublic = selectedBucket.public
   const itemWithColumnIndex = { ...item, columnIndex }
   const isSelected = !!selectedItems.find((i) => i.id === item.id)
   const isOpened =
     openedFolders.length > columnIndex ? openedFolders[columnIndex].name === item.name : false
-  const isPreviewed = !isEmpty(selectedFilePreview) && isEqual(selectedFilePreview?.id, item.id)
+  const isPreviewed =
+    (!isEmpty(selectedFilePreview) && isEqual(selectedFilePreview?.id, item.id)) ||
+    (isArchivedFile && selectedArchivedObject?.id === archivedObjectId)
   const { can: canUpdateFiles } = useAsyncCheckPermissions(PermissionAction.STORAGE_WRITE, '*')
 
   const onSelectFile = async (columnIndex: number) => {
     popColumnAtIndex(columnIndex)
     popOpenedFoldersAtIndex(columnIndex - 1)
-    setSelectedFilePreview(itemWithColumnIndex)
+    if (isArchivedFile) {
+      setSelectedFilePreview(undefined)
+      selectArchivedObject(archivedObjectId)
+    } else {
+      clearArchivedSelection()
+      setSelectedFilePreview(itemWithColumnIndex)
+    }
     clearSelectedItems()
   }
 
@@ -245,9 +266,10 @@ export const FileExplorerRow = ({
     <div
       style={style}
       className="h-full border-b border-default"
-      onContextMenu={(e) => ctx?.onRowContextMenu(e, rowOptions)}
+      onContextMenu={(e) => (isArchived ? undefined : ctx?.onRowContextMenu(e, rowOptions))}
     >
       <div
+        style={isArchived ? ARCHIVED_STRIPES_STYLE : undefined}
         className={cn(
           'storage-row group flex h-full items-center px-2.5 rounded-sm',
           'hover:bg-panel-footer-light in-data-[theme*=dark]:hover:bg-panel-footer-dark',
@@ -255,6 +277,8 @@ export const FileExplorerRow = ({
           isSelected && 'bg-selection',
           isPreviewed && 'bg-selection hover:bg-selection',
           item.status !== STORAGE_ROW_STATUS.LOADING && 'cursor-pointer',
+          // Also drives the stripe color via `currentColor`.
+          isArchived && 'text-foreground-lighter [&_p]:text-foreground-lighter',
           // Keyboard focus on the checkbox: ring the whole row
           'has-[:focus-visible]:outline-solid has-[:focus-visible]:outline-2 has-[:focus-visible]:outline-offset-[-2px] has-[:focus-visible]:outline-[var(--ring)]'
         )}
@@ -262,9 +286,12 @@ export const FileExplorerRow = ({
           event.stopPropagation()
           event.preventDefault()
           if (item.status !== STORAGE_ROW_STATUS.LOADING && !isOpened && !isPreviewed) {
-            item.type === STORAGE_ROW_TYPES.FOLDER
-              ? openFolder(columnIndex, item)
-              : onSelectFile(columnIndex)
+            if (item.type === STORAGE_ROW_TYPES.FOLDER) {
+              clearArchivedSelection()
+              openFolder(columnIndex, item)
+            } else {
+              onSelectFile(columnIndex)
+            }
           }
         }}
       >
@@ -293,7 +320,7 @@ export const FileExplorerRow = ({
                 />
               </div>
             )}
-            {isFile ? (
+            {isFile && !isArchived ? (
               <Checkbox
                 className={
                   isSelected
@@ -351,6 +378,24 @@ export const FileExplorerRow = ({
               className={`animate-spin text-foreground-lighter ${view === STORAGE_VIEWS.LIST ? 'invisible' : ''}`}
               size={14}
             />
+          ) : isArchived ? (
+            // Archived rows have no checkbox or context menu, so without this
+            // button they'd have nothing keyboard-reachable.
+            isArchivedFile ? (
+              <button
+                type="button"
+                tabIndex={0}
+                aria-label={`View archived file ${item.name}`}
+                onClick={() => onSelectFile(columnIndex)}
+                className="focus-ring rounded-sm border border-strong px-1 font-mono text-[10px] uppercase text-foreground-lighter"
+              >
+                Archived
+              </button>
+            ) : (
+              <span className="rounded-sm border border-strong px-1 font-mono text-[10px] uppercase text-foreground-lighter">
+                Archived
+              </span>
+            )
           ) : (
             <DropdownMenu>
               <DropdownMenuTrigger className="focus-ring rounded-sm">

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/StorageExplorer.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/StorageExplorer.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useEffectEvent, useRef, useState } from 'react'
 
 import { useSelectedBucket } from '../FilesBuckets/useSelectedBucket'
 import { STORAGE_ROW_TYPES, STORAGE_VIEWS } from '../Storage.constants'
+import { ArchivedFilesProvider } from './ArchivedFilesContext'
 import { ConfirmDeleteModal } from './ConfirmDeleteModal'
 import { CustomExpiryModal } from './CustomExpiryModal'
 import { FileExplorer } from './FileExplorer'
@@ -19,7 +20,14 @@ import type { Bucket } from '@/data/storage/buckets-query'
 import { IS_PLATFORM } from '@/lib/constants'
 import { useStorageExplorerStateSnapshot } from '@/state/storage-explorer'
 
-export const StorageExplorer = () => {
+/** Mounted here rather than on the page so the bucket page keeps its shape. */
+export const StorageExplorer = () => (
+  <ArchivedFilesProvider>
+    <StorageExplorerContent />
+  </ArchivedFilesProvider>
+)
+
+const StorageExplorerContent = () => {
   const { ref, bucketId } = useParams()
   const storageExplorerRef = useRef(null)
   const {

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/useStoragePreference.ts
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/useStoragePreference.ts
@@ -14,6 +14,7 @@ interface StoragePreference {
   sortBy: STORAGE_SORT_BY
   sortByOrder: STORAGE_SORT_BY_ORDER
   sortBucket: STORAGE_BUCKET_SORT
+  showArchivedInline: boolean
 }
 
 const DEFAULT_PREFERENCES: StoragePreference = {
@@ -21,6 +22,7 @@ const DEFAULT_PREFERENCES: StoragePreference = {
   sortBy: STORAGE_SORT_BY.NAME,
   sortByOrder: STORAGE_SORT_BY_ORDER.ASC,
   sortBucket: STORAGE_BUCKET_SORT.CREATED_AT,
+  showArchivedInline: false,
 }
 
 /**
@@ -64,6 +66,13 @@ export function useStoragePreference(projectRef: string) {
     [setPreference]
   )
 
+  const setShowArchivedInline = useCallback(
+    (showArchivedInline: boolean) => {
+      setPreference((prev) => ({ ...prev, showArchivedInline }))
+    },
+    [setPreference]
+  )
+
   const setSortBucket = useCallback(
     (sortBucket: STORAGE_BUCKET_SORT) => {
       setPreference((prev) => ({ ...prev, sortBucket }))
@@ -76,9 +85,11 @@ export function useStoragePreference(projectRef: string) {
     sortBy: preference.sortBy,
     sortByOrder: preference.sortByOrder,
     sortBucket: preference.sortBucket,
+    showArchivedInline: preference.showArchivedInline,
     setView,
     setSortBy,
     setSortByOrder,
     setSortBucket,
+    setShowArchivedInline,
   }
 }


### PR DESCRIPTION
## This PR

Adds **Show archived** to the file explorer's view options. With it on, archived files appear in place in the listing — dimmed and striped, with an Archived badge — instead of being invisible. Folders that exist only because something archived sits inside them are synthesized too, so a nested archived file is reachable by drilling in.

The badge is the only way to reach the file for now; the archived file preview pane it opens arrives in #9.

- `useStoragePreference` — `showArchivedInline`, stored per project
- `ArchivedFilesContext` — owns the archived list and which object is selected
- `FileExplorer` — merges archived rows into each column and re-sorts, since the server-side sort never sees them
- `FileExplorerRow` — dimmed striped rendering, no checkbox, no context menu
- `FileExplorerHeader` — the toggle, rendered only behind the feature preview
- `StorageExplorer` — mounts the provider

## Three prototype problems fixed rather than carried over

**Two queries where one would do.** The prototype fetched the archived list with no `enabled` gate, so every bucket page fetched it whether or not the feature was on — and it mounted a *second* subscription per archived row just to resolve that row's id on click. Both are now one query in the provider, gated on the flag, the toggle and the bucket.

**Archived rows were unreachable by keyboard.** The prototype's marker was an `aria-hidden` span, and archived rows drop both the checkbox and the context menu — so they had nothing keyboard-reachable and nothing a screen reader could announce. The badge is now a real button that opens the file; folders keep a plain label since they have no object to open.

**A hardcoded color.** The stripe pattern was `rgba(120,120,120,0.05)`; it now derives from `currentColor` so it tracks the row's text color across themes.

## Worth a look

The overlay is deliberately **not** gated on the bucket's versioning state. A never-versioned bucket simply has nothing archived, and a suspended one can still be retaining files, so the query result is the honest answer either way — and it avoids a gate that would be wrong once the API lands.

## Testing

Covered by the 19 unit tests on `getArchivedOverlayItems` in #7 (folder coalescing, one-level descent, live-item-wins). With the query stubbed to `[]` there's no populated state to assert against in a component test, so those land with the endpoint.

To see only this PR's changes:

```bash
git diff feat/storage-versioning/007-archived-objects-data...feat/storage-versioning/008-archived-rows
```

## Stack

| # | Branch | Base |
| - | ------ | ---- |
| 1 | `feat/storage-versioning-private-alpha` | `master` |
| 2 | `feat/storage-versioning/002-bucket-form-fields` | 1 |
| 3 | `feat/storage-versioning/003-bucket-modals` | 2 |
| 4 | `feat/storage-versioning/004-object-versions-data` | 3 |
| 5 | `feat/storage-versioning/005-file-preview-versions` | 4 |
| 6 | `feat/storage-versioning/006-billing-storage-retention` | 5 |
| 7 | `feat/storage-versioning/007-archived-objects-data` | 6 |
| 8 | `feat/storage-versioning/008-archived-rows` | 7 |
| 9 | `feat/storage-versioning/009-archived-preview-pane` | 8 |

## Stack-wide decisions

- **Nothing is user-visible by default.** Every surface is gated on `useIsStorageVersioningEnabled()` — the `storageVersioningPrivateAlpha` ConfigCat flag *and* the feature preview opt-in. The flag does not exist in ConfigCat yet, so on merge this is dead code for everyone.
- **No plan gating** for the private alpha.
- **No mock data lands on master.** Query hooks return empty until the endpoints exist.
- **Archived files ship as the inline overlay only.** The prototype also had a `Switch` replacing the explorer with a dedicated archived table plus a bulk selection bar, an older `Trash/` implementation, and an unreachable `bucketsV2` page — all dropped (~900 lines). That also resolves the prototype having two different controls both labelled "Show archived" in the same header.
