### PR TITLE
fix(workers): rename image version label FE-4317

### DIFF
--- a/apps/studio/components/interfaces/Workers/WorkerDetail/WorkerDetail.tsx
+++ b/apps/studio/components/interfaces/Workers/WorkerDetail/WorkerDetail.tsx
@@ -118,7 +118,7 @@ export const WorkerDetail = () => {
               {worker.imageVersion !== undefined && (
                 <span className="flex items-center gap-2 text-foreground-light">
                   <Package size={14} strokeWidth={1.5} className="text-foreground-lighter" />
-                  Image {worker.imageVersion}
+                  Version {worker.imageVersion}
                 </span>
               )}
             </PageHeaderDescription>

--- a/apps/studio/components/interfaces/Workers/WorkerDetail/WorkerOverviewTab.tsx
+++ b/apps/studio/components/interfaces/Workers/WorkerDetail/WorkerOverviewTab.tsx
@@ -156,7 +156,7 @@ export const WorkerOverviewTab = ({ worker }: WorkerOverviewTabProps) => {
               <RuntimeBadge runtime={worker.runtime} />
             </SettingsRow>
             {worker.imageVersion !== undefined && (
-              <SettingsRow label="Image version">
+              <SettingsRow label="Version">
                 <span className="font-mono text-xs text-foreground-light">
                   {worker.imageVersion}
                 </span>


### PR DESCRIPTION
## Problem

The Workers UI exposed the internal image terminology in the displayed version label.

## Fix

Rename the Worker detail header and Container setting label to Version while preserving the underlying API field.

## How to test

- Open a Worker detail page with an image version.
- Expected result: the header reads Version <number> and the Container row label reads Version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated worker details labels from “Image” and “Image version” to “Version” for clearer, more consistent terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->