### PR TITLE
feat(telemetry): tag embedded agent browser events

### DIFF
--- a/packages/common/embedded-agent-browser.test.ts
+++ b/packages/common/embedded-agent-browser.test.ts
@@ -51,7 +51,31 @@ describe('detectEmbeddedAgentBrowser', () => {
     ).toBe('chatgpt_desktop')
   })
 
-  it('does not tag ChatGPT Android in-app WebView (no Electron token)', () => {
+  it('detects ChatGPT Desktop if a future build drops the Electron token', () => {
+    expect(
+      detectEmbeddedAgentBrowser(
+        'ChatGPT/1.2027.10 (Windows_NT 10.0.26200; x86_64; build ) Chrome/142.0.7444.235'
+      )
+    ).toBe('chatgpt_desktop')
+  })
+
+  it('does not tag a hypothetical Claude mobile in-app WebView', () => {
+    expect(
+      detectEmbeddedAgentBrowser(
+        'Mozilla/5.0 (Linux; Android 16; Pixel 9; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/139.0.7258.153 Mobile Safari/537.36 Claude/1.50000.0'
+      )
+    ).toBeUndefined()
+  })
+
+  it('does not tag a hypothetical Claude iOS in-app WebView', () => {
+    expect(
+      detectEmbeddedAgentBrowser(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 19_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Claude/1.50000.0'
+      )
+    ).toBeUndefined()
+  })
+
+  it('does not tag ChatGPT Android in-app WebView', () => {
     expect(
       detectEmbeddedAgentBrowser(
         'Mozilla/5.0 (Linux; Android 16; 25100RA69G Build/BP2A.250605.031.A3; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/139.0.7258.153 Mobile Safari/537.36 ChatGPT/1.2026.230 (Android 16; 25100RA69G)'
@@ -86,10 +110,6 @@ describe('buildEmbeddedAgentBrowserConfig', () => {
         'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36'
       )
     ).toEqual({})
-  })
-
-  it('returns an empty config when the user agent is unavailable', () => {
-    expect(buildEmbeddedAgentBrowserConfig(undefined)).toEqual({})
   })
 
   it('annotates captured events with the detected agent browser', () => {

--- a/packages/common/embedded-agent-browser.test.ts
+++ b/packages/common/embedded-agent-browser.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+
+import { detectEmbeddedAgentBrowser } from './embedded-agent-browser'
+
+describe('detectEmbeddedAgentBrowser', () => {
+  it('detects Claude Desktop on Mac with Electron token', () => {
+    expect(
+      detectEmbeddedAgentBrowser(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Claude/1.34493.1 Chrome/148.0.7778.280 Electron/42.9.2 Safari/537.36'
+      )
+    ).toBe('claude_desktop')
+  })
+
+  it('detects Claude Desktop on Windows MSIX with Electron token', () => {
+    expect(
+      detectEmbeddedAgentBrowser(
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Claude/1.34493.1 Chrome/148.0.7778.280 Electron/42.9.2 Safari/537.36 MSIX'
+      )
+    ).toBe('claude_desktop')
+  })
+
+  it('detects Claude Desktop on Mac without Electron token', () => {
+    expect(
+      detectEmbeddedAgentBrowser(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Claude/1.40609.0 Chrome/148.0.7778.280 Safari/537.36'
+      )
+    ).toBe('claude_desktop')
+  })
+
+  it('detects Claude Desktop on Windows MSIX without Electron token', () => {
+    expect(
+      detectEmbeddedAgentBrowser(
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Claude/1.37937.3 Chrome/148.0.7778.280 Safari/537.36 MSIX'
+      )
+    ).toBe('claude_desktop')
+  })
+
+  it('detects Claude Desktop when the token starts the UA string', () => {
+    expect(detectEmbeddedAgentBrowser('Claude/1.2.3 Chrome/148.0.0.0')).toBe('claude_desktop')
+  })
+
+  it('detects ChatGPT Desktop with Electron token', () => {
+    expect(
+      detectEmbeddedAgentBrowser(
+        'ChatGPT/1.2026.190 (Windows_NT 10.0.26200; x86_64; build ) Electron/39.2.7 Chrome/142.0.7444.235'
+      )
+    ).toBe('chatgpt_desktop')
+  })
+
+  it('does not tag ChatGPT Android in-app WebView (no Electron token)', () => {
+    expect(
+      detectEmbeddedAgentBrowser(
+        'Mozilla/5.0 (Linux; Android 16; 25100RA69G Build/BP2A.250605.031.A3; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/139.0.7258.153 Mobile Safari/537.36 ChatGPT/1.2026.230 (Android 16; 25100RA69G)'
+      )
+    ).toBeUndefined()
+  })
+
+  it('does not tag stock desktop Chrome', () => {
+    expect(
+      detectEmbeddedAgentBrowser(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36'
+      )
+    ).toBeUndefined()
+  })
+
+  it('does not tag a token without a leading boundary', () => {
+    expect(detectEmbeddedAgentBrowser('Mozilla/5.0 NotClaude/1.0')).toBeUndefined()
+  })
+
+  it('returns undefined for an empty string', () => {
+    expect(detectEmbeddedAgentBrowser('')).toBeUndefined()
+  })
+})

--- a/packages/common/embedded-agent-browser.test.ts
+++ b/packages/common/embedded-agent-browser.test.ts
@@ -1,6 +1,10 @@
+import type { CaptureResult } from 'posthog-js'
 import { describe, expect, it } from 'vitest'
 
-import { detectEmbeddedAgentBrowser } from './embedded-agent-browser'
+import {
+  buildEmbeddedAgentBrowserConfig,
+  detectEmbeddedAgentBrowser,
+} from './embedded-agent-browser'
 
 describe('detectEmbeddedAgentBrowser', () => {
   it('detects Claude Desktop on Mac with Electron token', () => {
@@ -69,5 +73,45 @@ describe('detectEmbeddedAgentBrowser', () => {
 
   it('returns undefined for an empty string', () => {
     expect(detectEmbeddedAgentBrowser('')).toBeUndefined()
+  })
+})
+
+describe('buildEmbeddedAgentBrowserConfig', () => {
+  const claudeUserAgent =
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Claude/1.37937.3 Chrome/148.0.7778.280 Safari/537.36 MSIX'
+
+  it('returns an empty config for non-agent user agents', () => {
+    expect(
+      buildEmbeddedAgentBrowserConfig(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36'
+      )
+    ).toEqual({})
+  })
+
+  it('returns an empty config when the user agent is unavailable', () => {
+    expect(buildEmbeddedAgentBrowserConfig(undefined)).toEqual({})
+  })
+
+  it('annotates captured events with the detected agent browser', () => {
+    const config = buildEmbeddedAgentBrowserConfig(claudeUserAgent)
+    const beforeSend = config.before_send as (cr: CaptureResult | null) => CaptureResult | null
+
+    const result = beforeSend({
+      uuid: '00000000-0000-0000-0000-000000000000',
+      event: '$pageview',
+      properties: { $current_url: 'https://supabase.com/dashboard/projects' },
+    } as CaptureResult)
+
+    expect(result?.properties).toEqual({
+      $current_url: 'https://supabase.com/dashboard/projects',
+      embedded_agent_browser: 'claude_desktop',
+    })
+  })
+
+  it('passes through null capture results', () => {
+    const config = buildEmbeddedAgentBrowserConfig(claudeUserAgent)
+    const beforeSend = config.before_send as (cr: CaptureResult | null) => CaptureResult | null
+
+    expect(beforeSend(null)).toBeNull()
   })
 })

--- a/packages/common/embedded-agent-browser.ts
+++ b/packages/common/embedded-agent-browser.ts
@@ -1,0 +1,15 @@
+export type EmbeddedAgentBrowser = 'claude_desktop' | 'chatgpt_desktop'
+
+const CLAUDE_DESKTOP_UA = /(^| )Claude\/\d/
+const CHATGPT_DESKTOP_UA = /(^| )ChatGPT\/\d/
+
+// Claude Desktop >= ~1.37937 drops the Electron/ UA token on every platform, so Claude
+// matches on its product token alone. ChatGPT's token also appears in mobile in-app
+// WebView UAs (human browsing), so it stays gated on the Electron/ token.
+export function detectEmbeddedAgentBrowser(userAgent: string): EmbeddedAgentBrowser | undefined {
+  if (CLAUDE_DESKTOP_UA.test(userAgent)) return 'claude_desktop'
+  if (CHATGPT_DESKTOP_UA.test(userAgent) && userAgent.includes('Electron/')) {
+    return 'chatgpt_desktop'
+  }
+  return undefined
+}

--- a/packages/common/embedded-agent-browser.ts
+++ b/packages/common/embedded-agent-browser.ts
@@ -2,23 +2,22 @@ import type { PostHogConfig } from 'posthog-js'
 
 export type EmbeddedAgentBrowser = 'claude_desktop' | 'chatgpt_desktop'
 
-const CLAUDE_DESKTOP_UA = /(^| )Claude\/\d/
-const CHATGPT_DESKTOP_UA = /(^| )ChatGPT\/\d/
+const CLAUDE_UA = /(^| )Claude\/\d/
+const CHATGPT_UA = /(^| )ChatGPT\/\d/
+const MOBILE_UA = /Mobile|Android|iPhone|iPad/
 
-// Newer Claude Desktop builds omit the Electron/ token, so Claude matches on its product
-// token alone. ChatGPT's token also appears in mobile in-app WebViews, so it stays Electron-gated.
+// Agent product tokens also appear in mobile in-app WebView UAs, which are human browsing,
+// so mobile UAs are excluded. Vendor Electron/ tokens come and go across releases, so
+// desktop detection never gates on them.
 export function detectEmbeddedAgentBrowser(userAgent: string): EmbeddedAgentBrowser | undefined {
-  if (CLAUDE_DESKTOP_UA.test(userAgent)) return 'claude_desktop'
-  if (CHATGPT_DESKTOP_UA.test(userAgent) && userAgent.includes('Electron/')) {
-    return 'chatgpt_desktop'
-  }
+  if (MOBILE_UA.test(userAgent)) return undefined
+  if (CLAUDE_UA.test(userAgent)) return 'claude_desktop'
+  if (CHATGPT_UA.test(userAgent)) return 'chatgpt_desktop'
   return undefined
 }
 
-export function buildEmbeddedAgentBrowserConfig(
-  userAgent: string | undefined
-): Partial<PostHogConfig> {
-  const embeddedAgentBrowser = userAgent ? detectEmbeddedAgentBrowser(userAgent) : undefined
+export function buildEmbeddedAgentBrowserConfig(userAgent: string): Partial<PostHogConfig> {
+  const embeddedAgentBrowser = detectEmbeddedAgentBrowser(userAgent)
   if (!embeddedAgentBrowser) return {}
 
   return {

--- a/packages/common/embedded-agent-browser.ts
+++ b/packages/common/embedded-agent-browser.ts
@@ -1,15 +1,34 @@
+import type { PostHogConfig } from 'posthog-js'
+
 export type EmbeddedAgentBrowser = 'claude_desktop' | 'chatgpt_desktop'
 
 const CLAUDE_DESKTOP_UA = /(^| )Claude\/\d/
 const CHATGPT_DESKTOP_UA = /(^| )ChatGPT\/\d/
 
-// Claude Desktop >= ~1.37937 drops the Electron/ UA token on every platform, so Claude
-// matches on its product token alone. ChatGPT's token also appears in mobile in-app
-// WebView UAs (human browsing), so it stays gated on the Electron/ token.
+// Newer Claude Desktop builds omit the Electron/ token, so Claude matches on its product
+// token alone. ChatGPT's token also appears in mobile in-app WebViews, so it stays Electron-gated.
 export function detectEmbeddedAgentBrowser(userAgent: string): EmbeddedAgentBrowser | undefined {
   if (CLAUDE_DESKTOP_UA.test(userAgent)) return 'claude_desktop'
   if (CHATGPT_DESKTOP_UA.test(userAgent) && userAgent.includes('Electron/')) {
     return 'chatgpt_desktop'
   }
   return undefined
+}
+
+export function buildEmbeddedAgentBrowserConfig(
+  userAgent: string | undefined
+): Partial<PostHogConfig> {
+  const embeddedAgentBrowser = userAgent ? detectEmbeddedAgentBrowser(userAgent) : undefined
+  if (!embeddedAgentBrowser) return {}
+
+  return {
+    before_send: (captureResult) => {
+      if (!captureResult) return captureResult
+      captureResult.properties = {
+        ...captureResult.properties,
+        embedded_agent_browser: embeddedAgentBrowser,
+      }
+      return captureResult
+    },
+  }
 }

--- a/packages/common/posthog-client.ts
+++ b/packages/common/posthog-client.ts
@@ -4,7 +4,7 @@ import posthog, {
   type SessionRecordingOptions,
 } from 'posthog-js'
 
-import { detectEmbeddedAgentBrowser } from './embedded-agent-browser'
+import { buildEmbeddedAgentBrowserConfig } from './embedded-agent-browser'
 import { safeSessionStorage } from './safe-storage'
 
 export type { CapturedNetworkRequest, SessionRecordingOptions }
@@ -89,27 +89,15 @@ class PostHogClient {
       return
     }
 
-    const embeddedAgentBrowser =
-      typeof navigator !== 'undefined' ? detectEmbeddedAgentBrowser(navigator.userAgent) : undefined
-
     const config: Partial<PostHogConfig> = {
       api_host: this.config.apiHost,
       ui_host: this.config.uiHost,
       autocapture: false, // We'll manually track events
       capture_pageview: false, // We'll manually track pageviews
       capture_pageleave: false, // We'll manually track page leaves
-      ...(embeddedAgentBrowser && {
-        before_send: (captureResult) => {
-          if (!captureResult) return captureResult
-          return {
-            ...captureResult,
-            properties: {
-              ...captureResult.properties,
-              embedded_agent_browser: embeddedAgentBrowser,
-            },
-          }
-        },
-      }),
+      ...buildEmbeddedAgentBrowserConfig(
+        typeof navigator !== 'undefined' ? navigator.userAgent : undefined
+      ),
       ...buildSessionRecordingConfig(sessionReplay),
       loaded: (posthog) => {
         // Apply pending properties that were set before PostHog

--- a/packages/common/posthog-client.ts
+++ b/packages/common/posthog-client.ts
@@ -4,6 +4,7 @@ import posthog, {
   type SessionRecordingOptions,
 } from 'posthog-js'
 
+import { detectEmbeddedAgentBrowser } from './embedded-agent-browser'
 import { safeSessionStorage } from './safe-storage'
 
 export type { CapturedNetworkRequest, SessionRecordingOptions }
@@ -88,12 +89,27 @@ class PostHogClient {
       return
     }
 
+    const embeddedAgentBrowser =
+      typeof navigator !== 'undefined' ? detectEmbeddedAgentBrowser(navigator.userAgent) : undefined
+
     const config: Partial<PostHogConfig> = {
       api_host: this.config.apiHost,
       ui_host: this.config.uiHost,
       autocapture: false, // We'll manually track events
       capture_pageview: false, // We'll manually track pageviews
       capture_pageleave: false, // We'll manually track page leaves
+      ...(embeddedAgentBrowser && {
+        before_send: (captureResult) => {
+          if (!captureResult) return captureResult
+          return {
+            ...captureResult,
+            properties: {
+              ...captureResult.properties,
+              embedded_agent_browser: embeddedAgentBrowser,
+            },
+          }
+        },
+      }),
       ...buildSessionRecordingConfig(sessionReplay),
       loaded: (posthog) => {
         // Apply pending properties that were set before PostHog

--- a/packages/common/posthog-client.ts
+++ b/packages/common/posthog-client.ts
@@ -95,9 +95,7 @@ class PostHogClient {
       autocapture: false, // We'll manually track events
       capture_pageview: false, // We'll manually track pageviews
       capture_pageleave: false, // We'll manually track page leaves
-      ...buildEmbeddedAgentBrowserConfig(
-        typeof navigator !== 'undefined' ? navigator.userAgent : undefined
-      ),
+      ...buildEmbeddedAgentBrowserConfig(navigator.userAgent),
       ...buildSessionRecordingConfig(sessionReplay),
       loaded: (posthog) => {
         // Apply pending properties that were set before PostHog


### PR DESCRIPTION
Claude Desktop's embedded webview sends a real Chrome UA with a `Claude/<version>` product token, and its newer builds drop the `Electron/` token that UA-based app detection keys on, so that traffic reads as ordinary human Chrome in our product analytics. I added capture-time tagging so the traffic can be segmented at query time without dropping the events, which stay valuable as agent-surface signal.

**Changed:**
- **Embedded-agent events are now tagged**: `detectEmbeddedAgentBrowser` excludes mobile UAs (agent product tokens also appear in mobile in-app WebViews, which are human browsing), then matches token-boundary `Claude/<digit>` or `ChatGPT/<digit>`. Detection never gates on the vendor-controlled `Electron/` token, so it survives vendors dropping it, which Claude Desktop already did. `buildEmbeddedAgentBrowserConfig` wires a `before_send` hook into the shared PostHog client that attaches `embedded_agent_browser: 'claude_desktop' | 'chatgpt_desktop'` to every captured event across studio, www, and docs; non-matching browsers get no hook at all.

**Note:** tagging alone doesn't exclude anything from existing insights. The exclusion is a follow-up PostHog project-settings change (add an `embedded_agent_browser is not set` condition to the internal/test-account filter), written up on the Linear issue for manual application after this deploys. That's also why the Linear ref below isn't a `fixes` keyword: the issue stays open until the filter is applied and the delta recorded.

`before_send` is set as a single function; posthog-js also accepts an array, so a future second hook should move to the array form rather than replace this one.

## To test
Tested on Vercel preview (spoofed UAs via init-script override, verified wire-level and again at ingestion in the staging analytics project):
- [x] Load the preview with a spoofed Claude Desktop UA (both with and without the `Electron/` token), accept the consent banner, navigate once - expect the pageview capture request payload to carry `embedded_agent_browser: 'claude_desktop'` - observed on both UA variants, on the initial pageview, the SPA-nav pageview, and pageleave events
- [x] Load with a spoofed ChatGPT Desktop UA - expect `embedded_agent_browser: 'chatgpt_desktop'` on capture payloads - observed
- [x] Load with a stock Chrome UA - expect the property absent from capture payloads - observed (property null on all events)

Note from the run: no consent banner appears outside the EU geo ruleset, so the client initialized immediately; UA override was applied pre-init, which is what the detector reads.

## Linear
- GROWTH-1159 (kept open for the follow-up PostHog filter change; do not auto-close on merge)
