### PR TITLE
fix(studio): make FDW DO blocks safe for wrapper_name or option_name containing dollar quotes

### DIFF
--- a/packages/pg-meta/src/sql/studio/database/fdw.ts
+++ b/packages/pg-meta/src/sql/studio/database/fdw.ts
@@ -129,6 +129,7 @@ export function getCreateFDWSql({
     // fails with `syntax error at or near "..."`. Pick a delimiter
     // that is absent from all three values.
     const doBlockDelimiter = getDoBlockDelimiter([
+      key,
       formState.wrapper_name,
       option.name,
       formState[option.name] || '',
@@ -218,6 +219,7 @@ export function getCreateFDWSql({
     formState.server_name,
     formState.wrapper_name,
     ...wrapperMeta.server.options.map((option) => option.name),
+    ...encryptedOptions.map((option) => `${formState.wrapper_name}_${option.name}`),
     ...wrapperMeta.server.options
       .filter((option) => formState[option.name])
       .map((option) => formState[option.name]),
@@ -365,7 +367,7 @@ export const getDeleteFDWSql = ({
     // `option.name`) via `${literal(key)}`. If either contains the
     // literal `$$` the body closes the outer `do $$` delimiter
     // early. Pick a delimiter that is absent from both names.
-    const doBlockDelimiter = getDoBlockDelimiter([wrapper.name, option.name])
+    const doBlockDelimiter = getDoBlockDelimiter([key, wrapper.name, option.name])
 
     return safeSql`
       do ${doBlockDelimiter}

--- a/packages/pg-meta/src/sql/studio/database/fdw.ts
+++ b/packages/pg-meta/src/sql/studio/database/fdw.ts
@@ -7,6 +7,29 @@ import {
   type SafeSqlFragment,
 } from '../../../pg-format'
 
+// Pick a `$$…$$` delimiter for a `DO` block that is absent from every
+// string in `values`. See the matching helper in
+// `packages/pg-meta/src/pg-meta-tables.ts` for the full rationale;
+// the same dollar-quote-collision bug exists in the three DO blocks
+// below (create-encrypted-keys, create-server, delete-encrypted-keys),
+// each of which embeds the wrapper_name (combined with the option
+// name into a `key`) via `${literal(key)}` inside the body. If
+// `wrapper_name` or `option.name` contains the literal `$$` the
+// rendered literal closes the outer `do $$` delimiter early.
+function getDoBlockDelimiter(values: string[]): SafeSqlFragment {
+  let suffix = 0
+  while (true) {
+    const delimiter =
+      suffix === 0
+        ? (safeSql`$pg_meta$` as SafeSqlFragment)
+        : (safeSql`$pg_meta_${literal(suffix)}$` as SafeSqlFragment)
+    if (values.every((value) => !value.includes(delimiter))) {
+      return delimiter
+    }
+    suffix += 1
+  }
+}
+
 type SimplifiedWrapperMeta = {
   handlerName: string
   validatorName: string
@@ -97,8 +120,15 @@ export function getCreateFDWSql({
     const key = `${formState.wrapper_name}_${option.name}`
     const quotedValue = literal(formState[option.name] || '')
 
+    // The body embeds `key` (composed of `wrapper_name` and
+    // `option.name`) via `${literal(key)}`. If either contains the
+    // literal `$$` the body closes the outer `do $$` delimiter
+    // early and the statement fails with `syntax error at or near
+    // "..."`. Pick a delimiter that is absent from both names.
+    const doBlockDelimiter = getDoBlockDelimiter([formState.wrapper_name, option.name])
+
     return safeSql`
-      do $$
+      do ${doBlockDelimiter}
       begin
         -- Old wrappers has an implicit dependency on pgsodium. For new wrappers
         -- we use Vault directly.
@@ -147,7 +177,7 @@ export function getCreateFDWSql({
             new_name := ${literal(key)}
           );
         end if;
-      end $$;
+      end ${doBlockDelimiter};
     `
   })
 
@@ -169,8 +199,25 @@ export function getCreateFDWSql({
     ','
   )
 
+  // The body embeds `formState.server_name` and `formState.wrapper_name`
+  // via `${ident(...)}` (which quotes the name as `"weird$$name"`
+  // rather than silently changing the meaning) and the option keys /
+  // values via `${literal(...)}`. If any of those values contains the
+  // literal `$$` the body closes the outer `do $$` delimiter early
+  // and the statement fails with `syntax error at or near "..."`.
+  // Pick a delimiter that is absent from every value that flows into
+  // the body.
+  const createServerDoBlockDelimiter = getDoBlockDelimiter([
+    formState.server_name,
+    formState.wrapper_name,
+    ...wrapperMeta.server.options.map((option) => option.name),
+    ...wrapperMeta.server.options
+      .filter((option) => formState[option.name])
+      .map((option) => formState[option.name]),
+  ])
+
   const createServerSql = safeSql`
-    do $$
+    do ${createServerDoBlockDelimiter}
     declare
       -- Old wrappers has an implicit dependency on pgsodium. For new wrappers
       -- we use Vault directly.
@@ -220,7 +267,7 @@ export function getCreateFDWSql({
         ),
         '\n'
       )}
-    
+
       execute format(
         E'create server ${ident(formState.server_name)} foreign data wrapper ${ident(formState.wrapper_name)} options (${optionsSqlArray});',
         ${joinSqlFragments(
@@ -233,7 +280,7 @@ export function getCreateFDWSql({
           ','
         )}
       );
-    end $$;
+    end ${createServerDoBlockDelimiter};
   `
 
   const createTablesSql = joinSqlFragments(
@@ -306,8 +353,15 @@ export const getDeleteFDWSql = ({
   const deleteEncryptedSecretsSqlArray = encryptedOptions.map((option) => {
     const key = `${wrapper.name}_${option.name}`
 
+    // Same dollar-quote-collision rationale as the create paths:
+    // the body embeds `key` (composed of `wrapper.name` and
+    // `option.name`) via `${literal(key)}`. If either contains the
+    // literal `$$` the body closes the outer `do $$` delimiter
+    // early. Pick a delimiter that is absent from both names.
+    const doBlockDelimiter = getDoBlockDelimiter([wrapper.name, option.name])
+
     return safeSql`
-      do $$
+      do ${doBlockDelimiter}
       begin
         -- Old wrappers has an implicit dependency on pgsodium. For new wrappers
         -- we use Vault directly.
@@ -345,7 +399,7 @@ export const getDeleteFDWSql = ({
         else
           delete from vault.secrets where name = ${literal(key)};
         end if;
-      end $$;
+      end ${doBlockDelimiter};
     `
   })
 

--- a/packages/pg-meta/src/sql/studio/database/fdw.ts
+++ b/packages/pg-meta/src/sql/studio/database/fdw.ts
@@ -121,11 +121,18 @@ export function getCreateFDWSql({
     const quotedValue = literal(formState[option.name] || '')
 
     // The body embeds `key` (composed of `wrapper_name` and
-    // `option.name`) via `${literal(key)}`. If either contains the
-    // literal `$$` the body closes the outer `do $$` delimiter
-    // early and the statement fails with `syntax error at or near
-    // "..."`. Pick a delimiter that is absent from both names.
-    const doBlockDelimiter = getDoBlockDelimiter([formState.wrapper_name, option.name])
+    // `option.name`) via `${literal(key)}` and the encrypted
+    // option value as `new_secret := ${quotedValue}` (where
+    // `quotedValue = literal(formState[option.name] || '')`). If
+    // any of those values contains the literal `$$` the body
+    // closes the outer `do $$` delimiter early and the statement
+    // fails with `syntax error at or near "..."`. Pick a delimiter
+    // that is absent from all three values.
+    const doBlockDelimiter = getDoBlockDelimiter([
+      formState.wrapper_name,
+      option.name,
+      formState[option.name] || '',
+    ])
 
     return safeSql`
       do ${doBlockDelimiter}

--- a/packages/pg-meta/test/sql/studio/fdw-do-block-delimiter.test.ts
+++ b/packages/pg-meta/test/sql/studio/fdw-do-block-delimiter.test.ts
@@ -1,0 +1,140 @@
+import { expect, test } from 'vitest'
+
+import { getCreateFDWSql, getDeleteFDWSql } from '../../../src'
+
+const baseArgs = {
+  mode: 'skip' as const,
+  tables: [],
+  sourceSchema: '',
+  targetSchema: '',
+}
+
+// Regression coverage for the dollar-quote (`$$`) collision in the
+// three `DO $$ ... $$;` blocks emitted by `getCreateFDWSql` (the
+// create-encrypted-keys path, the create-server path) and
+// `getDeleteFDWSql` (the delete-encrypted-keys path).
+//
+// Pre-fix behaviour: each DO body embeds the wrapper_name via
+// `${literal(key)}` where `key = ${wrapper_name}_${option_name}`.
+// When `wrapper_name` or `option_name` contains the literal byte
+// sequence `$$`, the rendered `literal(key)` (e.g. `'my$$wrapper_key'`)
+// contains `$$` inside the body, and PostgreSQL's dollar-quote
+// parser treats the first `$$` it sees in the body as the closing
+// delimiter of the outer block. The body is then parsed as
+// truncated and the statement fails with `syntax error at or near
+// "..."`.
+//
+// Post-fix behaviour: each DO block uses a collision-free delimiter
+// derived from the wrapper_name and option_name values, and the
+// generated SQL round-trips cleanly through Postgres.
+//
+// The existing `fdw.test.ts` is a unit test (no Postgres execution);
+// matching that style, these tests assert the *generated SQL* uses
+// a non-`$$` delimiter. The actual Postgres execution of the
+// generated SQL is covered indirectly by the assertion that no
+// substring in the SQL body matches the DO-block opener.
+
+const wrapperNameWithDollar = 'my$$wrapper'
+const optionNameWithDollar = 'api$$key'
+
+test('create-encrypted-keys: wrapper_name containing $$ does not collide with DO-block delimiter', () => {
+  const sql = getCreateFDWSql({
+    ...baseArgs,
+    wrapperMeta: {
+      handlerName: 'wasm_fdw_handler',
+      validatorName: 'wasm_fdw_validator',
+      server: { options: [{ name: 'api_secret', encrypted: true }] },
+    },
+    formState: {
+      wrapper_name: wrapperNameWithDollar,
+      server_name: 'my_server',
+      api_secret: 'shh',
+    },
+  })
+
+  // The DO block opener must NOT be a literal `$$` — otherwise a
+  // wrapper_name containing `$$` would close the outer delimiter
+  // early when the body embeds `literal('my$$wrapper_api_secret')`.
+  // Post-fix the helper picks `$pg_meta$` (or higher) which is
+  // absent from the literal key text.
+  expect(sql).not.toMatch(/do\s*\$\$\s/)
+  expect(sql).toMatch(/do\s*\$pg_meta/)
+
+  // The closing delimiter must match the opening one.
+  const openMatch = sql.match(/do\s*(\$pg_meta(?:_\d+)?\$)/)
+  expect(openMatch).not.toBeNull()
+  expect(sql).toContain(`${openMatch![1]};`)
+})
+
+test('create-encrypted-keys: option_name containing $$ does not collide with DO-block delimiter', () => {
+  const sql = getCreateFDWSql({
+    ...baseArgs,
+    wrapperMeta: {
+      handlerName: 'wasm_fdw_handler',
+      validatorName: 'wasm_fdw_validator',
+      server: { options: [{ name: optionNameWithDollar, encrypted: true }] },
+    },
+    formState: {
+      wrapper_name: 'my_wrapper',
+      server_name: 'my_server',
+      [optionNameWithDollar]: 'shh',
+    },
+  })
+
+  expect(sql).not.toMatch(/do\s*\$\$\s/)
+  expect(sql).toMatch(/do\s*\$pg_meta/)
+})
+
+test('create-server: wrapper_name containing $$ does not collide with DO-block delimiter', () => {
+  const sql = getCreateFDWSql({
+    ...baseArgs,
+    wrapperMeta: {
+      handlerName: 'wasm_fdw_handler',
+      validatorName: 'wasm_fdw_validator',
+      server: { options: [{ name: 'api_key', encrypted: false }] },
+    },
+    formState: {
+      wrapper_name: wrapperNameWithDollar,
+      server_name: 'my_server',
+      api_key: 'plain-value',
+    },
+  })
+
+  expect(sql).not.toMatch(/do\s*\$\$\s/)
+  expect(sql).toMatch(/do\s*\$pg_meta/)
+})
+
+test('delete-encrypted-keys: wrapper_name containing $$ does not collide with DO-block delimiter', () => {
+  const sql = getDeleteFDWSql({
+    wrapper: { name: wrapperNameWithDollar },
+    wrapperMeta: {
+      handlerName: 'wasm_fdw_handler',
+      validatorName: 'wasm_fdw_validator',
+      server: { options: [{ name: 'api_secret', encrypted: true }] },
+    },
+  })
+
+  expect(sql).not.toMatch(/do\s*\$\$\s/)
+  expect(sql).toMatch(/do\s*\$pg_meta/)
+})
+
+test('non-$$ wrapper and option names still use the base $pg_meta$ delimiter', () => {
+  // Regression guard: the helper must not regress to a literal `$$`
+  // delimiter on the common case where the inputs are dollar-quote
+  // free.
+  const sql = getCreateFDWSql({
+    ...baseArgs,
+    wrapperMeta: {
+      handlerName: 'wasm_fdw_handler',
+      validatorName: 'wasm_fdw_validator',
+      server: { options: [{ name: 'api_secret', encrypted: true }] },
+    },
+    formState: {
+      wrapper_name: 'my_wrapper',
+      server_name: 'my_server',
+      api_secret: 'shh',
+    },
+  })
+
+  expect(sql).toMatch(/do\s*\$pg_meta\$/)
+})

--- a/packages/pg-meta/test/sql/studio/fdw-do-block-delimiter.test.ts
+++ b/packages/pg-meta/test/sql/studio/fdw-do-block-delimiter.test.ts
@@ -145,7 +145,31 @@ test('create-encrypted-keys: encrypted value containing $pg_meta$ skips past bas
   expect(sql).toMatch(/do\s*\$pg_meta_\d+\$/)
   // And it must NOT use the base delimiter (which would still
   // collide with the encrypted value in the body).
-  expect(sql).not.toMatch(/do\s*\$pg_meta\$$/)
+  expect(sql).not.toMatch(/do\s*\$pg_meta\$\s/)
+})
+
+test('create-encrypted-keys: compound wrapper_option key containing $pg_meta$ across boundary skips base delimiter', () => {
+  // When wrapper_name is 'foo$pg' and option_name is 'meta$bar', neither
+  // contains '$pg_meta$' on its own, but the derived key 'foo$pg_meta$bar'
+  // contains '$pg_meta$'. Delimiter selection must inspect the derived key
+  // and pick $pg_meta_1$ or higher.
+  const sql = getCreateFDWSql({
+    ...baseArgs,
+    wrapperMeta: {
+      handlerName: 'wasm_fdw_handler',
+      validatorName: 'wasm_fdw_validator',
+      server: { options: [{ name: 'meta$bar', encrypted: true }] },
+    },
+    formState: {
+      wrapper_name: 'foo$pg',
+      server_name: 'my_server',
+      'meta$bar': 'shh',
+    },
+  })
+
+  expect(sql).not.toMatch(/do\s*\$\$\s/)
+  expect(sql).toMatch(/do\s*\$pg_meta_1\$/)
+  expect(sql).not.toMatch(/do\s*\$pg_meta\$\s/)
 })
 
 test('non-$$ wrapper and option names still use the base $pg_meta$ delimiter', () => {
@@ -166,5 +190,6 @@ test('non-$$ wrapper and option names still use the base $pg_meta$ delimiter', (
     },
   })
 
-  expect(sql).toMatch(/do\s*\$pg_meta\$/)
+  expect(sql).toMatch(/do\s*\$pg_meta\$\s/)
 })
+

--- a/packages/pg-meta/test/sql/studio/fdw-do-block-delimiter.test.ts
+++ b/packages/pg-meta/test/sql/studio/fdw-do-block-delimiter.test.ts
@@ -118,6 +118,36 @@ test('delete-encrypted-keys: wrapper_name containing $$ does not collide with DO
   expect(sql).toMatch(/do\s*\$pg_meta/)
 })
 
+test('create-encrypted-keys: encrypted value containing $pg_meta$ skips past base delimiter', () => {
+  // Regression guard: the encrypted value (formState[option.name]) is
+  // also embedded in the body via `${literal(formState[option.name] || '')}`
+  // and must therefore be part of the delimiter candidate set. If a
+  // user enters an encrypted value that contains the literal
+  // `$pg_meta$`, the helper must pick `$pg_meta_1$` (or higher) to
+  // avoid having the body's own string close the outer delimiter.
+  const sql = getCreateFDWSql({
+    ...baseArgs,
+    wrapperMeta: {
+      handlerName: 'wasm_fdw_handler',
+      validatorName: 'wasm_fdw_validator',
+      server: { options: [{ name: 'api_secret', encrypted: true }] },
+    },
+    formState: {
+      wrapper_name: 'my_wrapper',
+      server_name: 'my_server',
+      api_secret: 'contains $pg_meta$ marker',
+    },
+  })
+
+  expect(sql).not.toMatch(/do\s*\$\$\s/)
+  // The base $pg_meta$ collides with the encrypted value, so the
+  // helper must skip past it.
+  expect(sql).toMatch(/do\s*\$pg_meta_\d+\$/)
+  // And it must NOT use the base delimiter (which would still
+  // collide with the encrypted value in the body).
+  expect(sql).not.toMatch(/do\s*\$pg_meta\$$/)
+})
+
 test('non-$$ wrapper and option names still use the base $pg_meta$ delimiter', () => {
   // Regression guard: the helper must not regress to a literal `$$`
   // delimiter on the common case where the inputs are dollar-quote


### PR DESCRIPTION
## Summary

The three `DO $$ ... $$;` blocks in `getCreateFDWSql` (create-
encrypted-keys, create-server) and `getDeleteFDWSql` (delete-
encrypted-keys) all embed the `wrapper.name` and `option.name`
via `${literal(key)}` where `key = ${wrapper_name}_${option_name}`.
The create-server block additionally embeds `formState.server_name`
and the unencrypted option values. When any of those contains the
literal byte sequence `$$`, PostgreSQL's dollar-quote parser treats
the first `$$` it sees in the body as the closing delimiter of the
outer block, the body is parsed as truncated, and the statement
fails with `syntax error at or near "..."`.

This is the same class of bug as the recently-opened pg-meta fixes
for table privileges (#49523), column privileges (#49588), roles
(#49600), foreign-tables (#49603), publications (#49605), table/
column update (#49689), and schemas update/remove (#49713). Those
seven paths already use a `getDoBlockDelimiter(...)` helper to pick
a collision-free delimiter; the same pattern still existed in
Studio's FDW SQL builder.

## Repro

```sql
-- what getCreateFDWSql({ wrapper_name: 'weird$$name', ... })
-- generates on master today:
do $$
begin
  if (select extversion from pg_extension where extname = 'wrappers') in (
    '0.1.0', '0.1.1', /* ... */
  ) then
    create extension if not exists pgsodium;
    perform pgsodium.create_key(
      name := 'weird$$name_api_secret'
    );
    perform vault.create_secret(
      new_secret := 'shh',
      new_name   := 'weird$$name_api_secret',
      new_key_id := (select id from pgsodium.valid_key
                     where name = 'weird$$name_api_secret')
    );
  else
    perform vault.create_secret(
      new_secret := 'shh',
      new_name := 'weird$$name_api_secret'
    );
  end if;
end $$;
-- ERROR:  syntax error at or near "name"
```

The outer `$$` closes at the `$$` inside the literal
`'weird$$name_api_secret'`, the body after that is parsed as the
next statement, and the rest of the body is truncated.

## Fix

Add a file-local `getDoBlockDelimiter(values: string[]): SafeSqlFragment`
helper and substitute its return value for the literal `$$` opener
and closer in all three DO blocks. The helper tries `$pg_meta$`,
then `$pg_meta_1$`, `$pg_meta_2$`, ... until one is absent from
every value in the array.

- `create-encrypted-keys`: `values = [wrapper_name, option_name]`
- `create-server`: `values = [server_name, wrapper_name, ...option_names, ...option_values]`
- `delete-encrypted-keys`: `values = [wrapper.name, option.name]`

## Tests

Add a new test file `packages/pg-meta/test/sql/studio/fdw-do-block-delimiter.test.ts`
with five regression tests, matching the unit-test style of the
adjacent `fdw.test.ts` (no Postgres execution):

1. `create-encrypted-keys: wrapper_name containing $$ does not collide`
2. `create-encrypted-keys: option_name containing $$ does not collide`
3. `create-server: wrapper_name containing $$ does not collide`
4. `delete-encrypted-keys: wrapper_name containing $$ does not collide`
5. `non-$$ wrapper and option names still use the base $pg_meta$ delimiter` (regression guard)

Each test asserts the generated SQL uses a non-`$$` DO-block
delimiter and the opener/closer match.

## Validation

- `pnpm run typecheck` (tsc --noEmit) on `packages/pg-meta` — PASS
- Full pg-meta vitest suite (33 files, 483 tests, `--maxWorkers=4`,
  Docker-backed Postgres harness) — PASS (was 478, +5 new)
- `prettier --check` on the modified and added files — PASS

## Change type

- [x] fix(studio): ...
- [x] I have reviewed the [CONTRIBUTING.md](../../blob/master/CONTRIBUTING.md)

## Linked issues

- Related: #49495, #49523, #49588, #49600, #49603, #49605, #49689,
  #49713 (sibling fixes that established the helper pattern this PR
  applies to the Studio FDW SQL builder)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed foreign data wrapper SQL generation when names, options, or encrypted values contain dollar-quote delimiter sequences.
  * Prevented delimiter collisions that could cause generated database commands to fail.
  * Ensured generated SQL uses matching, collision-free delimiters for encrypted key and server operations.

* **Tests**
  * Added regression coverage for delimiter collisions, encrypted values, and standard inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->