### PR TITLE
docs: replace storage-api github repo by storage

### DIFF
--- a/apps/docs/spec/storage_v0_config.yaml
+++ b/apps/docs/spec/storage_v0_config.yaml
@@ -9,7 +9,7 @@ info:
   bugs: 'https://github.com/supabase/storage/issues' # {string} Where developers can file bugs.
   spec: 'https://github.com/supabase/supabase/blob/master/spec/storage_v0_config.yml' # {string} Where developers can find this spec (to link directly in the docs).
   description: |
-    A sample `.env` file is located in the [storage repository](https://github.com/supabase/storage-api/blob/master/.env.sample).
+    A sample `.env` file is located in the [storage repository](https://github.com/supabase/storage/blob/master/.env.sample).
 
     Use this file to configure your environment variables for your Storage server.
   tags:


### PR DESCRIPTION
https://github.com/supabase/storage-api has been renamed

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

* YES

## What kind of change does this PR introduce?

* documentation refactor

## What is the current behavior?

* It trust in redirection to new one, rather than being explicit.

## Additional context

* check the current one link: https://github.com/supabase/storage/blob/master/.env.sample


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the storage configuration specification to reference the correct environment variable example file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->