### PR TITLE
fix(ai-commands): stop a missing studio .env.local failing the whole suite

### DIFF
--- a/packages/ai-commands/vitest.setup.ts
+++ b/packages/ai-commands/vitest.setup.ts
@@ -1,14 +1,17 @@
-import { statSync } from 'fs'
+import { existsSync } from 'fs'
 import { config } from 'dotenv'
 
 import './test/extensions'
 
 if (!process.env.CI) {
-  // Use keys from studio .env.local for local tests
+  // Use keys from studio .env.local for local tests, if the developer has one. It is
+  // gitignored, so it is absent in a fresh clone and this has to stay optional: `statSync`
+  // threw ENOENT here and took the whole suite down before a single test collected.
   const envPath = '../../apps/studio/.env.local'
 
-  statSync(envPath)
-  config({ path: envPath })
+  if (existsSync(envPath)) {
+    config({ path: envPath })
+  }
 }
 
 // Modify fetch to support wasm file URLs


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix, in `packages/ai-commands` test setup. One line of behaviour.

## What is the current behavior?

`packages/ai-commands/vitest.setup.ts`:

```ts
if (!process.env.CI) {
  // Use keys from studio .env.local for local tests
  const envPath = '../../apps/studio/.env.local'

  statSync(envPath)
  config({ path: envPath })
}
```

`statSync` throws `ENOENT` when the path is missing, it does not return false. So it is being used as an existence probe but behaves as an assertion. `apps/studio/.env.local` is gitignored in both the root `.gitignore` and `apps/studio/.gitignore`, so it is never present in a fresh clone, and this runs during setup, before collection:

```
Error: ENOENT: no such file or directory, stat '../../apps/studio/.env.local'
 ❯ vitest.setup.ts:10:3
Test Files  1 failed (1)
Tests  no tests
```

The sharper part is that it blocks the suite even when the key is already available. With `OPENAI_API_KEY` exported and no `.env.local`, on master:

```
Error: ENOENT: no such file or directory, stat '../../apps/studio/.env.local'
Tests  no tests
```

and with this change, same conditions:

```
Failed Tests 3
Error: 401 Incorrect API key provided: sk-test-****real
```

Three tests collect and run and reach OpenAI. That is the case the optional load exists to serve, and it was the one being broken.

## What is the new behavior?

`existsSync`, so the load is genuinely optional, which is what the comment and the `!process.env.CI` guard both already imply.

I checked the other direction too. With a `.env.local` present the file is still read: I dropped a throwaway one containing a fake key, and the fake key reached OpenAI, so `config({ path: envPath })` is still doing its job.

## What this does not do

It does not make the suite pass without a key, and I do not want to imply otherwise. Without `OPENAI_API_KEY` you now get `The OPENAI_API_KEY environment variable is missing or empty`, which is the real requirement, instead of an ENOENT about a gitignored file you have never heard of.

CI is unaffected in both directions, since the whole block sits behind `!process.env.CI` and `ai-tests.yml` supplies the key from secrets. That is also why this has not shown up as a red build.

## Additional context

Root cause at `packages/ai-commands/vitest.setup.ts:10`.

No test. This is the test harness itself, and the check that matters is running `pnpm --filter ai-commands test` in a clone without `apps/studio/.env.local`, which is what I did in both directions above.

Gates: `test:prettier` clean repo wide, `typecheck --force` 16/16.

Freshman contributor, and I use Claude Code as an assistant. I found this while checking which packages have test scripts that CI does not run, and this one turned out to be unrunnable locally instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented local test setup errors when the optional environment configuration file is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->