### PR TITLE
chore(docs): remove the codemod:frontmatter script whose file is gone

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -22,7 +22,6 @@
     "codegen:references:new": "pnpm run codegen:references:new:ensure && tsx scripts/build-reference-content.ts",
     "codegen:references:legacy": "tsx features/docs/Reference.generated.script.ts",
     "codegen:references": "pnpm codegen:references:legacy && pnpm codegen:references:new",
-    "codemod:frontmatter": "node ./scripts/codemod/mdx-meta.mjs && prettier --cache --write \"content/**/*.mdx\"",
     "dev": "run-p --race dev:next dev:watch:troubleshooting",
     "dev:next": "next dev --port 3001",
     "dev:secrets:pull": "AWS_PROFILE=supa-dev node ../../scripts/getSecrets.js -n local/docs",


### PR DESCRIPTION
## What

Removes the `codemod:frontmatter` script from `apps/docs/package.json`. The file it runs is not in the repo.

## Why

`apps/docs/scripts/codemod/mdx-meta.mjs` was deleted in #39595 (`1c5deab2fa`, 2025-10-17), which is titled "docs: Remove unused scripts". That commit removed the file but did not touch any `package.json`, so the script entry pointing at it stayed behind. Running it today just errors:

```
$ pnpm --filter docs codemod:frontmatter
Error: Cannot find module '.../apps/docs/scripts/codemod/mdx-meta.mjs'
```

The `&&` means `prettier --write "content/**/*.mdx"` never runs either, so the entry does nothing except fail. I ran it against current master to confirm that rather than assuming, and checked afterwards that it left the working tree untouched.

## Scope

#39595 deleted two files. The other one, `apps/docs/scripts/orphans/detect-orphan-mdx.ts`, had no `package.json` entry, so there is nothing dangling for it and this is the only leftover from that commit. I also checked every other script in `apps/docs/package.json` that points at a file path, and all eight of them resolve:

```
build:guides-markdown      -> ./internals/generate-guides-markdown.ts       OK
build:federated-content    -> ./scripts/federated-content/fetch-...ts       OK
build:reference-markdown   -> ./internals/generate-reference-markdown.ts    OK
build:gz-archive           -> ./internals/generate-gz-archive.ts            OK
build:sitemap              -> ./internals/generate-sitemap.ts               OK
codegen:graphql            -> ./scripts/graphqlSchema.ts                    OK
dev:watch:troubleshooting  -> ./scripts/troubleshooting/watch.mjs           OK
sync                       -> ./resources/rootSync.ts                       OK
codemod:frontmatter        -> ./scripts/codemod/mdx-meta.mjs                MISSING
```

Nothing else in the repo references `codemod:frontmatter` or `mdx-meta`, including `turbo.json` and the workflows, so removing the entry cannot break a caller.

If you would rather keep the codemod and restore the script instead, say so and I will close this. Deleting looked like the right call given #39595 was deliberately removing unused scripts, and this is the same operation finished.

## Verification

`prettier --check` clean on the changed file, and the JSON still parses with 46 scripts remaining.

No test. There is no behavior here to assert, and a test pinning a `package.json` string would just restate the diff.

Freshman contributor, and I use Claude Code as an assistant. I found this by scanning every `package.json` script in the monorepo for file targets that no longer exist.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the obsolete documentation frontmatter codemod command from the available project scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->