### PR TITLE
feat(studio): design pass on BigQuery table layout

### DIFF
--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/AdvancedSettings.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/AdvancedSettings.tsx
@@ -5,7 +5,6 @@ import {
   AccordionContent,
   AccordionItem,
   AccordionTrigger,
-  Badge,
   FormControl,
   FormField,
   FormInputGroupInput,
@@ -60,7 +59,6 @@ export const AdvancedSettings = ({
             </div>
           </AccordionTrigger>
           <AccordionContent className="pb-0! pt-3 [&>div]:flex [&>div]:flex-col [&>div]:gap-y-4">
-            {/* Batch wait time - applies to all destinations */}
             <FormField
               control={form.control}
               name="maxFillMs"
@@ -189,12 +187,7 @@ export const AdvancedSettings = ({
                   name="connectionPoolSize"
                   render={({ field }) => (
                     <FormItemLayout
-                      label={
-                        <div className="flex flex-col gap-y-2">
-                          <span>Connection pool size</span>
-                          <Badge className="w-min">BigQuery only</Badge>
-                        </div>
-                      }
+                      label="Connection pool size"
                       layout="horizontal"
                       description="Number of BigQuery connections used for destination writes."
                     >
@@ -223,12 +216,7 @@ export const AdvancedSettings = ({
                   name="maxStalenessMins"
                   render={({ field }) => (
                     <FormItemLayout
-                      label={
-                        <div className="flex flex-col gap-y-2">
-                          <span>Maximum staleness*</span>
-                          <Badge className="w-min">BigQuery only</Badge>
-                        </div>
-                      }
+                      label="Maximum staleness"
                       layout="horizontal"
                       description="Set the maximum age of query results while BigQuery applies ongoing changes, or leave blank for the freshest results."
                     >
@@ -253,23 +241,14 @@ export const AdvancedSettings = ({
 
                 <div className="flex flex-col gap-y-3">
                   <div className="flex flex-col gap-y-1">
-                    <div className="flex items-center gap-x-2">
-                      <span className="text-sm text-foreground">
-                        Table partitioning and clustering*
-                      </span>
-                      <Badge className="w-min">BigQuery only</Badge>
-                    </div>
+                    <span className="text-sm text-foreground">Table layout</span>
                     <p className="text-sm text-foreground-lighter">
-                      Configure partitioning and clustering for individual tables in the selected
-                      publication.
+                      Partitioning and clustering for each BigQuery table. Applied when a
+                      destination table is first created or reset.
                     </p>
                   </div>
                   <TableOptions control={form.control} />
                 </div>
-
-                <p className="text-sm text-foreground-lighter leading-normal">
-                  * Applied when a destination table is first created or after you use Reset table.
-                </p>
               </>
             )}
           </AccordionContent>

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/BigQuery/BigQuery.schema.test.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/BigQuery/BigQuery.schema.test.ts
@@ -35,13 +35,18 @@ describe('BigQuery replication schemas', () => {
     expect(BigQueryTableOptionSchema.safeParse({ tableId: 1 }).success).toBe(true)
   })
 
-  it('allows an unfinished time-column partition so save can omit it', () => {
-    expect(
-      BigQueryTableOptionSchema.safeParse({
-        tableId: 1,
-        partitionBy: { kind: 'time_column', column: '', granularity: 'day' },
-      }).success
-    ).toBe(true)
+  it('rejects a column-based partition with no column instead of dropping it on save', () => {
+    for (const partitionBy of [
+      { kind: 'time_column', column: '', granularity: 'day' },
+      { kind: 'integer_range', column: '', start: 0, end: 10, interval: 1 },
+    ]) {
+      const result = BigQueryTableOptionSchema.safeParse({ tableId: 1, partitionBy })
+
+      expect(result.success).toBe(false)
+      expect(result.error?.issues.map(({ message }) => message)).toContain(
+        'Select a partition column'
+      )
+    }
   })
 
   it('requires the integer range end to be greater than the start', () => {

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/BigQuery/BigQuery.schema.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/BigQuery/BigQuery.schema.ts
@@ -15,15 +15,19 @@ const integerRangeValue = (label: string) =>
     ])
     .refine((value): boolean => value !== '', `${label} is required`)
 
+// A column-based partition is dropped from the save payload when its column is missing, so
+// require one here rather than letting the form accept a layout it will silently discard.
+const partitionColumn = z.string().min(1, 'Select a partition column')
+
 export const BigQueryPartitionBySchema = z.discriminatedUnion('kind', [
   z.object({
     kind: z.literal('time_column'),
-    column: z.string(),
+    column: partitionColumn,
     granularity: BigQueryTimePartitionGranularitySchema.optional(),
   }),
   z.object({
     kind: z.literal('integer_range'),
-    column: z.string(),
+    column: partitionColumn,
     start: integerRangeValue('Start'),
     end: integerRangeValue('End'),
     interval: integerRangeValue('Interval'),

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/BigQuery/TableOptionFields.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/BigQuery/TableOptionFields.tsx
@@ -15,7 +15,7 @@ import {
 } from '@/data/replication/create-destination-pipeline-mutation'
 
 const PARTITION_KIND_LABELS: Record<BigQueryPartitionKind, string> = {
-  none: 'No partitioning',
+  none: 'None',
   time_column: 'Time column',
   integer_range: 'Integer range',
   ingestion_time: 'Ingestion time',
@@ -100,10 +100,14 @@ export const PartitioningFields = ({
           )
         )
       : columnSelection.availableColumnNames
+  const compatibleColumnEmptyLabel =
+    partitionBy?.kind === 'time_column'
+      ? 'No published date or timestamp columns'
+      : 'No published integer columns'
 
   return (
     <>
-      <FormItemLayout isReactForm={false} label="Partitioning" layout="vertical">
+      <FormItemLayout isReactForm={false} label="Partition by" layout="vertical">
         <Select
           value={partitionKind}
           onValueChange={(kind: BigQueryPartitionKind) => {
@@ -162,7 +166,7 @@ export const PartitioningFields = ({
                   !columnSelection.isError &&
                   compatibleColumnNames.length === 0
                 }
-                emptyLabel="No compatible published columns available"
+                emptyLabel={compatibleColumnEmptyLabel}
                 errorLabel="Unable to load columns. Open the list again to retry."
               />
               {compatibleColumnNames.map((column) => (
@@ -198,7 +202,7 @@ export const PartitioningFields = ({
       )}
 
       {partitionBy?.kind === 'integer_range' && (
-        <div className="grid grid-cols-3 gap-x-2">
+        <div className="grid grid-cols-[repeat(auto-fit,minmax(10rem,1fr))] gap-2">
           <FormItemLayout
             isReactForm={false}
             label="Start"
@@ -280,7 +284,7 @@ export const ClusteringFields = ({
   return (
     <FormItemLayout
       isReactForm={false}
-      label="Clustering columns"
+      label="Cluster by"
       layout="vertical"
       description={`Selection order sets the clustering order. Maximum ${BIGQUERY_MAX_CLUSTERING_COLUMNS} columns.`}
       error={error}

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/BigQuery/TableOptionRow.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/BigQuery/TableOptionRow.tsx
@@ -1,6 +1,9 @@
 import { useParams } from 'common'
+import { RotateCcw } from 'lucide-react'
 import { useState } from 'react'
 import { get, useController, useFormState, type Control, type FieldErrors } from 'react-hook-form'
+import { Button } from 'ui'
+import { Admonition } from 'ui-patterns/Admonition'
 
 import type { DestinationPanelSchemaType } from '../DestinationForm.schema'
 import {
@@ -16,46 +19,55 @@ import {
 import { useReplicationSourceId } from '@/data/replication/sources-query'
 import { useReplicationTableColumnsQuery } from '@/data/replication/table-columns-query'
 
+type TableOption = NonNullable<DestinationPanelSchemaType['tableOptions']>[number]
+type PartitionBy = TableOption['partitionBy']
+
 const getFieldErrorMessage = (errors: FieldErrors<DestinationPanelSchemaType>, path: string) => {
   const error = get(errors, path)
   return typeof error?.message === 'string' ? error.message : undefined
 }
 
-interface TableOptionRowProps {
-  control: Control<DestinationPanelSchemaType>
-  index: number
+interface TableOptionErrors {
+  partitionBy?: string
+  column?: string
+  start?: string
+  end?: string
+  interval?: string
+  clusterBy?: string
+}
+
+interface TableOptionEditorProps {
+  partitionBy: PartitionBy
+  clusterBy: string[]
+  onPartitionByChange: (partitionBy: PartitionBy) => void
+  onClusterByChange: (clusterBy: string[]) => void
+  errors?: TableOptionErrors
   isPublicationColumnsError?: boolean
   isPublicationColumnsPending?: boolean
   publishedColumnNames?: ReadonlySet<string> | null
   tableId: number
+  onClear?: () => void
 }
 
-export const TableOptionRow = ({
-  control,
-  index,
+const TableOptionEditor = ({
+  partitionBy,
+  clusterBy,
+  onPartitionByChange,
+  onClusterByChange,
+  errors = {},
   isPublicationColumnsError = false,
   isPublicationColumnsPending = false,
   publishedColumnNames,
   tableId,
-}: TableOptionRowProps) => {
+  onClear,
+}: TableOptionEditorProps) => {
   const { ref: projectRef } = useParams()
   const sourceId = useReplicationSourceId({ projectRef })
-  const { errors } = useFormState({ control })
 
-  const { field: partitionByField } = useController({
-    control,
-    name: `tableOptions.${index}.partitionBy`,
-  })
-  const { field: clusterByField } = useController({
-    control,
-    name: `tableOptions.${index}.clusterBy`,
-  })
-
-  const partitionBy = partitionByField.value
   const shouldInitiallyLoadColumns =
     partitionBy?.kind === 'time_column' ||
     partitionBy?.kind === 'integer_range' ||
-    (clusterByField.value?.length ?? 0) > 0
+    clusterBy.length > 0
   const [shouldLoadColumns, setShouldLoadColumns] = useState(shouldInitiallyLoadColumns)
   const {
     data: columns = [],
@@ -85,7 +97,7 @@ export const TableOptionRow = ({
   const columnTypeByName = new Map(columns.map((column) => [column.name, column.type]))
   const areColumnsVerified = isSuccess && canUseColumns
   const partitionColumn = partitionBy && 'column' in partitionBy ? partitionBy.column : undefined
-  const configuredColumns = [partitionColumn, ...(clusterByField.value ?? [])].filter(
+  const configuredColumns = [partitionColumn, ...clusterBy].filter(
     (column, columnIndex, allConfiguredColumns): column is string =>
       typeof column === 'string' &&
       column.trim().length > 0 &&
@@ -113,15 +125,6 @@ export const TableOptionRow = ({
     handleRefreshColumnsOnOpen(isOpen)
   }
 
-  const fieldPath = `tableOptions.${index}`
-  const partitionByError = getFieldErrorMessage(errors, `${fieldPath}.partitionBy`)
-  const partitionErrors = {
-    column: getFieldErrorMessage(errors, `${fieldPath}.partitionBy.column`),
-    start: getFieldErrorMessage(errors, `${fieldPath}.partitionBy.start`),
-    end: getFieldErrorMessage(errors, `${fieldPath}.partitionBy.end`),
-    interval: getFieldErrorMessage(errors, `${fieldPath}.partitionBy.interval`),
-  }
-  const clusterByError = getFieldErrorMessage(errors, `${fieldPath}.clusterBy`)
   const columnSelection: ColumnSelectionState = {
     availableColumnNames,
     columnTypeByName,
@@ -132,36 +135,125 @@ export const TableOptionRow = ({
   }
 
   return (
-    <div className="flex flex-col gap-y-3 rounded-md border p-3 ml-6">
+    <div className="flex flex-col gap-y-4 border-t px-3 py-4">
       <PartitioningFields
         partitionBy={partitionBy}
-        onChange={partitionByField.onChange}
+        onChange={onPartitionByChange}
         onNeedsColumns={() => setShouldLoadColumns(true)}
         columnSelection={columnSelection}
-        errors={partitionErrors}
+        errors={{
+          column: errors.column,
+          start: errors.start,
+          end: errors.end,
+          interval: errors.interval,
+        }}
       />
+
+      {errors.partitionBy && <p className="text-sm text-destructive-600">{errors.partitionBy}</p>}
 
       <ClusteringFields
-        clusterBy={clusterByField.value ?? []}
-        onChange={clusterByField.onChange}
+        clusterBy={clusterBy}
+        onChange={onClusterByChange}
         columnSelection={columnSelection}
-        error={clusterByError}
+        error={errors.clusterBy}
       />
 
-      {partitionByError && <p className="text-sm text-destructive-600">{partitionByError}</p>}
-
       {shouldLoadColumns && isColumnSelectionError && (
-        <p className="text-sm text-warning-600">
-          Unable to verify columns against the source and publication. Refresh and try again.
-        </p>
+        <Admonition
+          type="warning"
+          title="Columns could not be verified"
+          description="Refresh the page before changing or saving this table’s layout."
+        />
       )}
 
       {unavailableColumns.length > 0 && (
-        <p className="text-sm text-destructive-600 leading-normal">
-          Some columns are no longer in the source or publication. Choose different columns or
-          remove them.
-        </p>
+        <Admonition
+          type="destructive"
+          title="Some selected columns are no longer available"
+          description="Choose columns that are still in the source and publication."
+        />
+      )}
+
+      {onClear !== undefined && (
+        <Button
+          type="button"
+          variant="default"
+          className="self-start"
+          icon={<RotateCcw size={14} />}
+          onClick={onClear}
+        >
+          Clear
+        </Button>
       )}
     </div>
   )
 }
+
+type SharedRowProps = Pick<
+  TableOptionEditorProps,
+  'isPublicationColumnsError' | 'isPublicationColumnsPending' | 'publishedColumnNames' | 'tableId'
+>
+
+interface TableOptionRowProps extends SharedRowProps {
+  control: Control<DestinationPanelSchemaType>
+  index: number
+  onClear: () => void
+}
+
+export const TableOptionRow = ({
+  control,
+  index,
+  onClear,
+  ...sharedProps
+}: TableOptionRowProps) => {
+  const { errors } = useFormState({ control })
+
+  const { field: partitionByField } = useController({
+    control,
+    name: `tableOptions.${index}.partitionBy`,
+  })
+  const { field: clusterByField } = useController({
+    control,
+    name: `tableOptions.${index}.clusterBy`,
+  })
+
+  const fieldPath = `tableOptions.${index}`
+
+  return (
+    <TableOptionEditor
+      partitionBy={partitionByField.value}
+      clusterBy={clusterByField.value ?? []}
+      onPartitionByChange={partitionByField.onChange}
+      onClusterByChange={clusterByField.onChange}
+      errors={{
+        partitionBy: getFieldErrorMessage(errors, `${fieldPath}.partitionBy`),
+        column: getFieldErrorMessage(errors, `${fieldPath}.partitionBy.column`),
+        start: getFieldErrorMessage(errors, `${fieldPath}.partitionBy.start`),
+        end: getFieldErrorMessage(errors, `${fieldPath}.partitionBy.end`),
+        interval: getFieldErrorMessage(errors, `${fieldPath}.partitionBy.interval`),
+        clusterBy: getFieldErrorMessage(errors, `${fieldPath}.clusterBy`),
+      }}
+      onClear={onClear}
+      {...sharedProps}
+    />
+  )
+}
+
+interface TableOptionDraftRowProps extends SharedRowProps {
+  onCreate: (option: Pick<TableOption, 'partitionBy' | 'clusterBy'>) => void
+}
+
+/**
+ * Rendered while a table has no entry in the tableOptions field array. Expanding a row must not
+ * touch form state, otherwise merely looking at a table leaves the form dirty and triggers the
+ * unsaved-changes prompt. The first edit creates the entry, after which TableOptionRow takes over.
+ */
+export const TableOptionDraftRow = ({ onCreate, ...sharedProps }: TableOptionDraftRowProps) => (
+  <TableOptionEditor
+    partitionBy={undefined}
+    clusterBy={[]}
+    onPartitionByChange={(partitionBy) => onCreate({ partitionBy, clusterBy: [] })}
+    onClusterByChange={(clusterBy) => onCreate({ partitionBy: undefined, clusterBy })}
+    {...sharedProps}
+  />
+)

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/BigQuery/TableOptions.test.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/BigQuery/TableOptions.test.tsx
@@ -96,15 +96,17 @@ const mockTables = (tables: ReadTablesResponse['tables']) => {
 
 const TableOptionsHarness = ({
   tableOptions,
+  publicationName = 'analytics',
 }: {
   tableOptions: NonNullable<DestinationPanelSchemaType['tableOptions']>
+  publicationName?: string
 }) => {
   const form = useForm<DestinationPanelSchemaType>({
     mode: 'onChange',
     resolver: zodResolver(DestinationPanelFormSchema),
     defaultValues: {
       name: 'Warehouse',
-      publicationName: 'analytics',
+      publicationName,
       tableSyncCopyMode: 'include_all_tables',
       tableSyncCopyTableIds: [],
       tableOptions,
@@ -114,6 +116,7 @@ const TableOptionsHarness = ({
   return (
     <Form {...form}>
       <TableOptions control={form.control} />
+      <p>{form.formState.isDirty ? 'Form is dirty' : 'Form is pristine'}</p>
       <button type="button" tabIndex={0} onClick={() => void form.trigger()}>
         Validate form
       </button>
@@ -122,6 +125,76 @@ const TableOptionsHarness = ({
 }
 
 describe('TableOptions source reconciliation', () => {
+  it('explains why a publication is required before showing table settings', async () => {
+    mockSources()
+
+    customRender(<TableOptionsHarness publicationName="" tableOptions={[]} />)
+
+    expect(await screen.findByText('Select a publication')).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'Choose the publication whose destination tables you want to partition or cluster.'
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('discloses table settings without implying that the table is excluded', async () => {
+    mockSources()
+    mockPublication()
+
+    customRender(<TableOptionsHarness tableOptions={[]} />)
+
+    const tableTrigger = await screen.findByRole('button', {
+      name: 'public.Orders: Not configured',
+    })
+    expect(screen.queryByText('Partition by')).not.toBeInTheDocument()
+
+    fireEvent.click(tableTrigger)
+    expect(await screen.findByText('Partition by')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Clear' })).not.toBeInTheDocument()
+
+    fireEvent.click(tableTrigger)
+    expect(screen.queryByText('Partition by')).not.toBeInTheDocument()
+    expect(screen.getByText('Not configured')).toBeInTheDocument()
+  })
+
+  it('keeps the form pristine when a table row is only expanded', async () => {
+    mockSources()
+    mockPublication()
+
+    customRender(<TableOptionsHarness tableOptions={[]} />)
+
+    const tableTrigger = await screen.findByRole('button', {
+      name: 'public.Orders: Not configured',
+    })
+    expect(screen.getByText('Form is pristine')).toBeInTheDocument()
+
+    fireEvent.click(tableTrigger)
+    expect(await screen.findByText('Partition by')).toBeInTheDocument()
+    expect(screen.getByText('Form is pristine')).toBeInTheDocument()
+
+    fireEvent.click(tableTrigger)
+    expect(screen.getByText('Form is pristine')).toBeInTheDocument()
+  })
+
+  it('clears a configured layout without removing its table row', async () => {
+    mockSources()
+    mockPublication()
+    mockColumns(101, [{ name: 'region', type: 'text', nullable: false, primary_key: false }])
+
+    customRender(<TableOptionsHarness tableOptions={[{ tableId: 101, clusterBy: ['region'] }]} />)
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'public.Orders: 1 clustering column' })
+    )
+    fireEvent.click(await screen.findByRole('button', { name: 'Clear' }))
+
+    expect(
+      screen.getByRole('button', { name: 'public.Orders: Not configured' })
+    ).toBeInTheDocument()
+    expect(screen.queryByText('Partition by')).not.toBeInTheDocument()
+  })
+
   it('shows integer range validation errors beside the invalid fields', async () => {
     mockSources()
     mockPublication()
@@ -144,10 +217,40 @@ describe('TableOptions source reconciliation', () => {
       />
     )
 
-    await screen.findByText('public.Orders')
+    fireEvent.click(await screen.findByRole('button', { name: /public\.Orders: Integer range/ }))
     fireEvent.click(screen.getByRole('button', { name: 'Validate form' }))
-    expect(await screen.findByText('End must be greater than start.')).toBeInTheDocument()
     expect(await screen.findByText('Interval must be greater than 0.')).toBeInTheDocument()
+    // Once beside the End field, and once on the trigger so a collapsed row still explains itself.
+    expect(screen.getAllByText('End must be greater than start.')).toHaveLength(2)
+    expect(
+      screen.getByRole('button', { name: 'public.Orders: End must be greater than start.' })
+    ).toBeInTheDocument()
+  })
+
+  it('blocks an incomplete partition instead of dropping it silently on save', async () => {
+    mockSources()
+    mockPublication()
+    mockColumns(101, [
+      { name: 'CreatedAt', type: 'timestamptz', nullable: false, primary_key: true },
+    ])
+
+    customRender(
+      <TableOptionsHarness
+        tableOptions={[{ tableId: 101, partitionBy: { kind: 'time_column', column: '' } }]}
+      />
+    )
+
+    const tableTrigger = await screen.findByRole('button', {
+      name: 'public.Orders: Time column partitioning',
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Validate form' }))
+    expect(await screen.findByText('Select a partition column')).toBeInTheDocument()
+
+    // The row can be collapsed when the save is attempted, so the trigger has to explain it too.
+    expect(
+      await screen.findByRole('button', { name: 'public.Orders: Select a partition column' })
+    ).toBe(tableTrigger)
   })
 
   it('marks configured columns that no longer exist while preserving valid names and types', async () => {
@@ -170,9 +273,12 @@ describe('TableOptions source reconciliation', () => {
       />
     )
 
+    fireEvent.click(
+      await screen.findByRole('button', { name: /public\.Orders: Daily by DroppedAt/ })
+    )
     expect(
-      await screen.findByText(/Some columns are no longer in the source or publication/)
-    ).toHaveClass('text-destructive-600')
+      await screen.findByText('Some selected columns are no longer available')
+    ).toBeInTheDocument()
     expect(screen.getAllByText('region')[0]).toBeInTheDocument()
     expect(screen.getByText('text')).toBeInTheDocument()
     expect(screen.getByText('DroppedAt').parentElement).toHaveClass('text-destructive-600')
@@ -207,9 +313,12 @@ describe('TableOptions source reconciliation', () => {
       <TableOptionsHarness tableOptions={[{ tableId: 101, clusterBy: ['PrivateNote'] }]} />
     )
 
+    fireEvent.click(
+      await screen.findByRole('button', { name: /public\.Orders: 1 clustering column/ })
+    )
     expect(
-      await screen.findByText(/Some columns are no longer in the source or publication/)
-    ).toHaveClass('text-destructive-600')
+      await screen.findByText('Some selected columns are no longer available')
+    ).toBeInTheDocument()
     expect(screen.getByText('PrivateNote').parentElement).toHaveClass('text-destructive-600')
   })
 
@@ -273,8 +382,13 @@ describe('TableOptions source reconciliation', () => {
       <TableOptionsHarness tableOptions={[{ tableId: 12, clusterBy: ['ExcludedColumn'] }]} />
     )
 
+    fireEvent.click(
+      await screen.findByRole('button', {
+        name: /public\.Events2026August: 1 clustering column/,
+      })
+    )
     expect(
-      await screen.findByText(/Some columns are no longer in the source or publication/)
+      await screen.findByText('Some selected columns are no longer available')
     ).toBeInTheDocument()
     expect(screen.getByText('ExcludedColumn').parentElement).toHaveClass('text-destructive-600')
   })
@@ -325,13 +439,14 @@ describe('TableOptions source reconciliation', () => {
       <TableOptionsHarness tableOptions={[{ tableId: 12, clusterBy: ['UnverifiedColumn'] }]} />
     )
 
+    fireEvent.click(
+      await screen.findByRole('button', {
+        name: /public\.Events2026August: 1 clustering column/,
+      })
+    )
+    expect(await screen.findByText('Columns could not be verified')).toBeInTheDocument()
     expect(
-      await screen.findByText(
-        'Unable to verify columns against the source and publication. Refresh and try again.'
-      )
-    ).toBeInTheDocument()
-    expect(
-      screen.queryByText(/Some columns are no longer in the source or publication/)
+      screen.queryByText('Some selected columns are no longer available')
     ).not.toBeInTheDocument()
   })
 
@@ -351,11 +466,8 @@ describe('TableOptions source reconciliation', () => {
     customRender(<TableOptionsHarness tableOptions={[{ tableId: 202, clusterBy: ['Region'] }]} />)
 
     expect(await screen.findByText('Billing.Invoices')).toBeInTheDocument()
-    expect(screen.getByText('Billing.Invoices')).toHaveClass('text-destructive-600')
-    expect(screen.getByText('Some tables are no longer in the publication.')).toHaveClass(
-      'text-destructive-600'
-    )
-    expect(screen.queryByText('No longer in this publication')).not.toBeInTheDocument()
+    expect(screen.getByText('No longer in publication')).toHaveClass('text-destructive-600')
+    expect(screen.getByText('Some tables are no longer in the publication')).toBeInTheDocument()
     expect(screen.queryByText('Region')).not.toBeInTheDocument()
     expect(document.body).not.toHaveTextContent('202')
   })
@@ -387,7 +499,7 @@ describe('TableOptions source reconciliation', () => {
 
     expect(await screen.findByText('Previously configured table')).toBeInTheDocument()
     expect(screen.queryByText('OccurredAt')).not.toBeInTheDocument()
-    expect(screen.getByText('Some tables are no longer in the publication.')).toBeInTheDocument()
+    expect(screen.getByText('Some tables are no longer in the publication')).toBeInTheDocument()
     expect(document.body).not.toHaveTextContent('999')
   })
 })

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/BigQuery/TableOptions.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/BigQuery/TableOptions.tsx
@@ -1,17 +1,75 @@
 import { useParams } from 'common'
-import { useFieldArray, useWatch, type Control } from 'react-hook-form'
-import { Checkbox } from 'ui'
-import { GenericSelectionSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
+import { Table2, Trash2 } from 'lucide-react'
+import { useState } from 'react'
+import { useFieldArray, useFormState, useWatch, type Control } from 'react-hook-form'
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger, Button, cn } from 'ui'
+import { Admonition } from 'ui-patterns/Admonition'
+import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 
 import type { DestinationPanelSchemaType } from '../DestinationForm.schema'
 import { isMetadataValueLoading } from '../useRefreshOnOpen'
-import { TableOptionRow } from './TableOptionRow'
-import { resolvePublishedColumnNames } from './TableOptions.utils'
+import { TableOptionDraftRow, TableOptionRow } from './TableOptionRow'
+import { findFirstErrorMessage, resolvePublishedColumnNames } from './TableOptions.utils'
 import { useReplicationPublicationQuery } from '@/data/replication/publication-query'
 import { useReplicationSourceId } from '@/data/replication/sources-query'
 import { useReplicationTablesQuery } from '@/data/replication/tables-query'
 
 const tableLabel = (table: { schema: string; name: string }) => `${table.schema}.${table.name}`
+
+const GRANULARITY_SUMMARIES = {
+  hour: 'Hourly',
+  day: 'Daily',
+  month: 'Monthly',
+  year: 'Yearly',
+} as const
+
+// Returns undefined when a table has nothing applied, so the caller can both render and
+// de-emphasise the placeholder rather than comparing against its wording.
+const tableOptionSummary = (
+  option: NonNullable<DestinationPanelSchemaType['tableOptions']>[number] | undefined
+): string | undefined => {
+  if (option === undefined) return undefined
+
+  const parts: string[] = []
+  const partitionBy = option.partitionBy
+
+  if (partitionBy?.kind === 'time_column') {
+    parts.push(
+      partitionBy.column
+        ? `${GRANULARITY_SUMMARIES[partitionBy.granularity ?? 'day']} by ${partitionBy.column}`
+        : 'Time column partitioning'
+    )
+  } else if (partitionBy?.kind === 'integer_range') {
+    parts.push(
+      partitionBy.column ? `Integer range by ${partitionBy.column}` : 'Integer range partitioning'
+    )
+  } else if (partitionBy?.kind === 'ingestion_time') {
+    parts.push(
+      `${GRANULARITY_SUMMARIES[partitionBy.granularity ?? 'day']} ingestion-time partitioning`
+    )
+  }
+
+  const clusteringColumnCount = option.clusterBy?.length ?? 0
+  if (clusteringColumnCount > 0) {
+    parts.push(
+      `${clusteringColumnCount} clustering ${clusteringColumnCount === 1 ? 'column' : 'columns'}`
+    )
+  }
+
+  return parts.length > 0 ? parts.join(' · ') : undefined
+}
+
+// Mirrors the row list so the list does not resize when the publication resolves.
+const TableOptionsSkeleton = () => (
+  <div className="overflow-hidden rounded-md border" aria-hidden="true">
+    {['w-2/3', 'w-1/2', 'w-3/4'].map((width, index) => (
+      <div key={width} className="flex flex-col gap-1.5 px-3.5 py-3.5 border-t first:border-t-0">
+        <ShimmeringLoader className={cn('h-3 py-0', width)} delayIndex={index} />
+        <ShimmeringLoader className="h-3 w-1/4 py-0" delayIndex={index} />
+      </div>
+    ))}
+  </div>
+)
 
 interface TableOptionsProps {
   control: Control<DestinationPanelSchemaType>
@@ -21,6 +79,8 @@ export const TableOptions = ({ control }: TableOptionsProps) => {
   const { ref: projectRef } = useParams()
   const sourceId = useReplicationSourceId({ projectRef })
   const publicationName = useWatch({ control, name: 'publicationName' })
+  const tableOptions = useWatch({ control, name: 'tableOptions' }) ?? []
+  const [expandedTableId, setExpandedTableId] = useState<number>()
 
   const {
     data: selectedPublication,
@@ -42,6 +102,7 @@ export const TableOptions = ({ control }: TableOptionsProps) => {
   )
 
   const { fields, append, remove } = useFieldArray({ control, name: 'tableOptions' })
+  const { errors } = useFormState({ control, name: 'tableOptions' })
   const publicationTableIds = new Set(publicationTables.map(({ id }) => id))
   const publicationTablesById = new Map(publicationTables.map((table) => [table.id, table]))
   const configuredTables =
@@ -52,8 +113,14 @@ export const TableOptions = ({ control }: TableOptionsProps) => {
         .map((field, index) => ({ field, index }))
         .filter(({ field }) => !publicationTableIds.has(field.tableId))
     : []
+  // An expanded row needs its published columns resolved even before it has an entry, so that
+  // the first column picker it opens is already filtered correctly.
+  const activeTableIds = new Set([
+    ...fields.map(({ tableId }) => tableId),
+    ...(expandedTableId === undefined ? [] : [expandedTableId]),
+  ])
   const tablesNeedingPartitionAncestry = new Set(
-    fields.flatMap(({ tableId }) => {
+    [...activeTableIds].flatMap((tableId) => {
       if (!publicationTableIds.has(tableId) || configuredTablesById.has(tableId)) return []
 
       const parentId = publicationTablesById.get(tableId)?.partition_parent_id
@@ -76,18 +143,26 @@ export const TableOptions = ({ control }: TableOptionsProps) => {
   )
 
   if (!publicationName) {
-    return <p className="text-sm text-foreground-lighter">Select a publication first.</p>
+    return (
+      <Admonition
+        type="note"
+        title="Select a publication"
+        description="Choose the publication whose destination tables you want to partition or cluster."
+      />
+    )
   }
 
   if (isLoadingPublicationTables) {
-    return <GenericSelectionSkeletonLoader className="-mx-2 w-auto" />
+    return <TableOptionsSkeleton />
   }
 
   if (isPublicationError) {
     return (
-      <p className="text-sm text-warning-600">
-        Unable to verify table settings against the publication. Refresh and try again.
-      </p>
+      <Admonition
+        type="warning"
+        title="Table settings could not be loaded"
+        description="Refresh the page before changing or saving the table layout."
+      />
     )
   }
 
@@ -97,74 +172,131 @@ export const TableOptions = ({ control }: TableOptionsProps) => {
 
   return (
     <div className="flex flex-col gap-y-3">
-      {publicationTables.map((table) => {
-        const index = fields.findIndex((field) => field.tableId === table.id)
-        const isChecked = index !== -1
-        const publishedColumnNames =
-          selectedPublication?.config.type === 'tables'
-            ? resolvePublishedColumnNames(table.id, configuredTablesById, knownSourceTablesById)
-            : undefined
-        const isPublicationColumnsPending =
-          tablesNeedingPartitionAncestry.has(table.id) && isSourceTablesPending
+      <div className="overflow-hidden rounded-md border">
+        <Accordion
+          type="single"
+          collapsible
+          value={expandedTableId?.toString() ?? ''}
+          onValueChange={(value) => setExpandedTableId(value === '' ? undefined : Number(value))}
+        >
+          {publicationTables.map((table) => {
+            const index = fields.findIndex((field) => field.tableId === table.id)
+            const isConfigured = index !== -1
+            const summary = tableOptionSummary(isConfigured ? tableOptions[index] : undefined)
+            // Errors live inside the collapsed row, so the trigger has to carry them or a
+            // blocked save looks like nothing happened at all.
+            const rowError = isConfigured
+              ? findFirstErrorMessage(errors.tableOptions?.[index])
+              : undefined
+            const summaryLabel = rowError ?? summary ?? 'Not configured'
+            const publishedColumnNames =
+              selectedPublication?.config.type === 'tables'
+                ? resolvePublishedColumnNames(table.id, configuredTablesById, knownSourceTablesById)
+                : undefined
+            const isPublicationColumnsPending =
+              tablesNeedingPartitionAncestry.has(table.id) && isSourceTablesPending
+            const sharedProps = {
+              isPublicationColumnsError:
+                selectedPublication?.config.type === 'tables' &&
+                publishedColumnNames === null &&
+                !isPublicationColumnsPending,
+              isPublicationColumnsPending,
+              publishedColumnNames,
+              tableId: table.id,
+            }
 
-        return (
-          <div key={table.id} className="flex flex-col gap-y-3">
-            <label className="flex items-center gap-x-2 text-sm">
-              <Checkbox
-                checked={isChecked}
-                onCheckedChange={(checked) => {
-                  if (checked === true) {
-                    append({ tableId: table.id, partitionBy: undefined, clusterBy: [] })
-                  } else if (index !== -1) {
-                    remove(index)
-                  }
-                }}
-              />
-              {tableLabel(table)}
-            </label>
-            {isChecked && (
-              <TableOptionRow
-                control={control}
-                index={index}
-                isPublicationColumnsError={
-                  selectedPublication?.config.type === 'tables' &&
-                  publishedColumnNames === null &&
-                  !isPublicationColumnsPending
-                }
-                isPublicationColumnsPending={isPublicationColumnsPending}
-                publishedColumnNames={publishedColumnNames}
-                tableId={table.id}
-              />
-            )}
-          </div>
-        )
-      })}
+            return (
+              <AccordionItem key={table.id} value={table.id.toString()} className="last:border-b-0">
+                <AccordionTrigger
+                  aria-label={`${tableLabel(table)}: ${summaryLabel}`}
+                  className="px-3.5 py-3 font-normal hover:bg-surface-200 hover:no-underline [&>svg]:text-foreground-lighter"
+                >
+                  <span className="flex min-w-0 items-center gap-3.5">
+                    <Table2
+                      size={16}
+                      strokeWidth={1.5}
+                      className="shrink-0 text-foreground-lighter"
+                    />
+                    <span className="flex min-w-0 flex-col gap-0.5">
+                      <span className="truncate text-sm font-medium text-foreground">
+                        {tableLabel(table)}
+                      </span>
+                      <span
+                        className={cn(
+                          'truncate text-sm',
+                          rowError && 'text-destructive-600',
+                          !rowError && summary && 'text-foreground-lighter',
+                          // Most rows in a large publication are unconfigured, so keep the
+                          // placeholder quieter than the summaries worth scanning for.
+                          !rowError && !summary && 'text-foreground-muted'
+                        )}
+                      >
+                        {summaryLabel}
+                      </span>
+                    </span>
+                  </span>
+                </AccordionTrigger>
+                {/* Radix unmounts closed content after its exit animation, so this must not be
+                    gated on the expanded state as well or the row collapses as an empty box. */}
+                <AccordionContent className="[&>div]:p-0">
+                  {isConfigured ? (
+                    <TableOptionRow
+                      control={control}
+                      index={index}
+                      onClear={() => {
+                        remove(index)
+                        setExpandedTableId(undefined)
+                      }}
+                      {...sharedProps}
+                    />
+                  ) : (
+                    <TableOptionDraftRow
+                      onCreate={(option) => append({ tableId: table.id, ...option })}
+                      {...sharedProps}
+                    />
+                  )}
+                </AccordionContent>
+              </AccordionItem>
+            )
+          })}
+        </Accordion>
 
-      {unavailableTableOptions.map(({ field, index }) => {
-        const sourceTable = sourceTablesById.get(field.tableId)
+        {unavailableTableOptions.map(({ field, index }) => {
+          const sourceTable = sourceTablesById.get(field.tableId)
 
-        return (
-          <div key={field.id} className="flex flex-col gap-y-3">
-            <label className="flex items-center gap-x-2 text-sm">
-              <Checkbox
-                checked
-                onCheckedChange={(checked) => {
-                  if (checked === false) remove(index)
-                }}
-              />
-              <span className="text-destructive-600">
-                {sourceTable ? tableLabel(sourceTable) : 'Previously configured table'}
-                <span className="sr-only"> (no longer in publication)</span>
+          return (
+            <div
+              key={field.id}
+              className="flex items-center justify-between gap-3 border-t px-3.5 py-3"
+            >
+              <span className="flex min-w-0 items-center gap-3.5">
+                <Table2 size={16} strokeWidth={1.5} className="shrink-0 text-foreground-lighter" />
+                <span className="flex min-w-0 flex-col gap-0.5">
+                  <span className="truncate text-sm font-medium text-foreground">
+                    {sourceTable ? tableLabel(sourceTable) : 'Previously configured table'}
+                  </span>
+                  <span className="text-sm text-destructive-600">No longer in publication</span>
+                </span>
               </span>
-            </label>
-          </div>
-        )
-      })}
+              <Button
+                type="button"
+                variant="default"
+                icon={<Trash2 size={14} />}
+                onClick={() => remove(index)}
+              >
+                Remove
+              </Button>
+            </div>
+          )
+        })}
+      </div>
 
       {unavailableTableOptions.length > 0 && (
-        <p className="text-sm text-destructive-600">
-          Some tables are no longer in the publication.
-        </p>
+        <Admonition
+          type="destructive"
+          title="Some tables are no longer in the publication"
+          description="Remove their configuration before saving."
+        />
       )}
     </div>
   )

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/BigQuery/TableOptions.utils.test.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/BigQuery/TableOptions.utils.test.ts
@@ -97,4 +97,20 @@ describe('findFirstErrorMessage', () => {
     ).toBeUndefined()
     expect(findFirstErrorMessage({ clusterBy: { message: '' } })).toBeUndefined()
   })
+
+  it('does not walk into the DOM node that react-hook-form attaches to every field error', () => {
+    const input = document.createElement('input')
+    input.setAttribute('message', 'not an error message')
+
+    expect(
+      findFirstErrorMessage({ partitionBy: { column: { type: 'too_small', ref: input } } })
+    ).toBeUndefined()
+  })
+
+  it('survives a cyclic error graph', () => {
+    const partitionBy: Record<string, unknown> = { column: { type: 'too_small' } }
+    partitionBy.self = partitionBy
+
+    expect(findFirstErrorMessage({ partitionBy })).toBeUndefined()
+  })
 })

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/BigQuery/TableOptions.utils.test.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/BigQuery/TableOptions.utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  findFirstErrorMessage,
   isIntegerPartitionColumnType,
   isPartitionColumnTypeCompatible,
   isTimePartitionColumnType,
@@ -77,5 +78,23 @@ describe('partition column type compatibility', () => {
   it('treats an unknown type as compatible so columns can still be chosen while loading', () => {
     expect(isPartitionColumnTypeCompatible('time_column')).toBe(true)
     expect(isPartitionColumnTypeCompatible('integer_range', 'text')).toBe(false)
+  })
+})
+
+describe('findFirstErrorMessage', () => {
+  it('returns the first message nested anywhere inside a field-array error', () => {
+    expect(
+      findFirstErrorMessage({
+        partitionBy: { column: { type: 'too_small', message: 'Select a partition column' } },
+      })
+    ).toBe('Select a partition column')
+  })
+
+  it('ignores branches without a message rather than reporting an empty error', () => {
+    expect(findFirstErrorMessage(undefined)).toBeUndefined()
+    expect(
+      findFirstErrorMessage({ partitionBy: { column: { type: 'too_small' } } })
+    ).toBeUndefined()
+    expect(findFirstErrorMessage({ clusterBy: { message: '' } })).toBeUndefined()
   })
 })

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/BigQuery/TableOptions.utils.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/BigQuery/TableOptions.utils.ts
@@ -76,3 +76,19 @@ export const resolvePublishedColumnNames = (
 
   return null
 }
+
+// React Hook Form nests field-array errors by field name. A collapsed row can only show one
+// line, and any error there blocks the save, so the first message is enough to explain why.
+export const findFirstErrorMessage = (error: unknown): string | undefined => {
+  if (error === null || typeof error !== 'object') return undefined
+
+  const { message } = error as { message?: unknown }
+  if (typeof message === 'string' && message.length > 0) return message
+
+  for (const nested of Object.values(error)) {
+    const nestedMessage = findFirstErrorMessage(nested)
+    if (nestedMessage !== undefined) return nestedMessage
+  }
+
+  return undefined
+}

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/BigQuery/TableOptions.utils.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/BigQuery/TableOptions.utils.ts
@@ -79,14 +79,30 @@ export const resolvePublishedColumnNames = (
 
 // React Hook Form nests field-array errors by field name. A collapsed row can only show one
 // line, and any error there blocks the save, so the first message is enough to explain why.
-export const findFirstErrorMessage = (error: unknown): string | undefined => {
-  if (error === null || typeof error !== 'object') return undefined
+// Only plain objects and arrays are worth walking. React Hook Form hangs a `ref` on every
+// field error, which points at a DOM node whose graph is deep and cyclic.
+const isTraversable = (value: unknown): value is Record<string, unknown> => {
+  if (typeof value !== 'object' || value === null) return false
+  if (Array.isArray(value)) return true
 
-  const { message } = error as { message?: unknown }
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}
+
+export const findFirstErrorMessage = (
+  error: unknown,
+  visited = new WeakSet<object>()
+): string | undefined => {
+  if (!isTraversable(error) || visited.has(error)) return undefined
+  visited.add(error)
+
+  const { message } = error
   if (typeof message === 'string' && message.length > 0) return message
 
-  for (const nested of Object.values(error)) {
-    const nestedMessage = findFirstErrorMessage(nested)
+  for (const [key, nested] of Object.entries(error)) {
+    if (key === 'ref') continue
+
+    const nestedMessage = findFirstErrorMessage(nested, visited)
     if (nestedMessage !== undefined) return nestedMessage
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Design and UX pass, plus two behaviour fixes.

## What is the current behavior?

On https://github.com/supabase/supabase/pull/49535:

Each publication table has a checkbox beside it. Checking it reveals partitioning and clustering fields. Every table stays in the pipeline regardless, so the checkbox reads as a replication opt-out that it is not, and it adds a lot of weight to an already tall sheet.

## What is the new behavior?

Every publication table is an Accordion row with a table icon and a summary. Expanding reveals the optional partitioning and clustering fields. Supported partition modes and the API payload are unchanged.

Design changes:

- Checkboxes are gone. Rows are always present, so nothing implies a table can be excluded here.
- Collapsed rows summarise what is applied: `Not configured`, `Daily by created_at`, `Integer range by id`, clustering counts.
- `Not configured` is dimmed a step further than real summaries, so configured rows are what the eye lands on in a long publication.
- "Partitioning" is now "Partition by", "Clustering columns" is now "Cluster by", matching BigQuery DDL and the `partition_by` / `cluster_by` payload.
- The partition kind "No partitioning" is now "None", so the field reads "Partition by: None".
- A configured table gets Clear, which returns it to `Not configured` and never removes the row. Remove with a trash icon is reserved for stale configuration whose table has left the publication.
- Rows for tables no longer in the publication are neutral, with only the status line in destructive. The Admonition below carries the instruction instead of repeating it three times.
- Section is "Table layout", described as "Partitioning and clustering for each BigQuery table. Applied when a destination table is first created or reset." The BigQuery-only badges, the asterisks and the detached footnote are gone, since the whole block is already BigQuery-gated.
- Before a publication is picked, the section stays discoverable through a note Admonition rather than a bare line of text.
- Empty column lists say which type is missing: "No published date or timestamp columns", "No published integer columns".
- Metadata failures and stale configuration use `Admonition`. Field validation errors render inline against their field, not as an alert block.
- Loading uses a skeleton shaped like the row list, so it does not resize when the publication resolves.
- Integer range fields respond to their container width instead of a fixed three column grid.


| Before | After |
| --- | --- |
| <img width="880" height="922" alt="Replication  Database  Chives  Pantry  Supabase" src="https://github.com/user-attachments/assets/7da9f268-ac57-4467-b189-538bdb392202" /> | <img width="880" height="922" alt="Replication  Database  Chives  Pantry  Supabase" src="https://github.com/user-attachments/assets/d21d8553-04ca-4582-b867-bc6008902deb" /> |
| <img width="880" height="922" alt="Replication  Database  Chives  Pantry  Supabase" src="https://github.com/user-attachments/assets/f4d4552f-a928-40d1-b841-d441a47ca56a" /> | <img width="880" height="922" alt="27390" src="https://github.com/user-attachments/assets/c86ccf83-57b4-47a1-b8d6-082024e607de" /> |
| <img width="880" height="922" alt="Replication  Database  Chives  Pantry  Supabase" src="https://github.com/user-attachments/assets/9b7056f0-8764-48f5-91ad-a66ab7ca575a" /> | <img width="880" height="922" alt="Replication  Database  Chives  Pantry  Supabase" src="https://github.com/user-attachments/assets/9cbd5987-852a-40fb-bf64-dd615b14b0f0" /> |

Behaviour fixes:

- Expanding a row no longer appends to `tableOptions`. It used to, which made `formState.isDirty` true and triggered the unsaved changes prompt for anyone who only expanded a row and closed the sheet. `TableOptionRow` is split into a presentational editor plus a draft wrapper, so the entry is created on the first real edit.
- A column based partition now requires a column. It was accepted by the form and then dropped by `isBigQueryTableOptionConfigured` on save, so a row could read "Time column partitioning" while nothing was applied. The error also surfaces on the collapsed row, otherwise it lands inside two collapsed accordions and Save appears to do nothing.

## To test

Studio, Database, Replication, New destination, BigQuery, then pick a publication and open Advanced settings, Table layout.

1. Expand a table row, change nothing, collapse it, close the sheet. No unsaved changes prompt.
2. Set Partition by to Time column and pick a column. Collapse. The row reads `Daily by <column>`. Hit Clear. The row returns to `Not configured` and stays in the list.
3. Set Partition by to Time column, leave Partition column empty, collapse, Save. The row explains "Select a partition column" in red rather than saving and silently dropping it.
4. Switch publications and watch the loading state. The row list should not jump size when it resolves.
5. Narrow the sheet. The integer range Start, End and Interval fields should reflow rather than stay in three columns.