### PR TITLE
fix: attempt project wake only if its in ACTIVE_HEALTHY state

### DIFF
--- a/apps/studio/data/projects/project-detail-query.ts
+++ b/apps/studio/data/projects/project-detail-query.ts
@@ -43,7 +43,7 @@ export async function getProjectDetail(
    * To prevent odd side effects like pg-meta queries failing or the likes, we wake up the project proactively and wait for it
    * to be back online before returning the project details.
    */
-  if (data?.is_hibernating && !skipWake) {
+  if (data?.status === 'ACTIVE_HEALTHY' && data?.is_hibernating && !skipWake) {
     // In case project was scaled down, explicitly wake it up before continuing to return the project details
     const { error: errorWaking, data: wakeResponse } = await post('/platform/projects/{ref}/wake', {
       params: { path: { ref } },


### PR DESCRIPTION
There is no point in trying to wake up a project that is not `ACTIVE_HEALTHY` as it will always fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project wake-up behavior by limiting automatic wake-ups to hibernating projects with a healthy active status.
  * Prevented unnecessary wake-up attempts for projects in other states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->