### PR TITLE
feat(explorer): add path back to SQL Editor for snippet access

### DIFF
--- a/apps/studio/components/layouts/EditorNavigationButton.tsx
+++ b/apps/studio/components/layouts/EditorNavigationButton.tsx
@@ -1,0 +1,18 @@
+import { SqlEditor } from 'icons'
+import { ComponentProps } from 'react'
+
+import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
+
+export const EditorNavigationButton = ({
+  tooltip,
+  ...props
+}: { tooltip: string } & Omit<ComponentProps<typeof ButtonTooltip>, 'tooltip'>) => (
+  <ButtonTooltip
+    size="tiny"
+    variant="outline"
+    className="size-7 shrink-0 px-0"
+    icon={<SqlEditor size={14} strokeWidth={1.5} />}
+    tooltip={{ content: { side: 'bottom', text: tooltip } }}
+    {...props}
+  />
+)

--- a/apps/studio/components/layouts/ExplorerLayout/ExplorerLayout.tsx
+++ b/apps/studio/components/layouts/ExplorerLayout/ExplorerLayout.tsx
@@ -42,9 +42,19 @@ export interface ExplorerLayoutProps extends ComponentProps<typeof ProjectLayout
 }
 
 export const ExplorerLayout = ({ browserTitle, children, title }: ExplorerLayoutProps) => {
+  const { ref } = useParams()
   const tabs = useTabsStateSnapshot()
 
   const [section, setSection] = useState<ExplorerResourceType>()
+
+  const [, setIsTemporarySqlEditorVisit] = useLocalStorageQuery(
+    LOCAL_STORAGE_KEYS.SQL_EDITOR_TEMPORARY_FROM_EXPLORER(ref ?? ''),
+    false
+  )
+
+  useEffect(() => {
+    if (ref) setIsTemporarySqlEditorVisit(false)
+  }, [ref, setIsTemporarySqlEditorVisit])
 
   const activeTab = tabs.activeTab ? tabs.tabsMap[tabs.activeTab] : undefined
   const isActiveExplorerTab =
@@ -100,6 +110,8 @@ const BackToSqlEditorButton = () => {
     LOCAL_STORAGE_KEYS.SQL_EDITOR_TEMPORARY_FROM_EXPLORER(ref ?? ''),
     false
   )
+
+  if (!ref) return null
 
   return (
     <ButtonTooltip

--- a/apps/studio/components/layouts/ExplorerLayout/ExplorerLayout.tsx
+++ b/apps/studio/components/layouts/ExplorerLayout/ExplorerLayout.tsx
@@ -1,6 +1,5 @@
-import { LOCAL_STORAGE_KEYS, useParams } from 'common'
+import { useParams } from 'common'
 import { AnimatePresence, motion } from 'framer-motion'
-import { SqlEditor } from 'icons'
 import { Home, MessageCirclePlus, NotebookText, Plus, SquareCode } from 'lucide-react'
 import Link from 'next/link'
 import { ComponentProps, ReactNode, useEffect, useEffectEvent, useState } from 'react'
@@ -13,6 +12,7 @@ import {
   TabsTrigger,
 } from 'ui'
 
+import { EditorNavigationButton } from '../EditorNavigationButton'
 import { ProjectLayoutWithAuth } from '../ProjectLayout'
 import { EditorTabs } from '../Tabs/Tabs'
 import { type ExplorerResourceType } from './ExplorerLayout.constants'
@@ -26,8 +26,7 @@ import {
   useCreateNotebook,
   useCreateQuery,
 } from '@/components/interfaces/Explorer/hooks'
-import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
-import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
+import { useIsTemporarySqlEditorVisit } from '@/hooks/misc/useIsTemporarySqlEditorVisit'
 import {
   editorEntityTypes,
   EXPLORER_HOME_TAB,
@@ -47,10 +46,7 @@ export const ExplorerLayout = ({ browserTitle, children, title }: ExplorerLayout
 
   const [section, setSection] = useState<ExplorerResourceType>()
 
-  const [, setIsTemporarySqlEditorVisit] = useLocalStorageQuery(
-    LOCAL_STORAGE_KEYS.SQL_EDITOR_TEMPORARY_FROM_EXPLORER(ref ?? ''),
-    false
-  )
+  const { setIsTemporary: setIsTemporarySqlEditorVisit } = useIsTemporarySqlEditorVisit(ref)
 
   useEffect(() => {
     if (ref) setIsTemporarySqlEditorVisit(false)
@@ -106,33 +102,21 @@ export const ExplorerLayout = ({ browserTitle, children, title }: ExplorerLayout
 
 const BackToSqlEditorButton = () => {
   const { ref } = useParams()
-  const [, setIsTemporary] = useLocalStorageQuery(
-    LOCAL_STORAGE_KEYS.SQL_EDITOR_TEMPORARY_FROM_EXPLORER(ref ?? ''),
-    false
-  )
+  const { setIsTemporary } = useIsTemporarySqlEditorVisit(ref)
 
   if (!ref) return null
 
   return (
-    <ButtonTooltip
+    <EditorNavigationButton
       asChild
-      size="tiny"
-      variant="outline"
-      className="size-7 shrink-0 px-0"
-      icon={<SqlEditor size={14} strokeWidth={1.5} />}
-      tooltip={{
-        content: {
-          side: 'bottom',
-          text: 'Temporarily switch to SQL Editor to access your snippets',
-        },
-      }}
+      tooltip="Temporarily switch to SQL Editor to access your snippets"
     >
       <Link
         href={`/project/${ref}/sql`}
         aria-label="Switch to SQL Editor"
         onClick={() => setIsTemporary(true)}
       />
-    </ButtonTooltip>
+    </EditorNavigationButton>
   )
 }
 

--- a/apps/studio/components/layouts/ExplorerLayout/ExplorerLayout.tsx
+++ b/apps/studio/components/layouts/ExplorerLayout/ExplorerLayout.tsx
@@ -1,5 +1,8 @@
+import { LOCAL_STORAGE_KEYS, useParams } from 'common'
 import { AnimatePresence, motion } from 'framer-motion'
+import { SqlEditor } from 'icons'
 import { Home, MessageCirclePlus, NotebookText, Plus, SquareCode } from 'lucide-react'
+import Link from 'next/link'
 import { ComponentProps, ReactNode, useEffect, useEffectEvent, useState } from 'react'
 import {
   cn,
@@ -23,6 +26,8 @@ import {
   useCreateNotebook,
   useCreateQuery,
 } from '@/components/interfaces/Explorer/hooks'
+import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
+import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
 import {
   editorEntityTypes,
   EXPLORER_HOME_TAB,
@@ -56,6 +61,7 @@ export const ExplorerLayout = ({ browserTitle, children, title }: ExplorerLayout
     <ProjectLayoutWithAuth
       product="Explorer"
       browserTitle={mergedBrowserTitle}
+      productMenuBadge={<BackToSqlEditorButton />}
       productMenu={
         <div className="relative h-full overflow-hidden">
           <AnimatePresence mode="wait">
@@ -85,6 +91,36 @@ export const ExplorerLayout = ({ browserTitle, children, title }: ExplorerLayout
         <div className="flex-grow min-h-0">{children}</div>
       </div>
     </ProjectLayoutWithAuth>
+  )
+}
+
+const BackToSqlEditorButton = () => {
+  const { ref } = useParams()
+  const [, setIsTemporary] = useLocalStorageQuery(
+    LOCAL_STORAGE_KEYS.SQL_EDITOR_TEMPORARY_FROM_EXPLORER(ref ?? ''),
+    false
+  )
+
+  return (
+    <ButtonTooltip
+      asChild
+      size="tiny"
+      variant="outline"
+      className="size-7 shrink-0 px-0"
+      icon={<SqlEditor size={14} strokeWidth={1.5} />}
+      tooltip={{
+        content: {
+          side: 'bottom',
+          text: 'Temporarily switch to SQL Editor to access your snippets',
+        },
+      }}
+    >
+      <Link
+        href={`/project/${ref}/sql`}
+        aria-label="Switch to SQL Editor"
+        onClick={() => setIsTemporary(true)}
+      />
+    </ButtonTooltip>
   )
 }
 

--- a/apps/studio/components/layouts/Navigation/ProductMenuBar.tsx
+++ b/apps/studio/components/layouts/Navigation/ProductMenuBar.tsx
@@ -24,11 +24,9 @@ export const ProductMenuBar = ({
         'hide-scrollbar bg-dash-sidebar border-default'
       )}
     >
-      <div className="border-default flex min-h-(--header-height) items-center border-b px-6 justify-between">
-        <div className="flex items-center gap-2">
-          <h4 className="text-lg">{title}</h4>
-          {titleBadge}
-        </div>
+      <div className="border-default flex min-h-(--header-height) items-center gap-2 border-b px-6 justify-between">
+        <h4 className="text-lg truncate">{title}</h4>
+        {titleBadge}
       </div>
       <div className={cn('grow overflow-y-auto', className)}>{children}</div>
     </div>

--- a/apps/studio/components/layouts/Navigation/ProductMenuBar.tsx
+++ b/apps/studio/components/layouts/Navigation/ProductMenuBar.tsx
@@ -25,7 +25,7 @@ export const ProductMenuBar = ({
       )}
     >
       <div className="border-default flex min-h-(--header-height) items-center gap-2 border-b px-6 justify-between">
-        <h4 className="text-lg truncate">{title}</h4>
+        <h4 className="text-lg truncate min-w-0 flex-1">{title}</h4>
         {titleBadge}
       </div>
       <div className={cn('grow overflow-y-auto', className)}>{children}</div>

--- a/apps/studio/components/layouts/editors/EditorBaseLayout.tsx
+++ b/apps/studio/components/layouts/editors/EditorBaseLayout.tsx
@@ -1,15 +1,14 @@
-import { LOCAL_STORAGE_KEYS, useParams } from 'common'
-import { SqlEditor } from 'icons'
+import { useParams } from 'common'
 import { usePathname, useRouter } from 'next/navigation'
 import { ComponentProps, ReactNode } from 'react'
 import { cn } from 'ui'
 
+import { EditorNavigationButton } from '../EditorNavigationButton'
 import { ProjectLayoutWithAuth } from '../ProjectLayout'
 import { CollapseButton } from '../Tabs/CollapseButton'
 import { EditorTabs } from '../Tabs/Tabs'
 import { useEditorType } from './EditorsLayout.hooks'
-import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
-import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
+import { useIsTemporarySqlEditorVisit } from '@/hooks/misc/useIsTemporarySqlEditorVisit'
 import { useTabsStateSnapshot } from '@/state/tabs'
 
 export interface ExplorerLayoutProps extends ComponentProps<typeof ProjectLayoutWithAuth> {
@@ -87,20 +86,13 @@ export const EditorBaseLayout = ({
 const BackToExplorerButton = () => {
   const { ref } = useParams()
   const router = useRouter()
-  const [isTemporary, setIsTemporary] = useLocalStorageQuery(
-    LOCAL_STORAGE_KEYS.SQL_EDITOR_TEMPORARY_FROM_EXPLORER(ref ?? ''),
-    false
-  )
+  const { isTemporary, setIsTemporary } = useIsTemporarySqlEditorVisit(ref)
 
   if (!ref || !isTemporary) return null
 
   return (
-    <ButtonTooltip
-      size="tiny"
-      variant="outline"
-      className="size-7 shrink-0 px-0"
-      icon={<SqlEditor size={14} strokeWidth={1.5} />}
-      tooltip={{ content: { side: 'bottom', text: 'Back to Explorer' } }}
+    <EditorNavigationButton
+      tooltip="Back to Explorer"
       onClick={() => {
         setIsTemporary(false)
         router.push(`/project/${ref}/explorer`)

--- a/apps/studio/components/layouts/editors/EditorBaseLayout.tsx
+++ b/apps/studio/components/layouts/editors/EditorBaseLayout.tsx
@@ -1,4 +1,4 @@
-import { LOCAL_STORAGE_KEYS, safeLocalStorage, useParams } from 'common'
+import { LOCAL_STORAGE_KEYS, useParams } from 'common'
 import { SqlEditor } from 'icons'
 import { usePathname, useRouter } from 'next/navigation'
 import { ComponentProps, ReactNode } from 'react'
@@ -87,12 +87,12 @@ export const EditorBaseLayout = ({
 const BackToExplorerButton = () => {
   const { ref } = useParams()
   const router = useRouter()
-  const [isTemporary] = useLocalStorageQuery(
+  const [isTemporary, setIsTemporary] = useLocalStorageQuery(
     LOCAL_STORAGE_KEYS.SQL_EDITOR_TEMPORARY_FROM_EXPLORER(ref ?? ''),
     false
   )
 
-  if (!isTemporary) return null
+  if (!ref || !isTemporary) return null
 
   return (
     <ButtonTooltip
@@ -102,9 +102,7 @@ const BackToExplorerButton = () => {
       icon={<SqlEditor size={14} strokeWidth={1.5} />}
       tooltip={{ content: { side: 'bottom', text: 'Back to Explorer' } }}
       onClick={() => {
-        safeLocalStorage.removeItem(
-          LOCAL_STORAGE_KEYS.SQL_EDITOR_TEMPORARY_FROM_EXPLORER(ref ?? '')
-        )
+        setIsTemporary(false)
         router.push(`/project/${ref}/explorer`)
       }}
     />

--- a/apps/studio/components/layouts/editors/EditorBaseLayout.tsx
+++ b/apps/studio/components/layouts/editors/EditorBaseLayout.tsx
@@ -1,5 +1,6 @@
-import { useParams } from 'common'
-import { usePathname } from 'next/navigation'
+import { LOCAL_STORAGE_KEYS, safeLocalStorage, useParams } from 'common'
+import { SqlEditor } from 'icons'
+import { usePathname, useRouter } from 'next/navigation'
 import { ComponentProps, ReactNode } from 'react'
 import { cn } from 'ui'
 
@@ -7,6 +8,8 @@ import { ProjectLayoutWithAuth } from '../ProjectLayout'
 import { CollapseButton } from '../Tabs/CollapseButton'
 import { EditorTabs } from '../Tabs/Tabs'
 import { useEditorType } from './EditorsLayout.hooks'
+import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
+import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
 import { useTabsStateSnapshot } from '@/state/tabs'
 
 export interface ExplorerLayoutProps extends ComponentProps<typeof ProjectLayoutWithAuth> {
@@ -62,6 +65,7 @@ export const EditorBaseLayout = ({
       resizableSidebar
       product={product}
       browserTitle={mergedBrowserTitle}
+      productMenuBadge={editor === 'sql' ? <BackToExplorerButton /> : undefined}
       productMenuClassName={productMenuClassName}
       productMenu={productMenu}
     >
@@ -77,5 +81,32 @@ export const EditorBaseLayout = ({
         <div className="h-full">{children}</div>
       </div>
     </ProjectLayoutWithAuth>
+  )
+}
+
+const BackToExplorerButton = () => {
+  const { ref } = useParams()
+  const router = useRouter()
+  const [isTemporary] = useLocalStorageQuery(
+    LOCAL_STORAGE_KEYS.SQL_EDITOR_TEMPORARY_FROM_EXPLORER(ref ?? ''),
+    false
+  )
+
+  if (!isTemporary) return null
+
+  return (
+    <ButtonTooltip
+      size="tiny"
+      variant="outline"
+      className="size-7 shrink-0 px-0"
+      icon={<SqlEditor size={14} strokeWidth={1.5} />}
+      tooltip={{ content: { side: 'bottom', text: 'Back to Explorer' } }}
+      onClick={() => {
+        safeLocalStorage.removeItem(
+          LOCAL_STORAGE_KEYS.SQL_EDITOR_TEMPORARY_FROM_EXPLORER(ref ?? '')
+        )
+        router.push(`/project/${ref}/explorer`)
+      }}
+    />
   )
 }

--- a/apps/studio/hooks/misc/useIsTemporarySqlEditorVisit.ts
+++ b/apps/studio/hooks/misc/useIsTemporarySqlEditorVisit.ts
@@ -1,0 +1,12 @@
+import { LOCAL_STORAGE_KEYS } from 'common'
+
+import { useLocalStorageQuery } from './useLocalStorage'
+
+export const useIsTemporarySqlEditorVisit = (ref: string | undefined) => {
+  const [isTemporary, setIsTemporary] = useLocalStorageQuery(
+    LOCAL_STORAGE_KEYS.SQL_EDITOR_TEMPORARY_FROM_EXPLORER(ref ?? ''),
+    false
+  )
+
+  return { isTemporary, setIsTemporary }
+}

--- a/packages/common/constants/local-storage.ts
+++ b/packages/common/constants/local-storage.ts
@@ -51,6 +51,9 @@ export const LOCAL_STORAGE_KEYS = {
   SQL_EDITOR_SECTION_STATE: (ref: string) => `sql-editor-section-state-${ref}`,
   SQL_EDITOR_SORT: (ref: string) => `sql-editor-sort-${ref}`,
   SQL_EDITOR_MANUAL_SAVE_NOTICE_DISMISSED: 'sql-editor-manual-save-notice-dismissed',
+  // Set when a user follows the "temporarily switch to SQL Editor" link from Explorer;
+  // shows a way back and is cleared once they return to Explorer
+  SQL_EDITOR_TEMPORARY_FROM_EXPLORER: (ref: string) => `sql-editor-temporary-from-explorer-${ref}`,
 
   EXPLORER_QUERY_DRAFTS: (ref: string) => `explorer-query-drafts-${ref}`,
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Users who have opted into the Explorer feature preview have no way back to the SQL Editor from within Explorer, so they can't easily check their old snippets.

## What is the new behavior?

- The Explorer sidebar title bar now has a button (using the same icon as the SQL Editor/Explorer nav entry) that links to the SQL Editor, with a tooltip explaining it's a temporary switch to access snippets.
- Clicking it marks the visit as temporary in localStorage, which surfaces a matching "Back to Explorer" button in the SQL Editor title bar. Clicking that button clears the temporary flag and returns to Explorer.
- Fixed the product menu title bar badge slot to sit flush right instead of directly next to the title text.

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a quick switch from the Explorer to the project’s SQL Editor.
  * Added a “Back to Explorer” option in the SQL Editor when opened from Explorer.
  * Added tooltips to clarify these navigation actions.
  * Navigation state is preserved per project for a smoother return experience.

* **UI Improvements**
  * Improved product menu spacing and title truncation for better layout handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->