### PR TITLE
feat(studio): clarify quick query as temporary space

### DIFF
--- a/apps/studio/components/interfaces/Explorer/ExplorerQueryTab.tsx
+++ b/apps/studio/components/interfaces/Explorer/ExplorerQueryTab.tsx
@@ -107,7 +107,7 @@ export const ExplorerQueryTab = () => {
       roleImpersonationState={roleImpersonationState}
       onTitleChange={(value) => {
         persistTab()
-        const name = value.trim() || 'Quick query'
+        const name = value.trim() || 'Run SQL'
         explorerQueryState.updateDraft({ id, name })
         tabs.updateTab(createTabId('query', { id }), { label: name })
       }}

--- a/apps/studio/components/interfaces/Explorer/ExplorerQueryTab.tsx
+++ b/apps/studio/components/interfaces/Explorer/ExplorerQueryTab.tsx
@@ -107,7 +107,7 @@ export const ExplorerQueryTab = () => {
       roleImpersonationState={roleImpersonationState}
       onTitleChange={(value) => {
         persistTab()
-        const name = value.trim() || 'Untitled query'
+        const name = value.trim() || 'Quick query'
         explorerQueryState.updateDraft({ id, name })
         tabs.updateTab(createTabId('query', { id }), { label: name })
       }}

--- a/apps/studio/components/interfaces/Explorer/QueryEditor/index.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryEditor/index.tsx
@@ -377,7 +377,7 @@ export const QueryEditor = forwardRef<QueryEditorHandle, QueryEditorProps>(funct
           </ExplorerToolbarIcon>
           {variant === 'viewport' ? (
             <ExplorerToolbarTitle className="text-muted text-xs italic">
-              Temporary space for one-off queries
+              Run SQL
             </ExplorerToolbarTitle>
           ) : (
             <ExplorerToolbarTitle onSaveTitle={onTitleChange}>{title}</ExplorerToolbarTitle>

--- a/apps/studio/components/interfaces/Explorer/QueryEditor/index.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryEditor/index.tsx
@@ -375,7 +375,13 @@ export const QueryEditor = forwardRef<QueryEditorHandle, QueryEditorProps>(funct
           <ExplorerToolbarIcon>
             <CodeSquare size={14} />
           </ExplorerToolbarIcon>
-          <ExplorerToolbarTitle onSaveTitle={onTitleChange}>{title}</ExplorerToolbarTitle>
+          {variant === 'viewport' ? (
+            <ExplorerToolbarTitle className="text-muted text-xs italic">
+              Temporary space for one-off queries
+            </ExplorerToolbarTitle>
+          ) : (
+            <ExplorerToolbarTitle onSaveTitle={onTitleChange}>{title}</ExplorerToolbarTitle>
+          )}
           <ExplorerToolbarActions>
             {toolbarActions}
             {onSourceChange && (

--- a/apps/studio/state/explorer-query.ts
+++ b/apps/studio/state/explorer-query.ts
@@ -237,7 +237,7 @@ export const createExplorerQueryState = (storage: StorageLike = safeLocalStorage
     createDraft: ({
       id,
       projectRef,
-      name = 'Untitled query',
+      name = 'Quick query',
       sql = '',
       source = createDefaultSourceBinding('database'),
       rowLimit = DEFAULT_CELL_ROW_LIMIT,

--- a/apps/studio/state/explorer-query.ts
+++ b/apps/studio/state/explorer-query.ts
@@ -237,7 +237,7 @@ export const createExplorerQueryState = (storage: StorageLike = safeLocalStorage
     createDraft: ({
       id,
       projectRef,
-      name = 'Quick query',
+      name = 'Run SQL',
       sql = '',
       source = createDefaultSourceBinding('database'),
       rowLimit = DEFAULT_CELL_ROW_LIMIT,


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Standalone queries in the Explorer "Quick Query" surface have editable titles (defaulting to "Untitled query") without clear indication that they are temporary and not saved, similar to the old SQL Editor snippet model.

## What is the new behavior?

The Quick Query tab now clearly indicates that standalone queries are temporary. The title is no longer editable and displays "Temporary space for one-off queries" as static muted italic text. The default query name has been changed from "Untitled query" to "Quick query" for clarity.

## Additional context

Resolves FE-4297. Notebook cells (variant === 'embedded') remain unchanged with editable titles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Renamed new one-off queries from **“Quick query”** to **“Run SQL”** when no title is provided.
  * Updated viewport query editor toolbars to display the fixed **“Run SQL”** label.
  * Preserved editable titles for embedded query editors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->