### PR TITLE
chore(studio): align query results grid typography with table editor

### DIFF
--- a/apps/studio/components/interfaces/Explorer/ExplorerHomeTab.tsx
+++ b/apps/studio/components/interfaces/Explorer/ExplorerHomeTab.tsx
@@ -50,7 +50,7 @@ export const ExplorerHomeTab = () => {
               title="Run SQL"
               description="Write and run an ad-hoc query"
               bgColor="bg-blue-500"
-              onClick={createQuery}
+              onClick={() => createQuery()}
             />
           </div>
         </section>

--- a/apps/studio/components/interfaces/Explorer/__tests__/hooks.test.tsx
+++ b/apps/studio/components/interfaces/Explorer/__tests__/hooks.test.tsx
@@ -1,10 +1,11 @@
 import { act, renderHook } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { useCreateChat } from '../hooks'
+import { useCreateChat, useCreateQuery } from '../hooks'
 
 const {
   mockCreateChat,
+  mockCreateDraft,
   mockPush,
   mockSelectChat,
   mockSetContext,
@@ -12,6 +13,7 @@ const {
   mockWhenInitialized,
 } = vi.hoisted(() => ({
   mockCreateChat: vi.fn(() => 'chat-2'),
+  mockCreateDraft: vi.fn(),
   mockPush: vi.fn(),
   mockSelectChat: vi.fn(),
   mockSetContext: vi.fn(),
@@ -27,6 +29,12 @@ vi.mock('@/hooks/misc/useSelectedProject', () => ({
 }))
 vi.mock('@/hooks/misc/useSelectedOrganization', () => ({
   useSelectedOrganizationQuery: () => ({ data: { slug: 'acme' } }),
+}))
+vi.mock('@/lib/api/snippets.browser', () => ({
+  generateUuid: () => 'query-new',
+}))
+vi.mock('@/state/explorer-query', () => ({
+  useExplorerQueryStateSnapshot: () => ({ createDraft: mockCreateDraft }),
 }))
 vi.mock('@/state/ai-assistant-state', () => ({
   useAiAssistantState: () => ({
@@ -107,5 +115,38 @@ describe('useCreateChat', () => {
     })
     expect(mockSetModel).toHaveBeenCalledWith('gpt-5.4-nano')
     expect(mockPush).toHaveBeenCalledWith('/project/default/explorer/chat/chat-2')
+  })
+})
+
+describe('useCreateQuery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('creates a draft and opens it as an Explorer query tab', () => {
+    const { result } = renderHook(() => useCreateQuery())
+
+    expect(result.current.createQuery({ sql: 'select 1', name: 'Untitled query' })).toBe(
+      'query-new'
+    )
+    expect(mockCreateDraft).toHaveBeenCalledWith({
+      id: 'query-new',
+      projectRef: 'default',
+      sql: 'select 1',
+      name: 'Untitled query',
+    })
+    expect(mockPush).toHaveBeenCalledWith('/project/default/explorer/query/query-new')
+  })
+
+  it('creates an empty draft when no sql or name is provided', () => {
+    const { result } = renderHook(() => useCreateQuery())
+
+    expect(result.current.createQuery()).toBe('query-new')
+    expect(mockCreateDraft).toHaveBeenCalledWith({
+      id: 'query-new',
+      projectRef: 'default',
+      sql: undefined,
+      name: undefined,
+    })
   })
 })

--- a/apps/studio/components/interfaces/Explorer/hooks.ts
+++ b/apps/studio/components/interfaces/Explorer/hooks.ts
@@ -148,11 +148,11 @@ export const useCreateQuery = () => {
   const { data: project } = useSelectedProjectQuery()
   const querySnap = useExplorerQueryStateSnapshot()
 
-  const createQuery = () => {
+  const createQuery = ({ sql, name }: { sql?: string; name?: string } = {}) => {
     if (!project) return console.error('Project is required')
 
     const id = generateUuid()
-    querySnap.createDraft({ id, projectRef: project.ref })
+    querySnap.createDraft({ id, projectRef: project.ref, sql, name })
 
     router.push(`/project/${project.ref}/explorer/query/${id}`)
 

--- a/apps/studio/components/ui/DataGridResults/ResultCell.tsx
+++ b/apps/studio/components/ui/DataGridResults/ResultCell.tsx
@@ -1,7 +1,8 @@
 import { Expand } from 'lucide-react'
-import { Button, cn, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
+import { Button, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 
 import { formatCellValue, isLargeValue } from './DataGridResults.utils'
+import { NullValue } from '@/components/grid/components/common/NullValue'
 
 interface ResultCellProps {
   column: string
@@ -15,16 +16,13 @@ export const ResultCell = ({ column, value, onContextMenu, onExpand }: ResultCel
 
   return (
     <div
-      className={cn(
-        'group/cell relative flex items-center h-full font-mono text-xs w-full whitespace-pre',
-        value === null && 'text-foreground-lighter'
-      )}
+      className="group/cell relative flex h-full w-full items-center overflow-hidden text-ellipsis text-grid text-foreground"
       onContextMenu={(e) => {
         e.preventDefault()
         onContextMenu(e, column, value)
       }}
     >
-      {formatCellValue(value)}
+      {value === null ? <NullValue /> : formatCellValue(value)}
       {showExpand && (
         <Tooltip>
           <TooltipTrigger asChild>

--- a/apps/studio/components/ui/DataGridResults/index.tsx
+++ b/apps/studio/components/ui/DataGridResults/index.tsx
@@ -43,7 +43,11 @@ export const DataGridResults = ({ rows }: { rows: readonly ResultRow[] }) => {
   }, [])
 
   const columnRender = (name: string) => {
-    return <div className="flex h-full items-center justify-center font-mono text-xs">{name}</div>
+    return (
+      <div className="flex h-full items-center overflow-hidden text-ellipsis text-xs select-text text-foreground">
+        {name}
+      </div>
+    )
   }
 
   const columns: CalculatedColumn<ResultRow>[] = useMemo(
@@ -80,7 +84,7 @@ export const DataGridResults = ({ rows }: { rows: readonly ResultRow[] }) => {
   return (
     <>
       {rows.length === 0 ? (
-        <p className="px-4 py-3 font-mono text-sm text-foreground-light">
+        <p className="px-4 py-3 font-sans text-sm text-foreground-light">
           Success. No rows returned
         </p>
       ) : (

--- a/apps/studio/components/ui/EditorPanel/EditorPanel.tsx
+++ b/apps/studio/components/ui/EditorPanel/EditorPanel.tsx
@@ -44,7 +44,9 @@ import { DataGridResults } from '../DataGridResults'
 import { SqlWarningAdmonition } from '../SqlWarningAdmonition'
 import { formatSqlError } from './EditorPanel.utils'
 import { SaveSnippetDialog } from './SaveSnippetDialog'
+import { useIsExplorerEnabled } from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
 import { isExplainQuery } from '@/components/interfaces/ExplainVisualizer/ExplainVisualizer.utils'
+import { useCreateQuery } from '@/components/interfaces/Explorer/hooks'
 import { generateSnippetTitle } from '@/components/interfaces/SQLEditor/SQLEditor.constants'
 import { createSqlSnippetSkeletonV2 } from '@/components/interfaces/SQLEditor/SQLEditor.utils'
 import { useAddDefinitions } from '@/components/interfaces/SQLEditor/useAddDefinitions'
@@ -84,6 +86,8 @@ export const EditorPanel = () => {
   const { profile } = useProfile()
   const { closeSidebar } = useSidebarManagerSnapshot()
   const sqlEditorSnap = useSqlEditorV2StateSnapshot()
+  const isExplorerEnabled = useIsExplorerEnabled()
+  const { createQuery } = useCreateQuery()
   const queryClient = useQueryClient()
 
   const [activeSnippet, setActiveSnippet] = useState<Extract<Content, { type: 'sql' }> | null>(null)
@@ -271,6 +275,38 @@ export const EditorPanel = () => {
     editorPanelState.setActiveSnippetId(null)
   }
 
+  const handleExpand = () => {
+    if (isExplorerEnabled) {
+      const id = createQuery({ sql: currentValue, name: generateSnippetTitle() })
+      if (id) handleClosePanel()
+      return
+    }
+
+    if (!ref) return console.error('Project ref is required')
+
+    if (!project) {
+      console.error('Project is required')
+      return
+    }
+    if (!profile) {
+      console.error('Profile is required')
+      return
+    }
+
+    const snippet = createSqlSnippetSkeletonV2({
+      name: generateSnippetTitle(),
+      sql: currentValue,
+      owner_id: profile.id,
+      project_id: project.id,
+    })
+
+    sqlEditorSnap.addSnippet({ projectRef: ref, snippet })
+    sqlEditorSnap.addNeedsSaving(snippet.id)
+
+    router.push(`/project/${ref}/sql/${snippet.id}`)
+    handleClosePanel()
+  }
+
   return (
     <div className="flex h-full flex-col bg-card">
       <div className="border-b border-b-muted flex items-center justify-between gap-x-4 pl-4 pr-3 h-(--header-height)">
@@ -426,37 +462,14 @@ export const EditorPanel = () => {
             variant="text"
             className="w-7 h-7 p-0"
             icon={<Maximize2 strokeWidth={1.5} />}
+            aria-label={isExplorerEnabled ? 'Open in Explorer' : 'Expand to SQL editor'}
             tooltip={{
               content: {
                 side: 'bottom',
-                text: 'Expand to SQL editor',
+                text: isExplorerEnabled ? 'Open in Explorer' : 'Expand to SQL editor',
               },
             }}
-            onClick={() => {
-              if (!ref) return console.error('Project ref is required')
-
-              if (!project) {
-                console.error('Project is required')
-                return
-              }
-              if (!profile) {
-                console.error('Profile is required')
-                return
-              }
-
-              const snippet = createSqlSnippetSkeletonV2({
-                name: generateSnippetTitle(),
-                sql: currentValue,
-                owner_id: profile.id,
-                project_id: project.id,
-              })
-
-              sqlEditorSnap.addSnippet({ projectRef: ref, snippet })
-              sqlEditorSnap.addNeedsSaving(snippet.id)
-
-              router.push(`/project/${ref}/sql/${snippet.id}`)
-              handleClosePanel()
-            }}
+            onClick={handleExpand}
           />
 
           <ButtonTooltip


### PR DESCRIPTION
## Summary
- Match Explorer/SQL query results table typography to Table Editor: sans cells at `text-grid`, headers at `text-xs` / `text-foreground`
- Reuse Table Editor `NullValue` for null cells so empty results read the same way
- When the Explorer feature preview is on, the inline editor "expand" action opens a new Explorer query tab (same pattern as the assistant) instead of the SQL Editor

## Test plan
- [ ] Run a query in Explorer and confirm header/cell font, size, and color match Table Editor
- [ ] Confirm `NULL` cells use the same faded treatment as Table Editor
- [ ] Check the SQL Editor results pane (shared `DataGridResults`) still looks correct
- [ ] With Explorer feature preview on, expand the inline editor and confirm it creates an Explorer query tab with the current SQL, then closes the panel
- [ ] With Explorer feature preview off, expand the inline editor and confirm it still opens a SQL Editor snippet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added the ability to open SQL directly in Explorer from the editor panel.
- Run SQL actions now create a query draft and navigate to the query tab.

## Style
- Improved data grid readability with clearer text, left-aligned headers, truncated labels, and selectable content.
- Added dedicated styling for null values.
- Updated empty-results messaging with standard sans-serif text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->