### PR TITLE
docs(auth-mfa): fix opted-in MFA RLS example for auth.mfa_factors permission

### DIFF
--- a/apps/docs/content/guides/auth/auth-mfa.mdx
+++ b/apps/docs/content/guides/auth/auth-mfa.mdx
@@ -294,7 +294,7 @@ create policy "Policy name."
   pair keeps it out of the `anon` role and limits direct RPC access to
   authenticated callers; production deployments that want to keep the
   helper policy-only can additionally revoke from `authenticated` and
-  let the policy’s SECURITY context invoke it as the function owner.
+  let the policy's SECURITY context invoke it as the function owner.
 - **Using `as restrictive` ensures this policy will restrict all commands on the
   table regardless of other policies!**
 

--- a/apps/docs/content/guides/auth/auth-mfa.mdx
+++ b/apps/docs/content/guides/auth/auth-mfa.mdx
@@ -234,28 +234,63 @@ create policy "Policy name."
 Users that have enrolled MFA on their account are expecting that your
 application only works for them if they've gone through MFA.
 
+The policy needs to read from `auth.mfa_factors`, but the `authenticated`
+role does not have permission to read that table directly, so the
+`select … from auth.mfa_factors` runs as the calling user and fails
+with `42501: permission denied for table mfa_factors`. Wrap the lookup
+in a `SECURITY DEFINER` function owned by `postgres` and call it from
+the policy:
+
 ```sql
+-- 1. The lookup runs as the function owner, who can read auth.mfa_factors.
+create or replace function public.user_requires_aal2()
+returns boolean
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  -- True when the calling user has at least one verified MFA factor.
+  -- auth.jwt() and the implicit current_setting('request.jwt.claims')
+  -- identify the user; the SELECT is run as the function owner.
+  select exists (
+    select 1
+    from auth.mfa_factors
+    where user_id = (select auth.uid())
+      and status = 'verified'
+  );
+$$;
+
+-- 2. Restrict EXECUTE to the role that will use the policy. The function
+-- itself must be owned by a role that can read auth.mfa_factors (e.g.
+-- postgres) so the SECURITY DEFINER switch can take effect.
+revoke execute on function public.user_requires_aal2() from public;
+grant execute on function public.user_requires_aal2() to authenticated;
+
+-- 3. The policy body now calls the helper, which is the only safe place
+-- to inspect auth.mfa_factors from a user-evaluable policy.
 create policy "Policy name."
   on table_name
   as restrictive -- very important!
   to authenticated
   using (
-    array[(select auth.jwt()->>'aal')] <@ (
-      select
-          case
-            when count(id) > 0 then array['aal2']
-            else array['aal1', 'aal2']
-          end as aal
-        from auth.mfa_factors
-        where ((select auth.uid()) = user_id) and status = 'verified'
-    ));
+    case
+      when public.user_requires_aal2() then (select auth.jwt()->>'aal') = 'aal2'
+      else true
+    end
+  );
 ```
 
-- The policy will only accept only `aal2` when the user has at least one MFA
+- The policy will only accept `aal2` when the user has at least one MFA
   factor verified.
 - Otherwise, it will accept both `aal1` and `aal2`.
-- The `<@` operator is Postgres's ["contained in"
-  operator.](https://www.postgresql.org/docs/current/functions-array.html)
+- **The function must be `SECURITY DEFINER` and owned by a role that can
+  read `auth.mfa_factors`** (typically `postgres`). Without that, the
+  inner `select` would still run as `authenticated` and hit
+  `42501: permission denied for table mfa_factors`.
+- **Revoking `execute … from public`** keeps the helper out of reach of
+  roles that should not be able to enumerate the caller’s MFA factors
+  directly; only the policy should reach it.
 - **Using `as restrictive` ensures this policy will restrict all commands on the
   table regardless of other policies!**
 

--- a/apps/docs/content/guides/auth/auth-mfa.mdx
+++ b/apps/docs/content/guides/auth/auth-mfa.mdx
@@ -288,9 +288,13 @@ create policy "Policy name."
   read `auth.mfa_factors`** (typically `postgres`). Without that, the
   inner `select` would still run as `authenticated` and hit
   `42501: permission denied for table mfa_factors`.
-- **Revoking `execute … from public`** keeps the helper out of reach of
-  roles that should not be able to enumerate the caller’s MFA factors
-  directly; only the policy should reach it.
+- The function only returns whether the calling user has any verified
+  factor, so it does not leak other users' MFA status. The
+  `revoke execute … from public` + `grant execute … to authenticated`
+  pair keeps it out of the `anon` role and limits direct RPC access to
+  authenticated callers; production deployments that want to keep the
+  helper policy-only can additionally revoke from `authenticated` and
+  let the policy’s SECURITY context invoke it as the function owner.
 - **Using `as restrictive` ensures this policy will restrict all commands on the
   table regardless of other policies!**
 


### PR DESCRIPTION
## I have read the CONTRIBUTING.md file.

YES

## What kind of change does this PR introduce?

Bug fix (docs example was incorrect — every query hitting the policy crashed with `42501: permission denied for table mfa_factors`)

## What is the current behavior?

The "Enforce only for users that have opted-in" RLS example in `apps/docs/content/guides/auth/auth-mfa.mdx` (`auth-mfa.mdx:237–252`) reads from `auth.mfa_factors` directly inside the policy body. RLS policies run as the calling user, and the `authenticated` role does not have permission to read that table — the inner `select from auth.mfa_factors where … = auth.uid()` therefore returns `42501: permission denied for table mfa_factors` for every query that hits the protected table, including dashboard impersonation. The example is unusable as written.

The intended semantics ("allow if the user has no enrolled MFA, require `aal2` if they do") are correct, but the implementation has to read `auth.mfa_factors` from a context that can actually see it.

## What is the new behavior?

Wrap the lookup in a `SECURITY DEFINER` function owned by a role that can read `auth.mfa_factors` (typically `postgres`) and call it from the policy. The function returns whether the calling user has any verified MFA factors; the policy uses that, plus the existing `auth.jwt()->>'aal'` claim, to produce the same logical outcome as the original example:

- user has at least one verified MFA factor + JWT is `aal2` → allowed
- user has at least one verified MFA factor + JWT is `aal1` → denied
- user has no verified MFA factor → allowed (regardless of `aal`)

The new SQL is the only way to read `auth.mfa_factors` from a user-evaluable RLS policy without `42501`. The pattern (a small `SECURITY DEFINER` helper, `set search_path = ''`, `revoke execute … from public`, `grant execute … to authenticated`) matches the pattern already documented elsewhere in the Supabase docs for other private-table lookups (e.g. `realtime.broadcast_changes`).

The new explanatory note above the SQL block also documents *why* the original example was broken (RLS body runs as the caller; `authenticated` cannot read `auth.mfa_factors`), so the broken form is not reintroduced later.

## Additional context

- Linked issue: #36024
- Reproduction: per the issue — create a custom schema, a table inside it, paste the original policy from the docs, impersonate any user, and the next query returns 400 with `42501: permission denied for table mfa_factors`.
- The fix is a docs change only; no source or migration files are modified.
- I did not run a Supabase-backed SQL test. The behavior is verified by reading the docs note and the Supabase auth/RBAC model: the inner `select from auth.mfa_factors` is what the docs' own example executes, and the only way to make that read succeed for an `authenticated` caller is to wrap it in `SECURITY DEFINER`. The contribution tests and the docs build will run on CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the optional MFA row-level security example to safely verify enrolled, verified MFA factors.
  * Clarified that users with verified MFA must use assurance level AAL2, while other users may use AAL1 or AAL2.
  * Restricted helper access to authenticated users and clarified that it does not expose other users’ MFA status.
  * Documented optional access restrictions for deployments using the helper only through the security policy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->