### PR TITLE
fix(self-hosted): report why docker is unreachable instead of guessing

### DIFF
--- a/docker/utils/add-new-auth-keys.sh
+++ b/docker/utils/add-new-auth-keys.sh
@@ -38,8 +38,13 @@ else
         exit 1
     fi
 
-    if ! docker info >/dev/null 2>&1; then
-        echo "Error: docker is installed but the daemon is not running."
+    # Keep docker's own stderr: a socket permission error (non-root user not in the
+    # `docker` group) and a stopped daemon both fail here, and only docker knows which.
+    if ! docker_error=$(docker info 2>&1 >/dev/null); then
+        echo "Error: cannot connect to the Docker daemon."
+        if [ -n "$docker_error" ]; then
+            echo "$docker_error"
+        fi
         exit 1
     fi
 

--- a/docker/utils/rotate-new-api-keys.sh
+++ b/docker/utils/rotate-new-api-keys.sh
@@ -36,8 +36,13 @@ else
         exit 1
     fi
 
-    if ! docker info >/dev/null 2>&1; then
-        echo "Error: docker is installed but the daemon is not running."
+    # Keep docker's own stderr: a socket permission error (non-root user not in the
+    # `docker` group) and a stopped daemon both fail here, and only docker knows which.
+    if ! docker_error=$(docker info 2>&1 >/dev/null); then
+        echo "Error: cannot connect to the Docker daemon."
+        if [ -n "$docker_error" ]; then
+            echo "$docker_error"
+        fi
         exit 1
     fi
 


### PR DESCRIPTION
## What kind of change

Bug fix.

Part of #49739. This fixes the misleading error only, not the whole report (see "What this does not do").

## Current behavior

`docker/utils/add-new-auth-keys.sh` and `docker/utils/rotate-new-api-keys.sh` both guard their docker fallback like this:

```sh
if ! docker info >/dev/null 2>&1; then
    echo "Error: docker is installed but the daemon is not running."
    exit 1
fi
```

`2>&1` throws away everything docker said, so the script cannot know why the call failed, yet it asserts one specific cause. A regular user with sudo rights who is not in the `docker` group (the default account on most cloud-init VMs) gets a socket permission error and is told the daemon is down. As #49739 points out, `systemctl is-active docker` says `active` at that moment, so the message sends people to debug the wrong thing.

I reproduced it rather than taking it on trust, using a stub `docker` on PATH that exits non-zero and writes the real socket error to stderr:

```
$ ./guard
Error: docker is installed but the daemon is not running.

$ docker info 2>&1 >/dev/null
permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock
```

## New behavior

Keep docker's stderr and print it, instead of guessing:

```
Error: cannot connect to the Docker daemon.
permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock
```

The exit status and the control flow are unchanged. `2>&1 >/dev/null` captures stderr only, so a healthy docker still prints nothing extra.

Both scripts carry the identical guard, so both are fixed. Leaving `rotate-new-api-keys.sh` misreporting would just move the bug.

## What this does not do

The report contains two further problems and I have deliberately left both alone, because they are decisions rather than defects:

1. Whether `setup.sh` should add the invoking user to the `docker` group. That grants effective root, and it is not something I should decide in a drive-by PR.
2. Whether a failing `docker compose pull` should stop `setup.sh` rather than warn and still print "Setup complete".

Happy to send either as a follow-up once you say which way you want them.

## Verification

Both files are `#!/bin/sh` with `set -e`. I exercised the patched guard against four docker states with a stub on PATH:

```
permission denied  -> prints the real socket error, exit 1
daemon down        -> prints docker's own "Is the docker daemon running?", exit 1
fails, no stderr   -> prints just the Error line, exit 1
healthy            -> guard passes, exit 0
```

The empty-stderr case matters because these scripts run under `set -e`, so I used an explicit `if` rather than `[ -n "$x" ] && echo` to keep the `exit 1` unambiguously reached.

`sh -n` parses both files clean, and `prettier --check` is clean. I did not add a test: `docker/tests/` exercises the real end-to-end flow, and covering this path means stubbing the docker CLI, which is a larger change to that harness than the fix itself. Say the word if you would rather have it.

Freshman contributor, and I use Claude Code as an assistant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker connectivity error messages.
  * Displays the Docker daemon’s diagnostic details when connection attempts fail, making setup and key-management issues easier to troubleshoot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->