### PR TITLE
fix(studio): label omitted worker runtime as custom FE-4314

### DIFF
--- a/apps/studio/components/interfaces/Workers/Workers.utils.test.ts
+++ b/apps/studio/components/interfaces/Workers/Workers.utils.test.ts
@@ -112,8 +112,8 @@ describe('formatRuntime', () => {
     expect(formatRuntime('rust')).toBe('rust')
   })
 
-  it('reports unknown when the API omits the runtime', () => {
-    expect(formatRuntime(undefined)).toBe('Unknown')
+  it('labels an omitted runtime as custom', () => {
+    expect(formatRuntime(undefined)).toBe('Custom')
   })
 })
 

--- a/apps/studio/components/interfaces/Workers/Workers.utils.ts
+++ b/apps/studio/components/interfaces/Workers/Workers.utils.ts
@@ -42,7 +42,7 @@ export const getRuntimeMeta = (runtime: string | undefined): RuntimeMeta | undef
   runtime === undefined ? undefined : RUNTIMES[runtime]
 
 export const formatRuntime = (runtime: string | undefined): string =>
-  getRuntimeMeta(runtime)?.label ?? runtime ?? 'Unknown'
+  getRuntimeMeta(runtime)?.label ?? runtime ?? 'Custom'
 
 // The API reports size as e.g. "2gb-1vcpu"; render the parts when they parse, the raw value if not.
 export const formatSize = (size: string): string => {


### PR DESCRIPTION
## Problem

Workers with an omitted runtime are displayed as Unknown, even though an omitted runtime represents a custom worker image.

## Fix

Display Custom when the runtime is omitted. Preserve friendly labels for known runtimes and raw values for explicit unrecognized runtimes.

## How to test

- Run `node_modules/.bin/vitest --run components/interfaces/Workers/Workers.utils.test.ts` from `apps/studio`.
- Open a worker whose API response omits `spec.runtime`.
- Expected result: the runtime badge displays Custom.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Worker runtimes without available metadata are now labeled **“Custom”** instead of **“Unknown.”**
  - Updated the related behavior validation to reflect the corrected runtime label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->