### PR TITLE
fix: unlock disk edits when over-provisioned relative to guardrail

### DIFF
--- a/apps/studio/components/interfaces/DiskManagement/DiskManagement.schema.ts
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagement.schema.ts
@@ -52,10 +52,21 @@ export const CreateDiskStorageSchema = ({
   defaultTotalSize,
   cloudProvider,
   isSpendCapEnabled,
+  downsizeOnlyFrom,
 }: {
   defaultTotalSize: number
   cloudProvider: CloudProvider
   isSpendCapEnabled: boolean
+  /**
+   * When set, a cost guardrail (compute below Large, or spend cap enabled) is active
+   * and the persisted disk config it describes is over-provisioned relative to that
+   * guardrail. Storage type/IOPS/throughput may only move down from these values, never up.
+   */
+  downsizeOnlyFrom?: {
+    storageType: DiskType
+    provisionedIOPS: number
+    throughput?: number
+  }
 }) => {
   const isAwsNimbusProject = cloudProvider === 'AWS_NIMBUS'
   const isAwsK8sProject = cloudProvider === 'AWS_K8S'
@@ -69,6 +80,43 @@ export const CreateDiskStorageSchema = ({
       if (!parsedCompute.success) return Number.POSITIVE_INFINITY
       return COMPUTE_MAX_IOPS[parsedCompute.data] ?? Number.POSITIVE_INFINITY
     })()
+
+    if (validateDiskConfiguration && downsizeOnlyFrom) {
+      if (storageType === DiskType.IO2 && downsizeOnlyFrom.storageType !== DiskType.IO2) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            'Switching to io2 is unsupported. Your project is over-provisioned for its size, and can only be downsized.',
+          path: ['storageType'],
+        })
+      }
+
+      const iopsCeiling = Math.max(
+        downsizeOnlyFrom.provisionedIOPS,
+        DISK_LIMITS[storageType as DiskType].minIops
+      )
+      if (provisionedIOPS > iopsCeiling) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Maximum IOPS is ${formatNumber(iopsCeiling)} for your current configuration.`,
+          path: ['provisionedIOPS'],
+        })
+      }
+
+      if (storageType === DiskType.GP3 && throughput !== undefined) {
+        const throughputCeiling = Math.max(
+          downsizeOnlyFrom.throughput ?? DISK_LIMITS[DiskType.GP3].minThroughput,
+          DISK_LIMITS[DiskType.GP3].minThroughput
+        )
+        if (throughput > throughputCeiling) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `Maximum throughput is ${formatNumber(throughputCeiling)} MB/s for your current configuration.`,
+            path: ['throughput'],
+          })
+        }
+      }
+    }
 
     if (validateDiskConfiguration && totalSize < 8 && totalSize !== defaultTotalSize) {
       ctx.addIssue({

--- a/apps/studio/components/interfaces/DiskManagement/DiskManagement.test.ts
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagement.test.ts
@@ -9,6 +9,8 @@ import {
   calculateMaxIopsAllowedForDiskSizeWithGp3,
   calculateMaxIopsForComputeSize,
   calculateThroughputPrice,
+  getDiskConfigEditability,
+  isDiskConfigOverProvisioned,
   mapAddOnVariantIdToComputeSize,
   mapComputeSizeNameToAddonVariantId,
 } from './DiskManagement.utils'
@@ -286,4 +288,251 @@ describe('CreateDiskStorageSchema', () => {
       ).toBe(true)
     }
   )
+})
+
+describe('isDiskConfigOverProvisioned', () => {
+  test('io2 is always over-provisioned relative to the gp3 baseline', () => {
+    expect(
+      isDiskConfigOverProvisioned({
+        storageType: DiskType.IO2,
+        provisionedIOPS: 1500,
+        throughput: undefined,
+      })
+    ).toBe(true)
+  })
+
+  test('gp3 at the 3000 IOPS / 125 MB/s baseline is not over-provisioned', () => {
+    expect(
+      isDiskConfigOverProvisioned({
+        storageType: DiskType.GP3,
+        provisionedIOPS: 3000,
+        throughput: 125,
+      })
+    ).toBe(false)
+  })
+
+  test('gp3 with IOPS above the baseline is over-provisioned', () => {
+    expect(
+      isDiskConfigOverProvisioned({
+        storageType: DiskType.GP3,
+        provisionedIOPS: 8000,
+        throughput: 125,
+      })
+    ).toBe(true)
+  })
+
+  test('gp3 with throughput above the baseline is over-provisioned', () => {
+    expect(
+      isDiskConfigOverProvisioned({
+        storageType: DiskType.GP3,
+        provisionedIOPS: 3000,
+        throughput: 500,
+      })
+    ).toBe(true)
+  })
+})
+
+describe('getDiskConfigEditability', () => {
+  const base = {
+    isHardBlocked: false,
+    isComputeSizeGuardrailActive: false,
+    isSpendCapEnabled: false,
+    isDiskOverProvisioned: false,
+  }
+
+  test('no guardrail active — editable', () => {
+    expect(getDiskConfigEditability(base)).toEqual({ status: 'editable' })
+  })
+
+  test('compute-size guardrail active, disk within bounds — locked', () => {
+    expect(getDiskConfigEditability({ ...base, isComputeSizeGuardrailActive: true })).toEqual({
+      status: 'locked',
+      guardrails: ['computeSize'],
+    })
+  })
+
+  test('compute-size guardrail active, disk over-provisioned — downsizeOnly', () => {
+    expect(
+      getDiskConfigEditability({
+        ...base,
+        isComputeSizeGuardrailActive: true,
+        isDiskOverProvisioned: true,
+      })
+    ).toEqual({ status: 'downsizeOnly', guardrails: ['computeSize'] })
+  })
+
+  test('spend cap active, disk over-provisioned — downsizeOnly', () => {
+    expect(
+      getDiskConfigEditability({ ...base, isSpendCapEnabled: true, isDiskOverProvisioned: true })
+    ).toEqual({ status: 'downsizeOnly', guardrails: ['spendCap'] })
+  })
+
+  test('both guardrails active, disk over-provisioned — downsizeOnly with both reasons', () => {
+    expect(
+      getDiskConfigEditability({
+        ...base,
+        isComputeSizeGuardrailActive: true,
+        isSpendCapEnabled: true,
+        isDiskOverProvisioned: true,
+      })
+    ).toEqual({ status: 'downsizeOnly', guardrails: ['computeSize', 'spendCap'] })
+  })
+
+  test('hard block wins even when the disk is over-provisioned — never a downsize carve-out', () => {
+    expect(
+      getDiskConfigEditability({
+        ...base,
+        isHardBlocked: true,
+        isComputeSizeGuardrailActive: true,
+        isDiskOverProvisioned: true,
+      })
+    ).toEqual({ status: 'locked', guardrails: ['computeSize'] })
+  })
+
+  test('hard block wins even with no guardrail active', () => {
+    expect(getDiskConfigEditability({ ...base, isHardBlocked: true })).toEqual({
+      status: 'locked',
+      guardrails: [],
+    })
+  })
+})
+
+describe('CreateDiskStorageSchema with downsizeOnlyFrom', () => {
+  const baseConfig = {
+    storageType: DiskType.GP3,
+    totalSize: 100,
+    provisionedIOPS: 3000,
+    throughput: 125,
+    computeSize: 'ci_large' as const,
+    growthPercent: null,
+    minIncrementGb: null,
+    maxSizeGb: null,
+  }
+
+  test('rejects an IOPS increase above the persisted ceiling', () => {
+    const schema = CreateDiskStorageSchema({
+      defaultTotalSize: 100,
+      cloudProvider: 'AWS',
+      isSpendCapEnabled: false,
+      downsizeOnlyFrom: { storageType: DiskType.GP3, provisionedIOPS: 3000, throughput: 125 },
+    })
+
+    const result = schema.safeParse({ ...baseConfig, provisionedIOPS: 5000 })
+
+    expect(result.success).toBe(false)
+    if (result.success) return
+    expect(result.error.issues).toContainEqual(
+      expect.objectContaining({
+        path: ['provisionedIOPS'],
+        message: 'Maximum IOPS is 3,000 for your current configuration.',
+      })
+    )
+  })
+
+  test('accepts a reduced IOPS value', () => {
+    const schema = CreateDiskStorageSchema({
+      defaultTotalSize: 100,
+      cloudProvider: 'AWS',
+      isSpendCapEnabled: false,
+      downsizeOnlyFrom: { storageType: DiskType.GP3, provisionedIOPS: 8000, throughput: 125 },
+    })
+
+    expect(schema.safeParse({ ...baseConfig, provisionedIOPS: 3000 }).success).toBe(true)
+  })
+
+  test('rejects switching to io2 when the persisted type was gp3', () => {
+    const schema = CreateDiskStorageSchema({
+      defaultTotalSize: 100,
+      cloudProvider: 'AWS',
+      isSpendCapEnabled: false,
+      downsizeOnlyFrom: { storageType: DiskType.GP3, provisionedIOPS: 3000, throughput: 125 },
+    })
+
+    const result = schema.safeParse({
+      ...baseConfig,
+      storageType: DiskType.IO2,
+      provisionedIOPS: 1500,
+      throughput: undefined,
+    })
+
+    expect(result.success).toBe(false)
+    if (result.success) return
+    expect(result.error.issues).toContainEqual(
+      expect.objectContaining({
+        path: ['storageType'],
+        message:
+          'Switching to io2 is unsupported. Your project is over-provisioned for its size, and can only be downsized.',
+      })
+    )
+  })
+
+  test('accepts io2 with reduced IOPS when the persisted type was already io2', () => {
+    const schema = CreateDiskStorageSchema({
+      defaultTotalSize: 100,
+      cloudProvider: 'AWS',
+      isSpendCapEnabled: false,
+      downsizeOnlyFrom: { storageType: DiskType.IO2, provisionedIOPS: 50_000 },
+    })
+
+    const result = schema.safeParse({
+      ...baseConfig,
+      storageType: DiskType.IO2,
+      provisionedIOPS: 10_000,
+      throughput: undefined,
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  test("io2@1500 moving to gp3 floors the IOPS ceiling at gp3's own 3000 minimum", () => {
+    const schema = CreateDiskStorageSchema({
+      defaultTotalSize: 100,
+      cloudProvider: 'AWS',
+      isSpendCapEnabled: false,
+      downsizeOnlyFrom: { storageType: DiskType.IO2, provisionedIOPS: 1500 },
+    })
+
+    expect(schema.safeParse({ ...baseConfig, provisionedIOPS: 3000 }).success).toBe(true)
+
+    const result = schema.safeParse({ ...baseConfig, provisionedIOPS: 3001 })
+    expect(result.success).toBe(false)
+    if (result.success) return
+    expect(result.error.issues).toContainEqual(
+      expect.objectContaining({
+        path: ['provisionedIOPS'],
+        message: 'Maximum IOPS is 3,000 for your current configuration.',
+      })
+    )
+  })
+
+  test('throughput is capped at the gp3 minimum when the persisted type was io2', () => {
+    const schema = CreateDiskStorageSchema({
+      defaultTotalSize: 100,
+      cloudProvider: 'AWS',
+      isSpendCapEnabled: false,
+      downsizeOnlyFrom: { storageType: DiskType.IO2, provisionedIOPS: 1500 },
+    })
+
+    expect(schema.safeParse({ ...baseConfig, throughput: 125 }).success).toBe(true)
+
+    const result = schema.safeParse({ ...baseConfig, throughput: 200 })
+    expect(result.success).toBe(false)
+    if (result.success) return
+    expect(result.error.issues).toContainEqual(
+      expect.objectContaining({
+        path: ['throughput'],
+        message: 'Maximum throughput is 125 MB/s for your current configuration.',
+      })
+    )
+  })
+
+  test('behaves like the schema without downsizeOnlyFrom when no guardrail is active', () => {
+    const schema = CreateDiskStorageSchema({
+      defaultTotalSize: 100,
+      cloudProvider: 'AWS',
+      isSpendCapEnabled: false,
+    })
+
+    expect(schema.safeParse({ ...baseConfig, provisionedIOPS: 10_000 }).success).toBe(true)
+  })
 })

--- a/apps/studio/components/interfaces/DiskManagement/DiskManagement.types.ts
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagement.types.ts
@@ -71,3 +71,21 @@ export interface DiskManagementMessage {
   message: string
   type: 'error' | 'success'
 }
+
+/** A guardrail that exists to stop a customer from taking on new, expensive disk
+ *  provisioning: compute size below Large, or an org-level spend cap. */
+export type DiskConfigGuardrail = 'computeSize' | 'spendCap'
+
+/** Whether storageType/provisionedIOPS/throughput can be edited, and why not.
+ *  - `editable`: no active guardrail: any value is allowed (subject to the normal disk limits).
+ *  - `locked`: a guardrail is active and the persisted config is already within bounds, so no
+ *    edits are offered — or a reason unrelated to cost (permissions, plan, cooldown, HA, a
+ *    pending modification) blocks editing outright, in which case `guardrails` is empty.
+ *  - `downsizeOnly`: a guardrail is active AND the persisted config already exceeds it (e.g. set
+ *    before the guardrail took effect). Fields stay editable, but only to move values down —
+ *    never to increase them further while the guardrail remains active.
+ */
+export type DiskConfigEditability =
+  | { status: 'editable' }
+  | { status: 'locked'; guardrails: DiskConfigGuardrail[] }
+  | { status: 'downsizeOnly'; guardrails: DiskConfigGuardrail[] }

--- a/apps/studio/components/interfaces/DiskManagement/DiskManagement.utils.ts
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagement.utils.ts
@@ -7,9 +7,17 @@ import {
 import {
   ComputeInstanceAddonVariantId,
   ComputeInstanceSize,
+  DiskConfigEditability,
+  DiskConfigGuardrail,
   InfraInstanceSize,
 } from './DiskManagement.types'
-import { DISK_LIMITS, DISK_PRICING, DiskType, PLAN_DETAILS } from './ui/DiskManagement.constants'
+import {
+  DISK_LIMITS,
+  DISK_PRICING,
+  DiskType,
+  PLAN_DETAILS,
+  SUPPORTED_DISK_CONFIG_UNDER_COST_GUARDRAIL,
+} from './ui/DiskManagement.constants'
 import { ProjectDetail } from '@/data/projects/project-detail-query'
 import { PlanId, ProjectAddonVariantMeta } from '@/data/subscriptions/types'
 import { INSTANCE_MICRO_SPECS, INSTANCE_NANO_SPECS } from '@/lib/constants'
@@ -459,4 +467,49 @@ export const formatNumber = (num: number): string => {
 
 export const showMicroUpgrade = (plan: PlanId, infraComputeSize: InfraInstanceSize): boolean => {
   return plan !== 'free' && infraComputeSize === 'nano'
+}
+
+// Detects whether a project's *persisted* disk config already exceeds the baseline
+// that's safe under either cost guardrail (compute below Large, or spend cap enabled).
+export const isDiskConfigOverProvisioned = ({
+  storageType,
+  provisionedIOPS,
+  throughput,
+}: {
+  storageType?: DiskType
+  provisionedIOPS?: number
+  throughput?: number
+}): boolean => {
+  const supported = SUPPORTED_DISK_CONFIG_UNDER_COST_GUARDRAIL
+  return (
+    storageType !== supported.storageType ||
+    (provisionedIOPS ?? 0) > supported.provisionedIOPS ||
+    (throughput ?? 0) > supported.throughput
+  )
+}
+
+export const getDiskConfigEditability = ({
+  isHardBlocked,
+  isComputeSizeGuardrailActive,
+  isSpendCapEnabled,
+  isDiskOverProvisioned,
+}: {
+  /**
+   * Reasons unrelated to cost avoidance (a pending modification, plan entitlement, cooldown
+   * window, missing permission, non-AWS project, High Availability) — always wins.
+   */
+  isHardBlocked: boolean
+  isComputeSizeGuardrailActive: boolean
+  isSpendCapEnabled: boolean
+  isDiskOverProvisioned: boolean
+}): DiskConfigEditability => {
+  const guardrails: DiskConfigGuardrail[] = []
+  if (isComputeSizeGuardrailActive) guardrails.push('computeSize')
+  if (isSpendCapEnabled) guardrails.push('spendCap')
+
+  if (isHardBlocked) return { status: 'locked', guardrails }
+  if (guardrails.length === 0) return { status: 'editable' }
+  return isDiskOverProvisioned
+    ? { status: 'downsizeOnly', guardrails }
+    : { status: 'locked', guardrails }
 }

--- a/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.sections.test.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.sections.test.tsx
@@ -1,0 +1,279 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { mockAnimationsApi } from 'jsdom-testing-mocks'
+import { useForm } from 'react-hook-form'
+import { Form } from 'ui'
+import { describe, expect, test } from 'vitest'
+
+import { CreateDiskStorageSchema, DiskStorageSchemaType } from './DiskManagement.schema'
+import { getDiskConfigEditability, isDiskConfigOverProvisioned } from './DiskManagement.utils'
+import { AdvancedSection } from './DiskManagementForm.sections'
+import { DiskType } from './ui/DiskManagement.constants'
+import { customRender } from '@/tests/lib/custom-render'
+import { addAPIMock } from '@/tests/lib/msw'
+
+mockAnimationsApi()
+
+const PROJECT_REF = 'default'
+
+type TestHarnessProps = {
+  defaultValues: DiskStorageSchemaType
+  isSpendCapEnabled?: boolean
+  isComputeSizeGuardrailActive?: boolean
+  isHardBlocked?: boolean
+}
+
+function TestHarness({
+  defaultValues,
+  isSpendCapEnabled = false,
+  isComputeSizeGuardrailActive = false,
+  isHardBlocked = false,
+}: TestHarnessProps) {
+  const isCostGuardrailActive = isComputeSizeGuardrailActive || isSpendCapEnabled
+  const diskConfigEditability = getDiskConfigEditability({
+    isHardBlocked,
+    isComputeSizeGuardrailActive,
+    isSpendCapEnabled,
+    isDiskOverProvisioned: isDiskConfigOverProvisioned({
+      storageType: defaultValues.storageType as DiskType,
+      provisionedIOPS: defaultValues.provisionedIOPS,
+      throughput: defaultValues.throughput,
+    }),
+  })
+
+  const form = useForm<DiskStorageSchemaType>({
+    resolver: zodResolver(
+      CreateDiskStorageSchema({
+        defaultTotalSize: defaultValues.totalSize,
+        cloudProvider: 'AWS',
+        isSpendCapEnabled,
+        downsizeOnlyFrom: isCostGuardrailActive
+          ? {
+              storageType: defaultValues.storageType as DiskType,
+              provisionedIOPS: defaultValues.provisionedIOPS,
+              throughput: defaultValues.throughput,
+            }
+          : undefined,
+      })
+    ),
+    defaultValues,
+  })
+
+  return (
+    <Form {...form}>
+      <form>
+        <div data-testid="is-dirty">{String(form.formState.isDirty)}</div>
+        <AdvancedSection
+          form={form}
+          autoscaleSettingsRef={{ current: null }}
+          storageSettingsRef={{ current: null }}
+          showBillingBadge={false}
+          beforePrice={0}
+          afterPrice={0}
+          canUpdateDiskConfiguration
+          isDiskTooSmallForIopsOrThroughput={false}
+          disableDiskInputs={isHardBlocked}
+          disableDiskSizeInput={isHardBlocked}
+          suggestedDiskSizeForCustomIops={8}
+          diskConfigEditability={diskConfigEditability}
+          provisionedStorageType={defaultValues.storageType as DiskType}
+        />
+      </form>
+    </Form>
+  )
+}
+
+function mockDiskEndpoints({
+  storageType,
+  provisionedIOPS,
+  throughput,
+  region = 'us-east-1',
+}: {
+  storageType: DiskType
+  provisionedIOPS: number
+  throughput?: number
+  region?: string
+}) {
+  addAPIMock({
+    method: 'get',
+    path: '/platform/projects/:ref',
+    response: {
+      cloud_provider: 'AWS',
+      connectionString: 'postgresql://postgres:password@db.default.supabase.co:5432/postgres',
+      db_host: 'db.default.supabase.co',
+      dbVersion: 'supabase-postgres-15.1.0',
+      high_availability: false,
+      id: 1,
+      infra_compute_size: 'micro',
+      inserted_at: '2026-01-01T00:00:00.000Z',
+      integration_source: null,
+      is_branch_enabled: false,
+      is_physical_backups_enabled: false,
+      name: 'Test project',
+      organization_id: 1,
+      ref: PROJECT_REF,
+      region,
+      restUrl: `https://${PROJECT_REF}.supabase.co`,
+      status: 'ACTIVE_HEALTHY',
+      subscription_id: 'subscription-1',
+      updated_at: '2026-01-01T00:00:00.000Z',
+    },
+  })
+  addAPIMock({
+    method: 'get',
+    path: '/platform/projects/:ref/disk',
+    response: {
+      attributes: {
+        type: storageType,
+        iops: provisionedIOPS,
+        size_gb: 100,
+        throughput_mbps: throughput ?? 0,
+        throughput_mibps: throughput ?? 0,
+      },
+    },
+  })
+  addAPIMock({
+    method: 'get',
+    path: '/platform/projects/:ref/disk/custom-config',
+    response: { growth_percent: null, max_size_gb: null, min_increment_gb: null },
+  })
+}
+
+function buildDefaultValues(overrides: Partial<DiskStorageSchemaType> = {}): DiskStorageSchemaType {
+  return {
+    storageType: DiskType.GP3,
+    totalSize: 100,
+    provisionedIOPS: 3000,
+    throughput: 125,
+    computeSize: 'ci_micro',
+    growthPercent: null,
+    minIncrementGb: null,
+    maxSizeGb: null,
+    ...overrides,
+  }
+}
+
+describe('DiskManagementForm AdvancedSection — downsize-only cost guardrail carve-out', () => {
+  test('over-provisioned disk with a restricted compute size unlocks storage settings for downsizing', async () => {
+    const defaultValues = buildDefaultValues({ provisionedIOPS: 8000, throughput: 500 })
+    mockDiskEndpoints({ storageType: DiskType.GP3, provisionedIOPS: 8000, throughput: 500 })
+
+    customRender(<TestHarness defaultValues={defaultValues} isComputeSizeGuardrailActive />)
+
+    expect(
+      await screen.findByText(
+        "Storage type, IOPS, or throughput exceeds what's currently supported"
+      )
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText('Adjusting disk configuration requires Large compute size or above')
+    ).not.toBeInTheDocument()
+
+    expect(await screen.findByRole('combobox')).toBeEnabled()
+    expect(screen.getByRole('spinbutton', { name: 'IOPS' })).toBeEnabled()
+    expect(screen.getByRole('spinbutton', { name: 'Throughput' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Change to Large compute' })).toBeInTheDocument()
+  })
+
+  test('over-provisioned disk with spend cap enabled unlocks storage settings and offers to disable the spend cap', async () => {
+    const defaultValues = buildDefaultValues({ provisionedIOPS: 8000, throughput: 500 })
+    mockDiskEndpoints({ storageType: DiskType.GP3, provisionedIOPS: 8000, throughput: 500 })
+
+    customRender(<TestHarness defaultValues={defaultValues} isSpendCapEnabled />)
+
+    expect(
+      await screen.findByText(
+        "Storage type, IOPS, or throughput exceeds what's currently supported"
+      )
+    ).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Disable spend cap' })).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Change to Large compute' })
+    ).not.toBeInTheDocument()
+
+    expect(await screen.findByRole('combobox')).toBeEnabled()
+    expect(screen.getByRole('spinbutton', { name: 'IOPS' })).toBeEnabled()
+  })
+
+  test('a baseline gp3 disk with a restricted compute size stays fully disabled', async () => {
+    const defaultValues = buildDefaultValues()
+    mockDiskEndpoints({ storageType: DiskType.GP3, provisionedIOPS: 3000, throughput: 125 })
+
+    customRender(<TestHarness defaultValues={defaultValues} isComputeSizeGuardrailActive />)
+
+    expect(
+      await screen.findByText('Adjusting disk configuration requires Large compute size or above')
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText("Storage type, IOPS, or throughput exceeds what's currently supported")
+    ).not.toBeInTheDocument()
+
+    expect(await screen.findByRole('combobox')).toBeDisabled()
+    expect(screen.getByRole('spinbutton', { name: 'IOPS' })).toBeDisabled()
+    expect(screen.getByRole('spinbutton', { name: 'Throughput' })).toBeDisabled()
+  })
+
+  test('io2 is unselectable when the persisted storage type is gp3', async () => {
+    const user = userEvent.setup()
+    const defaultValues = buildDefaultValues({ provisionedIOPS: 8000, throughput: 500 })
+    mockDiskEndpoints({ storageType: DiskType.GP3, provisionedIOPS: 8000, throughput: 500 })
+
+    customRender(<TestHarness defaultValues={defaultValues} isComputeSizeGuardrailActive />)
+
+    await user.click(await screen.findByRole('combobox'))
+    const io2Option = await screen.findByRole('option', { name: /High Performance SSD/ })
+    expect(io2Option).toHaveAttribute('aria-disabled', 'true')
+  })
+
+  test('io2 stays selectable when the persisted storage type is already io2', async () => {
+    const user = userEvent.setup()
+    const defaultValues = buildDefaultValues({
+      storageType: DiskType.IO2,
+      provisionedIOPS: 50_000,
+      throughput: undefined,
+    })
+    mockDiskEndpoints({ storageType: DiskType.IO2, provisionedIOPS: 50_000 })
+
+    customRender(<TestHarness defaultValues={defaultValues} isComputeSizeGuardrailActive />)
+
+    await user.click(await screen.findByRole('combobox'))
+    const io2Option = await screen.findByRole('option', { name: /High Performance SSD/ })
+    expect(io2Option).not.toHaveAttribute('aria-disabled', 'true')
+  })
+
+  test('resetting to the supported configuration writes gp3/3000/125 and dirties the form', async () => {
+    const user = userEvent.setup()
+    const defaultValues = buildDefaultValues({ provisionedIOPS: 8000, throughput: 500 })
+    mockDiskEndpoints({ storageType: DiskType.GP3, provisionedIOPS: 8000, throughput: 500 })
+
+    customRender(<TestHarness defaultValues={defaultValues} isComputeSizeGuardrailActive />)
+
+    expect(screen.getByTestId('is-dirty')).toHaveTextContent('false')
+
+    await user.click(
+      await screen.findByRole('button', { name: 'Reset to supported configuration' })
+    )
+
+    expect(await screen.findByRole('spinbutton', { name: 'IOPS' })).toHaveValue(3000)
+    expect(screen.getByRole('spinbutton', { name: 'Throughput' })).toHaveValue(125)
+    expect(within(screen.getByRole('combobox')).getByText('gp3')).toBeInTheDocument()
+    expect(screen.getByTestId('is-dirty')).toHaveTextContent('true')
+  })
+
+  test('a hard-block reason keeps fields disabled even when the disk is over-provisioned', async () => {
+    const defaultValues = buildDefaultValues({ provisionedIOPS: 8000, throughput: 500 })
+    mockDiskEndpoints({ storageType: DiskType.GP3, provisionedIOPS: 8000, throughput: 500 })
+
+    customRender(
+      <TestHarness defaultValues={defaultValues} isComputeSizeGuardrailActive isHardBlocked />
+    )
+
+    expect(await screen.findByRole('combobox')).toBeDisabled()
+    expect(screen.getByRole('spinbutton', { name: 'IOPS' })).toBeDisabled()
+    expect(screen.getByRole('spinbutton', { name: 'Throughput' })).toBeDisabled()
+    expect(
+      screen.queryByText("Storage type, IOPS, or throughput exceeds what's currently supported")
+    ).not.toBeInTheDocument()
+  })
+})

--- a/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.sections.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.sections.tsx
@@ -1,6 +1,7 @@
+import Link from 'next/link'
 import { type RefObject } from 'react'
 import { type UseFormReturn } from 'react-hook-form'
-import { Button, Card, CardContent } from 'ui'
+import { Button, buttonVariants, Card, CardContent, cn } from 'ui'
 import { Admonition } from 'ui-patterns/Admonition'
 import {
   PageSection,
@@ -13,6 +14,7 @@ import {
 } from 'ui-patterns/PageSection'
 
 import { DiskStorageSchemaType } from './DiskManagement.schema'
+import { DiskConfigEditability } from './DiskManagement.types'
 import { AutoScaleFields } from './fields/AutoScaleFields'
 import {
   ComputeSectionBillingBadge,
@@ -25,12 +27,14 @@ import { StorageTypeField } from './fields/StorageTypeField'
 import { ThroughputField } from './fields/ThroughputField'
 import { BillingChangeBadge } from './ui/BillingChangeBadge'
 import { DiskCountdownRadial } from './ui/DiskCountdownRadial'
+import { DiskType, SUPPORTED_DISK_CONFIG_UNDER_COST_GUARDRAIL } from './ui/DiskManagement.constants'
 import { DiskSpaceBar } from './ui/DiskSpaceBar'
 import { NoticeBar } from './ui/NoticeBar'
 import { SpendCapDisabledSection } from './ui/SpendCapDisabledSection'
 import { DocsButton } from '@/components/ui/DocsButton'
 import { HighAvailabilityDisabledSectionNotice } from '@/components/ui/HighAvailability/HighAvailabilityDisabledSectionNotice'
 import { RequestUpgradeToBillingOwners } from '@/components/ui/RequestUpgradeToBillingOwners'
+import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 import { DOCS_URL } from '@/lib/constants'
 
 interface ComputeSectionProps {
@@ -216,12 +220,13 @@ interface AdvancedSectionProps {
   showBillingBadge: boolean
   beforePrice: number
   afterPrice: number
-  disableIopsThroughputConfig?: boolean
   canUpdateDiskConfiguration: boolean
-  isDiskTooSmallForCustomIops: boolean
+  isDiskTooSmallForIopsOrThroughput: boolean
   disableDiskInputs: boolean
   disableDiskSizeInput: boolean
   suggestedDiskSizeForCustomIops: number
+  diskConfigEditability: DiskConfigEditability
+  provisionedStorageType?: DiskType
 }
 
 export function AdvancedSection({
@@ -231,13 +236,22 @@ export function AdvancedSection({
   showBillingBadge,
   beforePrice,
   afterPrice,
-  disableIopsThroughputConfig,
   canUpdateDiskConfiguration,
-  isDiskTooSmallForCustomIops,
+  isDiskTooSmallForIopsOrThroughput,
   disableDiskInputs,
   disableDiskSizeInput,
   suggestedDiskSizeForCustomIops,
+  diskConfigEditability,
+  provisionedStorageType,
 }: AdvancedSectionProps) {
+  const { data: org } = useSelectedOrganizationQuery()
+  const canEditDiskConfig = diskConfigEditability.status !== 'locked'
+  const isDownsizeOnly = diskConfigEditability.status === 'downsizeOnly'
+  const activeGuardrails =
+    diskConfigEditability.status === 'editable' ? [] : diskConfigEditability.guardrails
+  const isLockedByComputeSize =
+    diskConfigEditability.status === 'locked' && activeGuardrails.includes('computeSize')
+
   return (
     <PageSection>
       <PageSectionMeta>
@@ -266,8 +280,8 @@ export function AdvancedSection({
           <CardContent className="flex flex-col gap-y-8">
             <NoticeBar
               type="default"
-              visible={!!disableIopsThroughputConfig}
-              title="Adjusting disk configuration requires LARGE Compute size or above"
+              visible={isLockedByComputeSize}
+              title="Adjusting disk configuration requires Large compute size or above"
               description={`Increase your compute size to adjust your disk's storage type, ${form.getValues('storageType') === 'gp3' ? 'IOPS, ' : ''} and throughput`}
               actions={
                 canUpdateDiskConfiguration ? (
@@ -282,7 +296,7 @@ export function AdvancedSection({
                       form.trigger('throughput')
                     }}
                   >
-                    Change to LARGE Compute
+                    Change to Large compute
                   </Button>
                 ) : (
                   <RequestUpgradeToBillingOwners
@@ -294,9 +308,62 @@ export function AdvancedSection({
             />
             <NoticeBar
               type="default"
-              visible={
-                isDiskTooSmallForCustomIops && !disableIopsThroughputConfig && !disableDiskInputs
+              visible={isDownsizeOnly}
+              title="Storage type, IOPS, or throughput exceeds what's currently supported"
+              description="These settings are provisioned above what your current compute size or spend cap allows. You can lower storage type, IOPS, and throughput. To raise them, disable spend cap and upgrade to Large compute as necessary."
+              actions={
+                <div className="flex flex-wrap items-center gap-2">
+                  <Button
+                    variant="default"
+                    onClick={() => {
+                      form.setValue(
+                        'storageType',
+                        SUPPORTED_DISK_CONFIG_UNDER_COST_GUARDRAIL.storageType,
+                        { shouldDirty: true, shouldValidate: true }
+                      )
+                      form.setValue(
+                        'provisionedIOPS',
+                        SUPPORTED_DISK_CONFIG_UNDER_COST_GUARDRAIL.provisionedIOPS,
+                        { shouldDirty: true, shouldValidate: true }
+                      )
+                      form.setValue(
+                        'throughput',
+                        SUPPORTED_DISK_CONFIG_UNDER_COST_GUARDRAIL.throughput,
+                        { shouldDirty: true, shouldValidate: true }
+                      )
+                    }}
+                  >
+                    Reset to supported configuration
+                  </Button>
+                  {activeGuardrails.includes('computeSize') && canUpdateDiskConfiguration && (
+                    <Button
+                      variant="default"
+                      onClick={() => {
+                        form.setValue('computeSize', 'ci_large', {
+                          shouldDirty: true,
+                          shouldValidate: true,
+                        })
+                        form.trigger('provisionedIOPS')
+                        form.trigger('throughput')
+                      }}
+                    >
+                      Change to Large compute
+                    </Button>
+                  )}
+                  {activeGuardrails.includes('spendCap') && (
+                    <Link
+                      href={`/org/${org?.slug}/billing?panel=costControl`}
+                      className={cn(buttonVariants({ variant: 'default', size: 'tiny' }))}
+                    >
+                      Disable spend cap
+                    </Link>
+                  )}
+                </div>
               }
+            />
+            <NoticeBar
+              type="default"
+              visible={isDiskTooSmallForIopsOrThroughput && canEditDiskConfig}
               title="Increase disk size to adjust IOPS or throughput"
               description={`This disk is too small to update IOPS or throughput, since gp3 volumes are capped at 500 IOPS per GB with a 3,000 IOPS minimum. Resizing to ${suggestedDiskSizeForCustomIops} GB unlocks custom IOPS and throughput, and leaves headroom for further adjustments (disk config changes are limited to 4 within a rolling 24-hour window).`}
               actions={
@@ -317,19 +384,17 @@ export function AdvancedSection({
             />
             <StorageTypeField
               form={form}
-              disableInput={!!disableIopsThroughputConfig || disableDiskInputs}
+              disableInput={!canEditDiskConfig}
+              downsizeOnly={isDownsizeOnly}
+              provisionedStorageType={provisionedStorageType}
             />
             <IOPSField
               form={form}
-              disableInput={
-                !!disableIopsThroughputConfig || disableDiskInputs || isDiskTooSmallForCustomIops
-              }
+              disableInput={!canEditDiskConfig || isDiskTooSmallForIopsOrThroughput}
             />
             <ThroughputField
               form={form}
-              disableInput={
-                !!disableIopsThroughputConfig || disableDiskInputs || isDiskTooSmallForCustomIops
-              }
+              disableInput={!canEditDiskConfig || isDiskTooSmallForIopsOrThroughput}
             />
           </CardContent>
         </Card>

--- a/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.tsx
@@ -2,8 +2,8 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useParams } from 'common'
 import { AnimatePresence, motion } from 'framer-motion'
-import { useEffect, useRef, useState, type ReactNode } from 'react'
-import { useForm, useWatch } from 'react-hook-form'
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { useForm, useWatch, type Resolver } from 'react-hook-form'
 import { CloudProvider } from 'shared-data'
 import { toast } from 'sonner'
 import { Button, cn, Form } from 'ui'
@@ -21,6 +21,8 @@ import { CreateDiskStorageSchema, DiskStorageSchemaType } from './DiskManagement
 import { DiskManagementMessage } from './DiskManagement.types'
 import {
   calculateDiskSizeRequiredForIopsWithGp3,
+  getDiskConfigEditability,
+  isDiskConfigOverProvisioned,
   mapComputeSizeNameToAddonVariantId,
 } from './DiskManagement.utils'
 import { AdvancedSection, ComputeSection, DiskSection } from './DiskManagementForm.sections'
@@ -33,6 +35,7 @@ import {
   DiskType,
   PLAN_DETAILS,
   RESTRICTED_COMPUTE_FOR_THROUGHPUT_ON_GP3,
+  SUPPORTED_DISK_CONFIG_UNDER_COST_GUARDRAIL,
 } from './ui/DiskManagement.constants'
 import { NoticeBar } from './ui/NoticeBar'
 import type { RecommendedComputeForReadReplicas } from '@/components/interfaces/Settings/Infrastructure/ReadReplicas/recommendCompute'
@@ -163,14 +166,23 @@ export function DiskManagementForm({
     maxSizeGb: max_size_gb,
   }
 
-  const form = useForm<DiskStorageSchemaType>({
-    resolver: zodResolver(
+  // The schema needs to react to live edits inside this dialog (e.g. raising compute size
+  // back above Large should immediately lift the downsize-only ceiling below), but those
+  // live values can only be read from `form.control`, which doesn't exist until after this
+  // useForm() call returns. Route the resolver through a ref so it can be kept in sync from
+  // further down in this component without a circular dependency on `form` itself.
+  const resolverRef = useRef<Resolver<DiskStorageSchemaType>>(
+    zodResolver(
       CreateDiskStorageSchema({
         defaultTotalSize: defaultValues.totalSize,
         cloudProvider: project?.cloud_provider as CloudProvider,
         isSpendCapEnabled,
       })
-    ),
+    )
+  )
+
+  const form = useForm<DiskStorageSchemaType>({
+    resolver: (values, context, options) => resolverRef.current(values, context, options),
     defaultValues,
     mode: 'onBlur',
     reValidateMode: 'onChange',
@@ -206,13 +218,12 @@ export function DiskManagementForm({
   const errors = formState.errors
   const usedSize = Math.round(((diskUtil?.metrics.fs_used_bytes ?? 0) / GB) * 100) / 100
   const totalSize = formState.defaultValues?.totalSize || 0
-  const usedPercentage = (usedSize / totalSize) * 100
+  const usedPercentage = totalSize === 0 ? 0 : (usedSize / totalSize) * 100
 
-  const disableIopsThroughputConfig =
-    isHighAvailability ||
-    (modifiedComputeSize &&
-      !isSpendCapEnabled &&
-      RESTRICTED_COMPUTE_FOR_THROUGHPUT_ON_GP3.includes(modifiedComputeSize))
+  const isComputeSizeGuardrailActive =
+    !!modifiedComputeSize && RESTRICTED_COMPUTE_FOR_THROUGHPUT_ON_GP3.includes(modifiedComputeSize)
+
+  const isCostGuardrailActive = isComputeSizeGuardrailActive || isSpendCapEnabled
 
   const watchedTotalSize = useWatch({ control: form.control, name: 'totalSize' }) ?? 0
   const watchedStorageType = useWatch({ control: form.control, name: 'storageType' })
@@ -223,7 +234,7 @@ export function DiskManagementForm({
   // Suggested target when prompting a resize, sits above the floor so users
   // aren't pinned at the minimum between disk-config modifications.
   const suggestedDiskSizeForCustomIops = PLAN_DETAILS.pro.includedDiskGB.gp3
-  const isDiskTooSmallForCustomIops =
+  const isDiskTooSmallForIopsOrThroughput =
     watchedStorageType === 'gp3' && watchedTotalSize < minDiskSizeForCustomIops
 
   const isBranch = project?.parent_project_ref !== undefined
@@ -237,6 +248,51 @@ export function DiskManagementForm({
     !isAws
 
   const disableDiskInputs = disableDiskSizeInput || isSpendCapEnabled || isHighAvailability
+
+  // Checks against the CURRENT PERSISTED configuration, not the requested
+  // configuration. The requested configuration's own validity is enforced by
+  // the schema below.
+  const isDiskOverProvisioned =
+    isAws &&
+    isDiskAttributesSuccess &&
+    isDiskConfigOverProvisioned({
+      storageType: defaultValues.storageType as DiskType,
+      provisionedIOPS: defaultValues.provisionedIOPS,
+      throughput: defaultValues.throughput,
+    })
+
+  const diskConfigEditability = getDiskConfigEditability({
+    isHardBlocked: disableDiskSizeInput,
+    isComputeSizeGuardrailActive,
+    isSpendCapEnabled,
+    isDiskOverProvisioned,
+  })
+
+  const diskStorageSchema = useMemo(
+    () =>
+      CreateDiskStorageSchema({
+        defaultTotalSize: defaultValues.totalSize,
+        cloudProvider: project?.cloud_provider as CloudProvider,
+        isSpendCapEnabled,
+        downsizeOnlyFrom: isCostGuardrailActive
+          ? {
+              storageType: defaultValues.storageType as DiskType,
+              provisionedIOPS: defaultValues.provisionedIOPS,
+              throughput: defaultValues.throughput,
+            }
+          : undefined,
+      }),
+    [
+      defaultValues.totalSize,
+      defaultValues.storageType,
+      defaultValues.provisionedIOPS,
+      defaultValues.throughput,
+      project?.cloud_provider,
+      isSpendCapEnabled,
+      isCostGuardrailActive,
+    ]
+  )
+  resolverRef.current = zodResolver(diskStorageSchema)
 
   // Compute resizing is not supported for High Availability projects during Alpha
   const disableComputeInputs = isPlanUpgradeRequired || isHighAvailability
@@ -361,17 +417,22 @@ export function DiskManagementForm({
     }
   }, [data, isDiskAttributesSuccess, form, refetchInterval])
 
-  // We only support disk configurations for >=Large instances
-  // If a customer downgrades back to <Large, we should reset the storage settings to avoid incurring unnecessary costs
+  // We only support disk configurations for >=Large instances. If a customer
+  // downgrades compute below Large *inside this dialog*, reset storage settings
+  // to avoid incurring unnecessary costs. Only active when the user downgrades
+  // their compute DURING THE CURRENT SET OF EDITS. When a user already has an
+  // over-provisioned disk created through another channel, the schema already
+  // enforces that they can configure options downwards but not upwards.
   useEffect(() => {
-    if (modifiedComputeSize && project?.infra_compute_size && isDialogOpen) {
-      if (RESTRICTED_COMPUTE_FOR_THROUGHPUT_ON_GP3.includes(modifiedComputeSize)) {
-        form.setValue('storageType', DiskType.GP3)
-        form.setValue('throughput', DISK_LIMITS['gp3'].minThroughput)
-        form.setValue('provisionedIOPS', DISK_LIMITS['gp3'].minIops)
-      }
-    }
-  }, [modifiedComputeSize, form, isDialogOpen, project])
+    if (!isDialogOpen) return
+    const provisionedComputeSize = form.formState.defaultValues?.computeSize
+    if (!modifiedComputeSize || modifiedComputeSize === provisionedComputeSize) return
+    if (!RESTRICTED_COMPUTE_FOR_THROUGHPUT_ON_GP3.includes(modifiedComputeSize)) return
+
+    form.setValue('storageType', SUPPORTED_DISK_CONFIG_UNDER_COST_GUARDRAIL.storageType)
+    form.setValue('throughput', SUPPORTED_DISK_CONFIG_UNDER_COST_GUARDRAIL.throughput)
+    form.setValue('provisionedIOPS', SUPPORTED_DISK_CONFIG_UNDER_COST_GUARDRAIL.provisionedIOPS)
+  }, [modifiedComputeSize, form, isDialogOpen])
 
   useEffect(() => {
     // Initialize field values properly when data has been loaded, preserving any user changes.
@@ -554,12 +615,13 @@ export function DiskManagementForm({
                   showBillingBadge={showAdvancedBillingBadge}
                   beforePrice={advancedBeforePrice}
                   afterPrice={advancedAfterPrice}
-                  disableIopsThroughputConfig={disableIopsThroughputConfig}
                   canUpdateDiskConfiguration={canUpdateDiskConfiguration}
-                  isDiskTooSmallForCustomIops={isDiskTooSmallForCustomIops}
+                  isDiskTooSmallForIopsOrThroughput={isDiskTooSmallForIopsOrThroughput}
                   disableDiskInputs={disableDiskInputs}
                   disableDiskSizeInput={disableDiskSizeInput}
                   suggestedDiskSizeForCustomIops={suggestedDiskSizeForCustomIops}
+                  diskConfigEditability={diskConfigEditability}
+                  provisionedStorageType={defaultValues.storageType as DiskType}
                 />
               )}
             </PageSectionContent>

--- a/apps/studio/components/interfaces/DiskManagement/fields/IOPSField.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/fields/IOPSField.tsx
@@ -16,7 +16,7 @@ import {
   mapAddOnVariantIdToComputeSize,
 } from '../DiskManagement.utils'
 import { ComputeSizeRecommendationSection } from '../ui/ComputeSizeRecommendationSection'
-import { DiskType, RESTRICTED_COMPUTE_FOR_IOPS_ON_GP3 } from '../ui/DiskManagement.constants'
+import { DiskType } from '../ui/DiskManagement.constants'
 import { DiskManagementIOPSReadReplicas } from '../ui/DiskManagementReadReplicas'
 import { useDiskAttributesQuery } from '@/data/config/disk-attributes-query'
 
@@ -29,14 +29,9 @@ export function IOPSField({ form, disableInput }: IOPSFieldProps) {
   const { ref: projectRef } = useParams()
   const { control, formState, setValue, trigger, getValues } = form
 
-  const watchedStorageType = useWatch({ control, name: 'storageType' })
-  const watchedComputeSize = useWatch({ control, name: 'computeSize' })
   const watchedIOPS = useWatch({ control, name: 'provisionedIOPS' }) ?? 0
 
   const { isError } = useDiskAttributesQuery({ projectRef })
-
-  const disableIopsInput =
-    RESTRICTED_COMPUTE_FOR_IOPS_ON_GP3.includes(watchedComputeSize) && watchedStorageType === 'gp3'
 
   return (
     <FormField
@@ -88,7 +83,7 @@ export function IOPSField({ form, disableInput }: IOPSFieldProps) {
                   {...field}
                   id={field.name}
                   value={field.value}
-                  disabled={disableInput || disableIopsInput || isError}
+                  disabled={disableInput || isError}
                   onChange={(e) => {
                     setValue('provisionedIOPS', e.target.valueAsNumber, {
                       shouldDirty: true,

--- a/apps/studio/components/interfaces/DiskManagement/fields/StorageTypeField.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/fields/StorageTypeField.tsx
@@ -29,9 +29,18 @@ import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 type StorageTypeFieldProps = {
   form: UseFormReturn<DiskStorageSchemaType>
   disableInput: boolean
+  /** When true, only storage types that are no more expensive than what's already provisioned can be selected. */
+  downsizeOnly?: boolean
+  /** The currently persisted storage type */
+  provisionedStorageType?: DiskType
 }
 
-export function StorageTypeField({ form, disableInput }: StorageTypeFieldProps) {
+export function StorageTypeField({
+  form,
+  disableInput,
+  downsizeOnly,
+  provisionedStorageType,
+}: StorageTypeFieldProps) {
   const { control, trigger } = form
   const { data: project } = useSelectedProjectQuery()
   const { ref: projectRef } = useParams()
@@ -52,26 +61,18 @@ export function StorageTypeField({ form, disableInput }: StorageTypeFieldProps) 
               field.onChange(e)
 
               /**
-               * Set default IOPS if not dirty
-               * This is to ensure that the IOPS is set to the minimum value if the user has not changed it
-               *
-               * Only set it if the current configured IOPS is smaller than the min IOPS, otherwise leave at same IOPS
+               * Clamp IOPS into the newly selected storage type's supported [min, max] range
+               * if the user hasn't manually edited it — otherwise leave their value in place
+               * and let validation surface any conflict.
                */
-              if (e === 'gp3') {
-                if (
-                  !form.getFieldState('provisionedIOPS').isDirty &&
-                  (!form.getValues('provisionedIOPS') ||
-                    form.getValues('provisionedIOPS') < DISK_LIMITS[DiskType.GP3].minIops)
-                ) {
-                  form.setValue('provisionedIOPS', DISK_LIMITS[DiskType.GP3].minIops)
-                }
-              } else {
-                if (
-                  !form.getFieldState('provisionedIOPS').isDirty &&
-                  (!form.getValues('provisionedIOPS') ||
-                    form.getValues('provisionedIOPS') < DISK_LIMITS[DiskType.IO2].minIops)
-                ) {
-                  form.setValue('provisionedIOPS', DISK_LIMITS[DiskType.IO2].minIops)
+              if (!form.getFieldState('provisionedIOPS').isDirty) {
+                const { minIops, maxIops } = DISK_LIMITS[e]
+                const currentIOPS = form.getValues('provisionedIOPS')
+
+                if (!currentIOPS || currentIOPS < minIops) {
+                  form.setValue('provisionedIOPS', minIops)
+                } else if (currentIOPS > maxIops) {
+                  form.setValue('provisionedIOPS', maxIops)
                 }
               }
 
@@ -99,7 +100,11 @@ export function StorageTypeField({ form, disableInput }: StorageTypeFieldProps) 
             <SelectContent>
               <>
                 {DISK_TYPE_OPTIONS.map((item) => {
-                  const disableIo2 = item.type === 'io2' && !isIo2Supported
+                  const isIo2Option = item.type === 'io2'
+                  const disableIo2ForRegion = isIo2Option && !isIo2Supported
+                  const disableIo2ForDownsize =
+                    isIo2Option && !!downsizeOnly && provisionedStorageType !== DiskType.IO2
+                  const disableIo2 = disableIo2ForRegion || disableIo2ForDownsize
                   return (
                     <Tooltip key={item.type}>
                       <TooltipTrigger asChild>
@@ -120,7 +125,7 @@ export function StorageTypeField({ form, disableInput }: StorageTypeFieldProps) 
                           </div>
                         </SelectItem>
                       </TooltipTrigger>
-                      {disableIo2 && (
+                      {disableIo2ForRegion && (
                         <TooltipContent side="right" className="w-64">
                           IO2 Volume Type is not available in your project's region (
                           {project?.region}). More information available{' '}
@@ -128,6 +133,12 @@ export function StorageTypeField({ form, disableInput }: StorageTypeFieldProps) 
                             here
                           </InlineLink>
                           .
+                        </TooltipContent>
+                      )}
+                      {disableIo2ForDownsize && (
+                        <TooltipContent side="right" className="w-64">
+                          An io2 disk is over-provisioned for your current compute. To use io2,
+                          upgrade to Large compute or greater.
                         </TooltipContent>
                       )}
                     </Tooltip>

--- a/apps/studio/components/interfaces/DiskManagement/fields/ThroughputField.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/fields/ThroughputField.tsx
@@ -13,11 +13,7 @@ import {
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
 import { DiskStorageSchemaType } from '../DiskManagement.schema'
-import {
-  DISK_LIMITS,
-  DiskType,
-  RESTRICTED_COMPUTE_FOR_IOPS_ON_GP3,
-} from '../ui/DiskManagement.constants'
+import { DISK_LIMITS, DiskType } from '../ui/DiskManagement.constants'
 import { DiskManagementThroughputReadReplicas } from '../ui/DiskManagementReadReplicas'
 import { useDiskAttributesQuery } from '@/data/config/disk-attributes-query'
 
@@ -33,13 +29,9 @@ export function ThroughputField({ form, disableInput }: ThroughputFieldProps) {
 
   const watchedStorageType = useWatch({ control, name: 'storageType' })
   const watchedTotalSize = useWatch({ control, name: 'totalSize' })
-  const watchedComputeSize = useWatch({ control, name: 'computeSize' })
   const throughput_mbps = formState.defaultValues?.throughput
 
   useDiskAttributesQuery({ projectRef })
-
-  const disableIopsInput =
-    RESTRICTED_COMPUTE_FOR_IOPS_ON_GP3.includes(watchedComputeSize) && watchedStorageType === 'gp3'
 
   // Watch storageType and allocatedStorage to adjust constraints dynamically
   useEffect(() => {
@@ -109,7 +101,7 @@ export function ThroughputField({ form, disableInput }: ThroughputFieldProps) {
                           shouldValidate: true,
                         })
                       }}
-                      disabled={disableInput || disableIopsInput || watchedStorageType === 'io2'}
+                      disabled={disableInput || watchedStorageType === 'io2'}
                     />
                     <InputGroupAddon align="inline-end">
                       <InputGroupText>MB/s</InputGroupText>

--- a/apps/studio/components/interfaces/DiskManagement/ui/DiskManagement.constants.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/ui/DiskManagement.constants.tsx
@@ -60,6 +60,12 @@ export const PLAN_DETAILS: Record<PlanId, PlanDetails> = {
   platform: { includedDiskGB: { gp3: 8, io2: 0 } },
 }
 
+export const SUPPORTED_DISK_CONFIG_UNDER_COST_GUARDRAIL = {
+  storageType: DiskType.GP3,
+  provisionedIOPS: DISK_LIMITS[DiskType.GP3].minIops,
+  throughput: DISK_LIMITS[DiskType.GP3].minThroughput,
+} as const
+
 export const RESTRICTED_COMPUTE_FOR_IOPS_ON_GP3 = ['ci_nano', 'ci_micro', 'ci_small', 'ci_medium']
 
 export const RESTRICTED_COMPUTE_FOR_THROUGHPUT_ON_GP3 = [


### PR DESCRIPTION
## Summary

* **Bug**: The disk management form enforces guardrails that disable all editing when compute size is below "Large" or an org spend cap is enabled. These guardrails are UI-only and don't reflect backend restrictions, trapping customers whose disk config became over-provisioned due to external changes.
* **Trigger scenario**: A compute instance is force-downgraded outside Studio (or a spend cap is enabled after a custom disk config was already set), leaving the disk configuration over-provisioned and expensive with no way for customers to self-serve downsize it.
* **Fix**: Detect when persisted disk config exceeds the active guardrail ceiling. When over-provisioned, unlock the form to allow downsize-only edits while enforcing a schema-level ceiling to prevent increases beyond the guardrail limit.

Note: Total disk size reduction via volume shrinking is out of scope and unsupported (pre-existing AWS EBS limitation with separate remediation path).

## Test plan

- [X] Unit tests added for new helpers (`isDiskConfigOverProvisioned`, `getDiskConfigEditability`) in `DiskManagement.test.ts`
- [X] Unit tests for schema downsize ceiling validation added to `DiskManagement.test.ts`
- [X] New component test suite `DiskManagementForm.sections.test.tsx` covering: unlock/lock state transitions, form availability based on over-provisioning, reset button behavior, guardrail-ceiling hard blocks for increases

Fixes [FE-4318](https://linear.app/supabase/issue/FE-4318/investigate-disk-configuration-guardrail-on-smaller-compute)