### PR TITLE
feat: Show min / max for integers in mgmt api docs

### DIFF
--- a/apps/docs/features/docs/Reference.ui.tsx
+++ b/apps/docs/features/docs/Reference.ui.tsx
@@ -474,7 +474,9 @@ export function ApiSchemaParamSubdetails({
   if (
     !('enum' in schema) &&
     'type' in schema &&
-    (['boolean', 'number', 'integer'].includes(schema.type) ||
+    (schema.type === 'boolean' ||
+      ((schema.type === 'number' || schema.type === 'integer') &&
+        !('minimum' in schema || 'maximum' in schema)) ||
       (schema.type === 'string' &&
         !('minLength' in schema || 'maxLength' in schema || 'pattern' in schema)) ||
       (schema.type === 'array' &&
@@ -501,7 +503,15 @@ export function ApiSchemaParamSubdetails({
                     constraint: key,
                     value: schema[key],
                   }))
-              : []
+              : 'type' in schema && (schema.type === 'number' || schema.type === 'integer')
+                ? ['minimum', 'maximum']
+                    .filter((key) => key in schema)
+                    .map((key) => ({
+                      constraint: key,
+                      value: schema[key],
+                    }))
+                : []
+
   const subContent = asSchemaArray(rawSubContent)
 
   return (
@@ -575,7 +585,10 @@ export function ApiSchemaParamSubdetails({
                   <span className="font-mono text-sm font-medium text-foreground">
                     {String(detail)}
                   </span>
-                ) : 'type' in schema && schema.type === 'string' ? (
+                ) : 'type' in schema &&
+                  (schema.type === 'string' ||
+                    schema.type === 'number' ||
+                    schema.type === 'integer') ? (
                   <span className="text-sm text-foreground flex items-baseline gap-2">
                     <span className="font-mono text-sm font-medium text-foreground">
                       {detail.constraint}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Improvement in docs

## What is the current behavior?

Not shown

## What is the new behavior?

Displays min / max when available in OpenAPI specs for integers and numbers

## Additional context

<img width="630" height="183" alt="image" src="https://github.com/user-attachments/assets/eb4e917a-d961-456c-810a-cba6aa2b0388" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API reference documentation now displays minimum and maximum constraints for numeric schema parameters, including `number` and `integer` types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->