### PR TITLE
fix(pg-meta): handle empty arrays in in filters

### DIFF
--- a/packages/pg-meta/src/query/Query.utils.ts
+++ b/packages/pg-meta/src/query/Query.utils.ts
@@ -231,6 +231,7 @@ function inFilterSql(filter: Filter) {
     const filterValueTxt = String(filter.value)
     values = filterValueTxt.split(',').map((x) => filterLiteral(x))
   }
+  if (values.length === 0) return safeSql`false`
   return safeSql`${ident(filter.column)} ${filter.operator as SafeSqlFragment} (${joinSqlFragments(values, ',')})`
 }
 
@@ -263,6 +264,7 @@ function inTupleFilterSql(filter: Filter) {
   if (!Array.isArray(filter.value)) {
     throw new Error(`Values for a tuple 'in' filter must be an array`)
   }
+  if (filter.value.length === 0) return safeSql`false`
 
   const columns = safeSql`(${joinSqlFragments(
     filter.column.map((c) => ident(c)),

--- a/packages/pg-meta/test/query/query.test.ts
+++ b/packages/pg-meta/test/query/query.test.ts
@@ -420,6 +420,18 @@ describe('Query.utils', () => {
         expect(result).toBe('select * from public.users where id in (1,2,3);')
       })
 
+      test('should handle "in" operator with an empty array', () => {
+        const filters: Filter[] = [{ column: 'id', operator: 'in', value: [] }]
+        const result = QueryUtils.selectQuery(table, safeSql`*`, { filters })
+        expect(result).toBe('select * from public.users where false;')
+      })
+
+      test('should handle tuple "in" operator with an empty array', () => {
+        const filters: Filter[] = [{ column: ['id', 'version'], operator: 'in', value: [] }]
+        const result = QueryUtils.selectQuery(table, safeSql`*`, { filters })
+        expect(result).toBe('select * from public.users where false;')
+      })
+
       test('should correctly handle "in" operator with comma-separated string', () => {
         const filters: Filter[] = [{ column: 'id', operator: 'in', value: '1,2,3' }]
         const result = QueryUtils.selectQuery(table, safeSql`*`, { filters: filters })


### PR DESCRIPTION
# fix(pg-meta): handle empty arrays in `in` filters

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix with regression tests.

## What is the current behavior?

Fixes #49788

Scalar and tuple `in` filters render an empty array as `IN ()`, which is invalid PostgreSQL syntax. Studio can reach this through the vault helper when a wrapper has no encrypted parameters to decrypt.

## What is the new behavior?

Empty `in` arrays render as `false`, matching empty-set membership semantics. Selects and counts return no matches, while updates and deletes safely affect no rows.

Regression tests cover both scalar and tuple filters.

## Additional context

Tests run locally:

- pg-meta Query tests: 90 passed
- Prettier on changed files: passed
- `git diff --check`: passed
- Language-server diagnostics: clean

Docker-backed PostgreSQL tests were not available locally, but the changed tests exercise the complete SQL rendering path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Empty “in” filters now correctly return no results instead of generating invalid or incomplete filter conditions.
  - This behavior is supported for both single-column and multi-column filters.

- **Tests**
  - Added coverage for empty single-column and tuple-based “in” filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->