### PR TITLE
fix(studio): prevent overlapping tooltips on the Invite members button

### DIFF
--- a/apps/studio/components/interfaces/Organization/TeamSettings/InviteMemberButton.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/InviteMemberButton.tsx
@@ -125,6 +125,8 @@ export const InviteMemberButton = () => {
       )
     )
 
+  const canOpenInviteSheet = organizationMembersCreationEnabled && canInviteMembers
+
   let inviteButtonTooltipText: string | undefined
   if (!organizationMembersCreationEnabled) {
     inviteButtonTooltipText = 'Inviting members is currently disabled'
@@ -134,7 +136,7 @@ export const InviteMemberButton = () => {
   }
 
   useShortcut(SHORTCUT_IDS.ORG_TEAM_INVITE, () => setIsOpen(true), {
-    enabled: canInviteMembers,
+    enabled: canOpenInviteSheet,
   })
 
   const { mutateAsync: inviteMemberAsync, isPending: isInviting } =
@@ -265,37 +267,37 @@ export const InviteMemberButton = () => {
     onClose: closeInviteSheet,
   })
 
-  const inviteMembersButton = (
-    <ButtonTooltip
-      variant="primary"
-      disabled={!canInviteMembers}
-      icon={<UserPlus size={14} />}
-      className="pointer-events-auto grow md:grow-0"
-      onClick={() => setIsOpen(true)}
-      tooltip={{
-        content: {
-          side: 'bottom',
-          text: inviteButtonTooltipText,
-        },
-      }}
-    >
-      Invite members
-    </ButtonTooltip>
+  const inviteMembersTrigger = (
+    <SheetTrigger asChild>
+      <ButtonTooltip
+        variant="primary"
+        disabled={!canOpenInviteSheet}
+        icon={<UserPlus size={14} />}
+        className="pointer-events-auto grow md:grow-0"
+        onClick={() => setIsOpen(true)}
+        tooltip={{
+          content: {
+            side: 'bottom',
+            text: inviteButtonTooltipText,
+          },
+        }}
+      >
+        Invite members
+      </ButtonTooltip>
+    </SheetTrigger>
   )
 
   const shouldShowShortcutTooltip = !isOpen && inviteButtonTooltipText === undefined
 
   return (
     <Sheet open={isOpen} onOpenChange={handleOpenChange}>
-      <SheetTrigger asChild>
-        {shouldShowShortcutTooltip ? (
-          <ShortcutTooltip shortcutId={SHORTCUT_IDS.ORG_TEAM_INVITE} side="bottom">
-            {inviteMembersButton}
-          </ShortcutTooltip>
-        ) : (
-          inviteMembersButton
-        )}
-      </SheetTrigger>
+      {shouldShowShortcutTooltip ? (
+        <ShortcutTooltip shortcutId={SHORTCUT_IDS.ORG_TEAM_INVITE} side="bottom">
+          {inviteMembersTrigger}
+        </ShortcutTooltip>
+      ) : (
+        inviteMembersTrigger
+      )}
       <SheetContent size="lg" className="flex flex-col gap-0">
         <SheetHeader>
           <SheetTitle>Invite team members</SheetTitle>

--- a/apps/studio/components/interfaces/Organization/TeamSettings/InviteMemberButton.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/InviteMemberButton.tsx
@@ -50,6 +50,7 @@ import { DocsButton } from '@/components/ui/DocsButton'
 import { InlineLink } from '@/components/ui/InlineLink'
 import { OrganizationProjectSelector } from '@/components/ui/OrganizationProjectSelector'
 import { Shortcut } from '@/components/ui/Shortcut'
+import { ShortcutTooltip } from '@/components/ui/ShortcutTooltip'
 import { UpgradePlanButton } from '@/components/ui/UpgradePlanButton'
 import { useOrganizationCreateInvitationMutation } from '@/data/organization-members/organization-invitation-create-mutation'
 import { useOrganizationRolesV2Query } from '@/data/organization-members/organization-roles-query'
@@ -65,6 +66,7 @@ import { DOCS_URL } from '@/lib/constants'
 import { MANAGED_BY } from '@/lib/constants/infrastructure'
 import { useProfile } from '@/lib/profile'
 import { SHORTCUT_IDS } from '@/state/shortcuts/registry'
+import { useShortcut } from '@/state/shortcuts/useShortcut'
 
 export const InviteMemberButton = () => {
   const { slug } = useParams()
@@ -122,6 +124,18 @@ export const InviteMemberButton = () => {
         organization?.slug
       )
     )
+
+  let inviteButtonTooltipText: string | undefined
+  if (!organizationMembersCreationEnabled) {
+    inviteButtonTooltipText = 'Inviting members is currently disabled'
+  } else if (!canInviteMembers) {
+    inviteButtonTooltipText =
+      'You need additional permissions to invite members to this organization'
+  }
+
+  useShortcut(SHORTCUT_IDS.ORG_TEAM_INVITE, () => setIsOpen(true), {
+    enabled: canInviteMembers,
+  })
 
   const { mutateAsync: inviteMemberAsync, isPending: isInviting } =
     useOrganizationCreateInvitationMutation()
@@ -251,37 +265,36 @@ export const InviteMemberButton = () => {
     onClose: closeInviteSheet,
   })
 
+  const inviteMembersButton = (
+    <ButtonTooltip
+      variant="primary"
+      disabled={!canInviteMembers}
+      icon={<UserPlus size={14} />}
+      className="pointer-events-auto grow md:grow-0"
+      onClick={() => setIsOpen(true)}
+      tooltip={{
+        content: {
+          side: 'bottom',
+          text: inviteButtonTooltipText,
+        },
+      }}
+    >
+      Invite members
+    </ButtonTooltip>
+  )
+
+  const shouldShowShortcutTooltip = !isOpen && inviteButtonTooltipText === undefined
+
   return (
     <Sheet open={isOpen} onOpenChange={handleOpenChange}>
       <SheetTrigger asChild>
-        <Shortcut
-          id={SHORTCUT_IDS.ORG_TEAM_INVITE}
-          onTrigger={() => {
-            if (canInviteMembers) setIsOpen(true)
-          }}
-          side="bottom"
-          tooltipOpen={isOpen ? false : undefined}
-        >
-          <ButtonTooltip
-            variant="primary"
-            disabled={!canInviteMembers}
-            icon={<UserPlus size={14} />}
-            className="pointer-events-auto grow md:grow-0"
-            onClick={() => setIsOpen(true)}
-            tooltip={{
-              content: {
-                side: 'bottom',
-                text: !organizationMembersCreationEnabled
-                  ? 'Inviting members is currently disabled'
-                  : !canInviteMembers
-                    ? 'You need additional permissions to invite members to this organization'
-                    : undefined,
-              },
-            }}
-          >
-            Invite members
-          </ButtonTooltip>
-        </Shortcut>
+        {shouldShowShortcutTooltip ? (
+          <ShortcutTooltip shortcutId={SHORTCUT_IDS.ORG_TEAM_INVITE} side="bottom">
+            {inviteMembersButton}
+          </ShortcutTooltip>
+        ) : (
+          inviteMembersButton
+        )}
       </SheetTrigger>
       <SheetContent size="lg" className="flex flex-col gap-0">
         <SheetHeader>

--- a/apps/studio/tests/components/Organization/TeamSettings/InviteMemberButton.test.tsx
+++ b/apps/studio/tests/components/Organization/TeamSettings/InviteMemberButton.test.tsx
@@ -168,11 +168,17 @@ describe('InviteMemberButton', () => {
     mockFeatureFlags.organizationMembersCreate = false
     customRender(<InviteMemberButton />)
 
-    await userEvent.hover(screen.getByRole('button', { name: /invite members/i }))
+    const inviteButton = screen.getByRole('button', { name: /invite members/i })
+    expect(inviteButton).toBeDisabled()
+
+    await userEvent.hover(inviteButton)
 
     const disabledTooltip = await screen.findByRole('tooltip')
     expect(disabledTooltip).toHaveTextContent('Inviting members is currently disabled')
     expect(disabledTooltip).not.toHaveTextContent('⇧')
+
+    await userEvent.keyboard('{Shift>}N{/Shift}')
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 
   it('opens the invite dialog when the button is clicked', async () => {

--- a/apps/studio/tests/components/Organization/TeamSettings/InviteMemberButton.test.tsx
+++ b/apps/studio/tests/components/Organization/TeamSettings/InviteMemberButton.test.tsx
@@ -31,8 +31,13 @@ vi.mock('@/hooks/misc/useCheckPermissions', () => ({
   useAsyncCheckPermissions: () => ({ can: true, isSuccess: true }),
 }))
 
+const mockFeatureFlags = vi.hoisted(() => ({
+  organizationMembersCreate: true,
+}))
 vi.mock('@/hooks/misc/useIsFeatureEnabled', () => ({
-  useIsFeatureEnabled: () => ({ organizationMembersCreate: true }),
+  useIsFeatureEnabled: () => ({
+    organizationMembersCreate: mockFeatureFlags.organizationMembersCreate,
+  }),
 }))
 
 vi.mock('@/data/organizations/organization-members-query', () => ({
@@ -76,9 +81,12 @@ vi.mock('@/hooks/misc/useCheckEntitlements', () => ({
   useCheckEntitlements: () => ({ hasAccess: false }),
 }))
 
+const mockRolesManagementPermissions = vi.hoisted(() => ({
+  rolesAddable: [1, 2, 3, 4] as number[],
+}))
 vi.mock('@/components/interfaces/Organization/TeamSettings/TeamSettings.utils', () => ({
   useGetRolesManagementPermissions: () => ({
-    rolesAddable: [1, 2, 3, 4],
+    rolesAddable: mockRolesManagementPermissions.rolesAddable,
     rolesRemovable: [1, 2, 3, 4],
   }),
 }))
@@ -120,11 +128,51 @@ describe('InviteMemberButton', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockInvite.mockResolvedValue({ succeeded: [], failed: [] })
+    mockRolesManagementPermissions.rolesAddable = [1, 2, 3, 4]
+    mockFeatureFlags.organizationMembersCreate = true
   })
 
   it('renders an enabled Invite members button', () => {
     customRender(<InviteMemberButton />)
     expect(screen.getByRole('button', { name: /invite members/i })).toBeEnabled()
+  })
+
+  it('shows the keyboard shortcut tooltip when inviting members is allowed', async () => {
+    customRender(<InviteMemberButton />)
+
+    await userEvent.hover(screen.getByRole('button', { name: /invite members/i }))
+
+    const shortcutTooltip = await screen.findByRole('tooltip')
+    expect(shortcutTooltip).toHaveTextContent('Invite members')
+    expect(shortcutTooltip).toHaveTextContent('⇧')
+  })
+
+  it('only shows the permission tooltip when inviting members is not allowed', async () => {
+    mockRolesManagementPermissions.rolesAddable = []
+    customRender(<InviteMemberButton />)
+
+    const inviteButton = screen.getByRole('button', { name: /invite members/i })
+    expect(inviteButton).toBeDisabled()
+
+    await userEvent.hover(inviteButton)
+
+    const permissionTooltip = await screen.findByRole('tooltip')
+    expect(permissionTooltip).toHaveTextContent(
+      'You need additional permissions to invite members to this organization'
+    )
+    expect(permissionTooltip).not.toHaveTextContent('⇧')
+    expect(screen.getAllByText('Invite members')).toHaveLength(1)
+  })
+
+  it('only shows the disabled tooltip when member invitations are turned off', async () => {
+    mockFeatureFlags.organizationMembersCreate = false
+    customRender(<InviteMemberButton />)
+
+    await userEvent.hover(screen.getByRole('button', { name: /invite members/i }))
+
+    const disabledTooltip = await screen.findByRole('tooltip')
+    expect(disabledTooltip).toHaveTextContent('Inviting members is currently disabled')
+    expect(disabledTooltip).not.toHaveTextContent('⇧')
   })
 
   it('opens the invite dialog when the button is clicked', async () => {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Fixes #49859

On Organization Team settings, hovering the disabled **Invite members** button (for example as a Developer) opens two tooltips at once: the keyboard shortcut tooltip and the permission tooltip. They render in the same place, so the copy overlaps and is unreadable.

## What is the new behavior?

If the button already has a permission or disabled-state tooltip, the shortcut tooltip is not rendered. Hover then shows only that message.

Users who can invite still get the keyboard shortcut tooltip. It also stays closed while the invite sheet is open.

## Additional context

Same approach as the Connect button: shortcut tooltip when the action is available, `ButtonTooltip` when it is not. Shift+N still works via `useShortcut`.

Supersedes #49860.

## Test plan

- [ ] As a Developer (or any role that cannot invite), open Organization Settings → Team and hover **Invite members**. Confirm only the permission tooltip appears.
- [ ] As an Owner/Admin, hover **Invite members**. Confirm the keyboard shortcut tooltip still appears.
- [ ] Open the invite sheet and hover the trigger. Confirm the shortcut tooltip stays closed.
- [ ] Repeat the hover when organization member creation is turned off. Confirm only “Inviting members is currently disabled” is shown.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a keyboard shortcut for opening the organization member invitation flow.
  * Added contextual tooltips explaining the shortcut and permission requirements.
  * The shortcut is available only when member invitations are permitted.

* **Bug Fixes**
  * Improved tooltip behavior when the invitation panel is open or the action is unavailable.
  * Prevented the keyboard shortcut from opening the invitation panel when invitations are disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->