### PR TITLE
docs: align link text for the API keys guide

### DIFF
--- a/apps/docs/content/_partials/api_settings.mdx
+++ b/apps/docs/content/_partials/api_settings.mdx
@@ -7,6 +7,6 @@ To interact with data in database tables, you use the client libraries that wrap
 
 <Admonition type="note">
 
-[Read the API keys docs](/docs/guides/getting-started/api-keys) for a full explanation of all key types, their uses, and where to find them.
+See [API keys](/docs/guides/getting-started/api-keys) for a full explanation of all key types, their uses, and where to find them.
 
 </Admonition>

--- a/apps/docs/content/_partials/metrics_access.mdx
+++ b/apps/docs/content/_partials/metrics_access.mdx
@@ -22,7 +22,7 @@ className="rounded-lg border border-foreground/10 bg-surface-100 text-foreground
     3. Authenticate with HTTP Basic Auth:
 
     - **Username**: `service_role`
-    - **Password**: a **Secret API key** (`sb_secret_...`). You can create/copy it in [**Project Settings → API Keys**](/dashboard/project/_/settings/api-keys). For more context, see [Understanding API keys](/docs/guides/getting-started/api-keys).
+    - **Password**: a **Secret API key** (`sb_secret_...`). You can create/copy it in [**Project Settings → API Keys**](/dashboard/project/_/settings/api-keys). For more context, see [API keys](/docs/guides/getting-started/api-keys).
 
     To test locally, run `curl` with your Secret API key:
 

--- a/apps/docs/content/guides/api/creating-routes.mdx
+++ b/apps/docs/content/guides/api/creating-routes.mdx
@@ -68,7 +68,7 @@ To do this, you need to get the Project URL and key from [the project's **Connec
 
 <$Partial path="api_keys_deprecation.mdx" variables={{ "framework": "{{ .framework }}", "tab": "{{ .tab }}" }} />
 
-[Read the API keys docs](/docs/guides/getting-started/api-keys) for a full explanation of all key types and their uses.
+See [API keys](/docs/guides/getting-started/api-keys) for a full explanation of all key types and their uses.
 
 The REST API is accessible through the URL `https://<project_ref>.supabase.co/rest/v1`
 

--- a/apps/docs/content/guides/auth/signing-keys.mdx
+++ b/apps/docs/content/guides/auth/signing-keys.mdx
@@ -214,7 +214,7 @@ Finally, you can use your newly minted JWT by setting the `Authorization: Bearer
 
 <Admonition type="note">
 
-A separate `apikey` header is required to access your project's APIs. This can be a [publishable, secret or the legacy `anon` or `service_role` keys](/docs/guides/getting-started/api-keys). Using your minted JWT is not possible in this header.
+A separate `apikey` header is required to access your project's APIs. Use a publishable or secret key, or a legacy `anon` or `service_role` key. See [API keys](/docs/guides/getting-started/api-keys). Using your minted JWT is not possible in this header.
 
 </Admonition>
 

--- a/apps/docs/content/guides/getting-started/migrating-to-new-api-keys.mdx
+++ b/apps/docs/content/guides/getting-started/migrating-to-new-api-keys.mdx
@@ -17,7 +17,7 @@ The migration maps onto your existing keys:
 | `anon`         | Publishable key | Browsers, mobile and desktop apps, CLIs, public source |
 | `service_role` | Secret key      | Servers, Edge Functions, workers, other backend code   |
 
-For a full explanation of each key type, read [the API keys guide](/docs/guides/getting-started/api-keys).
+For a full explanation of each key type, see [API keys](/docs/guides/getting-started/api-keys).
 
 ## Step 1: Create the new API keys
 

--- a/apps/docs/content/guides/self-hosting/self-hosted-auth-keys.mdx
+++ b/apps/docs/content/guides/self-hosting/self-hosted-auth-keys.mdx
@@ -4,7 +4,7 @@ description: 'Configure new API keys and ES256 asymmetric authentication for sel
 subtitle: 'Configure new API keys and ES256 asymmetric authentication for self-hosted Supabase.'
 ---
 
-You can configure self-hosted Supabase to use the [new API keys](/docs/guides/getting-started/api-keys) alongside the legacy API keys (`ANON_KEY` and `SERVICE_ROLE_KEY` HS256-signed JWTs).
+You can configure self-hosted Supabase to use the [publishable and secret API keys](/docs/guides/getting-started/api-keys) alongside the legacy API keys (`ANON_KEY` and `SERVICE_ROLE_KEY` HS256-signed JWTs).
 
 ## Before you begin
 
@@ -77,7 +77,7 @@ sh run.sh recreate
 
 ### New API keys format
 
-The new API keys use the [same format](/docs/guides/getting-started/api-keys) as the Supabase platform:
+These keys use the same format as [API keys](/docs/guides/getting-started/api-keys) on the Supabase platform:
 
 ```
 sb_publishable_<22-char-random>_<8-char-checksum>
@@ -204,7 +204,7 @@ For details on how the API gateway routes and authenticates requests, see the [E
 
 ## Additional resources
 
-- [Understanding API keys](/docs/guides/getting-started/api-keys) - How API keys work on the Supabase platform
+- [API keys](/docs/guides/getting-started/api-keys) - How API keys work on the Supabase platform
 - [Auth architecture](/docs/guides/auth/architecture) - How the Auth service handles authentication and token signing
 - [JWT Signing Keys](/docs/guides/auth/signing-keys) - Best practices on managing keys used by Supabase Auth to create and verify JSON Web Tokens
 - [JSON Web Token (JWT)](/docs/guides/auth/jwts) - How to best use JSON Web Tokens with Supabase

--- a/apps/docs/content/troubleshooting/rotating-anon-service-and-jwt-secrets-1Jq6yd.mdx
+++ b/apps/docs/content/troubleshooting/rotating-anon-service-and-jwt-secrets-1Jq6yd.mdx
@@ -9,7 +9,7 @@ database_id = "caa72a34-696c-47c6-8976-e50cf7fb396e"
 
 <Admonition type="deprecation">
 
-This troubleshooting guide is about rotating **Legacy anon, service_role API keys**. We are deprecating Legacy, and recommend migrating to New API keys. To learn more about API keys, refer to [the API documentation](/docs/guides/getting-started/api-keys).
+This troubleshooting guide is about rotating **Legacy anon, service_role API keys**. We are deprecating Legacy, and recommend migrating to New API keys. To learn more about API keys, refer to [API keys](/docs/guides/getting-started/api-keys).
 
 </Admonition>
 

--- a/apps/docs/content/troubleshooting/why-is-my-service-role-key-client-getting-rls-errors-or-not-returning-data-7_1K9z.mdx
+++ b/apps/docs/content/troubleshooting/why-is-my-service-role-key-client-getting-rls-errors-or-not-returning-data-7_1K9z.mdx
@@ -10,7 +10,7 @@ database_id = "677f0a69-e454-4718-ad92-91053d40c085"
 <Admonition type="deprecation">
 
 This troubleshooting guide is about rotating **Legacy anon, service_role API keys**. We are deprecating the Legacy API keys, and recommend migrating to New API keys. To learn more about API
-keys, refer to [the API documentation](/docs/guides/getting-started/api-keys).
+keys, refer to [API keys](/docs/guides/getting-started/api-keys).
 
 </Admonition>
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update. Link text only, no content changes.

## What is the current behavior?

Twenty-one links point at the API keys guide under fourteen different labels, and two of them name the wrong destination.

- Two troubleshooting entries call it "the API documentation", which sends a reader looking for the API reference.
- Three use "Understanding API keys", which is no longer the title.
- Two use "Read the API keys docs", putting the verb inside the link text.
- One uses "same format", which doesn't say where it goes.
- One runs to fourteen words.

## What is the new behavior?

One rule: when a link means the guide, the text is "API keys". When it means a specific key or section, the specific text stays.

Twelve links now share "API keys", up from three. The remaining variants are descriptive on purpose, such as "secret key" where that is what the reader needs, plus two section anchors.

Out of scope: the 2025 JWT signing keys blog post keeps "New API keys". It was accurate when published, and a blog post is not documentation. Its generated mirror in `apps/www/app/api-v2/md/content.generated.ts` is a build artifact.

## Additional context

PR 5 of 5. Base is #49799.

## Manual testing

1. Open the API keys guide on the deploy preview.
2. Open the two troubleshooting entries linked below and confirm the inbound links read "API keys" and land on the guide.
   - Rotating Anon, Service, and JWT Secrets
   - Why is my service_role key client getting RLS errors
3. Open the self-hosting "New API Keys and Asymmetric Authentication" guide and confirm its three links read as intended.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API key links and labels throughout the documentation for clearer, more consistent navigation.
  * Clarified that project API access requires a separate publishable, secret, or legacy API key.
  * Refined self-hosting guidance to describe publishable and secret API keys and their format.
  * Updated troubleshooting references to point directly to API key guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->