### PR TITLE
[FE-3716] fix(studio): restrict HA project creation to us-east-1 in prod

### DIFF
--- a/apps/studio/components/interfaces/ProjectCreation/ProjectCreation.utils.test.ts
+++ b/apps/studio/components/interfaces/ProjectCreation/ProjectCreation.utils.test.ts
@@ -94,7 +94,7 @@ describe('High Availability project creation constraints', () => {
   it.each([
     ['local', 'eu-central-1'],
     ['staging', 'us-east-1'],
-    ['prod', undefined],
+    ['prod', 'us-east-1'],
   ])('resolves the %s region restriction', (environment, expectedRegion) => {
     expect(getHighAvailabilityRegionCode(environment)).toBe(expectedRegion)
   })
@@ -102,7 +102,7 @@ describe('High Availability project creation constraints', () => {
   it.each([
     ['local', undefined],
     ['staging', 'us-east-1'],
-    ['prod', undefined],
+    ['prod', 'us-east-1'],
   ])(
     'applies the %s region restriction to high availability projects',
     (environment, expectedRegion) => {

--- a/apps/studio/components/interfaces/ProjectCreation/ProjectCreation.utils.ts
+++ b/apps/studio/components/interfaces/ProjectCreation/ProjectCreation.utils.ts
@@ -86,6 +86,7 @@ export const getHighAvailabilityRegionCode = (
   environment = process.env.NEXT_PUBLIC_ENVIRONMENT
 ) => {
   // Local dev stacks can run in any of the supported regions, so they're left unrestricted
+  if (environment === 'prod') return 'us-east-1'
   if (environment === 'staging') return 'us-east-1'
   if (environment === 'local') return 'eu-central-1'
   return undefined


### PR DESCRIPTION
`getHighAvailabilityRegionCode` had `staging` and `local` cases but no `prod` case, so it returned `undefined` in production and the High Availability region filtering never applied — the creation flow offered every AWS region while HA Alpha is only live in `us-east-1`. Adds the `prod` case returning `us-east-1`, matching staging. The region filter and the "High Availability projects are currently limited to…" banner both key off this value, so no other changes are needed.

This keeps the accepted hardcoded-per-environment pattern for Alpha; the API/entitlement-driven enabled-regions design stays open on the ticket for when the rollout expands.

**Changed:**
- `ProjectCreation.utils.ts` — `prod` → `us-east-1`
- `ProjectCreation.utils.test.ts` — the two env tables previously pinned prod as unrestricted; now expect `us-east-1`

Addresses [FE-3716](https://linear.app/supabase/issue/FE-3716/show-enabled-regions) (and the folded-in MUL-1337).

## To test

- `pnpm --filter studio exec vitest run components/interfaces/ProjectCreation/ProjectCreation.utils.test.ts`
- In prod after deploy: new project → toggle High Availability → region select offers only East US (North Virginia) and shows the "limited to" notice; staging/local behavior unchanged (only the `prod` env branch changed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - High-availability project creation now correctly uses the `us-east-1` region for production environments.
  - Region selection is now properly restricted to `us-east-1` when creating production projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->