### PR TITLE
fix(self-hosted): resolve cascading healthcheck failures and Auth Providers UI infinite loading

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/index.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/index.tsx
@@ -1,7 +1,8 @@
-import { useParams } from 'common'
+import { IS_PLATFORM, useParams } from 'common'
 import { ExternalLink } from 'lucide-react'
 import Link from 'next/link'
 import { Alert, AlertDescription, AlertTitle, Button, WarningIcon } from 'ui'
+import { Admonition } from 'ui-patterns/Admonition'
 import {
   PageSection,
   PageSectionContent,
@@ -41,7 +42,13 @@ export const AuthProvidersForm = () => {
         </PageSectionSummary>
       </PageSectionMeta>
       <PageSectionContent>
-        {isError ? (
+        {!IS_PLATFORM ? (
+          <Admonition
+            type="default"
+            title="Auth providers are not configurable for self-hosted projects"
+            description="Auth providers for self-hosted deployments are configured via environment variables. Please update your .env file."
+          />
+        ) : isError ? (
           <AlertError
             error={authConfigError}
             subject="Failed to retrieve auth configuration for hooks"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -123,6 +123,7 @@ services:
       timeout: 5s
       interval: 5s
       retries: 3
+      start_period: 20s
     depends_on:
       db:
         # Disable this if you are using an external Postgres database
@@ -509,6 +510,7 @@ services:
       interval: 5s
       timeout: 5s
       retries: 10
+      start_period: 60s
     environment:
       POSTGRES_HOST: /var/run/postgresql
       PGPORT: ${POSTGRES_PORT}


### PR DESCRIPTION
## What is the purpose of this PR?

Fixes two issues I ran into myself while self-hosting Supabase for my own project:

1. **Docker Compose Stability**: `db` container gets marked unhealthy and killed too early during initial seeding on slower hardware.
2. **Studio UI**: Auth Providers settings page hangs on skeleton loaders forever on self-hosted instances.

## How I found these

Was setting up a fresh self-hosted instance with `docker compose up -d` on a fairly standard machine (nothing high-spec) and the `db` container kept getting flagged unhealthy mid-boot, which then took `auth`, `rest`, and `realtime` down with it. Ran it a few more times to make sure it wasn't just a fluke on my end — same result each time, so it felt like a timing issue rather than an actual failure.

Once I got the stack stable, next thing I did was go configure Auth Providers in Studio and the page just sat there loading forever. No error, nothing in the console really pointing anywhere obvious. Went digging through `useAuthConfigQuery` and found `IS_PLATFORM` is hard-coded to disable that query on self-hosted, so `isSuccess` never fires - it's not slow, it's just never going to resolve.

Figured other people self-hosting on normal hardware are probably hitting the same thing without knowing why, so wanted to fix both properly instead of just working around them locally.

## What is the issue?

* **Issue 1 (Docker Compose)**: When booting a fresh self-hosted instance on standard or slower hardware, the `db` container runs multiple heavy initialization scripts. Because there is no `start_period` defined in `docker-compose.yml`, Docker immediately begins polling the healthcheck. It often exhausts the 10 retries (50 seconds) before the DB is ready, marking it unhealthy and causing dependent services like `auth`, `rest`, and `realtime` to fail.
* **Issue 2 (Studio UI)**: Navigating to `/project/default/auth/providers` in a self-hosted Studio results in an infinite skeleton loading state. The `useAuthConfigQuery` is hard-coded to return `enabled: false` when `IS_PLATFORM` is false, meaning `isSuccess` is never reached and the UI hangs indefinitely.

## What is the solution?

* **Docker Compose**: Added a `start_period: 60s` to the `db` service and `start_period: 20s` to the `auth` service. This provides a grace period for initialization scripts to finish running without triggering false-positive healthcheck failures.
* **Studio UI**: Updated `AuthProvidersForm/index.tsx` to explicitly check `IS_PLATFORM`. If it's a self-hosted environment, we now bypass the loading state and render an `Admonition` block (mirroring the UX of the Storage Settings page) informing the user that Auth Providers must be configured via environment variables.

## Testing

* Ran `docker compose up -d` from a clean slate a bunch of times, `db` and `auth` both come up `(healthy)` consistently now, no more crash looping.
* Also just clicked around Studio locally (`pnpm dev:studio`) to double check it looks right, not just passing in tests.

cc: @danthegoodman1 @joshenlim @aantti


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Self-hosted deployments now display guidance that authentication providers must be configured through environment variables rather than the UI.

* **Bug Fixes**
  * Improved startup health checks for authentication and database services by allowing additional initialization time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->