### PR TITLE
fix(self-hosted): resolve cascading healthcheck failures and Auth Providers UI infinite loading

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/index.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/index.tsx
@@ -1,7 +1,8 @@
-import { useParams } from 'common'
+import { IS_PLATFORM, useParams } from 'common'
 import { ExternalLink } from 'lucide-react'
 import Link from 'next/link'
 import { Alert, AlertDescription, AlertTitle, Button, WarningIcon } from 'ui'
+import { Admonition } from 'ui-patterns/Admonition'
 import {
   PageSection,
   PageSectionContent,
@@ -41,12 +42,20 @@ export const AuthProvidersForm = () => {
         </PageSectionSummary>
       </PageSectionMeta>
       <PageSectionContent>
-        {isError ? (
+        {!IS_PLATFORM && (
+          <Admonition
+            type="default"
+            title="Auth providers are not configurable for self-hosted projects"
+            description="Auth providers for self-hosted deployments are configured via environment variables. Please update your .env file."
+          />
+        )}
+        {IS_PLATFORM && isError && (
           <AlertError
             error={authConfigError}
             subject="Failed to retrieve auth configuration for hooks"
           />
-        ) : (
+        )}
+        {IS_PLATFORM && !isError && (
           <div className="-space-y-px">
             {authConfig?.EXTERNAL_EMAIL_ENABLED && authConfig?.MAILER_OTP_EXP > 3600 && (
               <Alert className="flex w-full items-center justify-between my-3" variant="warning">

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -123,6 +123,7 @@ services:
       timeout: 5s
       interval: 5s
       retries: 3
+      start_period: 20s
     depends_on:
       db:
         # Disable this if you are using an external Postgres database
@@ -509,6 +510,7 @@ services:
       interval: 5s
       timeout: 5s
       retries: 10
+      start_period: 60s
     environment:
       POSTGRES_HOST: /var/run/postgresql
       PGPORT: ${POSTGRES_PORT}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix (self-hosted stability and UI)

## What is the current behavior?

1. **Docker Compose**: On fresh self-hosted setups on standard hardware, initial database migrations and seeding take longer than the healthcheck polling period without a `start_period`, causing Docker to prematurely mark `db` unhealthy and crash dependent services (`auth`, `rest`, `realtime`).
2. **Studio Auth Providers**: Navigating to `/project/default/auth/providers` in self-hosted mode renders skeleton loaders indefinitely because `useAuthConfigQuery` is disabled when `IS_PLATFORM` is false.

## What is the new behavior?

1. **Docker Compose**: Adds `start_period: 60s` to `db` and `start_period: 20s` to `auth` so initial startup tasks can finish before healthcheck failures count toward retries.
2. **Studio Auth Providers**: Explicitly handles `!IS_PLATFORM` by rendering an `Admonition` notice informing users that self-hosted auth providers are configured via environment variables.

## How to test

- **Docker**: Run `docker compose up -d` on a clean environment and verify both `db` and `auth` transition to `(healthy)`.
- **Studio**: Open Studio in self-hosted mode (`IS_PLATFORM=false`), navigate to Auth Providers, and verify the configuration notice renders immediately without hanging loaders.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a notice explaining that authentication provider configuration is unavailable in self-hosted deployments.
  - Platform deployments retain the existing authentication configuration experience.

- **Bug Fixes**
  - Improved startup reliability by allowing authentication and database services additional time to initialize before health checks begin.
  - Reduced premature health-check failures during service startup by adding dedicated initialization grace periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->