### PR TITLE
[MUL-1475] fix(studio): show setup state on HA topology diagram during boot

### DIFF
--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/HaInstanceConfiguration.test.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/HaInstanceConfiguration.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react'
+import { screen, within } from '@testing-library/react'
 import { platformComponents as components } from 'api-types'
 import { http, HttpResponse } from 'msw'
 import { describe, expect, test, vi } from 'vitest'
@@ -94,7 +94,8 @@ describe('HaInstanceConfiguration', () => {
 
     customRender(<HaInstanceConfiguration />, { profileContext: PROFILE_CONTEXT })
 
-    expect(await screen.findByText('Setting up project')).toBeInTheDocument()
+    const statusRegion = await screen.findByRole('status')
+    expect(await within(statusRegion).findByText('Setting up project')).toBeInTheDocument()
     expect(screen.queryByText('Failed to retrieve cluster topology')).not.toBeInTheDocument()
   })
 

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/HaInstanceConfiguration.test.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/HaInstanceConfiguration.test.tsx
@@ -1,0 +1,128 @@
+import { screen } from '@testing-library/react'
+import { platformComponents as components } from 'api-types'
+import { http, HttpResponse } from 'msw'
+import { describe, expect, test, vi } from 'vitest'
+
+import { HaInstanceConfiguration } from './HaInstanceConfiguration'
+import { API_URL } from '@/lib/constants'
+import type { ProfileContextType } from '@/lib/profile'
+import { customRender } from '@/tests/lib/custom-render'
+import { addAPIMock, mswServer, type APIErrorBody } from '@/tests/lib/msw'
+
+type ProjectDetailResponse = components['schemas']['ProjectDetailResponse']
+
+vi.mock('@/lib/constants', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/constants')>()
+  return {
+    ...actual,
+    IS_PLATFORM: true,
+  }
+})
+
+const PROFILE_CONTEXT: ProfileContextType = {
+  profile: {
+    id: 1,
+    auth0_id: 'auth0|test',
+    gotrue_id: 'gotrue-test',
+    username: 'testuser',
+    primary_email: 'test@example.com',
+    first_name: null,
+    last_name: null,
+    mobile: null,
+    is_alpha_user: false,
+    is_sso_user: false,
+    disabled_features: [],
+    free_project_limit: null,
+  },
+  error: null,
+  isLoading: false,
+  isError: false,
+  isSuccess: true,
+}
+
+const PROJECT: ProjectDetailResponse = {
+  cloud_provider: 'AWS_K8S',
+  connectionString: 'postgresql://postgres:password@db.default.supabase.co:5432/postgres',
+  db_host: 'db.default.supabase.co',
+  dbVersion: 'supabase-postgres-15.1.0',
+  high_availability: true,
+  id: 1,
+  infra_compute_size: 'large',
+  inserted_at: '2026-01-01T00:00:00.000Z',
+  integration_source: null,
+  is_branch_enabled: false,
+  is_physical_backups_enabled: false,
+  name: 'Production',
+  organization_id: 1,
+  ref: 'default',
+  region: 'us-east-1',
+  restUrl: 'https://default.supabase.co',
+  status: 'ACTIVE_HEALTHY',
+  subscription_id: 'subscription-1',
+  updated_at: '2026-01-01T00:00:00.000Z',
+}
+
+const mockProject = (status: ProjectDetailResponse['status']) => {
+  addAPIMock({
+    method: 'get',
+    path: '/platform/projects/:ref',
+    response: { ...PROJECT, status } satisfies ProjectDetailResponse,
+  })
+}
+
+// The /ha-admin passthrough paths are off-schema (see get-ha-admin.ts), so they
+// can't go through the OpenAPI-typed addAPIMock.
+const mockHaAdmin = ({ isHealthy }: { isHealthy: boolean }) => {
+  mswServer.use(
+    http.get(`${API_URL}/platform/projects/:ref/ha-admin/v1/gateways`, () =>
+      isHealthy
+        ? HttpResponse.json({ gateways: [] })
+        : HttpResponse.json<APIErrorBody>({ message: 'upstream unavailable' }, { status: 500 })
+    ),
+    http.get(`${API_URL}/platform/projects/:ref/ha-admin/v1/poolers`, () =>
+      isHealthy
+        ? HttpResponse.json({ poolers: [] })
+        : HttpResponse.json<APIErrorBody>({ message: 'upstream unavailable' }, { status: 500 })
+    )
+  )
+}
+
+describe('HaInstanceConfiguration', () => {
+  test('shows the setup state instead of an error while the project is coming up', async () => {
+    mockProject('COMING_UP')
+    mockHaAdmin({ isHealthy: false })
+
+    customRender(<HaInstanceConfiguration />, { profileContext: PROFILE_CONTEXT })
+
+    expect(await screen.findByText('Setting up project')).toBeInTheDocument()
+    expect(screen.queryByText('Failed to retrieve cluster topology')).not.toBeInTheDocument()
+  })
+
+  test('shows the setup state instead of the unavailable state while the project is coming up with an empty topology', async () => {
+    mockProject('COMING_UP')
+    mockHaAdmin({ isHealthy: true })
+
+    customRender(<HaInstanceConfiguration />, { profileContext: PROFILE_CONTEXT })
+
+    expect(await screen.findByText('Setting up project')).toBeInTheDocument()
+    expect(screen.queryByText('Cluster topology unavailable')).not.toBeInTheDocument()
+  })
+
+  test('surfaces topology errors once the project is running', async () => {
+    mockProject('ACTIVE_HEALTHY')
+    mockHaAdmin({ isHealthy: false })
+
+    customRender(<HaInstanceConfiguration />, { profileContext: PROFILE_CONTEXT })
+
+    expect(await screen.findByText('Failed to retrieve cluster topology')).toBeInTheDocument()
+  })
+
+  test('shows the unavailable state for an empty topology once the project is running', async () => {
+    mockProject('ACTIVE_HEALTHY')
+    mockHaAdmin({ isHealthy: true })
+
+    customRender(<HaInstanceConfiguration />, { profileContext: PROFILE_CONTEXT })
+
+    expect(await screen.findByText('Cluster topology unavailable')).toBeInTheDocument()
+  })
+})

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/HaInstanceConfiguration.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/HaInstanceConfiguration.tsx
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 import { useParams } from 'common'
 import { Loader2 } from 'lucide-react'
 import { useMemo } from 'react'
+import { EmptyStatePresentational } from 'ui-patterns/EmptyStatePresentational'
 
 import { DiagramFlow } from './DiagramFlow'
 import { addShardNodes, generateHaNodesAndEdges } from './HaInstanceConfiguration.utils'
@@ -12,6 +13,8 @@ import { AlertError } from '@/components/ui/AlertError'
 import { HighAvailabilityDisabledEmptyState } from '@/components/ui/HighAvailability/HighAvailabilityDisabledEmptyState'
 import { haClusterGatewaysQueryOptions } from '@/data/ha-admin/ha-cluster-gateways-query'
 import { haClusterPoolersQueryOptions } from '@/data/ha-admin/ha-cluster-poolers-query'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { PROJECT_STATUS } from '@/lib/constants'
 
 const nodeTypes = {
   HA_GATEWAY: MultigatewayNode,
@@ -32,6 +35,10 @@ const POOLER_STATUS_REFRESH_MS = 30_000
  */
 export const HaInstanceConfiguration = () => {
   const { ref: projectRef } = useParams()
+  const { data: project } = useSelectedProjectQuery()
+
+  const isProjectBuilding =
+    project?.status === PROJECT_STATUS.COMING_UP || project?.status === PROJECT_STATUS.UNKNOWN
 
   // Gateways poll on the same interval as poolers so the gateway count and
   // gateway→primary edge track cluster changes while the page stays open.
@@ -75,6 +82,29 @@ export const HaInstanceConfiguration = () => {
       <div role="status" className="h-full w-full flex items-center justify-center">
         <span className="sr-only">Loading cluster topology...</span>
         <Loader2 aria-hidden="true" className="motion-safe:animate-spin text-foreground-light" />
+      </div>
+    )
+  }
+
+  // While the project is provisioning, the /ha-admin endpoints fail or return an
+  // empty topology as a matter of course — that's a project still booting, not an
+  // unhealthy cluster.
+  if (isProjectBuilding && (isError || (poolers ?? []).length === 0)) {
+    return (
+      <div className="h-full w-full flex items-center justify-center p-6">
+        <EmptyStatePresentational
+          icon={
+            <Loader2
+              size={24}
+              strokeWidth={1.5}
+              aria-hidden="true"
+              className="motion-safe:animate-spin text-foreground-muted"
+            />
+          }
+          title="Setting up project"
+          description="Cluster topology will be available once your project is ready. This may take a few minutes."
+          className="max-w-md"
+        />
       </div>
     )
   }

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/HaInstanceConfiguration.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/HaInstanceConfiguration.tsx
@@ -77,34 +77,40 @@ export const HaInstanceConfiguration = () => {
   const isError = isErrorGateways || isErrorPoolers
   const error = gatewaysError ?? poolersError
 
-  if (isPending) {
-    return (
-      <div role="status" className="h-full w-full flex items-center justify-center">
-        <span className="sr-only">Loading cluster topology...</span>
-        <Loader2 aria-hidden="true" className="motion-safe:animate-spin text-foreground-light" />
-      </div>
-    )
-  }
-
   // While the project is provisioning, the /ha-admin endpoints fail or return an
   // empty topology as a matter of course — that's a project still booting, not an
   // unhealthy cluster.
-  if (isProjectBuilding && (isError || (poolers ?? []).length === 0)) {
+  const isProvisioning = isProjectBuilding && (isError || (poolers ?? []).length === 0)
+
+  // The initial load and the provisioning placeholder share one persistent
+  // role="status" live region so screen readers announce the transition between
+  // them — a live region only announces updates to content it already contains.
+  if (isPending || isProvisioning) {
     return (
-      <div className="h-full w-full flex items-center justify-center p-6">
-        <EmptyStatePresentational
-          icon={
+      <div role="status" className="h-full w-full flex items-center justify-center p-6">
+        {isPending ? (
+          <>
+            <span className="sr-only">Loading cluster topology...</span>
             <Loader2
-              size={24}
-              strokeWidth={1.5}
               aria-hidden="true"
-              className="motion-safe:animate-spin text-foreground-muted"
+              className="motion-safe:animate-spin text-foreground-light"
             />
-          }
-          title="Setting up project"
-          description="Cluster topology will be available once your project is ready. This may take a few minutes."
-          className="max-w-md"
-        />
+          </>
+        ) : (
+          <EmptyStatePresentational
+            icon={
+              <Loader2
+                size={24}
+                strokeWidth={1.5}
+                aria-hidden="true"
+                className="motion-safe:animate-spin text-foreground-muted"
+              />
+            }
+            title="Setting up project"
+            description="Cluster topology will be available once your project is ready. This may take a few minutes."
+            className="max-w-md"
+          />
+        )}
       </div>
     )
   }


### PR DESCRIPTION
While an HA (Multigres) project is provisioning, the `/ha-admin` topology endpoints fail or return an empty topology as a matter of course — the cluster topology diagram rendered that as a hard "Failed to retrieve cluster topology" error (or the "Cluster topology unavailable" contact-support state). The diagram now checks the project status and, while the project is building (`COMING_UP`/`UNKNOWN`, same pair `ProjectLayout` treats as booting), shows a "Setting up project" empty state instead. Both the project-detail query (self-polls while booting) and the ha-admin queries (30s interval) keep refetching, so the diagram appears on its own once boot completes.

Once the project is past provisioning, genuine errors and the empty-topology state surface exactly as before.

<img width="1491" height="769" alt="mul1475-setting-up-state-wide" src="https://github.com/user-attachments/assets/3f095634-9939-41cd-88c3-0849cbad7374" />

**Added:**
- Component tests for the four states: booting + error, booting + empty (→ setup state), running + error (→ error alert), running + empty (→ unavailable state)

Addresses [MUL-1475](https://linear.app/supabase/issue/MUL-1475/polish-infra-diagram).

## To test

- On an HA project mid-provisioning (or simulate: dev toolbar project-status override → `COMING_UP`, with `/ha-admin` requests failing), open Settings → Infrastructure — the topology panel shows "Setting up project" with a spinner, not the error alert
- On a healthy HA project, the topology diagram renders as before; if `/ha-admin` genuinely fails there, the error alert still shows
- `pnpm --filter studio exec vitest run components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/HaInstanceConfiguration.test.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Setting up project” state while projects are provisioning or their status is unavailable.
  * Prevents premature topology errors or unavailable messages during project setup.
  * Added accessible status announcements for loading and setup-state transitions.

* **Bug Fixes**
  * Active projects now correctly display topology errors when cluster health data cannot be retrieved.
  * Healthy responses with no topology data display an appropriate unavailable state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->