### PR TITLE
fix(studio): align remaining platform auth labels

### DIFF
--- a/apps/studio/components/interfaces/Account/Preferences/ChangeEmailAddress.tsx
+++ b/apps/studio/components/interfaces/Account/Preferences/ChangeEmailAddress.tsx
@@ -17,7 +17,7 @@ export const GitHubChangeEmailAddress = () => {
         Email addresses for GitHub identities should be updated through GitHub
       </p>
       <ol className="flex flex-col gap-y-0.5 text-sm ml-4 pl-2 list-decimal text-foreground-light">
-        <li>Log out of Supabase</li>
+        <li>Sign out of Supabase</li>
         <li>
           Change your Primary Email in{' '}
           <InlineLink href="https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/changing-your-primary-email-address">
@@ -25,9 +25,9 @@ export const GitHubChangeEmailAddress = () => {
           </InlineLink>{' '}
           (your primary email)
         </li>
-        <li>Log out of GitHub</li>
-        <li>Log back into GitHub (with the new, desired email set as primary)</li>
-        <li>Log back into Supabase</li>
+        <li>Sign out of GitHub</li>
+        <li>Sign back into GitHub (with the new, desired email set as primary)</li>
+        <li>Sign back into Supabase</li>
       </ol>
     </DialogSection>
   )

--- a/apps/studio/components/interfaces/Docs/Pages/UserManagement.tsx
+++ b/apps/studio/components/interfaces/Docs/Pages/UserManagement.tsx
@@ -42,8 +42,8 @@ export const UserManagement = ({ selectedLang, showApiKey }: UserManagementProps
               the user using a <code>user_id</code> field.
             </p>
             <p>
-              Supabase already has built in the routes to sign up, login, and log out for managing
-              users in your apps and websites.
+              Supabase already has built in the routes to sign up, sign in, and sign out for
+              managing users in your apps and websites.
             </p>
           </>
         }
@@ -69,12 +69,12 @@ export const UserManagement = ({ selectedLang, showApiKey }: UserManagementProps
       />
 
       <DocSection
-        title="Log in with Email/Password"
+        title="Sign in with email/password"
         content={
           <>
-            <p>If an account is created, users can login to your app.</p>
+            <p>If an account is created, users can sign in to your app.</p>
             <p>
-              After they have logged in, all interactions using the Supabase JS client will be
+              After they have signed in, all interactions using the Supabase JS client will be
               performed as "that user".
             </p>
           </>
@@ -133,7 +133,7 @@ export const UserManagement = ({ selectedLang, showApiKey }: UserManagementProps
       />
 
       <DocSection
-        title="Login via SMS OTP"
+        title="Sign in via SMS OTP"
         content={
           <>
             <p>
@@ -142,7 +142,7 @@ export const UserManagement = ({ selectedLang, showApiKey }: UserManagementProps
             </p>
             <p>
               You must enter your own twilio credentials on the auth settings page to enable
-              SMS-based Logins.
+              SMS-based sign-in.
             </p>
           </>
         }
@@ -178,12 +178,12 @@ export const UserManagement = ({ selectedLang, showApiKey }: UserManagementProps
 
       {authenticationSignInProviders && (
         <DocSection
-          title="Log in with Third Party OAuth"
+          title="Sign in with third-party OAuth"
           content={
             <>
               <p>
-                Users can log in with Third Party OAuth like Google, Facebook, GitHub, and more. You
-                must first enable each of these in the Auth Providers settings{' '}
+                Users can sign in with third-party OAuth like Google, Facebook, GitHub, and more.
+                You must first enable each of these in the Auth Providers settings{' '}
                 <span className="text-green-500">
                   <InlineLink key={'AUTH'} href={`/project/${projectRef}/auth/providers`}>
                     here
@@ -198,7 +198,7 @@ export const UserManagement = ({ selectedLang, showApiKey }: UserManagementProps
                 </InlineLink>
               </p>
               <p>
-                After they have logged in, all interactions using the Supabase JS client will be
+                After they have signed in, all interactions using the Supabase JS client will be
                 performed as "that user".
               </p>
               <p>
@@ -229,7 +229,7 @@ export const UserManagement = ({ selectedLang, showApiKey }: UserManagementProps
 
       <DocSection
         title="User"
-        content={<p>Get the JSON object for the logged in user.</p>}
+        content={<p>Get the JSON object for the signed-in user.</p>}
         snippets={
           <CodeSnippet
             selectedLang={selectedLang}
@@ -242,7 +242,7 @@ export const UserManagement = ({ selectedLang, showApiKey }: UserManagementProps
         title="Forgotten Password Email"
         content={
           <p>
-            Sends the user a log in link via email. Once logged in you should direct the user to a
+            Sends the user a sign-in link via email. Once signed in you should direct the user to a
             new password form. And use "Update User" below to save the new password.
           </p>
         }
@@ -271,7 +271,7 @@ export const UserManagement = ({ selectedLang, showApiKey }: UserManagementProps
       />
 
       <DocSection
-        title="Log out"
+        title="Sign out"
         content={
           <p>
             After calling log out, all interactions using the Supabase JS client will be
@@ -290,7 +290,7 @@ export const UserManagement = ({ selectedLang, showApiKey }: UserManagementProps
         title="Send a User an Invite over Email"
         content={
           <>
-            <p>Send a user a passwordless link which they can use to sign up and log in.</p>
+            <p>Send a user a passwordless link which they can use to sign up and sign in.</p>
             <p>
               After they have clicked the link, all interactions using the Supabase JS client will
               be performed as "that user".

--- a/apps/studio/components/interfaces/Docs/Pages/UserManagement.tsx
+++ b/apps/studio/components/interfaces/Docs/Pages/UserManagement.tsx
@@ -107,7 +107,7 @@ export const UserManagement = ({ selectedLang, showApiKey }: UserManagementProps
       />
 
       <DocSection
-        title="Sign Up with Phone/Password"
+        title="Sign up with Phone/Password"
         content={
           <>
             <p>
@@ -274,7 +274,7 @@ export const UserManagement = ({ selectedLang, showApiKey }: UserManagementProps
         title="Sign out"
         content={
           <p>
-            After calling log out, all interactions using the Supabase JS client will be
+            After calling sign out, all interactions using the Supabase JS client will be
             "anonymous".
           </p>
         }

--- a/apps/studio/components/interfaces/OrganizationInvite/OrganizationInvite.test.tsx
+++ b/apps/studio/components/interfaces/OrganizationInvite/OrganizationInvite.test.tsx
@@ -140,7 +140,7 @@ describe('OrganizationInvite', () => {
       'href',
       '/sign-in?returnTo=%2Fjoin%3Ftoken%3Dinvite-token%26slug%3Dacme-corp'
     )
-    expect(screen.getByRole('link', { name: 'Create an account' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Sign up' })).toHaveAttribute(
       'href',
       '/sign-up?returnTo=%2Fjoin%3Ftoken%3Dinvite-token%26slug%3Dacme-corp'
     )

--- a/apps/studio/components/interfaces/OrganizationInvite/OrganizationInvite.tsx
+++ b/apps/studio/components/interfaces/OrganizationInvite/OrganizationInvite.tsx
@@ -117,7 +117,7 @@ export const OrganizationInvite = () => {
         </Button>
         {isSignUpEnabled && (
           <Button asChild variant="default" block>
-            <Link href={signupRedirectLink}>Create an account</Link>
+            <Link href={signupRedirectLink}>Sign up</Link>
           </Button>
         )}
       </div>

--- a/apps/studio/pages/forgot-password.tsx
+++ b/apps/studio/pages/forgot-password.tsx
@@ -14,7 +14,7 @@ const ForgotPasswordPage: NextPageWithLayout = () => {
       <div className="my-8 self-center text-sm">
         <span className="text-foreground-light">Already have an account?</span>{' '}
         <Link href="/sign-in" className="underline hover:text-foreground-light">
-          Sign In
+          Sign in
         </Link>
       </div>
     </>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Copy fix in Studio platform UI.

## What is the current behavior?

Studio still uses mixed auth wording outside nav dropdowns: in-app API docs use "Log in", account email change uses "Log out of", forgot-password uses title-case "Sign In", and org invites use "Create an account".

## What is the new behavior?

Aligns remaining Studio surfaces with **Sign in / Sign out / Sign up**. Related to [#49874](https://github.com/supabase/supabase/pull/49874) and [#49877](https://github.com/supabase/supabase/pull/49877).

CLI copy in `GeneratingTypes.tsx` is unchanged (`supabase login`).

## To test

- Account → change email (GitHub identity): instructions say **Sign out of**
- `/forgot-password`: footer link says **Sign in**
- Org invite (signed out): secondary button says **Sign up**
- Project → API docs → User Management: section titles use **Sign in** / **Sign out**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated authentication terminology across user management guidance and GitHub email-change instructions for consistency.

* **Improvements**
  * Changed the organization invitation link label to “Sign up.”
  * Standardized the forgot-password page link capitalization to “Sign in.”

* **Tests**
  * Updated invitation view coverage to reflect the revised “Sign up” label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->