### PR TITLE
feat(www): add service json-ld to homepage

### DIFF
--- a/apps/www/app/(home)/page.tsx
+++ b/apps/www/app/(home)/page.tsx
@@ -6,6 +6,7 @@ import { DEFAULT_META_DESCRIPTION } from '@/lib/constants'
 import {
   organizationSchema,
   serializeJsonLd,
+  serviceSchema,
   softwareApplicationSchema,
   websiteSchema,
 } from '@/lib/json-ld'
@@ -38,6 +39,27 @@ export default function HomePage() {
               description: DEFAULT_META_DESCRIPTION,
               url: 'https://supabase.com',
               image: 'https://supabase.com/images/og/supabase-og.png',
+            })
+          ),
+        }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: serializeJsonLd(
+            serviceSchema({
+              name: 'Supabase',
+              description: DEFAULT_META_DESCRIPTION,
+              url: 'https://supabase.com',
+              serviceType: 'Backend as a Service',
+              offerings: [
+                { name: 'Database', url: 'https://supabase.com/database' },
+                { name: 'Authentication', url: 'https://supabase.com/auth' },
+                { name: 'Storage', url: 'https://supabase.com/storage' },
+                { name: 'Edge Functions', url: 'https://supabase.com/edge-functions' },
+                { name: 'Realtime', url: 'https://supabase.com/realtime' },
+                { name: 'Vector', url: 'https://supabase.com/modules/vector' },
+              ],
             })
           ),
         }}

--- a/apps/www/app/(home)/page.tsx
+++ b/apps/www/app/(home)/page.tsx
@@ -51,7 +51,7 @@ export default function HomePage() {
               name: 'Supabase',
               description: DEFAULT_META_DESCRIPTION,
               url: 'https://supabase.com',
-              serviceType: 'Backend as a Service',
+              serviceType: 'Postgres development platform',
               offerings: [
                 { name: 'Database', url: 'https://supabase.com/database' },
                 { name: 'Authentication', url: 'https://supabase.com/auth' },

--- a/apps/www/lib/json-ld.ts
+++ b/apps/www/lib/json-ld.ts
@@ -96,6 +96,38 @@ export function softwareApplicationSchema(input: SoftwareApplicationSchemaInput)
   }
 }
 
+interface ServiceSchemaInput {
+  name: string
+  description: string
+  url: string
+  serviceType: string
+  offerings: Array<{ name: string; url: string }>
+}
+
+export function serviceSchema(input: ServiceSchemaInput) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Service',
+    name: input.name,
+    description: input.description,
+    url: input.url,
+    serviceType: input.serviceType,
+    provider: { '@id': ORG_ID },
+    hasOfferCatalog: {
+      '@type': 'OfferCatalog',
+      name: `${input.name} products`,
+      itemListElement: input.offerings.map((offering) => ({
+        '@type': 'Offer',
+        itemOffered: {
+          '@type': 'Service',
+          name: offering.name,
+          url: offering.url,
+        },
+      })),
+    },
+  }
+}
+
 export interface BreadcrumbItem {
   name: string
   url: string

--- a/apps/www/public/.well-known/api-catalog
+++ b/apps/www/public/.well-known/api-catalog
@@ -1,6 +1,14 @@
 {
   "linkset": [
     {
+      "anchor": "https://supabase.com/.well-known/api-catalog",
+      "item": [
+        {
+          "href": "https://api.supabase.com/v1"
+        }
+      ]
+    },
+    {
       "anchor": "https://api.supabase.com/v1",
       "service-desc": [
         {


### PR DESCRIPTION
Follow-up to #49768. Agent-readiness scanners grade schema breadth by extended schema.org types (Service, FAQPage, Product); SoftwareApplication alone doesn't register, so I added a Service block whose offer catalog mirrors the products already rendered on the homepage. I also brought `/.well-known/api-catalog` up to the RFC 9727 API-catalog profile.

**Changed:**
- **Homepage emits Service JSON-LD**: new `serviceSchema` builder in `lib/json-ld.ts`; the offer catalog lists the six products the homepage products section renders (Database, Authentication, Storage, Edge Functions, Realtime, Vector).
- **api-catalog leads with the catalog context**: `linkset[0]` now anchors the catalog URL and carries an `item` link to the Management API base, per the RFC 9727 profile; the existing service-desc context moves to `linkset[1]` unchanged.

## To test
Tested on Vercel preview:
- [ ] View source on the preview homepage: expect a fourth `application/ld+json` script with `"@type":"Service"` and six offerings
- [ ] `curl <preview>/.well-known/api-catalog`: expect `linkset[0]` to contain an `item` array pointing at `https://api.supabase.com/v1`

## Linear
- fixes GROWTH-1175


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured service information to the home page, including Supabase’s platform offerings.
  * Added an API catalog entry linking to the Supabase API endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->