### PR TITLE
fix: improve `useRefreshOnOpen` hook

### DIFF
--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/useRefreshOnOpen.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/useRefreshOnOpen.ts
@@ -1,6 +1,4 @@
-import { useCallback, useMemo } from 'react'
-
-import { useLatest } from '../../../../../../hooks/misc/useLatest'
+import { useMemo } from 'react'
 
 // Replication metadata (publication names, publication tables, source tables,
 // columns) and similar destination-form option lists follow one rule:

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/useRefreshOnOpen.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/useRefreshOnOpen.ts
@@ -1,4 +1,6 @@
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
+
+import { useLatest } from '../../../../../../hooks/misc/useLatest'
 
 // Replication metadata (publication names, publication tables, source tables,
 // columns) and similar destination-form option lists follow one rule:
@@ -26,12 +28,11 @@ interface UseRefreshOnOpenProps {
 }
 
 export const useRefreshOnOpen = ({ isEnabled = true, refetch }: UseRefreshOnOpenProps) => {
-  const handleOpenChange = useCallback(
-    (isOpen: boolean) => {
+  return useMemo(() => {
+    const handleOpenChange = (isOpen: boolean) => {
       if (isOpen && isEnabled) void refetch()
-    },
-    [isEnabled, refetch]
-  )
+    }
 
-  return { handleOpenChange }
+    return { handleOpenChange }
+  }, [isEnabled, refetch])
 }


### PR DESCRIPTION
## Problem
The `useRefreshOnOpen` returns a new object each time it runs, making the `useCallback` useless.

## Solution
Wrap the function content in `useMemo` instead

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved refresh handling for the replication destination form when it is opened.
  * Existing refresh behavior remains consistent and reliable.
  * No user-visible changes to functionality, controls, or configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->