### PR TITLE
docs: add pgcrypto legacy-cipher caveat for the 15.19/17.11 upgrade

### DIFF
--- a/apps/docs/content/guides/platform/upgrading.mdx
+++ b/apps/docs/content/guides/platform/upgrading.mdx
@@ -292,7 +292,7 @@ _Applies when upgrading to Postgres 15.19 or 17.11._
 
 <Admonition type="caution">
 
-On Supabase-managed instances, you are affected only if you call pgcrypto PGP functions with `cipher-algo=bf`, `cipher-algo=blowfish`, or `cipher-algo=cast5`. The default cipher (AES) and `3des` are not affected. On other deployments the affected set depends on that server's OpenSSL build — see the CVE for details.
+You are affected only if you call pgcrypto PGP functions with a `cipher-algo` that is unavailable in your server's OpenSSL build. On Supabase-managed instances that means `cipher-algo=bf`, `cipher-algo=blowfish`, or `cipher-algo=cast5`; the default cipher (AES) and `3des` are not affected.
 
 </Admonition>
 

--- a/apps/docs/content/guides/platform/upgrading.mdx
+++ b/apps/docs/content/guides/platform/upgrading.mdx
@@ -339,7 +339,7 @@ set <col> = pgp_sym_encrypt(
 where <id_column> in (/* rows found by the scan above */);
 ```
 
-Spot-check that a recovered value decrypts to the expected plaintext before running the update across all rows. Because affected values were not protected as intended, consider rotating any secrets stored this way.
+If the plaintext is binary (encrypted with `pgp_sym_encrypt_bytea`), use `pgp_sym_decrypt_bytea` and `pgp_sym_encrypt_bytea` in the same way — the text functions reject binary plaintext. Spot-check that a recovered value decrypts to the expected plaintext before running the update across all rows. Because affected values were not protected as intended, consider rotating any secrets stored this way.
 
 ### Btree_gist indexes on float columns require reindexing after upgrade
 

--- a/apps/docs/content/guides/platform/upgrading.mdx
+++ b/apps/docs/content/guides/platform/upgrading.mdx
@@ -296,7 +296,7 @@ You are affected only if you call pgcrypto PGP functions with `cipher-algo=bf`, 
 
 </Admonition>
 
-This release fixes [CVE-2026-14663](https://www.postgresql.org/support/security/CVE-2026-14663/): when a requested PGP cipher is disabled in the server's OpenSSL build, pgcrypto silently stored data effectively unencrypted, and decryption succeeds even with the wrong key. After upgrading, decrypting such messages fails by default, and encrypting with those ciphers returns an error instead of storing unprotected data.
+This release fixes [CVE-2026-14663](https://www.postgresql.org/support/security/CVE-2026-14663/): when a requested PGP cipher is disabled in the server's OpenSSL build, pgcrypto silently stored data without effective encryption, and decryption succeeds even with the wrong key. After upgrading, decrypting such messages fails by default, and encrypting with those ciphers returns an error instead of storing unprotected data.
 
 To check whether stored data is affected, decrypt one value with a deliberately wrong passphrase:
 

--- a/apps/docs/content/guides/platform/upgrading.mdx
+++ b/apps/docs/content/guides/platform/upgrading.mdx
@@ -292,20 +292,32 @@ _Applies when upgrading to Postgres 15.19 or 17.11._
 
 <Admonition type="caution">
 
-You are affected only if you call pgcrypto PGP functions with `cipher-algo=bf`, `cipher-algo=blowfish`, or `cipher-algo=cast5`. The default cipher (AES) and `3des` are not affected.
+On Supabase-managed instances, you are affected only if you call pgcrypto PGP functions with `cipher-algo=bf`, `cipher-algo=blowfish`, or `cipher-algo=cast5`. The default cipher (AES) and `3des` are not affected. On other deployments the affected set depends on that server's OpenSSL build — see the CVE for details.
 
 </Admonition>
 
 This release fixes [CVE-2026-14663](https://www.postgresql.org/support/security/CVE-2026-14663/): previously, when a requested PGP cipher was unavailable in the server's OpenSSL build, pgcrypto did not apply it, so affected values were not protected as intended and can be decrypted even with the wrong key. After upgrading, decrypting such messages fails by default, and encrypting with those ciphers returns an error.
 
-To check whether stored data is affected, decrypt one value with a deliberately wrong passphrase:
+To find affected rows, scan each stored value with a deliberately wrong passphrase: properly encrypted values raise an error, while affected values decrypt successfully even with the wrong key. Run the helper and the scan in the same session (`pg_temp` functions are session-scoped):
 
 ```sql
-select pgp_sym_decrypt(<your_encrypted_column>, 'deliberately-wrong-key')
-from <your_table> limit 1;
+create function pg_temp.affected_by_cve_2026_14663(msg bytea)
+returns boolean
+language plpgsql as $$
+begin
+  perform pgp_sym_decrypt_bytea(msg, 'deliberately-wrong-key');
+  return true;
+exception when others then
+  return false;
+end $$;
+
+select <id_column>
+from <your_table>
+where <your_encrypted_column> is not null
+  and pg_temp.affected_by_cve_2026_14663(<your_encrypted_column>);
 ```
 
-An error ("Wrong key or corrupt data") means the value is properly encrypted. If your data is returned, that value is affected: re-encrypt it with a modern cipher before you upgrade (or after upgrading by adding `ignore-cipher-failure=1` to the decrypt options):
+Any rows returned hold affected values: re-encrypt them with a modern cipher before you upgrade (or after upgrading by adding `ignore-cipher-failure=1` to the decrypt options):
 
 ```sql
 update <your_table>

--- a/apps/docs/content/guides/platform/upgrading.mdx
+++ b/apps/docs/content/guides/platform/upgrading.mdx
@@ -286,6 +286,37 @@ Reindex each index it returns, using the schema-qualified name. `REINDEX INDEX C
 REINDEX INDEX CONCURRENTLY <schema_name>.<index_name>;
 ```
 
+### Pgcrypto legacy PGP ciphers
+
+_Applies when upgrading to Postgres 15.19 or 17.11._
+
+<Admonition type="caution">
+
+You are affected only if you call pgcrypto PGP functions with `cipher-algo=bf`, `cipher-algo=blowfish`, or `cipher-algo=cast5`. The default cipher (AES) and `3des` are not affected.
+
+</Admonition>
+
+This release fixes [CVE-2026-14663](https://www.postgresql.org/support/security/CVE-2026-14663/): when a requested PGP cipher is disabled in the server's OpenSSL build, pgcrypto silently stored data effectively unencrypted, and decryption succeeds even with the wrong key. After upgrading, decrypting such messages fails by default, and encrypting with those ciphers returns an error instead of storing unprotected data.
+
+To check whether stored data is affected, decrypt one value with a deliberately wrong passphrase:
+
+```sql
+select pgp_sym_decrypt(<your_encrypted_column>, 'deliberately-wrong-key')
+from <your_table> limit 1;
+```
+
+An error ("Wrong key or corrupt data") means the value is properly encrypted. If your data is returned, that value is affected: re-encrypt it with a modern cipher before you upgrade (or after upgrading by adding `ignore-cipher-failure=1` to the decrypt options):
+
+```sql
+update <your_table>
+set <col> = pgp_sym_encrypt(
+              pgp_sym_decrypt(<col>, '<your-key>'),
+              '<your-key>', 'cipher-algo=aes256')
+where ...;
+```
+
+Because affected data was not effectively encrypted at rest, consider rotating any secrets stored this way.
+
 ### Btree_gist indexes on float columns require reindexing after upgrade
 
 _Applies when upgrading to Postgres 15.19 or 17.11._

--- a/apps/docs/content/guides/platform/upgrading.mdx
+++ b/apps/docs/content/guides/platform/upgrading.mdx
@@ -317,17 +317,29 @@ where <your_encrypted_column> is not null
   and pg_temp.affected_by_cve_2026_14663(<your_encrypted_column>);
 ```
 
-Any rows returned hold affected values: re-encrypt them with a modern cipher before you upgrade (or after upgrading by adding `ignore-cipher-failure=1` to the decrypt options):
+Any rows returned hold affected values. The scan covers symmetric (`pgp_sym_*`) messages; the wrong-key probe does not apply to public-key (`pgp_pub_*`) messages. If you call `pgp_pub_encrypt` with one of the affected `cipher-algo` options, treat those values as affected and re-encrypt them the same way using `pgp_pub_decrypt` and `pgp_pub_encrypt` with your key pair.
+
+Re-encrypt affected values with a modern cipher. Before you upgrade, the current version still decrypts them normally:
 
 ```sql
 update <your_table>
 set <col> = pgp_sym_encrypt(
               pgp_sym_decrypt(<col>, '<your-key>'),
               '<your-key>', 'cipher-algo=aes256')
-where ...;
+where <id_column> in (/* rows found by the scan above */);
 ```
 
-Because affected values were not protected as intended, consider rotating any secrets stored this way.
+After you upgrade, decrypting affected values fails by default — add `ignore-cipher-failure=1` to read them:
+
+```sql
+update <your_table>
+set <col> = pgp_sym_encrypt(
+              pgp_sym_decrypt(<col>, '<your-key>', 'ignore-cipher-failure=1'),
+              '<your-key>', 'cipher-algo=aes256')
+where <id_column> in (/* rows found by the scan above */);
+```
+
+Spot-check that a recovered value decrypts to the expected plaintext before running the update across all rows. Because affected values were not protected as intended, consider rotating any secrets stored this way.
 
 ### Btree_gist indexes on float columns require reindexing after upgrade
 

--- a/apps/docs/content/guides/platform/upgrading.mdx
+++ b/apps/docs/content/guides/platform/upgrading.mdx
@@ -292,7 +292,7 @@ _Applies when upgrading to Postgres 15.19 or 17.11._
 
 <Admonition type="caution">
 
-You are affected only if you call pgcrypto PGP functions with a `cipher-algo` that is unavailable in your server's OpenSSL build. On Supabase-managed instances that means `cipher-algo=bf`, `cipher-algo=blowfish`, or `cipher-algo=cast5`; the default cipher (AES) and `3des` are not affected.
+You are affected only if you call pgcrypto PGP functions with a `cipher-algo` that is unavailable in your server's OpenSSL build. The default cipher (AES) is not affected — if you never pass a `cipher-algo` option, no action is needed. Use the scan below to check stored values.
 
 </Admonition>
 

--- a/apps/docs/content/guides/platform/upgrading.mdx
+++ b/apps/docs/content/guides/platform/upgrading.mdx
@@ -296,7 +296,7 @@ You are affected only if you call pgcrypto PGP functions with `cipher-algo=bf`, 
 
 </Admonition>
 
-This release fixes [CVE-2026-14663](https://www.postgresql.org/support/security/CVE-2026-14663/): when a requested PGP cipher is disabled in the server's OpenSSL build, pgcrypto silently stored data without effective encryption, and decryption succeeds even with the wrong key. After upgrading, decrypting such messages fails by default, and encrypting with those ciphers returns an error instead of storing unprotected data.
+This release fixes [CVE-2026-14663](https://www.postgresql.org/support/security/CVE-2026-14663/): previously, when a requested PGP cipher was unavailable in the server's OpenSSL build, pgcrypto did not apply it, so affected values were not protected as intended and can be decrypted even with the wrong key. After upgrading, decrypting such messages fails by default, and encrypting with those ciphers returns an error.
 
 To check whether stored data is affected, decrypt one value with a deliberately wrong passphrase:
 
@@ -315,7 +315,7 @@ set <col> = pgp_sym_encrypt(
 where ...;
 ```
 
-Because affected data was not effectively encrypted at rest, consider rotating any secrets stored this way.
+Because affected values were not protected as intended, consider rotating any secrets stored this way.
 
 ### Btree_gist indexes on float columns require reindexing after upgrade
 

--- a/supa-mdx-lint/Rule003Spelling.toml
+++ b/supa-mdx-lint/Rule003Spelling.toml
@@ -350,6 +350,8 @@ allow_list = [
     "PGroonga",
     "pg_basebackup",
     "PgBouncer",
+    "pgcrypto",
+    "Pgcrypto",
     "pgjwt",
     "PHI",
     "Pico",


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update — follow-up to #49621 for the Postgres 15.19 / 17.11 release.

## What is the current behavior?

The upgrade guide covers three of the four customer-action items for this release; the pgcrypto legacy-cipher caveat (CVE-2026-14663) was deliberately held pending Security sign-off on the wording.

## What is the new behavior?

Adds a "Pgcrypto legacy PGP ciphers" section (between the Ltree and Btree_gist sections, matching the release comms order): who is affected (`bf`/`blowfish`/`cast5` only), the wrong-key decrypt probe to check stored data, the AES re-encrypt step (with `ignore-cipher-failure=1` for post-upgrade recovery), and the secret-rotation recommendation. Wording approved by Security.

## Additional context

Refs PSQL-1245 / PSQL-1110. Matches the customer email draft and changelog entry wording.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated `pgcrypto` upgrade guidance to separate pre-upgrade decryption from post-upgrade recovery, including the appropriate handling for cipher failures.
  - Added row-based targeting and plaintext spot checks before bulk updates.
  - Clarified that automated wrong-key scans cover symmetric messages; public-key messages require manual identification and key-pair re-encryption.
  - Updated the caution note to direct users to scan stored values rather than rely on a fixed list of cipher algorithms. No action is needed when `cipher-algo` was never specified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->