### PR TITLE
fix(studio): restore useTrackExperimentExposure hook

### DIFF
--- a/apps/studio/hooks/misc/useTrackExperimentExposure.ts
+++ b/apps/studio/hooks/misc/useTrackExperimentExposure.ts
@@ -1,0 +1,18 @@
+import { hasConsented, posthogClient } from 'common'
+import { useEffect } from 'react'
+
+export function useTrackExperimentExposure(
+  experimentId: string,
+  variant: string | undefined,
+  extraProperties?: Record<string, any>
+) {
+  useEffect(() => {
+    if (!variant) return
+
+    posthogClient.captureExperimentExposure(
+      experimentId,
+      { variant, ...extraProperties },
+      hasConsented()
+    )
+  }, [experimentId, variant])
+}


### PR DESCRIPTION
## Summary

Master is broken. #49534 and #49640 merged imports of `useTrackExperimentExposure`, but #49719 had deleted that hook file 2 days earlier as knip-flagged dead code (correct at the time — no consumers). Neither of our PRs' CI ran against the state where this would fail, so it slipped through.

**Impact:**
- knip check fails on master
- Studio Docker Build cancelled
- Vercel production deploy failing: `Command "pnpm typecheck && pnpm build" exited with 1`
- E2E tests failing

**Fix:** restore the hook file verbatim. It's now consumed by `plan-presentation.ts`, so knip will be happy.

This is exactly the stacked-merge race pattern that `apps/studio/CLAUDE.md:78` warns about — I missed adding the hook file to my PR because it already existed at branch-off time.

## Test plan
- [x] Locally: `apps/studio/hooks/misc/useTrackExperimentExposure.ts` restored
- [ ] CI: knip passes, typecheck passes, Studio Docker Build succeeds
- [ ] Vercel prod deploy on master succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added experiment exposure tracking for Studio experiences.
  - Exposure events include the experiment, selected variant, optional additional details, and consent status.
  - Tracking occurs when a valid variant is available and updates when the experiment assignment changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->