### PR TITLE
ci(studio): fetch enough history for paths-filter on push events

### DIFF
--- a/.github/workflows/studio-docker-build.yml
+++ b/.github/workflows/studio-docker-build.yml
@@ -21,6 +21,10 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+          # On push events paths-filter diffs against github.event.before with
+          # local git; without enough history it falls back to a git fetch that
+          # fails unauthenticated (persist-credentials is false).
+          fetch-depth: 50
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter
         with:

--- a/.github/workflows/studio-e2e-test.yml
+++ b/.github/workflows/studio-e2e-test.yml
@@ -38,6 +38,10 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+          # On push events paths-filter diffs against github.event.before with
+          # local git; without enough history it falls back to a git fetch that
+          # fails unauthenticated (persist-credentials is false).
+          fetch-depth: 50
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter
         with:

--- a/.github/workflows/studio-unit-tests.yml
+++ b/.github/workflows/studio-unit-tests.yml
@@ -36,6 +36,10 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+          # On push events paths-filter diffs against github.event.before with
+          # local git; without enough history it falls back to a git fetch that
+          # fails unauthenticated (persist-credentials is false).
+          fetch-depth: 50
           sparse-checkout: |
             apps/studio
             packages


### PR DESCRIPTION
Fixes the master-push failures in the Selfhosted Studio E2E workflow (e.g. [this run](https://github.com/supabase/supabase/actions/runs/33383940726)) where all shards die in ~30s at the `dorny/paths-filter` step with:

```
fatal: Not a valid object name <github.event.before>^{commit}
fatal: could not read Username for 'https://github.com': No such device or address
```

On push events, paths-filter diffs against `github.event.before` using local git. With the default depth-1 checkout that commit usually isn't present, so the action falls back to a `git fetch` — which runs unauthenticated because we set `persist-credentials: false`, and GitHub rejects unauthenticated git fetches from the runner IPs. Whether a job passed depended on whether the runner's shared git cache happened to contain the previous master tip, which is why shards fail nondeterministically and re-runs partially recover.

**Changed:**
- `fetch-depth: 50` on the checkout preceding paths-filter in the three workflows that run it on push (`studio-e2e-test`, `studio-unit-tests`, `studio-docker-build`), so the comparison base is always fetched with the checkout action's own credentials and no fallback fetch happens. `persist-credentials: false` stays.

PR events are unaffected either way — paths-filter uses the GitHub API there, not git.

## To test

- CI on this PR passes (PR path exercises the API code path)
- After merge, the next few master pushes run Selfhosted Studio E2E without the paths-filter step failing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated build, end-to-end test, and unit test workflows by ensuring sufficient Git history is available for change detection.
  * Increased reliability of workflow runs triggered by code pushes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->