### PR TITLE
[MUL-1346] chore(studio): hide metrics export banner for HA projects

### DIFF
--- a/apps/studio/components/ui/ObservabilityLink.tsx
+++ b/apps/studio/components/ui/ObservabilityLink.tsx
@@ -1,8 +1,14 @@
 import Link from 'next/link'
 
+import { useHighAvailability } from '@/hooks/misc/useHighAvailability'
 import { DOCS_URL } from '@/lib/constants'
 
 export const ObservabilityLink = () => {
+  const { isHighAvailability } = useHighAvailability()
+
+  // The Metrics API is not available for High Availability (Multigres) projects
+  if (isHighAvailability) return null
+
   return (
     <div className="flex items-center justify-center gap-1.5 text-sm">
       <p className="text-foreground-light">


### PR DESCRIPTION
Hides the "Export Metrics to your dashboards. Get started for free!" banner (`ObservabilityLink`) for High Availability (Multigres) projects — the Metrics API it links to is not available for them. The check lives inside the shared component, so it applies to every observability sub-page that renders the banner; non-HA projects are unchanged.

Addresses [MUL-1346](https://linear.app/supabase/issue/MUL-1346/database-observability-dashboard-remove-text-for-unsupported-feature).

## To test

- On an HA project: open Observability → Database (and any other observability sub-page, e.g. Auth) — the "Export Metrics to your dashboards" banner at the bottom of the page should be gone
- On a non-HA project: same pages — the banner still shows, with "Get started for free!" linking to the metrics docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Metrics export links are now hidden for High Availability projects, where the Metrics API isn’t available.
  * Existing metrics export functionality remains unchanged for supported projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->