### PR TITLE
docs: add all ways to get an API key (not just Studio)

### DIFF
--- a/apps/docs/content/_partials/api_keys_deprecation.mdx
+++ b/apps/docs/content/_partials/api_keys_deprecation.mdx
@@ -2,6 +2,6 @@
 
 Supabase is deprecating the `anon` and `service_role` keys by the end of 2026. Use the publishable (`sb_publishable_xxx`) and secret (`sb_secret_xxx`) keys instead. For the reasoning behind the change, see [the announcement on GitHub](https://github.com/orgs/supabase/discussions/29260).
 
-In most cases you can get keys from your project's [**Connect** dialog](/dashboard/project/\_?showConnect=true&connectTab={{ .tab }}&framework={{ .framework }}). For every way to retrieve a key, including the CLI and the Management API, see [Find your keys](/docs/guides/getting-started/api-keys#find-your-keys).
+In most cases you can get keys from your project's [**Connect** dialog](/dashboard/project/\_?showConnect=true&connectTab={{ .tab }}&framework={{ .framework }}). For every way to retrieve a key, including the CLI and the Management API, refer to [Find your keys](/docs/guides/getting-started/api-keys#find-your-keys).
 
 </Admonition>

--- a/apps/docs/content/_partials/api_keys_deprecation.mdx
+++ b/apps/docs/content/_partials/api_keys_deprecation.mdx
@@ -2,9 +2,6 @@
 
 Supabase is deprecating the `anon` and `service_role` keys by the end of 2026. Use the publishable (`sb_publishable_xxx`) and secret (`sb_secret_xxx`) keys instead. For the reasoning behind the change, see [the announcement on GitHub](https://github.com/orgs/supabase/discussions/29260).
 
-In most cases you can get keys from your project's [**Connect** dialog](/dashboard/project/\_?showConnect=true&connectTab={{ .tab }}&framework={{ .framework }}). To pick a specific key, open the [**Settings > API Keys**](/dashboard/project/_/settings/api-keys/) section of the Dashboard.
-
-- **For publishable and secret keys**, open the **API Keys** tab. If you don't have a publishable key, select **Create new API Keys**. Copy the **Publishable key** for client-side operations, and a key from **Secret keys** for server-side operations.
-- **For legacy keys**, open the **Legacy API Keys** tab. Copy the `anon` key for client-side operations and the `service_role` key for server-side operations.
+In most cases you can get keys from your project's [**Connect** dialog](/dashboard/project/\_?showConnect=true&connectTab={{ .tab }}&framework={{ .framework }}). For every way to retrieve a key, including the CLI and the Management API, see [Find your keys](/docs/guides/getting-started/api-keys#find-your-keys).
 
 </Admonition>

--- a/apps/docs/content/guides/getting-started/api-keys.mdx
+++ b/apps/docs/content/guides/getting-started/api-keys.mdx
@@ -155,7 +155,7 @@ Pass the branch's own project ref to read the keys for a preview branch. A branc
 
 Use the Management API to fetch keys from your own tooling, such as a deploy script or an internal provisioning service.
 
-Authenticate with a [personal access token](/dashboard/account/tokens). Pass `reveal=true` to include the key values in the response.
+Authenticate with a [personal access token](/dashboard/account/tokens). An OAuth application needs the `secrets:read` scope, and a fine-grained token needs the `api_gateway_keys_read` permission. Without either, the request returns 403 Forbidden.
 
 ```bash
 export PROJECT_REF="your-project-ref"
@@ -163,10 +163,10 @@ export SUPABASE_ACCESS_TOKEN="your-personal-access-token"
 
 curl -X GET "https://api.supabase.com/v1/projects/$PROJECT_REF/api-keys?reveal=true" \
   -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \
-  | jq '.[] | {name, type, api_key}'
+  | jq '.[] | {name, type}'
 ```
 
-The `jq` pipe only formats the output, so you can drop it. See [Get project API keys](/docs/reference/api/v1-get-project-api-keys) for the full response.
+`reveal=true` includes the key values in the response, and this `jq` filter drops them again so they stay out of your terminal. Write the values straight into your secret store rather than printing them, because anything on standard output lands in your CI logs. See [Get project API keys](/docs/reference/api/v1-get-project-api-keys) for the full response.
 
 </TabPanel>
 <TabPanel id="local" label="Local stack">

--- a/apps/docs/content/guides/getting-started/api-keys.mdx
+++ b/apps/docs/content/guides/getting-started/api-keys.mdx
@@ -155,7 +155,7 @@ Pass the branch's own project ref to read the keys for a preview branch. A branc
 
 Use the Management API to fetch keys from your own tooling, such as a deploy script or an internal provisioning service.
 
-Authenticate with a [personal access token](/dashboard/account/tokens). Secret key values are only returned when you ask for them with `reveal`.
+Authenticate with a [personal access token](/dashboard/account/tokens). Pass `reveal=true` to include the key values in the response.
 
 ```bash
 export PROJECT_REF="your-project-ref"
@@ -171,7 +171,7 @@ The `jq` pipe only formats the output, so you can drop it. See [Get project API 
 </TabPanel>
 <TabPanel id="local" label="Local stack">
 
-A local stack mints its own keys. They are unrelated to your hosted project's keys, and they are the same on every machine, so they are safe to commit in a local-only `.env`.
+A local stack mints its own keys. They are unrelated to your hosted project's keys, so a local key never grants access to your hosted data.
 
 This path needs the Supabase CLI and a container runtime. See [Running a local Supabase project](/docs/guides/local-development/cli/getting-started#running-a-local-supabase-project) for both.
 

--- a/apps/docs/content/guides/getting-started/api-keys.mdx
+++ b/apps/docs/content/guides/getting-started/api-keys.mdx
@@ -126,7 +126,7 @@ Use the Dashboard when you are setting up a project by hand. This is the fastest
 </TabPanel>
 <TabPanel id="cli" label="Supabase CLI">
 
-Use the CLI to script setup, or to read the keys for a preview branch.
+Use the CLI to script setup, or to read the keys for a preview branch. This path needs the Supabase CLI, so [install it](/docs/guides/local-development/cli/getting-started#installing-the-supabase-cli) first.
 
 1. Sign in, if you haven't already.
 
@@ -163,6 +163,8 @@ See [Get project API keys](/docs/reference/api/v1-get-project-api-keys) for the 
 <TabPanel id="local" label="Local stack">
 
 A local stack mints its own keys. They are unrelated to your hosted project's keys, and they are the same on every machine, so they are safe to commit in a local-only `.env`.
+
+This path needs the Supabase CLI and a container runtime. See [Running a local Supabase project](/docs/guides/local-development/cli/getting-started#running-a-local-supabase-project) for both.
 
 1. Start the stack. The publishable and secret keys are in the startup output, under **Authentication Keys**.
 

--- a/apps/docs/content/guides/getting-started/api-keys.mdx
+++ b/apps/docs/content/guides/getting-started/api-keys.mdx
@@ -10,7 +10,7 @@ This guide covers:
 
 - [Which key do you use?](#which-key-do-you-use) answers that in one table.
 - [How API keys work](#how-api-keys-work) explains what each key type is and which Postgres role it maps to.
-- [Find and use your keys](#find-and-use-your-keys) covers getting a key out of the Dashboard and rotating one that leaked.
+- [Find and use your keys](#find-and-use-your-keys) covers the ways to retrieve a key and how to rotate one that leaked.
 - [Security reference](#security-reference) lists what publishable keys don't protect against, how to handle secret keys, and the known limitations.
 
 ## Which key do you use?
@@ -108,6 +108,8 @@ Secret keys improve on the old JWT-based `service_role` key, and we recommend th
 
 There are several ways to read your keys. Pick the one that matches where you are working.
 
+Every path below reads keys that already exist. If your project has no publishable or secret key yet, create them first in the [**Settings > API Keys**](/dashboard/project/_/settings/api-keys/) section of the Dashboard.
+
 <Tabs
   scrollable
   size="small"
@@ -134,7 +136,13 @@ Use the CLI to script setup, or to read the keys for a preview branch. This path
    supabase login
    ```
 
-2. List the keys for a project.
+2. Find the project ref, if you don't know it.
+
+   ```bash
+   supabase projects list
+   ```
+
+3. List the keys for that project.
 
    ```bash
    supabase projects api-keys --project-ref your-project-ref
@@ -151,13 +159,14 @@ Authenticate with a [personal access token](/dashboard/account/tokens). Secret k
 
 ```bash
 export PROJECT_REF="your-project-ref"
+export SUPABASE_ACCESS_TOKEN="your-personal-access-token"
 
 curl -X GET "https://api.supabase.com/v1/projects/$PROJECT_REF/api-keys?reveal=true" \
   -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \
   | jq '.[] | {name, type, api_key}'
 ```
 
-See [Get project API keys](/docs/reference/api/v1-get-project-api-keys) for the full response.
+The `jq` pipe only formats the output, so you can drop it. See [Get project API keys](/docs/reference/api/v1-get-project-api-keys) for the full response.
 
 </TabPanel>
 <TabPanel id="local" label="Local stack">

--- a/apps/docs/content/guides/getting-started/api-keys.mdx
+++ b/apps/docs/content/guides/getting-started/api-keys.mdx
@@ -106,8 +106,78 @@ Secret keys improve on the old JWT-based `service_role` key, and we recommend th
 
 ### Find your keys
 
-1. Open your project's [**Connect** dialog](/dashboard/project/_?showConnect=true). It shows the keys for the framework you select, which is the fastest path for most setups.
-2. To pick a specific key, or to see every key your project has, open the [**Settings > API Keys**](/dashboard/project/_/settings/api-keys/) section of the Dashboard.
+There are several ways to read your keys. Pick the one that matches where you are working.
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="dashboard"
+  queryGroup="retrieval-method"
+>
+<TabPanel id="dashboard" label="Dashboard">
+
+Use the Dashboard when you are setting up a project by hand. This is the fastest path for most setups, and the only one that needs no prior authentication beyond being signed in.
+
+1. Open your project's [**Connect** dialog](/dashboard/project/_?showConnect=true). It shows the URL and publishable key for the framework you select, ready to paste into `.env`.
+2. To pick a specific key, or to see every key your project has, open the [**Settings > API Keys**](/dashboard/project/_/settings/api-keys/) section of the Dashboard instead.
+3. Copy each value into your project's `.env` file.
+
+</TabPanel>
+<TabPanel id="cli" label="Supabase CLI">
+
+Use the CLI to script setup, or to read the keys for a preview branch.
+
+1. Sign in, if you haven't already.
+
+   ```bash
+   supabase login
+   ```
+
+2. List the keys for a project.
+
+   ```bash
+   supabase projects api-keys --project-ref your-project-ref
+   ```
+
+Pass the branch's own project ref to read the keys for a preview branch. A branch has its own keys, and the command returns the linked project's keys when you omit the flag.
+
+</TabPanel>
+<TabPanel id="management-api" label="Management API">
+
+Use the Management API to fetch keys from your own tooling, such as a deploy script or an internal provisioning service.
+
+Authenticate with a [personal access token](/dashboard/account/tokens). Secret key values are only returned when you ask for them with `reveal`.
+
+```bash
+export PROJECT_REF="your-project-ref"
+
+curl -X GET "https://api.supabase.com/v1/projects/$PROJECT_REF/api-keys?reveal=true" \
+  -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \
+  | jq '.[] | {name, type, api_key}'
+```
+
+See [Get project API keys](/docs/reference/api/v1-get-project-api-keys) for the full response.
+
+</TabPanel>
+<TabPanel id="local" label="Local stack">
+
+A local stack mints its own keys. They are unrelated to your hosted project's keys, and they are the same on every machine, so they are safe to commit in a local-only `.env`.
+
+1. Start the stack. The publishable and secret keys are in the startup output, under **Authentication Keys**.
+
+   ```bash
+   supabase start
+   ```
+
+2. Print them again at any time while the stack is running.
+
+   ```bash
+   supabase status
+   ```
+
+</TabPanel>
+</Tabs>
 
 ### Rotate a leaked or compromised key [#leaked-key]
 

--- a/apps/docs/content/guides/getting-started/api-keys.mdx
+++ b/apps/docs/content/guides/getting-started/api-keys.mdx
@@ -130,19 +130,19 @@ Use the Dashboard when you are setting up a project by hand. It needs nothing bu
 
 Use the CLI to script setup, or to read the keys for a preview branch. This path needs the Supabase CLI, so [install it](/docs/guides/local-development/cli/getting-started#installing-the-supabase-cli) first.
 
-1. Sign in, if you haven't already.
+1. Sign in, if you haven't already:
 
    ```bash
    supabase login
    ```
 
-2. Find the project ref, if you don't know it.
+2. Find the project ref, if you don't know it:
 
    ```bash
    supabase projects list
    ```
 
-3. List the keys for that project.
+3. List the keys for that project:
 
    ```bash
    supabase projects api-keys --project-ref your-project-ref
@@ -175,13 +175,15 @@ A local stack mints its own keys. They are unrelated to your hosted project's ke
 
 This path needs the Supabase CLI and a container runtime. See [Running a local Supabase project](/docs/guides/local-development/cli/getting-started#running-a-local-supabase-project) for both.
 
-1. Start the stack. The publishable and secret keys are in the startup output, under **Authentication Keys**.
+1. Start the stack:
 
    ```bash
    supabase start
    ```
 
-2. Print them again at any time while the stack is running.
+   The publishable and secret keys are in the output, under **Authentication Keys**.
+
+2. Print them again at any time while the stack is running:
 
    ```bash
    supabase status

--- a/apps/docs/content/guides/getting-started/api-keys.mdx
+++ b/apps/docs/content/guides/getting-started/api-keys.mdx
@@ -106,7 +106,7 @@ Secret keys improve on the old JWT-based `service_role` key, and we recommend th
 
 ### Find your keys
 
-There are several ways to read your keys. Pick the one that matches where you are working.
+Pick the path that matches where you are working.
 
 Every path below reads keys that already exist. If your project has no publishable or secret key yet, create them first in the [**Settings > API Keys**](/dashboard/project/_/settings/api-keys/) section of the Dashboard.
 
@@ -119,7 +119,7 @@ Every path below reads keys that already exist. If your project has no publishab
 >
 <TabPanel id="dashboard" label="Dashboard">
 
-Use the Dashboard when you are setting up a project by hand. This is the fastest path for most setups, and the only one that needs no prior authentication beyond being signed in.
+Use the Dashboard when you are setting up a project by hand. It needs nothing but a signed-in session.
 
 1. Open your project's [**Connect** dialog](/dashboard/project/_?showConnect=true). It shows the URL and publishable key for the framework you select, ready to paste into `.env`.
 2. To pick a specific key, or to see every key your project has, open the [**Settings > API Keys**](/dashboard/project/_/settings/api-keys/) section of the Dashboard instead.


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update.

## What is the current behavior?

"Find your keys" offers only the Dashboard. Readers working from a script, a preview branch, or a local stack have no path, which accounts for several logged reports of people unable to locate a key.

## What is the new behavior?

Replace the procedure with a tabbed selector so a reader picks the path that matches where they work:

- Dashboard, through the Connect dialog or Settings > API Keys.
- Supabase CLI, `supabase projects api-keys --project-ref`, including the note that a preview branch has its own keys and needs its own ref.
- Management API, `GET /v1/projects/{ref}/api-keys?reveal=true`, for deploy scripts and provisioning tooling.
- Local stack, from `supabase start` output or `supabase status`.

`queryGroup="retrieval-method"` makes each tab deep-linkable, so a reader can be sent straight to one path.

## Additional context

PR 3 of 4. Base is #49796.

## Manual testing

1. Open the API keys guide on the deploy preview and find "Find your keys".
2. Select each tab. One panel shows at a time, and the URL gains `?retrieval-method=<tab>`.
3. Open that URL in a new tab. It restores the same selection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the API key deprecation guidance to link to the “Find your keys” guide.
  - Expanded the guide with instructions for retrieving keys through the Dashboard, CLI, Management API, and local stack.
  - Added guidance to create keys in the Dashboard when none are available.
  - Reworded the table of contents entry for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->