### PR TITLE
feat(studio): configure publication partition handling

### DIFF
--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/NewPublicationPanel.test.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/NewPublicationPanel.test.tsx
@@ -115,4 +115,37 @@ describe('NewPublicationPanel', () => {
       })
     )
   })
+
+  it('sends publish_via_partition_root as false when the option is turned off', async () => {
+    mockQueries()
+    let requestBody: unknown
+    addAPIMock({
+      method: 'put',
+      path: '/platform/replication/v2/:ref/sources/:source_id/publications/:publication_name',
+      response: async ({ request }) => {
+        requestBody = await request.json()
+        return HttpResponse.json<PublicationDetailsResponse>(mockPublication)
+      },
+    })
+
+    customRender(<NewPublicationPanel visible onClose={vi.fn()} />)
+
+    const trigger = screen.getAllByRole('combobox').find((element) => element.tagName === 'BUTTON')!
+    fireEvent.click(trigger)
+    fireEvent.click(await screen.findByText('CamelSchema.MixedCaseTable'))
+    fireEvent.change(screen.getByPlaceholderText('Name'), {
+      target: { value: 'MixedCasePublication' },
+    })
+    fireEvent.click(
+      screen.getByRole('checkbox', { name: 'Publish partitions as the parent table' })
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Create publication' }))
+
+    await waitFor(() =>
+      expect(requestBody).toMatchObject({
+        tables: [{ id: 17487 }],
+        publish_via_partition_root: false,
+      })
+    )
+  })
 })

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/NewPublicationPanel.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/NewPublicationPanel.tsx
@@ -5,6 +5,7 @@ import { useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 import {
   Button,
+  Checkbox,
   Form,
   FormControl,
   FormField,
@@ -42,12 +43,14 @@ const FORM_ID = 'publication-editor'
 const FormSchema = z.object({
   name: z.string().min(1, 'Name is required'),
   tableIds: z.array(z.string()).min(1, 'At least one table is required'),
+  publishViaPartitionRoot: z.boolean(),
 })
 type FormValues = z.infer<typeof FormSchema>
 
 const defaultValues: FormValues = {
   name: '',
   tableIds: [],
+  publishViaPartitionRoot: true,
 }
 
 export const NewPublicationPanel = ({ visible, onClose }: NewPublicationPanelProps) => {
@@ -110,6 +113,7 @@ export const NewPublicationPanel = ({ visible, onClose }: NewPublicationPanelPro
       sourceId,
       name: data.name,
       tableIds: data.tableIds.map(Number),
+      publishViaPartitionRoot: data.publishViaPartitionRoot,
     })
   }
 
@@ -188,6 +192,26 @@ export const NewPublicationPanel = ({ visible, onClose }: NewPublicationPanelPro
                               </MultiSelector.List>
                             </MultiSelector.Content>
                           </MultiSelector>
+                        </FormControl>
+                      </FormItemLayout>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="publishViaPartitionRoot"
+                    render={({ field }) => (
+                      <FormItemLayout
+                        hideMessage
+                        label="Publish partitions as the parent table"
+                        description="Changes from partitioned tables appear in one destination table. Turn off to create a table for each partition."
+                        layout="flex"
+                      >
+                        <FormControl>
+                          <Checkbox
+                            checked={field.value}
+                            aria-label="Publish partitions as the parent table"
+                            onCheckedChange={(checked) => field.onChange(checked === true)}
+                          />
                         </FormControl>
                       </FormItemLayout>
                     )}

--- a/apps/studio/data/replication/publication-create-mutation.ts
+++ b/apps/studio/data/replication/publication-create-mutation.ts
@@ -10,10 +10,11 @@ export type CreatePublicationParams = {
   sourceId: number
   name: string
   tableIds: number[]
+  publishViaPartitionRoot?: boolean
 }
 
 async function createPublication(
-  { projectRef, sourceId, name, tableIds }: CreatePublicationParams,
+  { projectRef, sourceId, name, tableIds, publishViaPartitionRoot = true }: CreatePublicationParams,
   signal?: AbortSignal
 ) {
   if (!projectRef) throw new Error('projectRef is required')
@@ -26,7 +27,7 @@ async function createPublication(
         type: 'tables',
         tables: tableIds.map((id) => ({ id })),
         operations: ['insert', 'update', 'delete', 'truncate'],
-        publish_via_partition_root: true,
+        publish_via_partition_root: publishViaPartitionRoot,
       },
       signal,
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Small Pipelines feature. Stacked on #49844.

## What is the current behavior?

New publications always publish changes from partitioned tables through their parent table. The creation sheet does not expose the v2 API option that controls this behavior.

## What is the new behavior?

Adds a default-on Publish partitions as the parent table checkbox to the publication sheet. Turning it off submits publish_via_partition_root as false so each partition can appear as a separate destination table.

## To test

1. Open the pipeline creation sheet and choose to create a publication.
2. Confirm Publish partitions as the parent table is selected by default.
3. Create a publication and confirm publish_via_partition_root is true.
4. Repeat with the option cleared and confirm publish_via_partition_root is false.
5. Confirm the selected tables and publication name are unchanged by the option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “Publish partitions as the parent table” option when creating publications.
  - The option is enabled by default and can be turned off before submitting the publication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->