### PR TITLE
fix(studio): allow newlines in SMS OTP template for WebOTP API

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/AuthProvidersForm.types.ts
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/AuthProvidersForm.types.ts
@@ -14,7 +14,7 @@ export interface Provider {
   properties: {
     [x: string]: {
       title: string
-      type: 'boolean' | 'string' | 'select' | 'number'
+      type: 'boolean' | 'string' | 'multiline-string' | 'select' | 'number' | 'datetime'
       enum: Enum[]
       show: {
         key: string

--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
@@ -102,11 +102,17 @@ export const ProviderForm = ({ config, provider, isActive }: ProviderFormProps) 
             values[key] = !(config as any)[key]
           } else {
             const configValue = (config as any)[key]
-            values[key] = configValue
+            let value: string | boolean = configValue
               ? configValue
               : provider.properties[key].type === 'boolean'
                 ? false
                 : ''
+            // Convert literal \n escape sequences to actual newlines so the textarea
+            // displays them correctly (supports WebOTP API formatting requirements).
+            if (key === 'SMS_TEMPLATE' && typeof value === 'string') {
+              value = value.replace(/\\n/g, '\n')
+            }
+            values[key] = value
           }
         }
       })

--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
@@ -102,11 +102,14 @@ export const ProviderForm = ({ config, provider, isActive }: ProviderFormProps) 
             values[key] = !(config as any)[key]
           } else {
             const configValue = (config as any)[key]
-            let value: string | boolean = configValue
-              ? configValue
-              : provider.properties[key].type === 'boolean'
-                ? false
-                : ''
+            let value: string | boolean
+            if (configValue) {
+              value = configValue
+            } else if (provider.properties[key].type === 'boolean') {
+              value = false
+            } else {
+              value = ''
+            }
             // Convert literal \n escape sequences to actual newlines so the textarea
             // displays them correctly (supports WebOTP API formatting requirements).
             if (key === 'SMS_TEMPLATE' && typeof value === 'string') {


### PR DESCRIPTION
Fixes #6435

**Problem:** SMS OTP template did not preserve newlines, breaking WebOTP API which requires at least one newline per https://web.dev/web-otp/#format.

**Fix:**
- \AuthProvidersForm.types.ts\: add \multiline-string\ and \datetime\ to Provider type union (already used in validation)
- \ProviderForm.tsx\: convert literal \\\\\n\ escapes to actual newlines when loading \SMS_TEMPLATE\ so textarea displays real line breaks

Studio already renders \SMS_TEMPLATE\ as \multiline-string\ textarea; this ensures stored literal \\n from old single-line configs displays correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authentication provider settings now support multiline text and date/time fields.
  * Multiline values can be entered and managed more easily in provider configuration forms.

* **Bug Fixes**
  * Existing default values for authentication provider fields continue to be preserved when editing settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->