### PR TITLE
feat(storage): archived file preview pane

### DIFF
--- a/apps/studio/components/interfaces/Storage/DeleteBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/DeleteBucketModal.tsx
@@ -3,6 +3,8 @@ import { useRouter } from 'next/router'
 import { toast } from 'sonner'
 
 import { extractBucketNameFromDefinition } from './Storage.utils'
+import { useIsStorageVersioningEnabled } from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
+import { hasVersioningHistory } from '@/components/interfaces/Storage/StorageVersioning.constants'
 import { TextConfirmModal } from '@/components/ui/TextConfirmModalWrapper'
 import { useDatabasePoliciesQuery } from '@/data/database-policies/database-policies-query'
 import { useDatabasePolicyDeleteMutation } from '@/data/database-policies/database-policy-delete-mutation'
@@ -74,6 +76,9 @@ export const DeleteBucketModal = ({ visible, bucket, onClose }: DeleteBucketModa
     deleteBucket({ projectRef, id: bucket.id })
   }
 
+  const isStorageVersioningEnabled = useIsStorageVersioningEnabled()
+  const isRetainingVersions = isStorageVersioningEnabled && hasVersioningHistory(bucket)
+
   return (
     <TextConfirmModal
       visible={visible}
@@ -94,6 +99,8 @@ export const DeleteBucketModal = ({ visible, bucket, onClose }: DeleteBucketModa
       <p className="text-sm">
         Your bucket <span className="font-bold text-foreground">{bucket.id}</span> and all of its
         contents will be permanently deleted.
+        {isRetainingVersions &&
+          ' That includes every archived file and every retained version, which cannot be restored afterwards.'}
       </p>
     </TextConfirmModal>
   )

--- a/apps/studio/components/interfaces/Storage/EmptyBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/EmptyBucketModal.tsx
@@ -12,6 +12,8 @@ import {
 } from 'ui'
 import { Admonition } from 'ui-patterns/Admonition'
 
+import { useIsStorageVersioningEnabled } from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
+import { hasVersioningHistory } from '@/components/interfaces/Storage/StorageVersioning.constants'
 import { useBucketEmptyMutation } from '@/data/storage/bucket-empty-mutation'
 import type { Bucket } from '@/data/storage/buckets-query'
 import { useStorageExplorerStateSnapshot } from '@/state/storage-explorer'
@@ -25,6 +27,8 @@ export interface EmptyBucketModalProps {
 export const EmptyBucketModal = ({ visible, bucket, onClose }: EmptyBucketModalProps) => {
   const { ref: projectRef } = useParams()
   const { fetchFolderContents } = useStorageExplorerStateSnapshot()
+  const isStorageVersioningEnabled = useIsStorageVersioningEnabled()
+  const isRetainingVersions = isStorageVersioningEnabled && hasVersioningHistory(bucket)
 
   const { mutate: emptyBucket, isPending } = useBucketEmptyMutation({
     onSuccess: async () => {
@@ -62,7 +66,11 @@ export const EmptyBucketModal = ({ visible, bucket, onClose }: EmptyBucketModalP
           type="destructive"
           className="rounded-none border-x-0 border-t-0"
           title="This action cannot be undone"
-          description="The contents of your bucket cannot be recovered once deleted."
+          description={
+            isRetainingVersions
+              ? 'Every live object, archived file and retained version in this bucket is permanently deleted and cannot be recovered.'
+              : 'The contents of your bucket cannot be recovered once deleted.'
+          }
         />
         <DialogSection>
           <p className="text-sm">

--- a/apps/studio/components/interfaces/Storage/FilesBuckets/BucketTable.tsx
+++ b/apps/studio/components/interfaces/Storage/FilesBuckets/BucketTable.tsx
@@ -12,7 +12,9 @@ import {
   TooltipTrigger,
 } from 'ui'
 
+import { useIsStorageVersioningEnabled } from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
 import { PUBLIC_BUCKET_TOOLTIP } from '@/components/interfaces/Storage/Storage.constants'
+import { getBucketVersioningState } from '@/components/interfaces/Storage/StorageVersioning.constants'
 import { useBucketPolicyCount } from '@/components/interfaces/Storage/useBucketPolicyCount'
 import {
   VirtualizedTableCell,
@@ -26,12 +28,22 @@ import { createNavigationHandler } from '@/lib/navigation'
 
 type BucketTableMode = 'standard' | 'virtualized'
 
+export const useVersioningColumnSpan = () => (useIsStorageVersioningEnabled() ? 1 : 0)
+
+const BucketVersioningBadge = ({ bucket }: { bucket: Bucket }) => {
+  const versioningState = getBucketVersioningState(bucket)
+  if (versioningState === 'enabled') return <Badge variant="success">Enabled</Badge>
+  if (versioningState === 'suspended') return <Badge variant="warning">Suspended</Badge>
+  return <span className="text-foreground-muted">-</span>
+}
+
 type BucketTableHeaderProps = {
   mode: BucketTableMode
   hasBuckets?: boolean
 }
 
 export const BucketTableHeader = ({ mode, hasBuckets = true }: BucketTableHeaderProps) => {
+  const isStorageVersioningEnabled = useIsStorageVersioningEnabled()
   const BucketTableHeader = mode === 'standard' ? TableHeader : VirtualizedTableHeader
   const BucketTableRow = mode === 'standard' ? TableRow : VirtualizedTableRow
   const BucketTableHead = mode === 'standard' ? TableHead : VirtualizedTableHead
@@ -50,6 +62,9 @@ export const BucketTableHeader = ({ mode, hasBuckets = true }: BucketTableHeader
         <BucketTableHead className={stickyClasses}>Policies</BucketTableHead>
         <BucketTableHead className={stickyClasses}>File size limit</BucketTableHead>
         <BucketTableHead className={stickyClasses}>Allowed MIME types</BucketTableHead>
+        {isStorageVersioningEnabled && (
+          <BucketTableHead className={stickyClasses}>Versioning</BucketTableHead>
+        )}
         <BucketTableHead className={stickyClasses}>
           <span className="sr-only">Actions</span>
         </BucketTableHead>
@@ -66,10 +81,11 @@ type BucketTableEmptyStateProps = {
 export const BucketTableEmptyState = ({ mode, filterString }: BucketTableEmptyStateProps) => {
   const BucketTableRow = mode === 'standard' ? TableRow : VirtualizedTableRow
   const BucketTableCell = mode === 'standard' ? TableCell : VirtualizedTableCell
+  const versioningColumnSpan = useVersioningColumnSpan()
 
   return (
     <BucketTableRow className="[&>td]:hover:bg-inherit">
-      <BucketTableCell colSpan={5}>
+      <BucketTableCell colSpan={5 + versioningColumnSpan}>
         <p className="text-sm text-foreground">No results found</p>
         <p className="text-sm text-foreground-lighter">
           Your search for “{filterString}” did not return any results
@@ -94,6 +110,7 @@ export const BucketTableRow = ({
 }: BucketTableRowProps) => {
   const router = useRouter()
   const { getPolicyCount } = useBucketPolicyCount()
+  const isStorageVersioningEnabled = useIsStorageVersioningEnabled()
 
   const BucketTableRow = mode === 'standard' ? TableRow : VirtualizedTableRow
   const BucketTableCell = mode === 'standard' ? TableCell : VirtualizedTableCell
@@ -153,6 +170,12 @@ export const BucketTableRow = ({
           {bucket.allowed_mime_types ? bucket.allowed_mime_types.join(', ') : 'Any'}
         </p>
       </BucketTableCell>
+
+      {isStorageVersioningEnabled && (
+        <BucketTableCell>
+          <BucketVersioningBadge bucket={bucket} />
+        </BucketTableCell>
+      )}
 
       <BucketTableCell>
         <div className="flex justify-end items-center h-full">

--- a/apps/studio/components/interfaces/Storage/FilesBuckets/BucketsTable.tsx
+++ b/apps/studio/components/interfaces/Storage/FilesBuckets/BucketsTable.tsx
@@ -3,7 +3,12 @@ import { Table, TableBody } from 'ui'
 
 import { LoadMoreRow } from './BucketsTable.LoadMoreRow'
 import type { BucketsTablePaginationProps } from './BucketsTable.types'
-import { BucketTableEmptyState, BucketTableHeader, BucketTableRow } from './BucketTable'
+import {
+  BucketTableEmptyState,
+  BucketTableHeader,
+  BucketTableRow,
+  useVersioningColumnSpan,
+} from './BucketTable'
 import { VirtualizedTable, VirtualizedTableBody } from '@/components/ui/VirtualizedTable'
 import { Bucket } from '@/data/storage/buckets-query'
 
@@ -32,6 +37,7 @@ const BucketsTableUnvirtualized = ({
   pagination: { hasMore = false, isLoadingMore = false, onLoadMore },
 }: BucketsTableProps) => {
   const showSearchEmptyState = buckets.length === 0 && filterString.length > 0
+  const versioningColumnSpan = useVersioningColumnSpan()
 
   return (
     <Table
@@ -57,7 +63,7 @@ const BucketsTableUnvirtualized = ({
         )}
         <LoadMoreRow
           mode="standard"
-          colSpan={6}
+          colSpan={6 + versioningColumnSpan}
           hasMore={hasMore}
           isLoadingMore={isLoadingMore}
           onLoadMore={onLoadMore}
@@ -75,6 +81,7 @@ const BucketsTableVirtualized = ({
   pagination: { hasMore = false, isLoadingMore = false, onLoadMore },
 }: BucketsTableProps) => {
   const showSearchEmptyState = buckets.length === 0 && filterString.length > 0
+  const versioningColumnSpan = useVersioningColumnSpan()
   const scrollContainerRef = useRef<HTMLDivElement>(null)
 
   return (
@@ -86,7 +93,7 @@ const BucketsTableVirtualized = ({
     >
       <BucketTableHeader mode="virtualized" hasBuckets={buckets.length > 0} />
       <VirtualizedTableBody<Bucket>
-        paddingColSpan={5}
+        paddingColSpan={5 + versioningColumnSpan}
         emptyContent={
           showSearchEmptyState ? (
             <BucketTableEmptyState mode="virtualized" filterString={filterString} />
@@ -95,7 +102,7 @@ const BucketsTableVirtualized = ({
         trailingContent={
           <LoadMoreRow
             mode="virtualized"
-            colSpan={6}
+            colSpan={6 + versioningColumnSpan}
             hasMore={hasMore}
             isLoadingMore={isLoadingMore}
             onLoadMore={onLoadMore}

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/ArchivedFilePreviewPane.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/ArchivedFilePreviewPane.tsx
@@ -1,0 +1,286 @@
+import { PermissionAction } from '@supabase/shared-types/out/constants'
+import dayjs from 'dayjs'
+import { RotateCcw, Trash2, X } from 'lucide-react'
+import { useState } from 'react'
+import { toast } from 'sonner'
+import { Badge, Button } from 'ui'
+import { ConfirmationModal } from 'ui-patterns/Dialogs/ConfirmationModal'
+
+import { useArchivedFilesContext } from './ArchivedFilesContext'
+import { ArchivedVersionRestoreWidget } from './ArchivedVersionRestoreWidget'
+import { ArchivedVersionRow as ArchivedVersionListRow } from './ArchivedVersionRow'
+import { getMergedArchivedVersions, type ArchivedVersionRow } from './archivedVersions.utils'
+import { PreviewSection } from './PreviewSection'
+import { shortVersion } from './VersionHistory'
+import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
+import { useArchivedObjectPurgeMutation } from '@/data/storage/versioning/archived-object-purge-mutation'
+import { useArchivedObjectRestoreMutation } from '@/data/storage/versioning/archived-object-restore-mutation'
+import { useArchivedObjectVersionDeleteMutation } from '@/data/storage/versioning/archived-object-version-delete-mutation'
+import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
+import { formatBytes } from '@/lib/helpers'
+import { useStorageExplorerStateSnapshot } from '@/state/storage-explorer'
+
+const PANEL_WIDTH = 450
+
+const ArchivedFileDetail = ({ label, value }: { label: string; value: string }) => (
+  <div>
+    <label className="mb-1 text-xs text-foreground-lighter">{label}</label>
+    <p className="break-all text-sm text-foreground-light">{value}</p>
+  </div>
+)
+
+/** Replaces `PreviewPane` while an archived row is selected. */
+export const ArchivedFilePreviewPane = () => {
+  const { projectRef, selectedBucket } = useStorageExplorerStateSnapshot()
+  const {
+    selectedArchivedObject: object,
+    selectedArchivedVersion: previewedVersion,
+    setSelectedArchivedVersion,
+    clearArchivedSelection,
+  } = useArchivedFilesContext()
+  const { can: canUpdateFiles } = useAsyncCheckPermissions(PermissionAction.STORAGE_WRITE, '*')
+
+  const [isPurgeConfirmVisible, setIsPurgeConfirmVisible] = useState(false)
+  const [versionToDelete, setVersionToDelete] = useState<ArchivedVersionRow>()
+
+  // Restoring any row un-archives the whole file; only the toast differs.
+  const { mutate: restoreObject, isPending: isRestoring } = useArchivedObjectRestoreMutation()
+
+  const { mutate: purgeObject, isPending: isPurging } = useArchivedObjectPurgeMutation({
+    onSuccess: () => {
+      toast.success('File permanently deleted')
+      setIsPurgeConfirmVisible(false)
+      clearArchivedSelection()
+    },
+  })
+
+  const { mutate: deleteVersion, isPending: isDeletingVersion } =
+    useArchivedObjectVersionDeleteMutation({
+      onSuccess: () => {
+        toast.success('Version permanently deleted')
+        setVersionToDelete(undefined)
+      },
+    })
+
+  if (object === undefined) return null
+
+  const mergedVersions = getMergedArchivedVersions(object)
+  const hasOlderVersions = object.noncurrentVersions.length > 0
+
+  const handleRestore = (version?: ArchivedVersionRow) => {
+    if (!projectRef || !selectedBucket?.id) return
+    restoreObject(
+      { projectRef, bucketId: selectedBucket.id, archivedObjectId: object.id },
+      {
+        onSuccess: () => {
+          toast.success(
+            version && !version.wasCurrentAtArchive
+              ? `File restored — version ${shortVersion(version.versionId)} is now current`
+              : 'File restored'
+          )
+          clearArchivedSelection()
+        },
+      }
+    )
+  }
+
+  const handleDeleteVersion = () => {
+    if (!projectRef || !selectedBucket?.id || versionToDelete === undefined) return
+    deleteVersion({
+      projectRef,
+      bucketId: selectedBucket.id,
+      archivedObjectId: object.id,
+      versionId: versionToDelete.versionId,
+      wasCurrentAtArchive: versionToDelete.wasCurrentAtArchive,
+    })
+  }
+
+  // A plain restore already produces the version that was current at archive time.
+  const handleSelectVersion = (version: ArchivedVersionRow) =>
+    setSelectedArchivedVersion(version.wasCurrentAtArchive ? undefined : version)
+
+  const getVersionDeleteCopy = () => {
+    if (versionToDelete === undefined) return null
+    if (!versionToDelete.wasCurrentAtArchive) {
+      return (
+        <>
+          Version{' '}
+          <span className="font-mono text-foreground">
+            {shortVersion(versionToDelete.versionId)}
+          </span>{' '}
+          of {object.path} will be deleted permanently. This cannot be undone.
+        </>
+      )
+    }
+    return (
+      <>
+        The version of {object.path} that was current when it was archived will be deleted
+        permanently
+        {hasOlderVersions
+          ? ' — its next most recent version becomes the one shown here'
+          : ', leaving nothing left to restore'}
+        . This cannot be undone.
+      </>
+    )
+  }
+
+  return (
+    <>
+      <div
+        key={object.id}
+        className="flex h-full flex-col border-l border-overlay bg-surface-100"
+        style={{ width: PANEL_WIDTH }}
+      >
+        <div className="flex items-center gap-x-2 border-b border-overlay px-4 py-2.5">
+          <p className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
+            Archived file
+          </p>
+          <Button
+            variant="text"
+            className="h-7 w-7 shrink-0 p-0"
+            onClick={clearArchivedSelection}
+            aria-label="Close preview"
+          >
+            <X size={14} />
+          </Button>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          {previewedVersion !== undefined ? (
+            <ArchivedVersionRestoreWidget
+              version={previewedVersion}
+              isRestoring={isRestoring}
+              onRestore={() => handleRestore(previewedVersion)}
+              onDismiss={() => setSelectedArchivedVersion(undefined)}
+            />
+          ) : (
+            <div className="border-b border-overlay p-3">
+              <div
+                className="flex items-center justify-center overflow-hidden rounded-md border border-dashed border-overlay"
+                style={{ height: 'clamp(120px, calc((100vh - 144px) * 0.4), 180px)' }}
+              >
+                <p className="px-4 text-center text-sm text-foreground-muted">
+                  No preview available for archived files
+                </p>
+              </div>
+
+              <div className="mt-2 flex flex-col">
+                <p className="truncate text-sm font-medium text-foreground" title={object.path}>
+                  {object.path}
+                </p>
+                <p className="mt-0.5 flex flex-wrap items-center gap-x-1.5 truncate text-xs text-foreground-light">
+                  {formatBytes(object.currentVersion.size)}
+                  <Badge variant="warning" className="-my-1">
+                    Archived
+                  </Badge>
+                </p>
+
+                <div className="mt-3 flex shrink-0 items-center gap-x-1">
+                  <ButtonTooltip
+                    variant="outline"
+                    size="tiny"
+                    icon={<RotateCcw size={14} />}
+                    loading={isRestoring}
+                    disabled={!canUpdateFiles}
+                    onClick={() => handleRestore()}
+                    tooltip={{
+                      content: {
+                        side: 'top',
+                        text: canUpdateFiles
+                          ? undefined
+                          : 'You need additional permissions to restore files',
+                      },
+                    }}
+                  >
+                    Restore file
+                  </ButtonTooltip>
+                  <ButtonTooltip
+                    variant="outline"
+                    size="tiny"
+                    icon={<Trash2 size={14} />}
+                    disabled={!canUpdateFiles}
+                    onClick={() => setIsPurgeConfirmVisible(true)}
+                    tooltip={{
+                      content: {
+                        side: 'top',
+                        text: canUpdateFiles
+                          ? undefined
+                          : 'You need additional permissions to delete files',
+                      },
+                    }}
+                  >
+                    Delete permanently
+                  </ButtonTooltip>
+                </div>
+              </div>
+            </div>
+          )}
+
+          <div className="space-y-3 px-4 pt-3">
+            {previewedVersion === undefined && (
+              <div className="space-y-2">
+                <ArchivedFileDetail label="Original location" value={object.path} />
+                <ArchivedFileDetail
+                  label="Archived"
+                  value={dayjs(object.archivedAt).format('MMM D, YYYY · HH:mm')}
+                />
+              </div>
+            )}
+
+            <PreviewSection title="Versions" count={mergedVersions.length} defaultOpen>
+              <ol className="flex flex-col gap-y-0.5">
+                {mergedVersions.map((version) => (
+                  <ArchivedVersionListRow
+                    key={version.versionId}
+                    version={version}
+                    isSelected={previewedVersion?.versionId === version.versionId}
+                    canUpdateFiles={canUpdateFiles}
+                    isRestoring={isRestoring}
+                    isDeleting={isDeletingVersion}
+                    onSelect={() => handleSelectVersion(version)}
+                    onRestore={() => handleRestore(version)}
+                    onDelete={() => setVersionToDelete(version)}
+                  />
+                ))}
+              </ol>
+            </PreviewSection>
+          </div>
+        </div>
+      </div>
+
+      <ConfirmationModal
+        variant="destructive"
+        visible={isPurgeConfirmVisible}
+        title={<span className="wrap-break-word">Permanently delete {object.path}?</span>}
+        confirmLabel="Delete permanently"
+        confirmLabelLoading="Deleting..."
+        loading={isPurging}
+        onCancel={() => setIsPurgeConfirmVisible(false)}
+        onConfirm={() => {
+          if (!projectRef || !selectedBucket?.id) return
+          purgeObject({ projectRef, bucketId: selectedBucket.id, archivedObjectId: object.id })
+        }}
+        alert={{
+          base: { variant: 'destructive' },
+          title: 'This cannot be undone',
+          description: `Deletes the file and all ${mergedVersions.length} retained version${
+            mergedVersions.length === 1 ? '' : 's'
+          }. None of them can be restored afterwards.`,
+        }}
+      />
+
+      <ConfirmationModal
+        variant="destructive"
+        visible={versionToDelete !== undefined}
+        title="Permanently delete this version?"
+        confirmLabel="Delete version"
+        confirmLabelLoading="Deleting..."
+        loading={isDeletingVersion}
+        onCancel={() => setVersionToDelete(undefined)}
+        onConfirm={handleDeleteVersion}
+      >
+        <p className="text-sm text-foreground-light">{getVersionDeleteCopy()}</p>
+      </ConfirmationModal>
+    </>
+  )
+}

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/ArchivedVersionRestoreWidget.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/ArchivedVersionRestoreWidget.tsx
@@ -1,0 +1,64 @@
+import dayjs from 'dayjs'
+import { RotateCcw, X } from 'lucide-react'
+import { Button } from 'ui'
+
+import type { ArchivedVersionRow } from './archivedVersions.utils'
+import { shortVersion } from './VersionHistory'
+import { VersionThumbnail } from './VersionThumbnail'
+import { formatBytes } from '@/lib/helpers'
+
+interface ArchivedVersionRestoreWidgetProps {
+  version: ArchivedVersionRow
+  isRestoring: boolean
+  onRestore: () => void
+  onDismiss: () => void
+}
+
+// No side-by-side comparison: the whole file is archived, so there's no current
+// version to sit beside.
+export const ArchivedVersionRestoreWidget = ({
+  version,
+  isRestoring,
+  onRestore,
+  onDismiss,
+}: ArchivedVersionRestoreWidgetProps) => (
+  <div className="space-y-3 border-b border-overlay bg-brand-200/30 p-3">
+    <div className="flex items-center gap-x-1.5">
+      <RotateCcw size={13} className="shrink-0 text-brand" />
+      <p className="truncate text-sm font-medium text-foreground">
+        Restore version {shortVersion(version.versionId)}?
+      </p>
+      <button
+        type="button"
+        tabIndex={0}
+        className="ml-auto shrink-0 text-foreground-lighter transition-colors hover:text-foreground"
+        onClick={onDismiss}
+        aria-label="Cancel restore"
+      >
+        <X size={13} />
+      </button>
+    </div>
+
+    <div className="flex items-center gap-x-2">
+      <VersionThumbnail isCurrent={false} size={20} />
+      <p className="min-w-0 flex-1 truncate font-mono text-[11px] text-foreground-light">
+        {dayjs(version.createdAt).format('MMM D, YYYY · HH:mm')} · {formatBytes(version.size)}
+      </p>
+    </div>
+
+    <Button
+      variant="primary"
+      block
+      icon={<RotateCcw size={14} />}
+      loading={isRestoring}
+      onClick={onRestore}
+    >
+      Restore as current version
+    </Button>
+
+    <p className="text-xs leading-relaxed text-foreground-lighter">
+      The file leaves the archive and this becomes its current version. Every other retained version
+      stays in its history.
+    </p>
+  </div>
+)

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/ArchivedVersionRow.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/ArchivedVersionRow.tsx
@@ -1,0 +1,103 @@
+import dayjs from 'dayjs'
+import { MoreVertical, RotateCcw, Trash2 } from 'lucide-react'
+import {
+  Badge,
+  Button,
+  cn,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from 'ui'
+
+import type { ArchivedVersionRow as ArchivedVersion } from './archivedVersions.utils'
+import { shortVersion } from './VersionHistory'
+import { VersionThumbnail } from './VersionThumbnail'
+import { formatBytes } from '@/lib/helpers'
+
+interface ArchivedVersionRowProps {
+  version: ArchivedVersion
+  isSelected: boolean
+  canUpdateFiles: boolean
+  isRestoring: boolean
+  isDeleting: boolean
+  onSelect: () => void
+  onRestore: () => void
+  onDelete: () => void
+}
+
+export const ArchivedVersionRow = ({
+  version,
+  isSelected,
+  canUpdateFiles,
+  isRestoring,
+  isDeleting,
+  onSelect,
+  onRestore,
+  onDelete,
+}: ArchivedVersionRowProps) => (
+  <li
+    className={cn(
+      'group -mx-2 flex items-center gap-x-2.5 rounded-md border border-transparent px-2 py-1.5',
+      isSelected ? 'border-brand-500 bg-brand-200' : 'hover:bg-surface-200'
+    )}
+  >
+    {/* A real button, so the actions menu isn't nested inside another control. */}
+    <button
+      type="button"
+      tabIndex={0}
+      className="flex min-w-0 flex-1 items-center gap-x-2.5 text-left"
+      onClick={onSelect}
+    >
+      <VersionThumbnail isCurrent={false} />
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-sm text-foreground group-hover:underline">
+          {dayjs(version.createdAt).format('MMM D, HH:mm')}
+        </span>
+        <span className="block truncate font-mono text-xs text-foreground-lighter">
+          {formatBytes(version.size)}
+        </span>
+      </span>
+    </button>
+
+    {version.wasCurrentAtArchive ? (
+      <Badge variant="warning">Was current</Badge>
+    ) : (
+      <span className="shrink-0 font-mono text-xs text-foreground-lighter">
+        {shortVersion(version.versionId)}
+      </span>
+    )}
+
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="text"
+          size="tiny"
+          className="px-1.5"
+          icon={<MoreVertical size={14} />}
+          aria-label={`Actions for version ${shortVersion(version.versionId)}`}
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem
+          className="gap-x-2"
+          disabled={!canUpdateFiles || isRestoring}
+          onClick={onRestore}
+        >
+          <RotateCcw size={14} />
+          Restore as current
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          onClick={onDelete}
+          disabled={!canUpdateFiles || isDeleting}
+          className="gap-x-2 text-destructive focus:text-destructive"
+        >
+          <Trash2 size={14} />
+          Delete permanently
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  </li>
+)

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/StorageExplorer.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/StorageExplorer.tsx
@@ -5,7 +5,8 @@ import { useCallback, useEffect, useEffectEvent, useRef, useState } from 'react'
 
 import { useSelectedBucket } from '../FilesBuckets/useSelectedBucket'
 import { STORAGE_ROW_TYPES, STORAGE_VIEWS } from '../Storage.constants'
-import { ArchivedFilesProvider } from './ArchivedFilesContext'
+import { ArchivedFilePreviewPane } from './ArchivedFilePreviewPane'
+import { ArchivedFilesProvider, useArchivedFilesContext } from './ArchivedFilesContext'
 import { ConfirmDeleteModal } from './ConfirmDeleteModal'
 import { CustomExpiryModal } from './CustomExpiryModal'
 import { FileExplorer } from './FileExplorer'
@@ -51,6 +52,7 @@ const StorageExplorerContent = () => {
     setIsSearching,
   } = useStorageExplorerStateSnapshot()
   const { view } = useStoragePreference(projectRef)
+  const { selectedArchivedObject } = useArchivedFilesContext()
 
   useProjectStorageConfigQuery({ projectRef: ref }, { enabled: IS_PLATFORM })
   const { data: bucket, isLoading: isBucketQueryLoading } = useSelectedBucket()
@@ -184,7 +186,7 @@ const StorageExplorerContent = () => {
             fetchMoreFolderContents({ index, column, searchString: itemSearchString })
           }
         />
-        <PreviewPane />
+        {selectedArchivedObject !== undefined ? <ArchivedFilePreviewPane /> : <PreviewPane />}
       </div>
 
       <ConfirmDeleteModal />


### PR DESCRIPTION
## This PR

Clicking an archived row now opens a preview pane for it: where the file used to live, when it was archived, its retained versions, and the actions to bring it back or delete it for good. This is what makes the **Archive** action in the file preview panel (#49208) a round trip rather than a one-way door.

- `ArchivedFilePreviewPane` — the pane, replacing `PreviewPane` while an archived row is selected
- `ArchivedVersionRestoreWidget` — takes over the top of the pane when a specific retained version is selected
- `ArchivedVersionRow` — one version, with its restore / delete actions
- `StorageExplorer` — the pane swap

Plus the tail of the feature, all behind the feature preview:

- The buckets list gains a **Versioning** column.
- `DeleteBucketModal` and `EmptyBucketModal` say what destruction takes with it once a bucket is retaining archived files and versions.

## Worth a look

**The buckets table is a fresh implementation, not a port.** Master restructured it into a shared standard/virtualized shape since the prototype was written, so the prototype's diff didn't apply. The prototype also hardcoded the column total in three places; a `useVersioningColumnSpan` hook now supplies the delta so the several `colSpan`s can't drift out of sync with the header.

The column shows `-` for every bucket until the API exposes `bucket.versioning`, since `getBucketVersioningState` still reports `disabled`.

## Fixes carried over rather than ported

**Nested interactive controls.** The prototype's version rows were an `<li role="button" tabIndex={0}>` with a dropdown trigger *inside* it. They're a real `<button>` beside the menu now, so Enter and Space work and the menu isn't swallowed. Same fix as the live version history in #49208.

**Two mutations where one belongs.** The prototype routed permanent version deletes through separate endpoints depending on whether the version was current at archive time. That's one mutation with a `wasCurrentAtArchive` variable, so whichever shape the API lands on stays a one-file change.

**Duplicated confirm copy.** The prototype had the same confirmation text, ternary-inside-ternary in JSX, in two files. There's one consumer now and the copy is a flat helper.

## Testing

Full studio suite green apart from `lib/local-storage.test.ts`, which fails identically on a clean `origin/master` worktree and is unrelated to this stack.

The pane itself has no component test: with `archivedObjectsQueryOptions` stubbed to `[]` nothing selects an archived object, so there is no populated state to drive. Those land with the endpoint.

To see only this PR's changes:

```bash
git diff feat/storage-versioning/008-archived-rows...feat/storage-versioning/009-archived-preview-pane
```

## Stack

| # | Branch | Base |
| - | ------ | ---- |
| 1 | `feat/storage-versioning-private-alpha` | `master` |
| 2 | `feat/storage-versioning/002-bucket-form-fields` | 1 |
| 3 | `feat/storage-versioning/003-bucket-modals` | 2 |
| 4 | `feat/storage-versioning/004-object-versions-data` | 3 |
| 5 | `feat/storage-versioning/005-file-preview-versions` | 4 |
| 6 | `feat/storage-versioning/006-billing-storage-retention` | 5 |
| 7 | `feat/storage-versioning/007-archived-objects-data` | 6 |
| 8 | `feat/storage-versioning/008-archived-rows` | 7 |
| 9 | `feat/storage-versioning/009-archived-preview-pane` | 8 **← THIS PR** |

## Stack-wide decisions

- **Nothing is user-visible by default.** Every surface is gated on `useIsStorageVersioningEnabled()` — the `storageVersioningPrivateAlpha` ConfigCat flag *and* the feature preview opt-in. The flag does not exist in ConfigCat yet, so on merge this is dead code for everyone.
- **No plan gating** for the private alpha.
- **No mock data lands on master.** Query hooks return empty until the endpoints exist.
- **Archived files ship as the inline overlay only.** The prototype also had a `Switch` replacing the explorer with a dedicated archived table plus a bulk selection bar, an older `Trash/` implementation, and an unreachable `bucketsV2` page — all dropped (~900 lines).
