### PR TITLE
fix: sync Bucket state when bucket public/private setting changes

### DIFF
--- a/apps/studio/state/storage-explorer.tsx
+++ b/apps/studio/state/storage-explorer.tsx
@@ -1899,6 +1899,16 @@ export const StorageExplorerStateContextProvider = ({ children }: PropsWithChild
     bucket,
   ])
 
+  // [Monica] The effect above only refreshes `selectedBucket` when the project changes, so
+  // editing the current bucket (e.g. toggling public/private) doesn't update it there. This
+  // keeps `selectedBucket` synced to the bucket query on every change, so Get URL always
+  // uses the current public/private state instead of a stale one from initial load.
+  useEffect(() => {
+    if (bucket && state.projectRef === project?.ref) {
+      state.selectedBucket = bucket
+    }
+  }, [bucket, project?.ref, state.projectRef])
+
   return (
     <StorageExplorerStateContext.Provider value={state}>
       {children}


### PR DESCRIPTION
### What is the current behavior?

Fixes FE-4056.

In the Storage Explorer, if you edit a bucket's access level (public/private) via "Edit bucket", the "Get URL" action keeps generating the old signed/public URL type. Clicking the in-explorer refresh button doesn't fix it either, since it only re-lists objects and never refetches bucket metadata. Only a full browser reload resolves it.

### What is the new behavior?

selectedBucket in the Storage Explorer's Valtio store is now kept in sync with the bucket query on every change, not just on project switch. "Get URL" now always reads the current public/private state, so it correctly returns a public URL or a signed URL immediately after the bucket's access level is changed - no reload required.

### Additional context

Added a second effect to sync selectedBucket whenever the bucket query value changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated bucket selection state when bucket settings change, preventing stale bucket information in actions such as “Get URL.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->