### PR TITLE
docs: Update limitations section for network restrictions

### DIFF
--- a/apps/docs/content/guides/platform/network-restrictions.mdx
+++ b/apps/docs/content/guides/platform/network-restrictions.mdx
@@ -103,3 +103,4 @@ To remove all network restrictions:
 
 - Network restrictions apply to Postgres and the database pooler. They don't apply to HTTPS APIs such as PostgREST, Storage, and Auth, or to Supabase client libraries like [supabase-js](/docs/reference/javascript/introduction).
 - With network restrictions applied, Edge functions lose direct access to the database. Use [supabase-js](/docs/reference/javascript/introduction) to connect to the database from Edge Functions instead.
+- Updating network restrictions may temporarily interrupt existing connections through the shared connection pooler (Supavisor). Existing pooled connections can be closed while the new configuration is applied. Clients should reconnect automatically if their IP address is permitted by the updated restrictions.


### PR DESCRIPTION
Clarify the impact of updating network restrictions on existing connections.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

Docs update.

## What is the current behavior?

Updating a project's network restrictions can close existing connections through the shared connection pooler while the new configuration is applied. This behavior isn't currently documented on the Network Restrictions page.

## What is the new behavior?

The Network Restrictions documentation now notes that updating the configuration may temporarily interrupt existing pooled connections, and that clients can reconnect if their IP is allowed by the updated restrictions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance that updating network restrictions may temporarily interrupt existing pooled connections.
  * Clarified that clients should reconnect automatically when their IP address is allowed by the updated restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->