### PR TITLE
chore(studio): refine Explorer query UI

### DIFF
--- a/apps/studio/components/interfaces/Explorer/QueryCell/index.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryCell/index.tsx
@@ -136,7 +136,7 @@ export const QueryCell = forwardRef<QueryEditorHandle, QueryCellProps>(function 
         onDisplayChange={handleDisplayChange}
         toolbarActions={
           <ExplorerToolbarAction
-            icon={<AlignLeft />}
+            icon={<AlignLeft size={16} strokeWidth={2} />}
             tooltip={
               <div className="flex items-center gap-2.5">
                 <span>Prettify SQL</span>

--- a/apps/studio/components/interfaces/Explorer/QueryEditor/QueryResultChart.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryEditor/QueryResultChart.tsx
@@ -1,10 +1,15 @@
 import { useMemo } from 'react'
-import { type ChartConfig as ChartSeriesConfig } from 'ui'
+import { cn, type ChartConfig as ChartSeriesConfig } from 'ui'
 import { Chart, ChartBar, ChartCard, ChartContent, ChartLine } from 'ui-patterns/Chart'
 
 import { type QueryResult } from '../types'
 import NoDataPlaceholder from '@/components/ui/Charts/NoDataPlaceholder'
-import { formatLogTick, getCumulativeResults } from '@/components/ui/QueryBlock/QueryBlock.utils'
+import {
+  computeYAxisWidth,
+  formatLogTick,
+  formatYAxisTick,
+  getCumulativeResults,
+} from '@/components/ui/QueryBlock/QueryBlock.utils'
 import { type ChartConfig } from '@/data/content/notebooks/notebook-schema'
 
 interface QueryResultChartProps {
@@ -58,6 +63,20 @@ export const QueryResultChart = ({ chart, result }: QueryResultChartProps) => {
   )
   const resultToRender = cumulative ? cumulativeResults : chartRows
 
+  const yAxisWidth = Math.max(
+    36,
+    ...y_series.map((key) =>
+      computeYAxisWidth(resultToRender, key, { isLogScale: effectiveScale === 'log' })
+    )
+  )
+
+  const yAxisProps = {
+    ...(show_labels ? { width: yAxisWidth } : {}),
+    scale: effectiveScale === 'log' ? 'log' : 'auto',
+    domain: effectiveScale === 'log' ? ([1, 'auto'] as const) : undefined,
+    tickFormatter: effectiveScale === 'log' ? formatLogTick : formatYAxisTick,
+  }
+
   if (!result || (result?.rows && result.rows.length === 0)) {
     return (
       <NoDataPlaceholder
@@ -85,7 +104,7 @@ export const QueryResultChart = ({ chart, result }: QueryResultChartProps) => {
   return (
     <Chart className="flex flex-grow min-h-0">
       <ChartCard className="flex flex-grow rounded-none border-0 min-h-0">
-        <ChartContent className="min-h-0 w-full">
+        <ChartContent className={cn('min-h-0 h-full w-full', show_labels && 'pl-2 pb-2')}>
           {type === 'bar' && (
             <ChartBar
               isFullHeight
@@ -96,11 +115,7 @@ export const QueryResultChart = ({ chart, result }: QueryResultChartProps) => {
               showXAxis={show_labels}
               showYAxis={show_labels}
               data={resultToRender}
-              YAxisProps={{
-                scale: effectiveScale === 'log' ? 'log' : 'auto',
-                domain: effectiveScale === 'log' ? [1, 'auto'] : undefined,
-                tickFormatter: effectiveScale === 'log' ? formatLogTick : undefined,
-              }}
+              YAxisProps={yAxisProps}
             />
           )}
           {type === 'line' && (
@@ -113,11 +128,7 @@ export const QueryResultChart = ({ chart, result }: QueryResultChartProps) => {
               showXAxis={show_labels}
               showYAxis={show_labels}
               data={resultToRender}
-              YAxisProps={{
-                scale: effectiveScale === 'log' ? 'log' : 'auto',
-                domain: effectiveScale === 'log' ? [1, 'auto'] : undefined,
-                tickFormatter: effectiveScale === 'log' ? formatLogTick : undefined,
-              }}
+              YAxisProps={yAxisProps}
             />
           )}
         </ChartContent>

--- a/apps/studio/components/interfaces/Explorer/QueryEditor/QueryRunButton.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryEditor/QueryRunButton.tsx
@@ -1,0 +1,84 @@
+import { ChevronDown, Play } from 'lucide-react'
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+  KeyboardShortcut,
+} from 'ui'
+
+import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
+import { DropdownMenuItemTooltip } from '@/components/ui/DropdownMenuItemTooltip'
+
+interface QueryRunButtonProps {
+  isExecuting: boolean
+  disabled: boolean
+  hasSelection: boolean
+  onRun: () => void
+  onRunSelected: () => void
+}
+
+export const QueryRunButton = ({
+  isExecuting,
+  disabled,
+  hasSelection,
+  onRun,
+  onRunSelected,
+}: QueryRunButtonProps) => {
+  return (
+    <div className="flex w-fit">
+      <ButtonTooltip
+        type="button"
+        variant="default"
+        size="tiny"
+        loading={isExecuting}
+        disabled={disabled}
+        icon={<Play size={16} strokeWidth={2} />}
+        className="rounded-r-none hover:z-10 focus-visible:z-10 focus-visible:rounded-r-sm"
+        onClick={onRun}
+        tooltip={{
+          content: {
+            side: 'bottom',
+            text: (
+              <div className="flex items-center gap-2.5">
+                <span>Run query</span>
+                <KeyboardShortcut keys={['Meta', 'Enter']} />
+              </div>
+            ),
+          },
+        }}
+      >
+        Run
+      </ButtonTooltip>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="default"
+            size="tiny"
+            disabled={disabled}
+            aria-label="More actions"
+            className="shrink-0 rounded-l-none px-[4px] py-[5px] -ml-px focus-visible:z-10 focus-visible:rounded-l-sm"
+            icon={<ChevronDown />}
+          />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-48">
+          <DropdownMenuItemTooltip
+            disabled={!hasSelection}
+            onClick={onRunSelected}
+            tooltip={{
+              content: {
+                side: 'left',
+                text: !hasSelection
+                  ? 'Select SQL in the editor to run part of the query'
+                  : undefined,
+              },
+            }}
+          >
+            Run selected
+          </DropdownMenuItemTooltip>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  )
+}

--- a/apps/studio/components/interfaces/Explorer/QueryEditor/index.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryEditor/index.tsx
@@ -1,7 +1,7 @@
 import { useMonaco } from '@monaco-editor/react'
 import { acceptUntrustedSql, untrustedSql, type UntrustedSqlFragment } from '@supabase/pg-meta'
 import { useFlag } from 'common'
-import { CodeSquare, Eye, EyeOff, Play } from 'lucide-react'
+import { CodeSquare, Eye, EyeOff } from 'lucide-react'
 import type { editor as monacoEditor, Selection } from 'monaco-editor'
 import {
   forwardRef,
@@ -12,7 +12,7 @@ import {
   useState,
   type ReactNode,
 } from 'react'
-import { Button, cn, KeyboardShortcut } from 'ui'
+import { Button, cn } from 'ui'
 
 import { resolveLogTimeRange } from '../../QuerySources/LogTimeRange.utils'
 import {
@@ -32,6 +32,7 @@ import {
 import { type QueryDisplay, type QueryResult } from '../types'
 import { DisplaySettingsButton } from './DisplaySettingsButton'
 import { QueryResultRenderer } from './QueryResultRenderer'
+import { QueryRunButton } from './QueryRunButton'
 import { QuerySourceMenu } from './QuerySourceMenu'
 import { useQueryEditorAi } from './useQueryEditorAi'
 import { LegacyLogsRewriteBanner } from '@/components/interfaces/Settings/Logs/LegacyLogsRewriteBanner'
@@ -437,26 +438,19 @@ export const QueryEditor = forwardRef<QueryEditorHandle, QueryEditorProps>(funct
 
             {toolbarActions}
 
-            <ExplorerToolbarAction
-              icon={<Play size={16} strokeWidth={2} />}
-              loading={isExecuting}
-              tooltip={
-                <div className="flex items-center gap-2.5">
-                  <span>{hasSelection ? 'Run selected query' : 'Run query'}</span>
-                  <KeyboardShortcut keys={['Meta', 'Enter']} />
-                </div>
-              }
+            <QueryRunButton
+              isExecuting={isExecuting}
               disabled={
                 isBusy || pendingProposal !== null || isRunDisabled || sql.trim().length === 0
               }
-              onClick={() => {
+              hasSelection={showQuery && hasSelection}
+              onRun={() => handleRunQuery({ rawSql: sql })}
+              onRunSelected={() => {
                 const editorInstance = editorInstanceRef.current
                 const rawSql = editorInstance ? getEditorValueOrSelection(editorInstance) : sql
                 handleRunQuery({ rawSql })
               }}
-            >
-              {hasSelection ? 'Run selected' : 'Run'}
-            </ExplorerToolbarAction>
+            />
           </ExplorerToolbarActions>
         </ExplorerToolbar>
 

--- a/apps/studio/components/interfaces/Explorer/__tests__/QueryTab.test.tsx
+++ b/apps/studio/components/interfaces/Explorer/__tests__/QueryTab.test.tsx
@@ -429,7 +429,34 @@ describe('QueryTab execution', () => {
     expect(executedQueries[0]).toContain('ALTER TABLE foo ENABLE ROW LEVEL SECURITY;')
   })
 
-  it('runs only the selected text, not the full editor content, when there is an active selection', async () => {
+  it('runs the full query from the Run button even when text is selected', async () => {
+    createDraft({ _tag: 'database' }, 'select 1;\nselect 2;')
+    testContext.selectedText = 'select 2;'
+
+    const executedQueries: string[] = []
+    addAPIMock({
+      method: 'post',
+      path: '/platform/pg-meta/:ref/query',
+      response: async ({ request }) => {
+        const key = new URL(request.url).searchParams.get('key')
+        if (key !== '') return HttpResponse.json([])
+        const { query } = (await request.json()) as { query: string }
+        executedQueries.push(query)
+        return HttpResponse.json([])
+      },
+    })
+
+    renderQueryTab()
+    const runButton = await screen.findByRole('button', { name: 'Run' })
+    await waitFor(() => expect(runButton).toBeEnabled())
+    await userEvent.click(runButton)
+
+    await waitFor(() => expect(executedQueries).toHaveLength(1))
+    expect(executedQueries[0]).toContain('select 1')
+    expect(executedQueries[0]).toContain('select 2')
+  })
+
+  it('runs only the selected text from the Run selected menu item', async () => {
     createDraft({ _tag: 'database' }, 'select 1;\nselect 2;')
     testContext.selectedText = 'select 2;'
 
@@ -450,9 +477,11 @@ describe('QueryTab execution', () => {
     })
 
     renderQueryTab()
-    const runButton = await screen.findByRole('button', { name: 'Run selected' })
+    const runButton = await screen.findByRole('button', { name: 'Run' })
     await waitFor(() => expect(runButton).toBeEnabled())
-    await userEvent.click(runButton)
+
+    await userEvent.click(screen.getByRole('button', { name: 'More actions' }))
+    await userEvent.click(await screen.findByRole('menuitem', { name: 'Run selected' }))
 
     await waitFor(() => expect(executedQueries).toHaveLength(1))
     expect(executedQueries[0]).toContain('select 2')
@@ -477,7 +506,9 @@ describe('QueryTab execution', () => {
     })
 
     renderQueryTab()
-    expect(await screen.findByRole('button', { name: 'Run selected' })).toBeInTheDocument()
+    await userEvent.click(await screen.findByRole('button', { name: 'More actions' }))
+    expect(await screen.findByRole('menuitem', { name: 'Run selected' })).toBeEnabled()
+    await userEvent.keyboard('{Escape}')
 
     // Hiding the query panel unmounts CodeEditor entirely. Simulate the selection being
     // gone by the time it's shown again (a fresh editor instance has no selection yet).
@@ -490,9 +521,14 @@ describe('QueryTab execution', () => {
     expect(showQueryButton).toBeInstanceOf(HTMLButtonElement)
     await userEvent.click(showQueryButton as HTMLButtonElement)
 
-    const runButton = await screen.findByRole('button', { name: 'Run' })
-    expect(screen.queryByRole('button', { name: 'Run selected' })).not.toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: 'More actions' }))
+    expect(await screen.findByRole('menuitem', { name: 'Run selected' })).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    )
+    await userEvent.keyboard('{Escape}')
 
+    const runButton = await screen.findByRole('button', { name: 'Run' })
     await userEvent.click(runButton)
 
     await waitFor(() => expect(executedQueries).toHaveLength(1))

--- a/apps/studio/components/ui/AIAssistantPanel/AssistantChatForm.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AssistantChatForm.tsx
@@ -122,7 +122,7 @@ const AssistantChatFormComponent = forwardRef<HTMLFormElement, FormProps>(
             ref={textAreaRef}
             disabled={disabled}
             className={cn(
-              'text-base md:text-sm pr-10 pb-9 max-h-64',
+              'text-base md:text-sm pr-10 pb-9 max-h-64 rounded-lg',
               sqlSnippets && sqlSnippets.length > 0 && 'pt-10'
             )}
             placeholder={placeholder}

--- a/packages/ui-patterns/src/Chart/charts/chart-bar.tsx
+++ b/packages/ui-patterns/src/Chart/charts/chart-bar.tsx
@@ -66,6 +66,12 @@ export interface ChartBarProps {
   showGrid?: boolean
   showYAxis?: boolean
   showXAxis?: boolean
+  XAxisProps?: {
+    tick?: boolean
+    tickFormatter?: (value: any) => string
+    height?: number
+    [key: string]: any
+  }
   YAxisProps?: {
     tick?: boolean
     tickFormatter?: (value: any) => string
@@ -96,6 +102,7 @@ export const ChartBar = ({
   showGrid = false,
   showYAxis = false,
   showXAxis = false,
+  XAxisProps,
   YAxisProps,
 }: ChartBarProps) => {
   const [focusDataIndex, setFocusDataIndex] = useState<number | null>(null)
@@ -132,8 +139,11 @@ export const ChartBar = ({
       : false,
     hide: !showXAxis,
     interval: 'preserveStartEnd' as const,
+    tickMargin: showXAxis ? (XAxisProps?.tickMargin ?? 4) : 0,
+    height: showXAxis ? (XAxisProps?.height ?? 24) : 0,
     axisLine: { stroke: CHART_COLORS.AXIS },
     tickLine: { stroke: CHART_COLORS.AXIS },
+    ...XAxisProps,
   }
 
   const yAxisConfig = {

--- a/packages/ui-patterns/src/Chart/charts/chart-line.tsx
+++ b/packages/ui-patterns/src/Chart/charts/chart-line.tsx
@@ -74,6 +74,12 @@ export interface ChartLineProps {
   showGrid?: boolean
   showXAxis?: boolean
   showYAxis?: boolean
+  XAxisProps?: {
+    tick?: boolean
+    tickFormatter?: (value: any) => string
+    height?: number
+    [key: string]: any
+  }
   YAxisProps?: {
     tick?: boolean
     tickFormatter?: (value: any) => string
@@ -106,6 +112,7 @@ export const ChartLine = ({
   showGrid = false,
   showXAxis = false,
   showYAxis = false,
+  XAxisProps,
   YAxisProps,
   strokeWidth = 1.5,
   referenceLines,
@@ -143,8 +150,11 @@ export const ChartLine = ({
       : false,
     hide: !showXAxis,
     interval: 'preserveStartEnd' as const,
+    tickMargin: showXAxis ? (XAxisProps?.tickMargin ?? 4) : 0,
+    height: showXAxis ? (XAxisProps?.height ?? 24) : 0,
     axisLine: { stroke: CHART_COLORS.AXIS },
     tickLine: { stroke: CHART_COLORS.AXIS },
+    ...XAxisProps,
   }
 
   const yAxisConfig = {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

UI refinements for Explorer query surfaces.

## What is the current behavior?

- The assistant chat textarea uses a tighter radius than the Run SQL / Create a notebook cards on Explorer home.
- Chart results sit unevenly in the results pane because axis gutters stack on card padding, and long Y labels can clip.
- Selecting SQL in the editor changes the primary Run button to Run selected, which is easy to trigger by accident.
- The Prettify SQL icon in notebook query cells uses Lucide's default size, so it doesn't match other toolbar actions.

## What is the new behavior?

- Assistant chat form uses `rounded-lg` so it matches the home action cards everywhere the form is used.
- Query result charts collapse unused axis space, add a little padding when labels are on, and size the Y axis from formatted ticks so longer labels fit.
- Run is a default split button that always executes the full query. Run selected is a secondary menu item, disabled until SQL is selected.
- Notebook cell Prettify SQL icons use `size={16}` and `strokeWidth={2}` like the rest of the Explorer toolbar.

## Additional context

Cmd+Enter in the editor still runs the current selection when there is one.

## Test plan

- [ ] Open Explorer home and confirm the assistant chat radius matches the Run SQL and Create a notebook cards.
- [ ] Run a query, switch to chart view, and check spacing with labels off and on, including large Y values.
- [ ] With no selection, click Run and confirm the full query runs. Open the split menu and confirm Run selected is disabled.
- [ ] Select SQL, click Run, and confirm the full query still runs. Use Run selected from the menu to run only the selection.
- [ ] In a notebook query cell, confirm Prettify SQL matches the size and stroke of nearby toolbar icons.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a split Run control in the query editor, with separate actions for running all content or only selected text.
  - Added support for customizing chart X-axis display settings.
  - Improved chart Y-axis sizing, scaling, and tick formatting for clearer results.

- **Bug Fixes**
  - The “Run selected” action is unavailable when no text is selected.

- **Style**
  - Updated toolbar icon sizing and added rounded corners to the assistant chat input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->