### PR TITLE
fix(ui-patterns): point the non-react-form label at the control id too

### DIFF
--- a/packages/ui-patterns/src/form/Layout/FormLayout.tsx
+++ b/packages/ui-patterns/src/form/Layout/FormLayout.tsx
@@ -406,7 +406,7 @@ export const FormLayout = React.forwardRef<
                 <Label
                   className="text-foreground flex gap-2 items-center wrap-break-word leading-normal"
                   data-formlayout-id="label"
-                  htmlFor={props.name || id}
+                  htmlFor={id}
                 >
                   <LabelContents />
                 </Label>


### PR DESCRIPTION
## What kind of change

Bug fix, latent rather than live. See "Does this change behaviour today".

## Background

#49637 (`4f92790587`, merged today) fixed a label that pointed at the wrong element:

```diff
-                  htmlFor={props.name || id}
+                  htmlFor={id}
```

`FormLayout` renders its label through one of two branches, though, and only the `isReactForm` one was changed. The other still has the original expression:

```tsx
{hasLabel && isReactForm ? (
  <FormLabel data-formlayout-id="formLabel" htmlFor={id}>          // fixed in #49637
) : (
  <Label data-formlayout-id="label" htmlFor={props.name || id}>    // still here
)}
```

`id` is the prop callers pass for the control they are labelling. `name` arrives through `...props` and is the form field name, which is a different thing. When both are set and differ, the label points at an element id that does not exist, so clicking it focuses nothing and assistive tech cannot resolve the association. That is the same defect, in the same file, on the sibling branch.

This makes both branches read `htmlFor={id}`.

## Does this change behaviour today

No, and I would rather say so plainly than oversell it. I checked every caller that renders `FormLayout` directly, which is the only way to reach the non-`isReactForm` branch, since `FormItemLayout` always passes `isReactForm`:

```
DisplayApiSettings.tsx:144        no name
CreateAppSheet.tsx:162            no name
SSLConfiguration.tsx:149, :216    no name
JitDbAccessConfiguration.tsx:429  no name
GithubSection.tsx:198             no name
jwt-settings.tsx:150, :211        no name
PermissionsAccordion.tsx:39       no name
```

None passes `name`, so `props.name || id` resolves to `id` for all of them and the rendered output is identical before and after. That is presumably why #49637 only needed the other branch.

What it removes is the footgun: the first caller to pass both `name` and `id` gets a silently broken label, and the two branches of the same component no longer disagree about what they label.

## Verification

- `ui-patterns` suite: 25 files, 247 tests, green.
- `pnpm --filter ui-patterns typecheck` clean, `prettier --check` clean.

No test. The rendered output is unchanged for every current caller, so there is no behaviour to assert without inventing a caller that does not exist. If you would rather have one pinning `htmlFor` to `id` when both props are passed, say so and I will add it.

Freshman contributor, and I use Claude Code as an assistant. I found this by checking whether #49637 had a sibling instance in the file it touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form label associations by consistently linking labels to their corresponding field IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->