### PR TITLE
feat(studio): add Deploy a Worker command to Cmd+K menu

### DIFF
--- a/apps/studio/components/interfaces/App/CommandMenu/CreateCommands.tsx
+++ b/apps/studio/components/interfaces/App/CommandMenu/CreateCommands.tsx
@@ -43,6 +43,7 @@ import { SIDEBAR_KEYS } from '@/components/layouts/ProjectLayout/LayoutSidebar/L
 const AiIconAnimation = dynamic(() => import('ui').then((mod) => mod.AiIconAnimation))
 const Badge = dynamic(() => import('ui').then((mod) => mod.Badge))
 const EdgeFunctions = dynamic(() => import('icons').then((mod) => mod.EdgeFunctions))
+const Workers = dynamic(() => import('icons').then((mod) => mod.Workers))
 const AnalyticsBucket = dynamic(() => import('icons').then((mod) => mod.AnalyticsBucket))
 const FilesBucket = dynamic(() => import('icons').then((mod) => mod.FilesBucket))
 const VectorBucket = dynamic(() => import('icons').then((mod) => mod.VectorBucket))
@@ -59,6 +60,7 @@ export function useCreateCommands(options?: CommandOptions) {
     authEnabled,
     edgeFunctionsEnabled,
     storageEnabled,
+    workersEnabled,
     sendSmsHook,
     sendEmailHook,
     customAccessTokenHook,
@@ -273,6 +275,21 @@ export function useCreateCommands(options?: CommandOptions) {
     [ref, edgeFunctionsEnabled, openSidebar, snap, setIsOpen]
   )
 
+  const workersCommands = useMemo(
+    () =>
+      workersEnabled
+        ? ([
+            {
+              id: 'deploy-worker',
+              name: 'Deploy a Worker',
+              route: `/project/${ref}/workers?deploy=true`,
+              icon: () => <Workers />,
+            },
+          ].filter(Boolean) as ICommand[])
+        : [],
+    [ref, workersEnabled]
+  )
+
   const storageCommands = useMemo(
     () =>
       storageEnabled
@@ -406,6 +423,15 @@ export function useCreateCommands(options?: CommandOptions) {
             },
           ]
         : []),
+      ...(workersCommands.length > 0
+        ? [
+            {
+              id: 'create-workers',
+              name: 'Workers',
+              commands: workersCommands,
+            },
+          ]
+        : []),
       ...(storageCommands.length > 0
         ? [
             {
@@ -438,6 +464,7 @@ export function useCreateCommands(options?: CommandOptions) {
       databaseCommands,
       authCommands,
       edgeFunctionsCommands,
+      workersCommands,
       storageCommands,
       integrationsCommands,
       observabilityCommands,

--- a/apps/studio/components/interfaces/App/CommandMenu/CreateCommands.utils.tsx
+++ b/apps/studio/components/interfaces/App/CommandMenu/CreateCommands.utils.tsx
@@ -1,4 +1,4 @@
-import { useParams } from 'common'
+import { useFlag, useParams } from 'common'
 import { useMemo } from 'react'
 import { useSetPage } from 'ui-patterns/CommandMenu'
 
@@ -89,6 +89,8 @@ export function useCreateCommandsConfig() {
   const setPage = useSetPage()
   const { openSidebar } = useSidebarManagerSnapshot()
   const snap = useAiAssistantStateSnapshot()
+
+  const workersEnabled = useFlag('workers')
 
   const {
     projectAuthAll: authEnabled,
@@ -183,6 +185,7 @@ export function useCreateCommandsConfig() {
     authEnabled,
     edgeFunctionsEnabled,
     storageEnabled,
+    workersEnabled,
     sendSmsHook,
     sendEmailHook,
     customAccessTokenHook,

--- a/apps/studio/pages/project/[ref]/workers/index.tsx
+++ b/apps/studio/pages/project/[ref]/workers/index.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { useParams } from 'common'
-import { useState } from 'react'
+import { parseAsBoolean, useQueryState } from 'nuqs'
 import { Admonition } from 'ui-patterns/Admonition'
 import { PageContainer } from 'ui-patterns/PageContainer'
 import {
@@ -31,7 +31,10 @@ import type { NextPageWithLayout } from '@/types'
 
 const WorkersPage: NextPageWithLayout = () => {
   const { ref } = useParams()
-  const [isDeployInstructionsOpen, setIsDeployInstructionsOpen] = useState(false)
+  const [isDeployInstructionsOpen, setIsDeployInstructionsOpen] = useQueryState(
+    'deploy',
+    parseAsBoolean.withDefault(false)
+  )
   const {
     data: workers,
     error,


### PR DESCRIPTION
## What

Adds a "Deploy a Worker" item to the command menu (⌘K) Create page, gated behind the existing `workers` feature flag.

Selecting it routes to `/project/[ref]/workers?deploy=true`, which opens the deploy instructions dialog (the workers deploy dialog is now driven by a `deploy` query param via nuqs, mirroring the Edge Functions `?create=cli` pattern).

## Notes

- New command only registers when `useFlag('workers')` is on, matching the existing Workers nav command.
- Pure page-body edit on the workers page, so the TanStack route mirror picks it up automatically.

Ref: FE-4216