### PR TITLE
[FE-4273] feat(studio): add Multigres to support form services

### DIFF
--- a/apps/studio/components/interfaces/Support/Support.constants.ts
+++ b/apps/studio/components/interfaces/Support/Support.constants.ts
@@ -129,18 +129,24 @@ export const SERVICE_OPTIONS = [
   },
   {
     id: 5,
+    name: 'Multigres',
+    value: 'Multigres',
+    disabled: false,
+  },
+  {
+    id: 6,
     name: 'Realtime',
     value: 'Realtime',
     disabled: false,
   },
   {
-    id: 6,
+    id: 7,
     name: 'Storage',
     value: 'Storage',
     disabled: false,
   },
   {
-    id: 7,
+    id: 8,
     name: 'Others',
     value: 'Others',
     disabled: false,


### PR DESCRIPTION
Adds "Multigres" to the "Which services are affected?" multi-select on the Contact Support form, so Alpha customers can tag tickets for the Multigres Front inbox. Placed alphabetically between Edge Functions and Realtime; the later option ids are renumbered, which is safe — they're only used as React list keys, and the submit payload sends the lowercase value tokens (`affectedServices: "multigres;..."`, verified with a live submission).

Addresses [FE-4273](https://linear.app/supabase/issue/FE-4273/add-multigres-to-support-form-services). Front-inbox routing itself is Platform-side (SUPPORT-421) and should match on the token `multigres`.

## To test

- Open /support/new → "Which services are affected?" → Multigres appears between Edge Functions and Realtime, selectable alongside other services, and the combobox search finds it
- Submit a ticket with it selected → the POST to `/platform/feedback/send` carries `affectedServices` containing `multigres`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Multigres as a selectable service option in the support interface.
  * Updated service ordering to accommodate the new option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->