### PR TITLE
chore(studio): update policy and role side panels

### DIFF
--- a/apps/studio/components/interfaces/Database/Policies/PolicyEditorPanel/PolicyDetailsV2.tsx
+++ b/apps/studio/components/interfaces/Database/Policies/PolicyEditorPanel/PolicyDetailsV2.tsx
@@ -19,9 +19,6 @@ import {
   CommandList,
   FormControl,
   FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
   Input,
   Popover,
   PopoverContent,
@@ -34,7 +31,9 @@ import {
   SelectGroup,
   SelectItem,
   SelectTrigger,
+  SheetSection,
 } from 'ui'
+import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import {
   MultiSelector,
   MultiSelectorContent,
@@ -121,249 +120,253 @@ export const PolicyDetailsV2 = ({
   }, [isEditing, form, searchString, tables, isSuccessTables, selectedTable])
 
   return (
-    <>
-      <div className="px-5 py-5 flex flex-col gap-y-4 border-b">
-        <div className="items-start justify-between gap-4 grid grid-cols-12">
-          <FormField
-            control={form.control}
-            name="name"
-            render={({ field }) => (
-              <FormItem className="col-span-6 flex flex-col gap-y-1">
-                <FormLabel>Policy Name</FormLabel>
-                <FormControl>
-                  <Input
-                    {...field}
-                    disabled={!canUpdatePolicies}
-                    className="bg-control border-control"
-                    placeholder="Provide a name for your policy"
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
+    <SheetSection className="flex flex-col gap-y-6 border-b">
+      <FormField
+        control={form.control}
+        name="name"
+        render={({ field }) => (
+          <FormItemLayout id="policy-name" layout="horizontal" label="Policy Name">
+            <FormControl>
+              <Input
+                id="policy-name"
+                {...field}
+                disabled={!canUpdatePolicies}
+                className="bg-control border-control"
+                placeholder="Provide a name for your policy"
+              />
+            </FormControl>
+          </FormItemLayout>
+        )}
+      />
 
-          <FormField
-            control={form.control}
-            name="table"
-            render={({ field }) => (
-              <FormItem className="col-span-6 flex flex-col gap-y-1">
-                <FormLabel>
-                  Table
-                  <code className="text-code-inline">on</code> clause
-                </FormLabel>
-                {authContext === 'database' && (
-                  <FormControl>
-                    <Popover open={open} onOpenChange={setOpen} modal={false}>
-                      <PopoverTrigger asChild>
-                        <Button
-                          variant="default"
-                          disabled={!canUpdatePolicies}
-                          className="w-full [&>span]:w-full h-[38px] text-sm"
-                          iconRight={
-                            <ChevronsUpDown
-                              className="text-foreground-muted"
-                              strokeWidth={2}
-                              size={14}
-                            />
-                          }
-                        >
-                          <div className="w-full flex gap-1">
-                            <span className="text-foreground">
-                              {schema}.{field.value}
-                            </span>
-                          </div>
-                        </Button>
-                      </PopoverTrigger>
-
-                      <PopoverContent
-                        className="p-0"
-                        side="bottom"
-                        align="start"
-                        sameWidthAsTrigger
-                      >
-                        <Command>
-                          <CommandInput placeholder="Find a table..." />
-                          <CommandList onWheel={(event) => event.stopPropagation()}>
-                            <CommandEmpty>No tables found</CommandEmpty>
-                            <CommandGroup>
-                              <ScrollArea className={(tables ?? []).length > 7 ? 'h-[200px]' : ''}>
-                                {(tables ?? []).map((table) => (
-                                  <CommandItem
-                                    key={table.id}
-                                    className="cursor-pointer flex items-center justify-between space-x-2 w-full"
-                                    onSelect={() => {
-                                      form.setValue('table', table.name)
-                                      setOpen(false)
-                                    }}
-                                    onClick={() => {
-                                      form.setValue('table', table.name)
-                                      setOpen(false)
-                                    }}
-                                  >
-                                    <span className="flex items-center gap-1.5">
-                                      {field.value === table.name ? <Check size={13} /> : ''}
-                                      {table.name}
-                                    </span>
-                                  </CommandItem>
-                                ))}
-                              </ScrollArea>
-                            </CommandGroup>
-                          </CommandList>
-                        </Command>
-                      </PopoverContent>
-                    </Popover>
-                  </FormControl>
-                )}
-                {authContext === 'realtime' && (
-                  <FormControl>
-                    <Input
-                      disabled
-                      value="messages.realtime"
-                      className="bg-control border-control"
-                    />
-                  </FormControl>
-                )}
-
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-
-          <FormField
-            control={form.control}
-            name="behavior"
-            render={({ field }) => (
-              <FormItem className="col-span-6 flex flex-col gap-y-1">
-                <FormLabel>
-                  Policy Behavior <code className="text-code-inline">as</code> clause
-                </FormLabel>
-                <FormControl>
-                  <Select
-                    disabled={isEditing}
-                    value={field.value}
-                    onValueChange={(value) => form.setValue('behavior', value)}
-                  >
-                    <SelectTrigger className="text-sm h-10 capitalize">{field.value}</SelectTrigger>
-                    <SelectContent>
-                      <SelectGroup>
-                        <SelectItem value="permissive" className="text-sm">
-                          <p>Permissive</p>
-                          <p className="text-foreground-light text-xs">
-                            Policies are combined using the "OR" Boolean operator
-                          </p>
-                        </SelectItem>
-                        <SelectItem value="restrictive" className="text-sm">
-                          <p>Restrictive</p>
-                          <p className="text-foreground-light text-xs">
-                            Policies are combined using the "AND" Boolean operator
-                          </p>
-                        </SelectItem>
-                      </SelectGroup>
-                    </SelectContent>
-                  </Select>
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-          <FormField
-            control={form.control}
-            name="command"
-            render={({ field }) => (
-              <FormItem className="col-span-12 flex flex-col gap-y-1">
-                <FormLabel>
-                  Policy Command <code className="text-code-inline">for</code> clause
-                </FormLabel>
-                <FormControl>
-                  <RadioGroup
-                    disabled={isEditing}
-                    value={field.value}
-                    defaultValue={field.value}
-                    onValueChange={(value) => {
-                      form.setValue('command', value)
-                      onUpdateCommand(value)
-                    }}
-                    className={cn('flex flex-wrap gap-3', isEditing && 'opacity-50')}
-                  >
-                    {[
-                      'select',
-                      'insert',
-                      ...(authContext === 'database' ? ['update', 'delete', 'all'] : []),
-                    ].map((x) => (
-                      <RadioGroupLargeItem
-                        key={x}
-                        value={x}
-                        disabled={isEditing}
-                        label={x.toLocaleUpperCase()}
-                        className={cn('w-auto', isEditing && 'cursor-not-allowed')}
-                      />
-                    ))}
-                  </RadioGroup>
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-          <FormField
-            control={form.control}
-            name="roles"
-            render={({ field }) => (
-              <FormItem className="col-span-12 flex flex-col gap-y-1">
-                <FormLabel htmlFor="roles">
-                  Target Roles <code className="text-code-inline">to</code> clause
-                </FormLabel>
-                <FormControl>
-                  <MultiSelector
-                    onValuesChange={(roles) => {
-                      field.onChange(roles.join(', '))
-                      onRolesChange?.(
-                        roles.length === 0
-                          ? safeSql`public`
-                          : joinSqlFragments(
-                              roles.map((r) => ident(r)),
-                              ', '
-                            )
-                      )
-                    }}
-                    disabled={!canUpdatePolicies}
-                    values={field.value.length === 0 ? [] : field.value?.split(', ')}
-                    size="small"
-                  >
-                    <MultiSelectorTrigger
-                      id="roles"
-                      mode="inline-combobox"
-                      label={
-                        field.value.length === 0
-                          ? 'Defaults to all (public) roles if none selected'
-                          : 'Search for a role'
+      <FormField
+        control={form.control}
+        name="table"
+        render={({ field }) => (
+          <FormItemLayout
+            id="policy-table"
+            layout="horizontal"
+            label={
+              <>
+                Table
+                <code className="text-code-inline">on</code> clause
+              </>
+            }
+          >
+            {authContext === 'database' && (
+              <FormControl>
+                <Popover open={open} onOpenChange={setOpen} modal={false}>
+                  <PopoverTrigger asChild>
+                    <Button
+                      id="policy-table"
+                      variant="default"
+                      disabled={!canUpdatePolicies}
+                      className="w-full [&>span]:w-full h-[38px] text-sm"
+                      iconRight={
+                        <ChevronsUpDown
+                          className="text-foreground-muted"
+                          strokeWidth={2}
+                          size={14}
+                        />
                       }
-                      badgeLimit="wrap"
-                      showIcon={false}
-                      deletableBadge
-                      className="w-full"
-                    />
-                    <MultiSelectorContent>
-                      <MultiSelectorList>
-                        {formattedRoles.map((role) => (
-                          <MultiSelectorItem
-                            key={role.id}
-                            value={role.value}
-                            disabled={role.disabled}
-                          >
-                            {role.name}
-                          </MultiSelectorItem>
-                        ))}
-                      </MultiSelectorList>
-                    </MultiSelectorContent>
-                  </MultiSelector>
-                </FormControl>
-                <FormMessage />
-              </FormItem>
+                    >
+                      <div className="w-full flex gap-1">
+                        <span className="text-foreground">
+                          {schema}.{field.value}
+                        </span>
+                      </div>
+                    </Button>
+                  </PopoverTrigger>
+
+                  <PopoverContent className="p-0" side="bottom" align="start" sameWidthAsTrigger>
+                    <Command>
+                      <CommandInput placeholder="Find a table..." />
+                      <CommandList onWheel={(event) => event.stopPropagation()}>
+                        <CommandEmpty>No tables found</CommandEmpty>
+                        <CommandGroup>
+                          <ScrollArea className={(tables ?? []).length > 7 ? 'h-[200px]' : ''}>
+                            {(tables ?? []).map((table) => (
+                              <CommandItem
+                                key={table.id}
+                                className="cursor-pointer flex items-center justify-between space-x-2 w-full"
+                                onSelect={() => {
+                                  form.setValue('table', table.name)
+                                  setOpen(false)
+                                }}
+                                onClick={() => {
+                                  form.setValue('table', table.name)
+                                  setOpen(false)
+                                }}
+                              >
+                                <span className="flex items-center gap-1.5">
+                                  {field.value === table.name ? <Check size={13} /> : ''}
+                                  {table.name}
+                                </span>
+                              </CommandItem>
+                            ))}
+                          </ScrollArea>
+                        </CommandGroup>
+                      </CommandList>
+                    </Command>
+                  </PopoverContent>
+                </Popover>
+              </FormControl>
             )}
-          />
-        </div>
-      </div>
-    </>
+            {authContext === 'realtime' && (
+              <FormControl>
+                <Input
+                  id="policy-table"
+                  disabled
+                  value="messages.realtime"
+                  className="bg-control border-control"
+                />
+              </FormControl>
+            )}
+          </FormItemLayout>
+        )}
+      />
+
+      <FormField
+        control={form.control}
+        name="behavior"
+        render={({ field }) => (
+          <FormItemLayout
+            id="policy-behavior"
+            layout="horizontal"
+            label={
+              <>
+                Policy Behavior <code className="text-code-inline">as</code> clause
+              </>
+            }
+          >
+            <FormControl>
+              <Select
+                disabled={isEditing}
+                value={field.value}
+                onValueChange={(value) => form.setValue('behavior', value)}
+              >
+                <SelectTrigger id="policy-behavior" className="text-sm h-10 capitalize">
+                  {field.value}
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    <SelectItem value="permissive" className="text-sm">
+                      <p>Permissive</p>
+                      <p className="text-foreground-light text-xs">
+                        Policies are combined using the "OR" Boolean operator
+                      </p>
+                    </SelectItem>
+                    <SelectItem value="restrictive" className="text-sm">
+                      <p>Restrictive</p>
+                      <p className="text-foreground-light text-xs">
+                        Policies are combined using the "AND" Boolean operator
+                      </p>
+                    </SelectItem>
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+            </FormControl>
+          </FormItemLayout>
+        )}
+      />
+      <FormField
+        control={form.control}
+        name="command"
+        render={({ field }) => (
+          <FormItemLayout
+            layout="horizontal"
+            label={
+              <>
+                Policy Command <code className="text-code-inline">for</code> clause
+              </>
+            }
+          >
+            <FormControl>
+              <RadioGroup
+                disabled={isEditing}
+                value={field.value}
+                defaultValue={field.value}
+                onValueChange={(value) => {
+                  form.setValue('command', value)
+                  onUpdateCommand(value)
+                }}
+                className={cn('flex flex-wrap gap-3', isEditing && 'opacity-50')}
+              >
+                {[
+                  'select',
+                  'insert',
+                  ...(authContext === 'database' ? ['update', 'delete', 'all'] : []),
+                ].map((x) => (
+                  <RadioGroupLargeItem
+                    key={x}
+                    value={x}
+                    disabled={isEditing}
+                    label={x.toLocaleUpperCase()}
+                    className={cn('w-auto', isEditing && 'cursor-not-allowed')}
+                  />
+                ))}
+              </RadioGroup>
+            </FormControl>
+          </FormItemLayout>
+        )}
+      />
+      <FormField
+        control={form.control}
+        name="roles"
+        render={({ field }) => (
+          <FormItemLayout
+            id="roles"
+            layout="horizontal"
+            label={
+              <>
+                Target Roles <code className="text-code-inline">to</code> clause
+              </>
+            }
+          >
+            <FormControl>
+              <MultiSelector
+                onValuesChange={(roles) => {
+                  field.onChange(roles.join(', '))
+                  onRolesChange?.(
+                    roles.length === 0
+                      ? safeSql`public`
+                      : joinSqlFragments(
+                          roles.map((r) => ident(r)),
+                          ', '
+                        )
+                  )
+                }}
+                disabled={!canUpdatePolicies}
+                values={field.value.length === 0 ? [] : field.value?.split(', ')}
+                size="small"
+              >
+                <MultiSelectorTrigger
+                  id="roles"
+                  mode="inline-combobox"
+                  label={
+                    field.value.length === 0
+                      ? 'Defaults to all (public) roles if none selected'
+                      : 'Search for a role'
+                  }
+                  badgeLimit="wrap"
+                  showIcon={false}
+                  deletableBadge
+                  className="w-full"
+                />
+                <MultiSelectorContent>
+                  <MultiSelectorList>
+                    {formattedRoles.map((role) => (
+                      <MultiSelectorItem key={role.id} value={role.value} disabled={role.disabled}>
+                        {role.name}
+                      </MultiSelectorItem>
+                    ))}
+                  </MultiSelectorList>
+                </MultiSelectorContent>
+              </MultiSelector>
+            </FormControl>
+          </FormItemLayout>
+        )}
+      />
+    </SheetSection>
   )
 }

--- a/apps/studio/components/interfaces/Database/Roles/CreateRolePanel.tsx
+++ b/apps/studio/components/interfaces/Database/Roles/CreateRolePanel.tsx
@@ -5,13 +5,18 @@ import {
   Form,
   FormControl,
   FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
   Input,
-  SidePanel,
+  Separator,
+  Sheet,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetSection,
+  SheetTitle,
   Switch,
 } from 'ui'
+import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
+import { FormLayout } from 'ui-patterns/form/Layout/FormLayout'
 import z from 'zod'
 
 import { ROLE_PERMISSIONS } from './Roles.constants'
@@ -76,115 +81,114 @@ export const CreateRolePanel = ({ visible, onClose }: CreateRolePanelProps) => {
   }
 
   return (
-    <SidePanel
-      size="large"
-      visible={visible}
-      header="Create a new role"
-      className="mr-0 transform transition-all duration-300 ease-in-out"
-      loading={false}
-      onCancel={handleClose}
-      customFooter={
-        <div className="flex w-full justify-end space-x-3 border-t border-default px-3 py-4">
+    <Sheet
+      open={visible}
+      onOpenChange={(open) => {
+        if (!open) handleClose()
+      }}
+    >
+      <SheetContent size="lg" className="flex flex-col gap-0">
+        <SheetHeader>
+          <SheetTitle>Create a new role</SheetTitle>
+        </SheetHeader>
+
+        <Form {...form}>
+          <form id={formId} className="flex-1 overflow-auto" onSubmit={form.handleSubmit(onSubmit)}>
+            <SheetSection className="flex flex-col gap-y-6">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItemLayout id="role-name" layout="horizontal" label="Name">
+                    <FormControl>
+                      <Input id="role-name" {...field} className="w-full" />
+                    </FormControl>
+                  </FormItemLayout>
+                )}
+              />
+
+              <FormLayout layout="horizontal" label="Role privileges">
+                <div className="grid gap-4">
+                  {(Object.keys(ROLE_PERMISSIONS) as (keyof typeof ROLE_PERMISSIONS)[])
+                    .filter((permissionKey) => ROLE_PERMISSIONS[permissionKey].grant_by_dashboard)
+                    .map((permissionKey) => {
+                      const permission = ROLE_PERMISSIONS[permissionKey]
+                      const id = `role-${permissionKey}`
+
+                      return (
+                        <FormField
+                          key={permissionKey}
+                          control={form.control}
+                          name={permissionKey}
+                          render={({ field }) => (
+                            <FormItemLayout id={id} layout="flex" label={permission.description}>
+                              <FormControl>
+                                <Switch
+                                  id={id}
+                                  checked={field.value}
+                                  onCheckedChange={field.onChange}
+                                />
+                              </FormControl>
+                            </FormItemLayout>
+                          )}
+                        />
+                      )
+                    })}
+
+                  <Separator />
+
+                  <div className="grid gap-4">
+                    <p className="text-sm">These privileges cannot be granted via the Dashboard:</p>
+                    {(Object.keys(ROLE_PERMISSIONS) as (keyof typeof ROLE_PERMISSIONS)[])
+                      .filter(
+                        (permissionKey) => !ROLE_PERMISSIONS[permissionKey].grant_by_dashboard
+                      )
+                      .map((permissionKey) => {
+                        const permission = ROLE_PERMISSIONS[permissionKey]
+                        const id = `role-${permissionKey}`
+
+                        return (
+                          <FormField
+                            key={permissionKey}
+                            control={form.control}
+                            name={permissionKey}
+                            render={({ field }) => (
+                              <FormItemLayout
+                                id={id}
+                                layout="flex"
+                                label={permission.description}
+                                className="opacity-70"
+                              >
+                                <FormControl>
+                                  <Switch
+                                    id={id}
+                                    checked={field.value}
+                                    onCheckedChange={field.onChange}
+                                    disabled
+                                    aria-readonly
+                                  />
+                                </FormControl>
+                              </FormItemLayout>
+                            )}
+                          />
+                        )
+                      })}
+                  </div>
+                </div>
+              </FormLayout>
+            </SheetSection>
+          </form>
+        </Form>
+
+        <SheetFooter>
           <FormActions
             form={formId}
             isSubmitting={isCreating}
             hasChanges={form.formState.isDirty}
             handleReset={handleClose}
           />
-        </div>
-      }
-    >
-      <Form {...form}>
-        <form
-          id={formId}
-          className="grid gap-6 w-full px-8 py-8"
-          onSubmit={form.handleSubmit(onSubmit)}
-        >
-          <FormField
-            control={form.control}
-            name="name"
-            render={({ field }) => (
-              <FormItem className="grid gap-2 md:grid md:grid-cols-12 space-y-0">
-                <FormLabel className="flex flex-col space-y-2 col-span-4 text-sm justify-center text-foreground-light">
-                  Name
-                </FormLabel>
-                <FormControl className="col-span-8">
-                  <Input {...field} className="w-full" />
-                </FormControl>
-                <FormMessage className="col-start-5 col-span-8" />
-              </FormItem>
-            )}
-          />
-          <div className="grid gap-2 mt-4 md:grid md:grid-cols-12">
-            <div className="col-span-4">
-              <FormLabel className="flex flex-col space-y-2 col-span-4 text-sm justify-center text-foreground-light">
-                Role privileges
-              </FormLabel>
-            </div>
-            <div className="col-span-8 grid gap-4">
-              {(Object.keys(ROLE_PERMISSIONS) as (keyof typeof ROLE_PERMISSIONS)[])
-                .filter((permissionKey) => ROLE_PERMISSIONS[permissionKey].grant_by_dashboard)
-                .map((permissionKey) => {
-                  const permission = ROLE_PERMISSIONS[permissionKey]
-
-                  return (
-                    <FormField
-                      key={permissionKey}
-                      control={form.control}
-                      name={permissionKey}
-                      render={({ field }) => (
-                        <FormItem className="grid gap-2 md:grid md:grid-cols-12 space-y-0">
-                          <FormControl className="col-span-8 flex items-center gap-4">
-                            <div className="w-full text-sm">
-                              <Switch checked={field.value} onCheckedChange={field.onChange} />
-                              <FormLabel>{permission.description}</FormLabel>
-                            </div>
-                          </FormControl>
-                          <FormMessage className="col-start-5 col-span-8" />
-                        </FormItem>
-                      )}
-                    />
-                  )
-                })}
-
-              <SidePanel.Separator />
-
-              <div className="grid gap-4">
-                <p className="text-sm">These privileges cannot be granted via the Dashboard:</p>
-                {(Object.keys(ROLE_PERMISSIONS) as (keyof typeof ROLE_PERMISSIONS)[])
-                  .filter((permissionKey) => !ROLE_PERMISSIONS[permissionKey].grant_by_dashboard)
-                  .map((permissionKey) => {
-                    const permission = ROLE_PERMISSIONS[permissionKey]
-
-                    return (
-                      <FormField
-                        key={permissionKey}
-                        control={form.control}
-                        name={permissionKey}
-                        render={({ field }) => (
-                          <FormItem className="space-y-0 opacity-70">
-                            <FormControl className="flex items-center gap-4">
-                              <div className="w-full text-sm">
-                                <Switch
-                                  checked={field.value}
-                                  onCheckedChange={field.onChange}
-                                  disabled
-                                  aria-readonly
-                                />
-                                <FormLabel>{permission.description}</FormLabel>
-                              </div>
-                            </FormControl>
-                            <FormMessage className="col-start-5 col-span-8" />
-                          </FormItem>
-                        )}
-                      />
-                    )
-                  })}
-              </div>
-            </div>
-          </div>
-        </form>
-      </Form>
-    </SidePanel>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
   )
 }

--- a/apps/studio/components/interfaces/Database/Roles/CreateRolePanel.tsx
+++ b/apps/studio/components/interfaces/Database/Roles/CreateRolePanel.tsx
@@ -49,6 +49,15 @@ const initialValues = {
   canBypassRls: false,
 }
 
+const ROLE_PERMISSION_ENTRIES = [
+  ['canLogin', ROLE_PERMISSIONS.canLogin],
+  ['canCreateRole', ROLE_PERMISSIONS.canCreateRole],
+  ['canCreateDb', ROLE_PERMISSIONS.canCreateDb],
+  ['canBypassRls', ROLE_PERMISSIONS.canBypassRls],
+  ['isSuperuser', ROLE_PERMISSIONS.isSuperuser],
+  ['isReplicationRole', ROLE_PERMISSIONS.isReplicationRole],
+] as const
+
 export const CreateRolePanel = ({ visible, onClose }: CreateRolePanelProps) => {
   const formId = 'create-new-role'
 
@@ -83,8 +92,8 @@ export const CreateRolePanel = ({ visible, onClose }: CreateRolePanelProps) => {
   return (
     <Sheet
       open={visible}
-      onOpenChange={(open) => {
-        if (!open) handleClose()
+      onOpenChange={(isOpen) => {
+        if (!isOpen) handleClose()
       }}
     >
       <SheetContent size="lg" className="flex flex-col gap-0">
@@ -109,10 +118,38 @@ export const CreateRolePanel = ({ visible, onClose }: CreateRolePanelProps) => {
 
               <FormLayout layout="horizontal" label="Role privileges">
                 <div className="grid gap-4">
-                  {(Object.keys(ROLE_PERMISSIONS) as (keyof typeof ROLE_PERMISSIONS)[])
-                    .filter((permissionKey) => ROLE_PERMISSIONS[permissionKey].grant_by_dashboard)
-                    .map((permissionKey) => {
-                      const permission = ROLE_PERMISSIONS[permissionKey]
+                  {ROLE_PERMISSION_ENTRIES.filter(
+                    ([, permission]) => permission.grant_by_dashboard
+                  ).map(([permissionKey, permission]) => {
+                    const id = `role-${permissionKey}`
+
+                    return (
+                      <FormField
+                        key={permissionKey}
+                        control={form.control}
+                        name={permissionKey}
+                        render={({ field }) => (
+                          <FormItemLayout id={id} layout="flex" label={permission.description}>
+                            <FormControl>
+                              <Switch
+                                id={id}
+                                checked={field.value}
+                                onCheckedChange={field.onChange}
+                              />
+                            </FormControl>
+                          </FormItemLayout>
+                        )}
+                      />
+                    )
+                  })}
+
+                  <Separator />
+
+                  <div className="grid gap-4">
+                    <p className="text-sm">These privileges cannot be granted via the Dashboard:</p>
+                    {ROLE_PERMISSION_ENTRIES.filter(
+                      ([, permission]) => !permission.grant_by_dashboard
+                    ).map(([permissionKey, permission]) => {
                       const id = `role-${permissionKey}`
 
                       return (
@@ -121,12 +158,19 @@ export const CreateRolePanel = ({ visible, onClose }: CreateRolePanelProps) => {
                           control={form.control}
                           name={permissionKey}
                           render={({ field }) => (
-                            <FormItemLayout id={id} layout="flex" label={permission.description}>
+                            <FormItemLayout
+                              id={id}
+                              layout="flex"
+                              label={permission.description}
+                              className="opacity-70"
+                            >
                               <FormControl>
                                 <Switch
                                   id={id}
                                   checked={field.value}
                                   onCheckedChange={field.onChange}
+                                  disabled
+                                  aria-readonly
                                 />
                               </FormControl>
                             </FormItemLayout>
@@ -134,45 +178,6 @@ export const CreateRolePanel = ({ visible, onClose }: CreateRolePanelProps) => {
                         />
                       )
                     })}
-
-                  <Separator />
-
-                  <div className="grid gap-4">
-                    <p className="text-sm">These privileges cannot be granted via the Dashboard:</p>
-                    {(Object.keys(ROLE_PERMISSIONS) as (keyof typeof ROLE_PERMISSIONS)[])
-                      .filter(
-                        (permissionKey) => !ROLE_PERMISSIONS[permissionKey].grant_by_dashboard
-                      )
-                      .map((permissionKey) => {
-                        const permission = ROLE_PERMISSIONS[permissionKey]
-                        const id = `role-${permissionKey}`
-
-                        return (
-                          <FormField
-                            key={permissionKey}
-                            control={form.control}
-                            name={permissionKey}
-                            render={({ field }) => (
-                              <FormItemLayout
-                                id={id}
-                                layout="flex"
-                                label={permission.description}
-                                className="opacity-70"
-                              >
-                                <FormControl>
-                                  <Switch
-                                    id={id}
-                                    checked={field.value}
-                                    onCheckedChange={field.onChange}
-                                    disabled
-                                    aria-readonly
-                                  />
-                                </FormControl>
-                              </FormItemLayout>
-                            )}
-                          />
-                        )
-                      })}
                   </div>
                 </div>
               </FormLayout>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Chore / design-system migration.

## What is the current behavior?

The policy details form uses the legacy top-aligned form layout, and the create-role flow still uses the legacy `SidePanel` components.

Closes #49639.

## What is the new behavior?

- Migrates policy fields to `SheetSection` and horizontal `FormItemLayout` rows.
- Migrates the create-role panel to `Sheet`, `SheetHeader`, `SheetSection`, and `SheetFooter`.
- Uses design-system form layouts for role privileges and explicitly associates each switch with its label.
- Preserves the existing submission, reset, permission, and disabled-state behavior.

## Additional context

Focused validation completed:

- Supabase Prettier 3.8.0 with the repository import-sorting plugins
- TSX compilation of both changed components with esbuild 0.27.4

The full Studio dependency graph was not installed in the sparse local checkout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated database policy editing with a cleaner, more consistent horizontal form layout.
  - Improved field labeling and accessibility with explicit input identifiers.
  - Refreshed role creation with a streamlined sheet layout and clearer privilege sections.
  - Improved separation of dashboard-grantable and read-only role privileges.
  - Preserved existing policy selection, role assignment, form validation, submission, reset, and loading behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->