### PR TITLE
fix(ui): standardise nav logout label to "Sign out"

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/useDropdownMenu.tsx
+++ b/apps/docs/components/Navigation/NavigationMenu/useDropdownMenu.tsx
@@ -69,7 +69,7 @@ const useDropdownMenu = (user: User | null) => {
     ],
     [
       {
-        label: 'Logout',
+        label: 'Sign out',
         type: 'button',
         icon: LogOut,
         onClick: async () => {

--- a/apps/learn/components/side-navigation.tsx
+++ b/apps/learn/components/side-navigation.tsx
@@ -45,7 +45,7 @@ function SideNavigation({ internalPaths }: SideNavigationProps) {
     ],
     [
       {
-        label: 'Logout',
+        label: 'Sign out',
         type: 'button',
         icon: LogOut,
         onClick: async () => {

--- a/apps/studio/components/interfaces/UserDropdown.tsx
+++ b/apps/studio/components/interfaces/UserDropdown.tsx
@@ -200,7 +200,7 @@ export function UserDropdown({
                   router.push('/logout')
                 }}
               >
-                Log out
+                Sign out
               </DropdownMenuItem>
             </DropdownMenuGroup>
           </>

--- a/apps/www/components/Nav/useDropdownMenu.tsx
+++ b/apps/www/components/Nav/useDropdownMenu.tsx
@@ -44,7 +44,7 @@ const useDropdownMenu = (user: User | null) => {
     ],
     [
       {
-        label: 'Logout',
+        label: 'Sign out',
         type: 'button',
         icon: LogOut,
         onClick: async () => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Copy fix across nav dropdowns.

## What is the current behavior?

Authenticated nav dropdowns use mixed logout wording: Studio shows "Log out", while www, docs, and learn show "Logout". Studio error flows already use "Sign out".

| Before |
| --- |
| <img width="482" height="670" alt="CleanShot 2026-09-02 at 13 07 46@2x" src="https://github.com/user-attachments/assets/d87b7c18-94c0-4c1c-917e-e17e4cb16dd3" /> |

## What is the new behavior?

All four nav dropdowns use **Sign out**, matching the Sign in / Sign up standard and the direction in [DOCS-1328](https://linear.app/supabase/issue/DOCS-1328).

Related: [Slack thread](https://supabase.slack.com/archives/C0429V78ACX/p1787081498302919)

## To test

Only Studio is possible to test (before merge) given how authentication works across apps on staging:

1. **Studio** (`/dashboard`): open the account avatar dropdown. Confirm the bottom item reads **Sign out**.
2. **www** (`supabase.com`): open the account avatar dropdown. Confirm **Sign out**.
3. **docs** (`supabase.com/docs`): open the account avatar dropdown. Confirm **Sign out**.
4. **learn** (`supabase.com/learn`): open the account avatar dropdown. Confirm **Sign out**.