### PR TITLE
fix(studio): count rows with a zero filter instead of ignoring it

### DIFF
--- a/apps/studio/data/table-rows/table-rows-count-query.ts
+++ b/apps/studio/data/table-rows/table-rows-count-query.ts
@@ -67,7 +67,12 @@ export async function getTableRowsCount(
 
   const table = parseSupaTable(entity)
 
-  const formattedFilters = filters?.map((x) => ({ ...x, value: formatFilterValue(table, x) }))
+  // Drop blanks BEFORE formatting: formatFilterValue coerces '' to Number('') === 0 on a
+  // numeric column, which would turn an empty filter into a real `= 0`. The rows and
+  // delete-all paths already guard in this order; only the count path formatted first.
+  const formattedFilters = filters
+    ?.filter((x) => x.value !== undefined && x.value !== null && x.value !== '')
+    .map((x) => ({ ...x, value: formatFilterValue(table, x) }))
   const sql = wrapWithRoleImpersonation(
     getTableRowsCountSql({
       table,

--- a/packages/pg-meta/src/sql/studio/database/rows.ts
+++ b/packages/pg-meta/src/sql/studio/database/rows.ts
@@ -31,7 +31,7 @@ export const getTableRowsCountSql = ({
     const query = new Query()
     let queryChains = query.from(table.name, table.schema ?? undefined).count()
     filters
-      .filter((x) => x.value && x.value !== '')
+      .filter((x) => x.value !== undefined && x.value !== null && x.value !== '')
       .forEach((x) => {
         queryChains = queryChains.filter(x.column, x.operator, x.value)
       })
@@ -44,7 +44,7 @@ export const getTableRowsCountSql = ({
     const selectQuery = new Query()
     let selectQueryChains = selectQuery.from(table.name, table.schema ?? undefined).select()
     filters
-      .filter((x) => x.value && x.value != '')
+      .filter((x) => x.value !== undefined && x.value !== null && x.value !== '')
       .forEach((x) => {
         selectQueryChains = selectQueryChains.filter(x.column, x.operator, x.value)
       })
@@ -56,7 +56,7 @@ export const getTableRowsCountSql = ({
     const countQuery = new Query()
     let countQueryChains = countQuery.from(table.name, table.schema ?? undefined).count()
     filters
-      .filter((x) => x.value && x.value != '')
+      .filter((x) => x.value !== undefined && x.value !== null && x.value !== '')
       .forEach((x) => {
         countQueryChains = countQueryChains.filter(x.column, x.operator, x.value)
       })

--- a/packages/pg-meta/test/sql/studio/rows-count-filters.test.ts
+++ b/packages/pg-meta/test/sql/studio/rows-count-filters.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'vitest'
+
+import { getTableRowsCountSql } from '../../../src'
+import type { Filter } from '../../../src/query'
+
+const table = {
+  name: 'orders',
+  schema: 'public',
+  columns: [{ name: 'quantity', format: 'int4' }],
+}
+
+const countSql = (value: Filter['value']) =>
+  String(
+    getTableRowsCountSql({
+      table: table as Parameters<typeof getTableRowsCountSql>[0]['table'],
+      filters: [{ column: 'quantity', operator: '=', value }],
+      enforceExactCount: true,
+    })
+  )
+
+describe('getTableRowsCountSql filter guards', () => {
+  test('keeps a zero filter, so the count matches the rows', () => {
+    // The rows query applies every filter it is given, so dropping `= 0` here is what made
+    // the grid show filtered rows next to a whole-table count.
+    expect(countSql(0)).toContain('where quantity = 0')
+  })
+
+  test('keeps a non-zero filter', () => {
+    expect(countSql(5)).toContain('where quantity = 5')
+  })
+
+  test('still ignores a blank filter', () => {
+    expect(countSql('')).not.toContain('where')
+  })
+})


### PR DESCRIPTION
## What kind of change

Bug fix.

Fixes #49776.

## Current behavior

Filtering a numeric column by `0` in the Table Editor filters the rows correctly but leaves the row count reflecting the whole table.

Three places guard filters with the same expression, `x.value && x.value !== ''`, but they differ in when they run relative to `formatFilterValue`:

```
table-rows-query.ts:148             guards the RAW value, then formats   -> '0' is a truthy string, survives
table-row-delete-all-mutation.ts:29 guards the RAW value, then formats   -> survives
table-rows-count-query.ts:68        FORMATS first, then rows.ts guards   -> '0' became 0, falsy, dropped
```

Only the count path formats first, so only the count loses the filter. Reproduced by generating the SQL:

```
value 0   -> select (select count(*) from public.orders), false as is_estimate;
value 5   -> select (select count(*) from public.orders where quantity = 5), ...
value ''  -> select (select count(*) from public.orders), ...        (correct, blanks are ignored)
```

The reporter's constraint is the tricky part: the guard cannot simply be relaxed to `!== undefined`, because `formatFilterValue` runs `Number(filter.value)` and `Number('')` is also `0`. Relaxing the guard alone would turn an empty filter into a real `= 0` and show zero rows for a blank input.

## New behavior

Two changes, one idea: a blank is never allowed to become `0` in the first place, and after that `0` can be treated as the value it is.

1. `table-rows-count-query.ts` drops blanks **before** `formatFilterValue` runs, matching the order the rows and delete-all paths already use.
2. The three guards in `getTableRowsCountSql` accept `0`, testing for absence rather than falsiness.

```
value 0   -> select (select count(*) from public.orders where quantity = 0), ...
value 5   -> unchanged
value ''  -> unchanged, still no where clause
```

## Not affected, and I checked because it worried me

`getTableRowDeleteAllSql` carries the same `x.value && ...` guard, and dropping a filter there would widen "delete all rows matching this filter" to the entire table. It is safe: it guards the raw string, so `'0'` is truthy and the filter reaches the delete. I left it alone rather than churn it.

## Tests

New DB-free file, `packages/pg-meta/test/sql/studio/rows-count-filters.test.ts`, asserting the generated SQL for `0`, `5` and `''`. The existing `rows-count.test.ts` is entirely DB-backed and I cannot run Postgres here, and this bug is in SQL generation rather than execution, so a string-level test is both the right level and one I can actually verify.

It fails on unmodified master:

```
× keeps a zero filter, so the count matches the rows
    Expected: "where quantity = 0"
    Received: "select (select count(*) from public.orders), false as is_estimate;"
```

The reordering in `table-rows-count-query.ts` is not unit-tested: the surrounding function needs a `queryClient` and a table prefetch, so there is no cheap seam. Its effect is the same guard the other two paths already apply, just moved ahead of the formatting step.

## Verification

- `pg-meta` query + new count-filter tests: 91 green.
- `pnpm --filter studio typecheck` and `pnpm --filter pg-meta typecheck` clean, `prettier --check` clean.

Freshman contributor, and I use Claude Code as an assistant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed table row filtering so numeric values of `0` and boolean `false` are handled correctly.
  * Prevented blank or missing filters from being interpreted as numeric zero.
  * Improved count and select query results when applying filters.

* **Tests**
  * Added coverage for zero, non-zero, and blank filter values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->