### PR TITLE
fix(pg-meta): emit an always-false predicate for an empty in filter

### DIFF
--- a/packages/pg-meta/src/query/Query.utils.ts
+++ b/packages/pg-meta/src/query/Query.utils.ts
@@ -224,6 +224,10 @@ function applyFilters(query: SafeSqlFragment, filters: Filter[]) {
 }
 
 function inFilterSql(filter: Filter) {
+  // Postgres rejects `in ()` outright. Membership in an empty set is always false, so emit
+  // that instead: selects return nothing and updates/deletes stay no-ops.
+  if (Array.isArray(filter.value) && filter.value.length === 0) return safeSql`false`
+
   let values: Array<SafeSqlFragment>
   if (Array.isArray(filter.value)) {
     values = filter.value.map((x) => filterLiteral(x))
@@ -263,6 +267,8 @@ function inTupleFilterSql(filter: Filter) {
   if (!Array.isArray(filter.value)) {
     throw new Error(`Values for a tuple 'in' filter must be an array`)
   }
+  // Same as inFilterSql: `(a, b) in ()` is a syntax error, and an empty set is always false.
+  if (filter.value.length === 0) return safeSql`false`
 
   const columns = safeSql`(${joinSqlFragments(
     filter.column.map((c) => ident(c)),

--- a/packages/pg-meta/test/query/query.test.ts
+++ b/packages/pg-meta/test/query/query.test.ts
@@ -420,6 +420,26 @@ describe('Query.utils', () => {
         expect(result).toBe('select * from public.users where id in (1,2,3);')
       })
 
+      test('should emit an always-false predicate for an empty "in" array', () => {
+        // `in ()` is a syntax error in Postgres, so an empty set has to become `false`:
+        // membership in nothing is never true.
+        const filters: Filter[] = [{ column: 'id', operator: 'in', value: [] }]
+        const result = QueryUtils.selectQuery(table, safeSql`*`, { filters: filters })
+        expect(result).toBe('select * from public.users where false;')
+      })
+
+      test('should emit an always-false predicate for an empty tuple "in" array', () => {
+        const filters: Filter[] = [{ column: ['id', 'version'], operator: 'in', value: [] }]
+        const result = QueryUtils.selectQuery(table, safeSql`*`, { filters: filters })
+        expect(result).toBe('select * from public.users where false;')
+      })
+
+      test('should keep an empty "in" delete a no-op rather than invalid sql', () => {
+        const filters: Filter[] = [{ column: 'id', operator: 'in', value: [] }]
+        const result = QueryUtils.deleteQuery(table, filters)
+        expect(result).toBe('delete from public.users where false;')
+      })
+
       test('should correctly handle "in" operator with comma-separated string', () => {
         const filters: Filter[] = [{ column: 'id', operator: 'in', value: '1,2,3' }]
         const result = QueryUtils.selectQuery(table, safeSql`*`, { filters: filters })


### PR DESCRIPTION
## What kind of change

Bug fix.

Fixes #49788.

## Current behavior

An empty array passed to an `in` filter renders empty parentheses, which Postgres rejects as a syntax error. Reproduced against master by running the builder:

```
new Query().from('users','public').select().filter('id','in',[]).toSql()
  -> select * from public.users where id in ();

new Query().from('users','public').delete().filter('id','in',[]).toSql()
  -> delete from public.users where id in ();

filter(['id','version'],'in',[])
  -> select * from public.users where (id, version) in ();
```

So it is not select-only. The delete and update paths generate the same invalid statement, and the tuple filter has its own copy of the problem in `inTupleFilterSql`.

The reporter names a live path: `getDecryptedParameters()` hands `Object.values(paramsToBeDecrypted)` to `getDecryptedValues()`, and for a wrapper with no encrypted parameters that is `[]`, so the generated vault query is invalid.

## New behavior

Both `inFilterSql` and `inTupleFilterSql` emit `false` when the value array is empty:

```
select * from public.users where false;
delete from public.users where false;
select * from public.users where false and z = 3;
```

Membership in an empty set is never true, so `false` is the faithful predicate: selects return no rows, and updates and deletes stay no-ops rather than failing or, worse, matching everything. It also composes correctly with other filters, as the third line shows.

`FilterOperator` has no negated `in`, so there is no `not in` case that would need `true` instead. If one is ever added, it will need its own branch.

## Tests

Three added to `test/query/query.test.ts`, next to the existing `in` cases. They fail on unmodified master, which I verified by checking out master's `Query.utils.ts` with the new tests in place:

```
× should emit an always-false predicate for an empty "in" array
    Expected: "select * from public.users where false;"
    Received: "select * from public.users where id in ();"
× should emit an always-false predicate for an empty tuple "in" array
    Received: "select * from public.users where (id, version) in ();"
× should keep an empty "in" delete a no-op rather than invalid sql
    Received: "delete from public.users where id in ();"
```

## What I left alone

A non-array value still goes down the comma-splitting branch, so `filter('id','in','')` produces `in ('')`. That is valid SQL with different semantics rather than a syntax error, so it is a separate question from this bug and I did not touch it.

Unrelated to this change, `test/query/advanced-query.test.ts` is already red on master (identifier-quoting cases). I confirmed that by stashing my diff and re-running, so it is not something this PR introduces, and I have left it alone.

## Verification

- `test/query/query.test.ts`: 91 tests, green.
- `pnpm --filter pg-meta typecheck` clean, `prettier --check` clean.

Freshman contributor, and I use Claude Code as an assistant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed queries using empty `in` filters to avoid invalid SQL errors.
  * Empty filters now return no results for selects and safely perform no action for updates or deletes.

* **Tests**
  * Added coverage for scalar and tuple filters, including safe delete behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->