### PR TITLE
chore(generator): drop the tsdoc v2 dereference scripts whose inputs were deleted

### DIFF
--- a/apps/docs/spec/Makefile
+++ b/apps/docs/spec/Makefile
@@ -1,5 +1,4 @@
 REPO_DIR=$(shell pwd)
-GENERATOR_DIR=../../../packages/generator
 
 .PHONY: run download download.api.v1 download.storage.v1 download.tsdoc.v2 download.server.v1 transform dereference.api.v1 dereference.auth.v1 dereference.storage.v0 generate generate.sections.api.v1 format
 

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -12,13 +12,7 @@
     "tsdoc:dereference:postgrest:v1": "tsx ./tsdoc.ts --input ../../apps/docs/spec/enrichments/tsdoc_v1/postgrest.json --output ../../apps/docs/spec/enrichments/tsdoc_v1/postgrest_dereferenced.json",
     "tsdoc:dereference:realtime:v1": "tsx ./tsdoc.ts --input ../../apps/docs/spec/enrichments/tsdoc_v1/realtime.json --output ../../apps/docs/spec/enrichments/tsdoc_v1/realtime_dereferenced.json",
     "tsdoc:dereference:storage:v1": "tsx ./tsdoc.ts --input ../../apps/docs/spec/enrichments/tsdoc_v1/storage.json --output ../../apps/docs/spec/enrichments/tsdoc_v1/storage_dereferenced.json",
-    "tsdoc:dereference:supabase:v1": "tsx ./tsdoc.ts --input ../../apps/docs/spec/enrichments/tsdoc_v1/supabase.json --output ../../apps/docs/spec/enrichments/tsdoc_v1/supabase_dereferenced.json",
-    "tsdoc:dereference:functions:v2": "tsx ./tsdoc.ts --input ../../apps/docs/spec/enrichments/tsdoc_v2/functions.json --output ../../apps/docs/spec/enrichments/tsdoc_v2/functions_dereferenced.json",
-    "tsdoc:dereference:gotrue:v2": "tsx ./tsdoc.ts --input ../../apps/docs/spec/enrichments/tsdoc_v2/gotrue.json --output ../../apps/docs/spec/enrichments/tsdoc_v2/gotrue_dereferenced.json",
-    "tsdoc:dereference:postgrest:v2": "tsx ./tsdoc.ts --input ../../apps/docs/spec/enrichments/tsdoc_v2/postgrest.json --output ../../apps/docs/spec/enrichments/tsdoc_v2/postgrest_dereferenced.json",
-    "tsdoc:dereference:realtime:v2": "tsx ./tsdoc.ts --input ../../apps/docs/spec/enrichments/tsdoc_v2/realtime.json --output ../../apps/docs/spec/enrichments/tsdoc_v2/realtime_dereferenced.json",
-    "tsdoc:dereference:storage:v2": "tsx ./tsdoc.ts --input ../../apps/docs/spec/enrichments/tsdoc_v2/storage.json --output ../../apps/docs/spec/enrichments/tsdoc_v2/storage_dereferenced.json",
-    "tsdoc:dereference:supabase:v2": "tsx ./tsdoc.ts --input ../../apps/docs/spec/enrichments/tsdoc_v2/supabase.json --output ../../apps/docs/spec/enrichments/tsdoc_v2/supabase_dereferenced.json"
+    "tsdoc:dereference:supabase:v1": "tsx ./tsdoc.ts --input ../../apps/docs/spec/enrichments/tsdoc_v1/supabase.json --output ../../apps/docs/spec/enrichments/tsdoc_v1/supabase_dereferenced.json"
   },
   "devDependencies": {
     "@types/json-stringify-safe": "^5.0.0",


### PR DESCRIPTION
## What

Removes the six `tsdoc:dereference:*:v2` scripts from `packages/generator`, whose input directory no longer exists, and the `GENERATOR_DIR` variable in `apps/docs/spec/Makefile`, which nothing reads.

## Why

Both are leftovers of #46163 (`f20cd22dc3`, 2026-06-03, "docs: improve SDK automation build step on docs").

That PR deleted `apps/docs/spec/enrichments/tsdoc_v2/` entirely, and said in the Makefile why the step is gone:

```make
# `download.tsdoc.v2` now writes raw TypeDoc JSON directly under
# `reference/javascript/v2/` ... the new pipeline walks those files
# at build time, so no separate `dereference` / `combine` step is needed.
```

It did not touch `packages/generator/package.json`, so all six v2 dereference scripts still point into the deleted directory:

```
tsdoc:dereference:functions:v2 -> ../../apps/docs/spec/enrichments/tsdoc_v2/functions.json
```

`apps/docs/spec/enrichments/` now contains only `tsdoc_v1`, so each of those six is a `tsx ./tsdoc.ts --input <missing file>`. Nothing in the repo invokes `tsdoc:dereference` either, in a script, workflow or Makefile target.

`GENERATOR_DIR` went unused in the same commit. It appears exactly once in the Makefile, on the line that defines it.

## What I deliberately left alone

**The six `:v1` scripts stay.** Unlike v2, `tsdoc_v1/` is still in the repo with all six inputs present, and `apps/docs/spec/supabase_js_v1.yml` still points its `definition` at `tsdoc_v1/combined.json`. The `download.tsdoc.v1` Makefile target is commented out as "No longer updated", so that data is frozen rather than dead, and removing the scripts that regenerate it is a separate decision I did not want to make for you.

I also left the `definition:` fields in five spec files (`supabase_js_v2`, `supabase_py_v2`, `supabase_dart_v1`, `supabase_csharp_v0`, `supabase_csharp_v1`) pointing at the deleted `tsdoc_v2/combined.json`. They are only read by `apps/docs/generator/legacy.ts`, via `fs.readFileSync` with no existence check, so running that generator by hand against any of those five would throw ENOENT. I could not find anything that invokes `apps/docs/generator/index.ts`, so I could not tell whether the generator is still meant to be used or is itself retired, and guessing seemed worse than flagging it. Happy to follow up either way once you tell me which it is.

## Verification

- `packages/generator/package.json` still parses, 8 scripts left, and `prettier --check` is clean.
- `make -n format` in `apps/docs/spec` still parses the Makefile.
- All six `tsdoc_v1` inputs confirmed present, so the scripts I kept still resolve.

No test. These are build script entries with no behavior to assert.

Freshman contributor, and I use Claude Code as an assistant. I found this by scanning every `package.json` script in the monorepo for file targets that no longer exist. That scan also turned up one in `apps/docs` that I sent separately as #49723, since it traces back to a different commit and I did not want to bundle two unrelated cleanups.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified documentation tooling configuration.
  * Removed obsolete v2 documentation generation commands.
  * Retained existing v1 documentation generation commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->