### PR TITLE
Improve link text for authentication documentation

### DIFF
--- a/apps/docs/content/guides/auth/auth-anonymous.mdx
+++ b/apps/docs/content/guides/auth/auth-anonymous.mdx
@@ -402,7 +402,7 @@ async function resolveDataConflicts(anonymousUserId, existingUserId) {
 
 ## Abuse prevention and rate limits
 
-Since anonymous users are stored in your database, bad actors can abuse the endpoint to increase your database size drastically. It is strongly recommended to [enable invisible CAPTCHA or Cloudflare Turnstile](/docs/guides/auth/auth-captcha) to prevent abuse for anonymous sign-ins. An IP-based rate limit is enforced at 30 requests per hour which can be modified in your [dashboard](/dashboard/project/_/auth/rate-limits). You can refer to the full list of rate limits [here](/docs/guides/deployment/going-into-prod#rate-limiting-resource-allocation--abuse-prevention).
+Since anonymous users are stored in your database, bad actors can abuse the endpoint to increase your database size drastically. It is strongly recommended to [enable invisible CAPTCHA or Cloudflare Turnstile](/docs/guides/auth/auth-captcha) to prevent abuse for anonymous sign-ins. An IP-based rate limit is enforced at 30 requests per hour which can be modified in your [dashboard](/dashboard/project/_/auth/rate-limits). You can refer to the full list of [rate limits](/docs/guides/deployment/going-into-prod#rate-limiting-resource-allocation--abuse-prevention).
 
 ## Automatic cleanup
 

--- a/apps/docs/content/guides/auth/auth-hooks.mdx
+++ b/apps/docs/content/guides/auth/auth-hooks.mdx
@@ -80,7 +80,7 @@ revoke execute
   from authenticated, anon, public;
 ```
 
-You will need to alter your row-level security (RLS) policies to allow the `supabase_auth_admin` role to access tables that you have RLS policies on. You can read more about RLS policies [here](/docs/guides/database/postgres/row-level-security).
+You will need to alter your row-level security (RLS) policies to allow the `supabase_auth_admin` role to access tables that you have RLS policies on. You can read more about [RLS policies](/docs/guides/database/postgres/row-level-security).
 
 Alternatively, you can create your Postgres function via the dashboard with the `security definer` tag. The `security definer` tag specifies that the function is to be executed with the privileges of the user that owns it.
 

--- a/apps/docs/content/guides/auth/auth-mfa/phone.mdx
+++ b/apps/docs/content/guides/auth/auth-mfa/phone.mdx
@@ -323,7 +323,7 @@ function AuthMFA() {
 
 Each code is valid for up to 5 minutes, after which a new one can be sent. Successive codes remain valid until expiry. When possible choose the longest code length acceptable to your use case, at a minimum of 6. This can be configured in the [Authentication Settings](/dashboard/project/_/auth/mfa).
 
-Be aware that Phone MFA is vulnerable to SIM swap attacks where an attacker will call a mobile provider and ask to port the target's phone number to a new SIM card and then use the said SIM card to intercept an MFA code. Evaluate the your application's tolerance for such an attack. You can read more about SIM swapping attacks [here](https://en.wikipedia.org/wiki/SIM_swap_scam)
+Be aware that Phone MFA is vulnerable to SIM swap attacks where an attacker will call a mobile provider and ask to port the target's phone number to a new SIM card and then use the said SIM card to intercept an MFA code. Evaluate the your application's tolerance for such an attack. You can read more about [SIM swapping attacks](https://en.wikipedia.org/wiki/SIM_swap_scam).
 
 <$Show if="billing:all">
 <$Partial path="billing/pricing/pricing_mfa_phone.mdx" />

--- a/apps/docs/content/guides/auth/redirect-urls.mdx
+++ b/apps/docs/content/guides/auth/redirect-urls.mdx
@@ -116,7 +116,7 @@ For example, change the following:
 
 For mobile applications you can use deep linking URIs. For example, for your `SITE_URL` you can specify something like `com.supabase://login-callback/` and for additional redirect URLs something like `com.supabase.staging://login-callback/` if needed.
 
-Read more about deep linking and find code examples for different frameworks [here](/docs/guides/auth/native-mobile-deep-linking).
+Read more about deep linking and find [code examples for different frameworks](/docs/guides/auth/native-mobile-deep-linking).
 
 ## Error handling
 

--- a/apps/docs/content/guides/auth/social-login/auth-google.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-google.mdx
@@ -614,7 +614,7 @@ When the user provides consent, Google issues an identity token (commonly abbrev
 
 **Note:** You have to create OAuth client IDs for both a Web and Android application. The Web client ID is the one used in your Android app.
 
-Add the following dependencies to your app. You can find the latest version of `credentials` [here](https://developer.android.com/jetpack/androidx/releases/credentials) and `googleid` [here](https://developers.google.com/identity/android-credential-manager/releases).
+Add the following dependencies to your app. You can find the latest version of [`credentials`](https://developer.android.com/jetpack/androidx/releases/credentials) and [`googleid`](https://developers.google.com/identity/android-credential-manager/releases).
 
 ```kotlin
 implementation("androidx.credentials:credentials:<latest version>")


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update (accessibility improvement).

This PR replaces non-descriptive `here` link text with descriptive link text across five Auth guide pages, following the docs contribution guidelines.

## What is the current behavior?

Several Auth guides use `here` as the visible text for links. The docs [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/apps/docs/CONTRIBUTING.md) guide explicitly advises against this:

> Use descriptive link text that tells the reader where the link goes. This is important for accessibility. For example, don't use `here` as link text.

Non-descriptive link text hurts accessibility. Screen reader users often navigate by pulling up a list of links on a page, where labels like "here" give no indication of the destination.

No related issue; this is a self-contained docs/accessibility fix.

## What is the new behavior?

The link text now describes each destination. No URLs, functionality, or surrounding meaning changed.

| File | Before | After |
| --- | --- | --- |
| `apps/docs/content/guides/auth/auth-anonymous.mdx` | `...the full list of rate limits [here](...)` | `...the full list of [rate limits](...)` |
| `apps/docs/content/guides/auth/auth-hooks.mdx` | `...read more about RLS policies [here](...)` | `...read more about [RLS policies](...)` |
| `apps/docs/content/guides/auth/auth-mfa/phone.mdx` | `...read more about SIM swapping attacks [here](...)` | `...read more about [SIM swapping attacks](...)` |
| `apps/docs/content/guides/auth/redirect-urls.mdx` | `...code examples for different frameworks [here](...)` | `...find [code examples for different frameworks](...)` |
| `apps/docs/content/guides/auth/social-login/auth-google.mdx` | `...version of `credentials` [here](...) and `googleid` [here](...)` | `...version of [`credentials`](...) and [`googleid`](...)` |

## Additional context

- Scope: 5 files, 5 changed lines (5 insertions, 5 deletions). Diff is one line per file.
- No behavior change: only visible link text was rewritten. All link targets (URLs) are unchanged.
- This is intentionally a small, focused subset (the `guides/auth/` pages) to keep the diff easy to review. Other `here` links elsewhere in the docs can be addressed in follow-up PRs if desired.
- Pre-flight checks: `git diff --check` is clean (no whitespace errors). The changes are plain-text Markdown link-label edits only; no code, SQL, JSX, frontmatter, or headings are touched, and no absolute `https://supabase.com` URLs were introduced. I was unable to run `pnpm format` / `pnpm lint:mdx` locally because the local Node version predates the version required by the repo's pinned `pnpm`; please let CI confirm formatting and mdx-lint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved link text across authentication guides to make referenced resources clearer.
  * Updated references to rate limits, RLS policies, SIM swapping attacks, and mobile deep-linking examples.
  * Clarified Android dependency links in the Google authentication guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->