### PR TITLE
fix(studio): hide shared pooler chart for high availability projects

### DIFF
--- a/apps/studio/data/reports/database-charts.test.ts
+++ b/apps/studio/data/reports/database-charts.test.ts
@@ -77,6 +77,29 @@ describe('getReportAttributesV2 dedicated pooler chart', () => {
   })
 })
 
+const getSupavisorChart = (project: Project) =>
+  getReportAttributesV2(ENTITLED_FEATURES, project).find(
+    (chart) => chart.id === 'supavisor-connections-active'
+  )
+
+describe('getReportAttributesV2 shared pooler chart', () => {
+  it('shows the chart for standard projects', () => {
+    expect(getSupavisorChart(buildProject())?.hide).toBe(false)
+  })
+
+  it('hides the chart for high availability projects', () => {
+    expect(getSupavisorChart(buildProject({ high_availability: true }))?.hide).toBe(true)
+  })
+
+  it('hides the chart when the database entitlement is missing', () => {
+    expect(
+      getReportAttributesV2([], buildProject()).find(
+        (chart) => chart.id === 'supavisor-connections-active'
+      )?.hide
+    ).toBe(true)
+  })
+})
+
 describe('getReportAttributesV2 disk-io-burst-balance chart', () => {
   it('shows the chart for burstable non high availability projects', () => {
     expect(getBurstBalanceChart(buildProject())?.hide).toBe(false)

--- a/apps/studio/data/reports/database-charts.ts
+++ b/apps/studio/data/reports/database-charts.ts
@@ -541,7 +541,8 @@ export const getReportAttributesV2: (
       valuePrecision: 0,
       entitlement: 'database',
       requiredPlan: 'Pro',
-      hide: !entitledFeatures.includes('database'),
+      // High Availability projects don't run Supavisor, so there's no data to show.
+      hide: !entitledFeatures.includes('database') || isHighAvailability,
       showTooltip: true,
       showLegend: false,
       showMaxValue: false,


### PR DESCRIPTION
High Availability projects run Multigres and don't have Supavisor, so the Shared Pooler (Supavisor) client connections chart in the database report only ever rendered an "Unable to load data" error for them. This hides the chart for HA projects, following the same pattern as the Disk IO Burst Balance chart.

**Changed:**
- `supavisor-connections-active` chart is now hidden when `project.high_availability` is true

**Added:**
- Unit tests covering the shared pooler chart's visibility for standard, HA, and unentitled projects

## To test

- Open Reports → Database on a High Availability project – the Shared Pooler (Supavisor) client connections chart should no longer appear
- Open the same report on a standard Pro project – the chart should still render as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The active connection chart is now hidden for High Availability projects and projects without the database entitlement, preventing empty or unavailable data from being displayed.

* **Tests**
  * Added coverage to verify the chart appears only for eligible standard projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->