### PR TITLE
fix(studio): keep zero-valued row count filters

### DIFF
--- a/apps/studio/data/table-rows/utils.test.ts
+++ b/apps/studio/data/table-rows/utils.test.ts
@@ -24,8 +24,15 @@ describe('formatFilterValue', () => {
   })
 
   it('coerces in-range numerical values to a number', () => {
+    expect(formatFilterValue(table, makeFilter('count', '0'))).toBe(0)
     expect(formatFilterValue(table, makeFilter('count', '42'))).toBe(42)
     expect(formatFilterValue(table, makeFilter('id', '-42'))).toBe(-42)
+  })
+
+  it('does not coerce absent numerical filter values to zero', () => {
+    expect(formatFilterValue(table, makeFilter('count', ''))).toBe('')
+    expect(formatFilterValue(table, makeFilter('count', null))).toBeNull()
+    expect(formatFilterValue(table, makeFilter('count', undefined))).toBeUndefined()
   })
 
   it('returns the original string when the value is not a valid number', () => {

--- a/apps/studio/data/table-rows/utils.ts
+++ b/apps/studio/data/table-rows/utils.ts
@@ -17,6 +17,10 @@ export function formatFilterValue(
 ) {
   const column = table.columns.find((x) => x.name == filter.column)
   if (column && isNumericalColumn(column.format)) {
+    if (filter.value === '' || filter.value === null || filter.value === undefined) {
+      return filter.value
+    }
+
     const numberValue = Number(filter.value)
     if (Number.isNaN(numberValue) || Math.abs(numberValue) > Number.MAX_SAFE_INTEGER)
       return filter.value

--- a/packages/pg-meta/src/sql/studio/database/rows.ts
+++ b/packages/pg-meta/src/sql/studio/database/rows.ts
@@ -2,6 +2,8 @@ import { literal, safeSql, type SafeSqlFragment } from '../../../pg-format'
 import { Filter, Query } from '../../../query'
 import { COUNT_ESTIMATE_SQL, THRESHOLD_COUNT, THRESHOLD_ESTIMATE_BYTES } from './get-count-estimate'
 
+const hasFilterValue = ({ value }: Filter) => value !== undefined && value !== null && value !== ''
+
 /**
  * Row-count for a table. reltuples = -1 (never analyzed) covers BOTH an
  * empty/small new table and a freshly bulk-loaded huge one, so the opt-in
@@ -30,11 +32,9 @@ export const getTableRowsCountSql = ({
   if (enforceExactCount) {
     const query = new Query()
     let queryChains = query.from(table.name, table.schema ?? undefined).count()
-    filters
-      .filter((x) => x.value && x.value !== '')
-      .forEach((x) => {
-        queryChains = queryChains.filter(x.column, x.operator, x.value)
-      })
+    filters.filter(hasFilterValue).forEach((x) => {
+      queryChains = queryChains.filter(x.column, x.operator, x.value)
+    })
     const queryChainsSql = queryChains.toSql()
     const queryChainsSqlWithoutSemicolon = queryChainsSql.endsWith(';')
       ? (queryChainsSql.slice(0, -1) as SafeSqlFragment)
@@ -43,11 +43,9 @@ export const getTableRowsCountSql = ({
   } else {
     const selectQuery = new Query()
     let selectQueryChains = selectQuery.from(table.name, table.schema ?? undefined).select()
-    filters
-      .filter((x) => x.value && x.value != '')
-      .forEach((x) => {
-        selectQueryChains = selectQueryChains.filter(x.column, x.operator, x.value)
-      })
+    filters.filter(hasFilterValue).forEach((x) => {
+      selectQueryChains = selectQueryChains.filter(x.column, x.operator, x.value)
+    })
     const selectBaseSql = selectQueryChains.toSql()
     const selectBaseSqlWithoutSemicolon = selectBaseSql.endsWith(';')
       ? (selectBaseSql.slice(0, -1) as SafeSqlFragment)
@@ -55,11 +53,9 @@ export const getTableRowsCountSql = ({
 
     const countQuery = new Query()
     let countQueryChains = countQuery.from(table.name, table.schema ?? undefined).count()
-    filters
-      .filter((x) => x.value && x.value != '')
-      .forEach((x) => {
-        countQueryChains = countQueryChains.filter(x.column, x.operator, x.value)
-      })
+    filters.filter(hasFilterValue).forEach((x) => {
+      countQueryChains = countQueryChains.filter(x.column, x.operator, x.value)
+    })
     const countBaseSql = countQueryChains.toSql()
     const countBaseSqlWithoutSemicolon = countBaseSql.endsWith(';')
       ? (countBaseSql.slice(0, -1) as SafeSqlFragment)

--- a/packages/pg-meta/test/sql/studio/rows-count.test.ts
+++ b/packages/pg-meta/test/sql/studio/rows-count.test.ts
@@ -8,6 +8,15 @@ type Db = Awaited<ReturnType<typeof createTestDatabase>>
 type CountRow = { count: number; is_estimate: boolean }
 type CountArgs = Parameters<typeof getTableRowsCountSql>[0]
 
+test('includes zero-valued filters in row count queries', () => {
+  const sql = getTableRowsCountSql({
+    table: { id: 1, schema: 'public', name: 'items' },
+    filters: [{ column: 'quantity', operator: '=', value: 0 }],
+  })
+
+  expect(sql).toContain('where quantity = 0')
+})
+
 afterAll(async () => {
   await cleanupRoot()
 })


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix with regression tests.

## What is the current behavior?

Fixes #49776

When a number filter contains `0`, Studio converts the input to a number before building the row-count query. The existing truthiness check then drops the filter, so the grid can show filtered rows while the count still reflects the whole table.

There is a related edge case with blank number filters: `Number('')` is also `0`, so accepting zero without preserving empty values would apply a filter the user did not enter.

## What is the new behavior?

Studio now keeps empty filter values unchanged during number formatting, while intentional `0` values are kept in the count query. The same check is used for the exact and estimated count paths.

I added tests for both sides of the behavior:

- `"0"` is converted to numeric `0`, while empty, `null`, and `undefined` values stay unchanged.
- Generated row-count SQL includes a numeric zero filter.

## Additional context

No visual changes.

Tests run locally:

- Studio table-row formatter tests: 7 passed
- pg-meta query tests: 88 passed
- Focused row-count regression test: passed
- Prettier on the changed files: passed

I could not run the Docker-backed PostgreSQL tests locally because Docker is not available on this machine.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed numerical filters so empty, null, and undefined values remain unset instead of being converted to zero or an invalid number.
  * Ensured zero-valued filters are correctly applied when filtering and counting table rows.
  * Standardized filter handling across row-count queries for more consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->