### PR TITLE
fix(studio): restore useTrackExperimentExposure hook

### DIFF
--- a/apps/studio/hooks/misc/useTrackExperimentExposure.ts
+++ b/apps/studio/hooks/misc/useTrackExperimentExposure.ts
@@ -1,0 +1,18 @@
+import { hasConsented, posthogClient } from 'common'
+import { useEffect } from 'react'
+
+export function useTrackExperimentExposure(
+  experimentId: string,
+  variant: string | undefined,
+  extraProperties?: Record<string, any>
+) {
+  useEffect(() => {
+    if (!variant) return
+
+    posthogClient.captureExperimentExposure(
+      experimentId,
+      { variant, ...extraProperties },
+      hasConsented()
+    )
+  }, [experimentId, variant])
+}


### PR DESCRIPTION
Restores `hooks/misc/useTrackExperimentExposure.ts`, fixing the typecheck failure on master that broke the latest Studio production deploy.

The hook was deleted as dead code in #49719 (it was genuinely unused on master at the time), but #49534 was in flight and reintroduced a usage in `plan-presentation.ts`. The two PRs merged cleanly with no textual conflict, so nothing typechecked the combination until the deploy off master failed with:

```
plan-presentation.ts(5,44): error TS2307: Cannot find module '@/hooks/misc/useTrackExperimentExposure'
```

**Added:**
- `apps/studio/hooks/misc/useTrackExperimentExposure.ts` — restored verbatim from before #49719; no longer dead code since `plan-presentation.ts` imports it

## To test

- `pnpm --filter studio typecheck` passes (verified locally)
- `pnpm knip --workspace apps/studio` no longer flags the hook (verified locally)
- Studio production deploy succeeds once merged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added experiment exposure tracking when a variant is selected.
  - Captures the experiment, variant, optional details, and consent status for analytics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->