### PR TITLE
docs(repo): list the kb and learn workspaces in the structure table

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -12,6 +12,8 @@ pnpm 11 + Turborepo monorepo. Requires Node >= 22.13.
 | `apps/design-system`     | Component demos — source of truth for Studio UI patterns (port 3003)        |
 | `apps/ui-library`        | shadcn-style registry site for Supabase UI blocks (port 3004)               |
 | `apps/lite-studio`       | Lightweight Studio — different stack: React Router 7 + Vite + Tailwind v4   |
+| `apps/learn`             | Courses site — Next.js + contentlayer2 (port 3007)                          |
+| `apps/kb`                | Knowledge Base — Astro (port 3008)                                          |
 | `packages/ui`            | Shared UI components (shadcn/ui based) — `import { Button } from 'ui'`      |
 | `packages/ui-patterns`   | Composite components — subpath imports, e.g. `ui-patterns/AssistantChat`    |
 | `packages/common`        | Shared utils, telemetry constants, feature flags                            |


### PR DESCRIPTION
## What kind of change

Repo documentation.

## Current behavior

The Structure table in `.claude/CLAUDE.md` lists six apps. There are eight:

```
on disk:  design-system  docs  kb  learn  lite-studio  studio  ui-library  www
listed:   design-system  docs        lite-studio  studio  ui-library  www
```

`apps/learn` has been a workspace since #41566 and `apps/kb` landed this morning in #49601. Both are picked up by the `apps/*` glob in `pnpm-workspace.yaml`, so they are real workspaces, just undocumented.

That table is the first thing an agent reads to orient itself in this repo, so a missing row means a whole app is invisible when deciding where a change belongs. I noticed it because I went looking for `apps/kb` after #49601 and could not find it described anywhere.

## New behavior

Two rows added, in the same shape as the existing ones (stack plus dev port, taken from each app's own `dev` script):

```
| `apps/learn` | Courses site, Next.js + contentlayer2 (port 3007) |
| `apps/kb`    | Knowledge Base, Astro (port 3008)                 |
```

Descriptions come from each package's actual dependencies and scripts rather than a guess: `learn` runs `next dev --port 3007` with `contentlayer2`, `kb` runs `astro dev --port 3008`.

## Notes

- No source change, and nothing else in the file is touched.
- `prettier --check` clean.
- The rows use the same em dash separator the surrounding rows use, to match the table rather than introduce a second style.

Docs only, so this does not consume a quota slot on my side. I mention it because #49750 landed this morning improving the same agent instructions, so if you have a preferred wording or placement for these two, say so and I will match it.

Freshman contributor, and I use Claude Code as an assistant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project structure documentation to include the Courses site and Knowledge Base applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->