### PR TITLE
[FE-4278] fix(studio): allow broadcast before any realtime message arrives

### DIFF
--- a/apps/studio/components/interfaces/Realtime/Inspector/MessagesTable.tsx
+++ b/apps/studio/components/interfaces/Realtime/Inspector/MessagesTable.tsx
@@ -164,31 +164,36 @@ const MessagesTable = ({
           )}
         >
           <div className="flex grow flex-col lg:w-1/2">
-            {enabled && (
-              <div className="w-full h-9 px-4 bg-surface-100 items-center inline-flex justify-between text-foreground-light">
-                <div className="inline-flex gap-2.5 text-xs">
-                  <Loader2 size="16" className="animate-spin" />
-                  <div>Listening</div>
-                  <div>•</div>
-                  <div>
-                    {data.length > 0
-                      ? data.length >= 100
-                        ? `Found a large number of messages, showing only the latest 100...`
-                        : `Found ${data.length} messages...`
-                      : `No message found yet...`}
+            {/* Persistent role="status" live region so screen readers announce when
+            listening starts — a live region only announces updates to content it
+            already contains. */}
+            <div role="status">
+              {enabled && (
+                <div className="w-full h-9 px-4 bg-surface-100 items-center inline-flex justify-between text-foreground-light">
+                  <div className="inline-flex gap-2.5 text-xs">
+                    <Loader2 size="16" aria-hidden="true" className="animate-spin" />
+                    <div>Listening</div>
+                    <div aria-hidden="true">•</div>
+                    <div>
+                      {data.length > 0
+                        ? data.length >= 100
+                          ? `Found a large number of messages, showing only the latest 100...`
+                          : `Found ${data.length} messages...`
+                        : `No message found yet...`}
+                    </div>
                   </div>
+                  <ShortcutTooltip shortcutId={SHORTCUT_IDS.INSPECTOR_BROADCAST} side="bottom">
+                    <Button
+                      variant="default"
+                      onClick={showSendMessage}
+                      icon={<Megaphone strokeWidth={1.5} />}
+                    >
+                      <span>Broadcast a message</span>
+                    </Button>
+                  </ShortcutTooltip>
                 </div>
-                <ShortcutTooltip shortcutId={SHORTCUT_IDS.INSPECTOR_BROADCAST} side="bottom">
-                  <Button
-                    variant="default"
-                    onClick={showSendMessage}
-                    icon={<Megaphone strokeWidth={1.5} />}
-                  >
-                    <span>Broadcast a message</span>
-                  </Button>
-                </ShortcutTooltip>
-              </div>
-            )}
+              )}
+            </div>
 
             <DataGrid
               className="data-grid--simple-logs h-full border-t-0! border-b-0!"

--- a/apps/studio/components/interfaces/Realtime/Inspector/index.tsx
+++ b/apps/studio/components/interfaces/Realtime/Inspector/index.tsx
@@ -55,6 +55,11 @@ export const RealtimeInspector = () => {
   const hasChannel = realtimeConfig.channelName.length > 0
   const isListening = realtimeConfig.enabled
 
+  // Once a channel is set, MessagesTable renders its own empty states (including
+  // the "Broadcast a message" entry point), so sending doesn't depend on a
+  // message having arrived first. EmptyRealtime is only the pre-channel onboarding.
+  const showMessagesTable = hasChannel || (logData ?? []).length > 0
+
   const handleJoinChannel = useCallback(() => {
     if (!hasChannel) {
       setChannelPopoverOpen(true)
@@ -98,7 +103,7 @@ export const RealtimeInspector = () => {
       />
       <div className="relative flex flex-col grow">
         <div className="flex grow">
-          {(logData ?? []).length > 0 ? (
+          {showMessagesTable ? (
             <MessagesTable
               hasChannelSet={hasChannel}
               enabled={isListening}


### PR DESCRIPTION
In the Realtime Inspector, the messages view — which holds every "Broadcast a message" entry point — only rendered once at least one message had been received. With only Broadcast enabled and no inbound traffic, the page stayed on the "Create realtime experiences" onboarding forever, so there was no way to send a broadcast at all.

The render gate now keys off a channel being set rather than `logData.length`: once you join a channel, `MessagesTable` renders and its existing empty states provide the send entry points ("Listening • No message found yet…" toolbar + the "No Realtime messages found" panel). The onboarding remains the pre-channel state.

Addresses [FE-4278](https://linear.app/supabase/issue/FE-4278/realtime-inspector-cant-send-broadcast-without-incoming-messages).

## To test

- Realtime → Inspector, before joining a channel: the "Create realtime experiences" onboarding still shows
- Join a channel (with Presence off / Broadcast only so nothing arrives): the listening view renders immediately with "No message found yet…" and "Broadcast a message" in both the toolbar and the empty-state panel — previously this was stuck on the onboarding
- Click "Broadcast a message" and send with defaults: the broadcast appears in the grid
- Stop listening: no crash, messages retained

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The Realtime Inspector now displays the messages view as soon as a channel is selected.
  * Empty-state guidance, including the option to broadcast a message, is now available before any messages arrive.
  * Pre-channel onboarding remains visible until a channel is configured.
* **Accessibility**
  * Listening-status updates are now announced to screen readers.
  * Decorative loading and separator elements are hidden from assistive technologies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->