### PR TITLE
docs(auth): make hashedNonce reachable in the Google nonce example

### DIFF
--- a/apps/docs/content/guides/auth/social-login/auth-google.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-google.mdx
@@ -352,10 +352,9 @@ Most web apps and websites can use Google's [personalized sign-in buttons](https
    const nonce = btoa(String.fromCharCode(...crypto.getRandomValues(new Uint8Array(32))))
    const encoder = new TextEncoder()
    const encodedNonce = encoder.encode(nonce)
-   crypto.subtle.digest('SHA-256', encodedNonce).then((hashBuffer) => {
-     const hashArray = Array.from(new Uint8Array(hashBuffer))
-     const hashedNonce = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')
-   })
+   const hashBuffer = await crypto.subtle.digest('SHA-256', encodedNonce)
+   const hashArray = Array.from(new Uint8Array(hashBuffer))
+   const hashedNonce = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')
 
    // Use 'hashedNonce' when making the authentication request to Google
    // Use 'nonce' when invoking the supabase.auth.signInWithIdToken() method


### PR DESCRIPTION
## What kind of change

Docs fix.

Fixes #49406.

## Current behavior

In the "Google pre-built" nonce step, the snippet declares `hashedNonce` with `const` inside the `.then()` callback:

```js
crypto.subtle.digest('SHA-256', encodedNonce).then((hashBuffer) => {
  const hashArray = Array.from(new Uint8Array(hashBuffer))
  const hashedNonce = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')
})

// Use 'hashedNonce' when making the authentication request to Google
```

So `hashedNonce` is scoped to the callback and is not reachable where the comment immediately below tells the reader to use it. Anyone copying this gets `ReferenceError: hashedNonce is not defined`. The value is also computed asynchronously, so even hoisting the declaration would leave it undefined at the point of use.

## New behavior

Awaits the digest and computes `hashedNonce` in the surrounding scope, so the two comments underneath are actually true.

This is not a new shape. The same page already does exactly this a little further down, inside `generateNonce` for the Next.js One Tap example, and after this change the six lines are identical to that block. Matching the page's own working example seemed better than inventing a third spelling.

## Why this was still open

Two earlier PRs are linked to the issue and both are closed, so I checked whether the fix had been turned down before starting. Neither was: #49407 was closed by its author @HariomPtdr ("Closing this to focus my contributions elsewhere ... The underlying issue (#49406) is still valid"), and #49508 was closed by its author @loulanyue. No maintainer rejected the change on the merits, and the issue is still open and still reproduces on master, so I picked it up and said so in the issue thread first.

## Verification

- Reproduced on current master before changing anything.
- `prettier --check` clean on the file.
- The edit is entirely inside a fenced code block, so the prose linting is untouched.

Freshman contributor, and I use Claude Code as an assistant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Google social login code example to use modern async syntax when generating the hashed nonce.
  * No change to the example’s behavior or output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->