### PR TITLE
chore(studio): keep useTrackExperimentExposure across experiment gaps

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -72,6 +72,12 @@
         // read are documentation of the valid values, not dead code. Scoped to
         // this file so `enumMembers` keeps working everywhere else.
         "data/database/constraints-query.ts": ["enumMembers"],
+        // Shared experiment plumbing every A/B test plugs into. Gaps between
+        // experiments are normal, but deleting-and-restoring this hook each
+        // cycle churns the codebase and caused a stacked-merge race that
+        // broke master (#49719 removed it, #49534 reintroduced a usage — see
+        // #49763 for the fix). Keep it around across the gaps.
+        "hooks/misc/useTrackExperimentExposure.ts": ["files"],
       },
       // `vercel` is a globally installed CLI used by the `deploy:staging` script
       "ignoreBinaries": ["vercel"],

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -72,11 +72,6 @@
         // read are documentation of the valid values, not dead code. Scoped to
         // this file so `enumMembers` keeps working everywhere else.
         "data/database/constraints-query.ts": ["enumMembers"],
-        // Shared experiment plumbing every A/B test plugs into. Gaps between
-        // experiments are normal, but deleting-and-restoring this hook each
-        // cycle churns the codebase and caused a stacked-merge race that
-        // broke master (#49719 removed it, #49534 reintroduced a usage — see
-        // #49763 for the fix). Keep it around across the gaps.
         "hooks/misc/useTrackExperimentExposure.ts": ["files"],
       },
       // `vercel` is a globally installed CLI used by the `deploy:staging` script


### PR DESCRIPTION
## Summary

Adds a narrow knip suppression so `hooks/misc/useTrackExperimentExposure.ts` isn't flagged as an unused file when no experiment is currently consuming it.

## Why

Different from the other files #49719 cleaned up. Those were one-off feature code (specific banners, mutations, table rows) — genuinely dead when their feature was removed. This hook is **shared experiment plumbing**: every A/B experiment plugs into it, and we run experiments frequently. Gaps between experiments are normal.

Deleting and re-adding it each cycle:
- Churns the codebase for no real cleanup value
- Adds review surface to every next experiment PR (has to also add the hook back)
- Caused a stacked-merge race today — #49719 deleted it, #49534 reintroduced a usage in `plan-presentation.ts`. Both PRs' CI ran green on their own bases, but merging both broke master's typecheck + Studio deploy. Fixed in #49763.

## What this changes

One entry in `knip.jsonc` under `workspaces["apps/studio"].ignoreIssues`:

\`\`\`jsonc
"hooks/misc/useTrackExperimentExposure.ts": ["files"]
\`\`\`

`ignoreIssues` (not `ignore`) is the right knob per the config's own guidance — it suppresses only the "unused file" issue for this specific path, while knip still traces the file's imports so anything it depends on stays honestly tracked.

## Test plan

- [ ] `pnpm knip --workspace apps/studio` still clean
- [ ] With no experiment referencing the hook, knip does not report it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project analysis configuration to prevent a false-positive unused-file warning for a tracked experiment exposure hook.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->