### PR TITLE
fix(pg-meta): use $pgmeta$ dollar-quote tag in DO blocks to avoid $$ collision

### DIFF
--- a/packages/pg-meta/src/pg-meta-columns.ts
+++ b/packages/pg-meta/src/pg-meta-columns.ts
@@ -300,7 +300,7 @@ function update(
   let isUniqueSql: SafeSqlFragment = safeSql``
   if (old.is_unique === true && is_unique === false) {
     isUniqueSql = safeSql`
-DO $$
+DO $pgmeta$
 DECLARE
   r record;
 BEGIN
@@ -314,7 +314,7 @@ BEGIN
     EXECUTE ${literal(`ALTER TABLE ${ident(old.schema)}.${ident(old.table)} DROP CONSTRAINT `)} || quote_ident(r.conname);
   END LOOP;
 END
-$$;`
+$pgmeta$;`
   } else if (old.is_unique === false && is_unique === true) {
     isUniqueSql = safeSql`ALTER TABLE ${ident(old.schema)}.${ident(old.table)} ADD UNIQUE (${ident(old.name)});`
   }
@@ -337,7 +337,7 @@ $$;`
   ASSERT v_conkey[1] = ${literal(old.ordinal_position)}, 'error creating column constraint: check condition cannot refer to other columns';`
         : safeSql``
     checkSql = safeSql`
-DO $$
+DO $pgmeta$
 DECLARE
   v_conname name;
   v_conkey int2[];
@@ -355,7 +355,7 @@ BEGIN
   END IF;
   ${addCheckSql}
 END
-$$;`
+$pgmeta$;`
   }
 
   // TODO: Can't set default if column is previously identity even if

--- a/packages/pg-meta/src/pg-meta-tables.ts
+++ b/packages/pg-meta/src/pg-meta-tables.ts
@@ -266,7 +266,7 @@ function update(
     // skip
   } else {
     primaryKeysSql = safeSql`${primaryKeysSql}
-DO $$
+DO $pgmeta$
 DECLARE
   r record;
 BEGIN
@@ -278,7 +278,7 @@ BEGIN
     EXECUTE ${literal(`${alter} DROP CONSTRAINT `)} || quote_ident(r.conname);
   END IF;
 END
-$$;
+$pgmeta$;
 `
 
     if (primary_keys.length === 0) {


### PR DESCRIPTION
## Problem

PostgreSQL's dollar-quote lexer scans the raw text of a `DO` block body to find the closing `$$` — it does **not** skip occurrences that appear inside nested string literals (`'...'`) or double-quoted identifiers (`"..."`).

Any table or schema name containing the two-character sequence `$$` will prematurely close the outer `DO $$ ... $$` block, producing a syntax error:

```sql
-- schema: public, table: "weird$$name"
DO $$
DECLARE r record;
BEGIN
  SELECT conname INTO r FROM pg_constraint
    WHERE contype = 'p' AND conrelid = 1;
  IF r IS NOT NULL THEN
    EXECUTE 'ALTER TABLE public."weird$$name" DROP CONSTRAINT ' || quote_ident(r.conname);
    --                             ^^ closes the DO block here ^^
  END IF;
END
$$;
-- ERROR: syntax error at or near "name"
```

Three DO blocks still use the bare `$$` tag:

| File | Block |
|------|-------|
| `pg-meta-tables.ts` | Primary-key drop block |
| `pg-meta-columns.ts` | UNIQUE constraint drop block |
| `pg-meta-columns.ts` | CHECK constraint replace block |

This is the same class of bug as the `pg-meta-table-privileges`, `pg-meta-column-privileges`, `pg-meta-roles`, `pg-meta-foreign-tables`, and `pg-meta-publications` paths.

## Fix

Replace `$$` with `$pgmeta$` in all three DO blocks. The `$pgmeta$` tag cannot appear in ordinary user-supplied identifiers or data values.

Closes #49688

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when updating database constraints by preventing conflicts in generated SQL quoting.
  * Applies consistently to primary-key, unique, and check-constraint operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->