### PR TITLE
fix(workers): update CLI call instructions FE-4316

### DIFF
--- a/apps/studio/components/interfaces/Workers/WorkerDetail/WorkerOverviewTab.tsx
+++ b/apps/studio/components/interfaces/Workers/WorkerDetail/WorkerOverviewTab.tsx
@@ -18,7 +18,7 @@ import { LISTENING_PORT, WORKERS_REGION_LABEL } from '../Workers.constants'
 import type { Worker } from '../Workers.types'
 import { formatSize, getRuntimeMeta } from '../Workers.utils'
 import { buildWorkerCliCommands } from '../workerSnippets'
-import { WorkerSnippetTabs } from '../WorkerSnippetTabs'
+import { WORKER_CALL_TABS, WorkerSnippetTabs } from '../WorkerSnippetTabs'
 import { CLI_NAME } from '@/lib/constants/workers'
 
 interface WorkerOverviewTabProps {
@@ -215,9 +215,7 @@ export const WorkerOverviewTab = ({ worker }: WorkerOverviewTabProps) => {
         <PageSectionMeta>
           <PageSectionSummary>
             <PageSectionTitle>How to call</PageSectionTitle>
-            <PageSectionDescription>
-              Call the worker over its gateway URL. Pass your project API key as a bearer token.
-            </PageSectionDescription>
+            <PageSectionDescription>Call the worker over its gateway URL.</PageSectionDescription>
           </PageSectionSummary>
         </PageSectionMeta>
         <PageSectionContent>
@@ -229,7 +227,7 @@ export const WorkerOverviewTab = ({ worker }: WorkerOverviewTabProps) => {
               access: worker.access,
               instances: worker.declaredInstances,
             }}
-            tabs={['cli', 'js', 'python']}
+            tabs={WORKER_CALL_TABS}
           />
         </PageSectionContent>
       </PageSection>

--- a/apps/studio/components/interfaces/Workers/WorkerSnippetTabs.tsx
+++ b/apps/studio/components/interfaces/Workers/WorkerSnippetTabs.tsx
@@ -19,7 +19,7 @@ const TAB_LABEL: Record<WorkerSnippetTab, string> = {
   ai: 'AI Prompt',
   config: 'config.toml',
   cli: 'CLI',
-  curl: 'CLI',
+  curl: 'cURL',
   js: 'JavaScript',
   python: 'Python',
 }

--- a/apps/studio/components/interfaces/Workers/WorkerSnippetTabs.tsx
+++ b/apps/studio/components/interfaces/Workers/WorkerSnippetTabs.tsx
@@ -7,12 +7,19 @@ import { buildWorkerSnippets, type WorkerSnippetInput } from './workerSnippets'
 import CopyButton from '@/components/ui/CopyButton'
 import { useProjectSettingsV2Query } from '@/data/config/project-settings-v2-query'
 
-export type WorkerSnippetTab = 'ai' | 'config' | 'cli' | 'js' | 'python'
+export type WorkerSnippetTab = 'ai' | 'config' | 'cli' | 'curl' | 'js' | 'python'
+
+export const WORKER_CALL_TABS = [
+  'curl',
+  'js',
+  'python',
+] as const satisfies readonly WorkerSnippetTab[]
 
 const TAB_LABEL: Record<WorkerSnippetTab, string> = {
   ai: 'AI Prompt',
   config: 'config.toml',
   cli: 'CLI',
+  curl: 'CLI',
   js: 'JavaScript',
   python: 'Python',
 }
@@ -21,13 +28,14 @@ const TAB_ICON: Record<WorkerSnippetTab, LucideIcon> = {
   ai: Sparkles,
   config: FileCode,
   cli: Terminal,
+  curl: Terminal,
   js: FileCode,
   python: FileCode,
 }
 
 interface WorkerSnippetTabsProps {
   input: Omit<WorkerSnippetInput, 'endpoint' | 'protocol'>
-  tabs?: [WorkerSnippetTab, ...WorkerSnippetTab[]]
+  tabs?: readonly [WorkerSnippetTab, ...WorkerSnippetTab[]]
   className?: string
 }
 
@@ -45,6 +53,7 @@ export const WorkerSnippetTabs = ({ input, tabs = ['cli'], className }: WorkerSn
     ai: snippets.aiPrompt,
     config: snippets.configToml,
     cli: snippets.cli,
+    curl: snippets.curl,
     js: snippets.javascript,
     python: snippets.python,
   }

--- a/apps/studio/components/interfaces/Workers/workerSnippets.test.ts
+++ b/apps/studio/components/interfaces/Workers/workerSnippets.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import { WORKERS_REGION } from './Workers.constants'
 import { buildWorkerCliCommands, buildWorkerSnippets, EXAMPLE_WORKER } from './workerSnippets'
+import { WORKER_CALL_TABS } from './WorkerSnippetTabs'
 
 const input = (overrides: Partial<Parameters<typeof buildWorkerSnippets>[0]> = {}) => ({
   ...EXAMPLE_WORKER,
@@ -10,17 +11,26 @@ const input = (overrides: Partial<Parameters<typeof buildWorkerSnippets>[0]> = {
 })
 
 describe('buildWorkerSnippets', () => {
+  it('uses the unauthenticated curl snippet in the call tab', () => {
+    expect(WORKER_CALL_TABS).toEqual(['curl', 'js', 'python'])
+  })
+
   it('points the invoke examples at the worker URL', () => {
-    const { javascript, python } = buildWorkerSnippets(input({ name: 'embed' }))
+    const { curl, javascript, python } = buildWorkerSnippets(input({ name: 'embed' }))
     const url = 'https://abcdefgh.supabase.co/workers/v1/embed'
 
+    expect(curl).toContain(`'${url}'`)
     expect(javascript).toContain(`'${url}'`)
     expect(python).toContain(`"${url}"`)
   })
 
   it('leaves a placeholder invoke URL until the project settings resolve', () => {
-    const { javascript } = buildWorkerSnippets(input({ endpoint: undefined }))
-    expect(javascript).toContain('[YOUR WORKER URL]')
+    const { curl } = buildWorkerSnippets(input({ endpoint: undefined }))
+    expect(curl).toContain('[YOUR WORKER URL]')
+  })
+
+  it('does not require authorization for the CLI invoke example', () => {
+    expect(buildWorkerSnippets(input()).curl).not.toContain('Authorization')
   })
 
   it('asks for the anon key to invoke a public worker and the service role key for a private one', () => {

--- a/apps/studio/components/interfaces/Workers/workerSnippets.test.ts
+++ b/apps/studio/components/interfaces/Workers/workerSnippets.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest'
 
 import { WORKERS_REGION } from './Workers.constants'
 import { buildWorkerCliCommands, buildWorkerSnippets, EXAMPLE_WORKER } from './workerSnippets'
-import { WORKER_CALL_TABS } from './WorkerSnippetTabs'
 
 const input = (overrides: Partial<Parameters<typeof buildWorkerSnippets>[0]> = {}) => ({
   ...EXAMPLE_WORKER,
@@ -11,10 +10,6 @@ const input = (overrides: Partial<Parameters<typeof buildWorkerSnippets>[0]> = {
 })
 
 describe('buildWorkerSnippets', () => {
-  it('uses the unauthenticated curl snippet in the call tab', () => {
-    expect(WORKER_CALL_TABS).toEqual(['curl', 'js', 'python'])
-  })
-
   it('points the invoke examples at the worker URL', () => {
     const { curl, javascript, python } = buildWorkerSnippets(input({ name: 'embed' }))
     const url = 'https://abcdefgh.supabase.co/workers/v1/embed'

--- a/apps/studio/components/interfaces/Workers/workerSnippets.ts
+++ b/apps/studio/components/interfaces/Workers/workerSnippets.ts
@@ -17,6 +17,7 @@ export interface WorkerSnippets {
   aiPrompt: string
   configToml: string
   cli: string
+  curl: string
   javascript: string
   python: string
 }
@@ -44,6 +45,12 @@ export function buildWorkerSnippets(input: WorkerSnippetInput): WorkerSnippets {
     // doesn't have a route to a private worker yet, so this always deploys as public.
     `supabase ${CLI_NAME} push ${name} --instances ${input.instances}`,
     ...(input.access === 'private' ? [`# note: the CLI can only deploy public workers today`] : []),
+  ].join('\n')
+
+  const curl = [
+    `curl --request POST '${url}' \\`,
+    `  --header 'Content-Type: application/json' \\`,
+    `  --data '{"name":"world"}'`,
   ].join('\n')
 
   const configBlock = [
@@ -102,7 +109,7 @@ export function buildWorkerSnippets(input: WorkerSnippetInput): WorkerSnippets {
     `print(res.json())`,
   ].join('\n')
 
-  return { aiPrompt, configToml, cli, javascript, python }
+  return { aiPrompt, configToml, cli, curl, javascript, python }
 }
 
 export interface WorkerCliCommand {


### PR DESCRIPTION
## Problem

The Workers overview showed deployment CLI instructions in the How to call section, while direct gateway calls do not require an API key.

## Fix

Add a dedicated unauthenticated cURL snippet for the overview CLI tab and preserve the deployment CLI snippet in the deploy dialog.

## How to test

- Open a Worker overview and select the CLI tab.
- Expected result: the copied cURL request targets the gateway URL and has no Authorization header.
- Open the deploy dialog.
- Expected result: the deployment CLI commands remain unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a cURL example for invoking Workers.
  - Updated the “How to call” section to display cURL, JavaScript, and Python examples.
  - cURL snippets now include the worker URL and request body.

- **Bug Fixes**
  - Improved snippet URL handling and clarified authorization behavior in CLI examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->