### PR TITLE
fix(studio): hide shortcut tooltip when invite members is disabled

### DIFF
--- a/apps/studio/components/interfaces/Organization/TeamSettings/InviteMemberButton.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/InviteMemberButton.tsx
@@ -123,6 +123,12 @@ export const InviteMemberButton = () => {
       )
     )
 
+  const inviteButtonTooltipText = !organizationMembersCreationEnabled
+    ? 'Inviting members is currently disabled'
+    : !canInviteMembers
+      ? 'You need additional permissions to invite members to this organization'
+      : undefined
+
   const { mutateAsync: inviteMemberAsync, isPending: isInviting } =
     useOrganizationCreateInvitationMutation()
 
@@ -260,7 +266,7 @@ export const InviteMemberButton = () => {
             if (canInviteMembers) setIsOpen(true)
           }}
           side="bottom"
-          tooltipOpen={isOpen ? false : undefined}
+          tooltipOpen={isOpen || inviteButtonTooltipText !== undefined ? false : undefined}
         >
           <ButtonTooltip
             variant="primary"
@@ -271,11 +277,7 @@ export const InviteMemberButton = () => {
             tooltip={{
               content: {
                 side: 'bottom',
-                text: !organizationMembersCreationEnabled
-                  ? 'Inviting members is currently disabled'
-                  : !canInviteMembers
-                    ? 'You need additional permissions to invite members to this organization'
-                    : undefined,
+                text: inviteButtonTooltipText,
               },
             }}
           >

--- a/apps/studio/tests/components/Organization/TeamSettings/InviteMemberButton.test.tsx
+++ b/apps/studio/tests/components/Organization/TeamSettings/InviteMemberButton.test.tsx
@@ -76,9 +76,12 @@ vi.mock('@/hooks/misc/useCheckEntitlements', () => ({
   useCheckEntitlements: () => ({ hasAccess: false }),
 }))
 
+const mockRolesManagementPermissions = vi.hoisted(() => ({
+  rolesAddable: [1, 2, 3, 4] as number[],
+}))
 vi.mock('@/components/interfaces/Organization/TeamSettings/TeamSettings.utils', () => ({
   useGetRolesManagementPermissions: () => ({
-    rolesAddable: [1, 2, 3, 4],
+    rolesAddable: mockRolesManagementPermissions.rolesAddable,
     rolesRemovable: [1, 2, 3, 4],
   }),
 }))
@@ -120,11 +123,28 @@ describe('InviteMemberButton', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockInvite.mockResolvedValue({ succeeded: [], failed: [] })
+    mockRolesManagementPermissions.rolesAddable = [1, 2, 3, 4]
   })
 
   it('renders an enabled Invite members button', () => {
     customRender(<InviteMemberButton />)
     expect(screen.getByRole('button', { name: /invite members/i })).toBeEnabled()
+  })
+
+  it('only shows the permission tooltip when inviting members is not allowed', async () => {
+    mockRolesManagementPermissions.rolesAddable = []
+    customRender(<InviteMemberButton />)
+
+    const inviteButton = screen.getByRole('button', { name: /invite members/i })
+    expect(inviteButton).toBeDisabled()
+
+    await userEvent.hover(inviteButton)
+
+    const permissionTooltip = await screen.findByRole('tooltip')
+    expect(permissionTooltip).toHaveTextContent(
+      'You need additional permissions to invite members to this organization'
+    )
+    expect(screen.getAllByText('Invite members')).toHaveLength(1)
   })
 
   it('opens the invite dialog when the button is clicked', async () => {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Fixes https://github.com/supabase/supabase/issues/49859

On Organization Team Settings, hovering the disabled **Invite members** button (for example as a Developer) opens two tooltips at once: the keyboard-shortcut tooltip and the permission-restriction tooltip. Both render at the same position, so the copy overlaps and is unreadable.

## What is the new behavior?

When the button already has a disabled/permission tooltip, the shortcut tooltip stays closed. Hover then shows only the permission message.

A component test covers the disabled-button hover path and asserts a single tooltip.

## Additional context

The shortcut tooltip is still shown for users who can invite members. It also remains closed while the invite sheet is open, matching the previous behavior.

## Test plan

- [x] As a Developer (or any role that cannot invite), open Organization Settings → Team and hover **Invite members**. Confirm only the permission tooltip appears.
- [x] As an Owner/Admin, hover **Invite members**. Confirm the keyboard-shortcut tooltip still appears.
- [x] Open the invite sheet and hover the trigger. Confirm the shortcut tooltip stays closed.
- [x] Repeat the disabled hover when organization member creation is turned off. Confirm only “Inviting members is currently disabled” is shown.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the Invite members button tooltip for disabled states, including insufficient permissions.
  - Ensured the correct tooltip remains visible while the invitation panel is open.
  - Prevented duplicate “Invite members” labels from appearing when role-management permissions are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->