### PR TITLE
fix(studio): clear the Explorer editor handle when its panel hides

### DIFF
--- a/apps/studio/components/interfaces/Explorer/QueryEditor/index.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryEditor/index.tsx
@@ -367,6 +367,17 @@ export const QueryEditor = forwardRef<QueryEditorHandle, QueryEditorProps>(funct
     prettify: handlePrettify,
   }))
 
+  // The editor only exists while `showQuery` is true. Hiding it unmounts the editor and
+  // Monaco disposes it, but a disposed editor still answers `getValue()` with `''`, so
+  // anything still holding this handle reads an empty query instead of the real one. Drop
+  // the handle and the selection flag it feeds; `onMount` re-establishes both from the new
+  // instance if the editor comes back.
+  useEffect(() => {
+    if (showQuery) return
+    editorInstanceRef.current = null
+    setHasSelection(false)
+  }, [showQuery])
+
   useEffect(() => {
     if (!promptState?.isOpen) return
     const node = editorInstanceRef.current?.getDomNode()

--- a/apps/studio/components/interfaces/Explorer/__tests__/ExplorerNotebookTab.test.tsx
+++ b/apps/studio/components/interfaces/Explorer/__tests__/ExplorerNotebookTab.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { LOCAL_STORAGE_KEYS, safeLocalStorage } from 'common'
 import { HttpResponse } from 'msw'
+import { useEffect, useRef } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ExplorerNotebookTab } from '../ExplorerNotebookTab'
@@ -35,16 +36,50 @@ vi.mock('@/components/ui/CodeEditor/CodeEditor', () => ({
   CodeEditor: ({
     value,
     onInputChange,
+    onMount,
   }: {
     value: string
     onInputChange?: (value: string | undefined) => void
-  }) => (
-    <textarea
-      aria-label="SQL editor"
-      value={value}
-      onChange={(e) => onInputChange?.(e.target.value)}
-    />
-  ),
+    onMount?: (editor: any, monaco: any) => void
+  }) => {
+    const valueRef = useRef(value)
+    valueRef.current = value
+
+    useEffect(() => {
+      // Monaco keeps answering after disposal: `getValue()` returns `''` and
+      // `getSelection()`/`getModel()`/`getAction()` return null (codeEditorWidget.js
+      // guards on `_modelData`). The fake mirrors that so a handle held past unmount
+      // behaves here like it does in the browser.
+      let isDisposed = false
+
+      onMount?.(
+        {
+          getValue: () => (isDisposed ? '' : valueRef.current),
+          getSelection: () => null,
+          getModel: () => (isDisposed ? null : { getValueInRange: () => undefined }),
+          getAction: () => (isDisposed ? null : { run: () => Promise.resolve() }),
+          onDidBlurEditorWidget: () => () => {},
+          onDidChangeCursorSelection: () => ({ dispose: () => {} }),
+          addAction: () => {},
+          focus: () => {},
+        },
+        { KeyMod: { CtrlCmd: 1, Shift: 2, Alt: 4 }, KeyCode: { KeyK: 3, Enter: 4, KeyF: 5 } }
+      )
+
+      return () => {
+        isDisposed = true
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
+
+    return (
+      <textarea
+        aria-label="SQL editor"
+        value={value}
+        onChange={(e) => onInputChange?.(e.target.value)}
+      />
+    )
+  },
 }))
 
 vi.mock('../QueryEditor/QuerySourceMenu', () => ({
@@ -387,5 +422,33 @@ describe('ExplorerNotebookTab', () => {
     // The in-flight save only persisted the older content, so the notebook must still be
     // considered unsaved rather than clobbered back to 'saved' by the stale response.
     expect(notebooksState.notebooks[NOTEBOOK_ID]?.status).toBe('unsaved')
+  })
+
+  it("keeps a collapsed cell's SQL when Prettify runs against it", async () => {
+    seedNotebook([databaseCell])
+
+    renderNotebookTab()
+
+    // A saved notebook renders its cells collapsed, so expand first: the editor has to
+    // mount before it can be disposed, which is what leaves a stale handle behind.
+    const showQuery = document.querySelector('.lucide-eye')?.closest('button')
+    expect(showQuery).toBeInstanceOf(HTMLButtonElement)
+    await userEvent.click(showQuery as HTMLButtonElement)
+    await screen.findByLabelText('SQL editor')
+
+    // Collapsing unmounts the CodeEditor, so the handle QueryEditor holds points at a
+    // disposed Monaco instance. Prettify sits in the cell toolbar, which stays rendered,
+    // and it commits whatever the editor reports back to the cell.
+    const hideQuery = document.querySelector('.lucide-eye-off')?.closest('button')
+    expect(hideQuery).toBeInstanceOf(HTMLButtonElement)
+    await userEvent.click(hideQuery as HTMLButtonElement)
+
+    const prettify = document.querySelector('.lucide-align-left')?.closest('button')
+    expect(prettify).toBeInstanceOf(HTMLButtonElement)
+    await userEvent.click(prettify as HTMLButtonElement)
+
+    expect(notebooksState.notebooks[NOTEBOOK_ID]?.notebook.content?.cells[0]).toMatchObject({
+      unchecked_sql: 'select 1',
+    })
   })
 })

--- a/apps/studio/components/interfaces/Explorer/__tests__/QueryTab.test.tsx
+++ b/apps/studio/components/interfaces/Explorer/__tests__/QueryTab.test.tsx
@@ -53,11 +53,16 @@ vi.mock('@/components/ui/CodeEditor/CodeEditor', () => ({
         ? { startLineNumber: 1, endLineNumber: 2, startColumn: 1, endColumn: 5 }
         : null
 
+      // Monaco keeps answering after the editor is disposed: `getValue()` returns `''` and
+      // `getSelection()`/`getModel()` return null (codeEditorWidget.js guards on `_modelData`).
+      // The fake mirrors that so a stale handle behaves here like it does in the browser.
+      let isDisposed = false
+
       onMount?.(
         {
-          getValue: () => valueRef.current,
-          getSelection: () => selection,
-          getModel: () => ({ getValueInRange: () => testContext.selectedText }),
+          getValue: () => (isDisposed ? '' : valueRef.current),
+          getSelection: () => (isDisposed ? null : selection),
+          getModel: () => (isDisposed ? null : { getValueInRange: () => testContext.selectedText }),
           onDidBlurEditorWidget: () => () => {},
           // Intentionally never invoked here — the real editor only fires this on a
           // subsequent user-driven selection change, not eagerly on mount. Tests that
@@ -67,6 +72,10 @@ vi.mock('@/components/ui/CodeEditor/CodeEditor', () => ({
         },
         { KeyMod: { CtrlCmd: 1, Shift: 2 }, KeyCode: { KeyK: 3, Enter: 4 } }
       )
+
+      return () => {
+        isDisposed = true
+      }
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
@@ -457,6 +466,41 @@ describe('QueryTab execution', () => {
     await waitFor(() => expect(executedQueries).toHaveLength(1))
     expect(executedQueries[0]).toContain('select 2')
     expect(executedQueries[0]).not.toContain('select 1')
+  })
+
+  it('still runs the query after the query panel is hidden', async () => {
+    createDraft({ _tag: 'database' }, 'select 1;\nselect 2;')
+
+    const executedQueries: string[] = []
+    addAPIMock({
+      method: 'post',
+      path: '/platform/pg-meta/:ref/query',
+      response: async ({ request }) => {
+        const key = new URL(request.url).searchParams.get('key')
+        if (key !== '') return HttpResponse.json([])
+        const { query } = (await request.json()) as { query: string }
+        executedQueries.push(query)
+        return HttpResponse.json([])
+      },
+    })
+
+    renderQueryTab()
+    await screen.findByRole('button', { name: 'Run' })
+
+    // Hiding unmounts CodeEditor, so the handle the run button reads points at a disposed
+    // editor. The SQL itself is still in state and the run button stays enabled, so the
+    // query has to keep running off that rather than off the dead editor.
+    const hideQueryButton = document.querySelector('.lucide-eye-off')?.closest('button')
+    expect(hideQueryButton).toBeInstanceOf(HTMLButtonElement)
+    await userEvent.click(hideQueryButton as HTMLButtonElement)
+
+    const runButton = await screen.findByRole('button', { name: 'Run' })
+    await waitFor(() => expect(runButton).toBeEnabled())
+    await userEvent.click(runButton)
+
+    await waitFor(() => expect(executedQueries).toHaveLength(1))
+    expect(executedQueries[0]).toContain('select 1')
+    expect(executedQueries[0]).toContain('select 2')
   })
 
   it('drops the stale "Run selected" state once the query panel is hidden and shown again', async () => {


### PR DESCRIPTION
## What kind of change

Bug fix.

## Current behavior

In the Explorer, hide the query panel with the eye button and then press Run. Nothing happens. No query executes, no error appears, and the button stays enabled and looks like it worked.

Repro:

1. Open a query tab with any SQL in it.
2. Click the eye icon to hide the query panel.
3. Click Run.

The result pane never updates and no request is sent.

## Why

#49651 changed the run button from `handleRunQuery()` to reading the editor first:

```tsx
const editorInstance = editorInstanceRef.current
const rawSql = editorInstance ? getEditorValueOrSelection(editorInstance) : sql
```

That is correct while the editor is on screen, but the editor is rendered inside `{showQuery && (...)}` while the run button sits in the toolbar above it and is always rendered. `editorInstanceRef.current` is assigned in `onMount` and never cleared, so once the panel is hidden the ref points at an editor React has unmounted and Monaco has disposed.

A disposed Monaco editor does not throw. It answers from a null `_modelData`:

```js
// monaco-editor/esm/vs/editor/browser/widget/codeEditor/codeEditorWidget.js
getValue(options = null) { if (!this._modelData) { return ''; } ... }
getSelection()           { if (!this._modelData) { return null; } ... }
```

So `getEditorValueOrSelection` returns `''`, and `handleRunQuery` drops it on its own guard:

```tsx
if (!project || isBusy || pendingProposal || isRunDisabled || rawSql.trim().length === 0) return
```

The button's own `disabled` check reads `sql.trim().length === 0` from state, which is not empty, so the button stays enabled. That is what makes it silent rather than obviously broken.

The same stale handle also left `hasSelection` frozen at whatever the editor last reported, so the button could keep reading "Run selected" after the panel was hidden.

## New behavior

Clear the handle and the selection flag when the panel is hidden, so the run button falls back to `sql` from state, which is the source of truth and stays in sync via `onInputChange`. `onMount` already re-establishes both from the new instance when the editor comes back, and it does so deliberately, so the reopen path is unchanged.

I fixed it here rather than adding a `|| sql` fallback at the call site because the stale handle is the actual defect, and other readers (`focus()`, the AI prompt widget, and the `prettify` handler in #49675) share it. Those are all optional-chained or guarded on truthiness, so a null is the value they already expect and a disposed instance is not.

## Test

Added to `QueryTab.test.tsx`, next to the selection cases from #49651. It fails on master:

```
× still runs the query after the query panel is hidden
AssertionError: expected [] to have a length of 1 but got +0
```

which is the bug exactly: zero queries executed. I verified that by checking out the unmodified `QueryEditor/index.tsx` from master with the new test in place, not by reasoning about it.

That required one change to the existing mocked `CodeEditor`: its fake editor kept answering `getValue()` with the last value forever, so a stale handle looked healthy in tests in a way it never is in the browser. The fake now flips to Monaco's disposed answers (`''` and `null`) on unmount, matching the guards quoted above. All 12 pre-existing tests in that file still pass against unmodified master with the new fake, so it is not loosened.

## Verification

- `QueryTab.test.tsx` 13/13.
- Explorer, CodeEditor and AIAssistantPanel suites together: 30 files, 255 tests, all passing.
- `pnpm --filter studio typecheck` clean, `prettier --check` clean, `lint:ratchet` reports no new warnings.

The diff touches no JSX, so it should not conflict with #49675, which edits the run button's tooltip a few lines away.

Freshman contributor, and I use Claude Code as an assistant. I found this while reading through what #49651 changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added query formatting through the editor toolbar and the Alt+Shift+F shortcut.
  * Added the Meta+Enter shortcut to the run-action tooltip.
* **Bug Fixes**
  * Fixed an issue where hiding and reopening the query editor could cause retained SQL queries to appear empty.
  * Query execution now continues to use saved query text after the editor panel is hidden.
  * Fixed formatting for collapsed query cells so SQL is preserved after the editor is reopened.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->