### PR TITLE
docs: fix typo contructor -> constructor

### DIFF
--- a/apps/docs/content/guides/functions/error-codes.mdx
+++ b/apps/docs/content/guides/functions/error-codes.mdx
@@ -159,7 +159,7 @@ export default {
         body: req.body,
       })
 
-      // Creating a 'new Response()' ensures contructor checks
+      // Creating a 'new Response()' ensures constructor checks
       return new Response(await res.body, {
         headers: res.headers,
         status: res.status,


### PR DESCRIPTION
Corrects the misspelling `contructor` -> `constructor` in `apps/docs/content/guides/functions/error-codes.mdx`.

Documentation only, no behaviour change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a spelling error in the `INVALID_RESPONSE_STATUS_CODE` example comment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->