### PR TITLE
chore(repo): add public-surfaces rule to agent instructions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -53,6 +53,8 @@ Never hand-edit generated files: `packages/api-types/types/**`, `**/routeTree.ge
 
 **Language** — Use U.S. English everywhere.
 
+**Public surfaces** — this repo is public: PR descriptions, issues, and code comments are world-readable. Keep internal content out of them: absolute production metrics (event counts, user counts, revenue figures: state percentages, ratios, or relative change instead), internal decision detail (vendor, legal, pricing, or strategy discussions), and competitor names (protocol identifiers such as user-agent strings are fine). Put that context in the Linear issue and link it.
+
 ## Skills
 
 The skills in `.claude/skills/` are the source of truth for conventions — load the relevant ones before working, don't guess:


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Repo maintenance: one bullet added to the committed agent instructions in `.claude/CLAUDE.md`.

## What is the new behavior?

Agent sessions working in this repo (including Slack-triggered ones) get an explicit rule that PR descriptions, issues, and code comments are world-readable, so internal content stays out of them: absolute production metrics (percentages, ratios, or relative change instead), internal decision detail (vendor, legal, pricing, or strategy discussions), and competitor names (protocol identifiers such as user-agent strings are fine). That context goes in the linked Linear issue. I added this after an agent-authored PR quoted absolute internal event volumes in its description.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance to keep public PRs, issues, and code comments free of sensitive internal details.
  * Clarified that production metrics, internal decisions, and competitor information should be documented privately instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->