### PR TITLE
fix(studio): write debug prompt into current chat when assistant is already open

### DIFF
--- a/apps/studio/components/interfaces/Explorer/ExplorerChatTab.tsx
+++ b/apps/studio/components/interfaces/Explorer/ExplorerChatTab.tsx
@@ -85,6 +85,7 @@ export const ExplorerChatTab = () => {
       onNewChat={() => createChat()}
       onSelectChat={openChat}
       onBranchChat={handleBranchChat}
+      composerContext={{ initialInput: aiAssistant.initialInput }}
       onInputChange={() => tabs.makeTabPermanent(createTabId('chat', { id }))}
       renderHeader={(headerProps) => (
         <ExplorerChatToolbar {...headerProps} chatId={id} shortcutsEnabled={shortcutsEnabled} />

--- a/apps/studio/components/interfaces/Explorer/QueryEditor/QueryResultError.test.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryEditor/QueryResultError.test.tsx
@@ -105,6 +105,24 @@ describe('QueryResultError', () => {
     )
   })
 
+  it('calls onDebug with the prompt instead of opening a new chat when provided', () => {
+    const onDebug = vi.fn()
+
+    customRender(
+      <QueryResultError
+        error={{ message: 'relation "foo" does not exist' }}
+        sql="select * from foo;"
+        source="database"
+        onDebug={onDebug}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Debug with Assistant' }))
+
+    expect(onDebug).toHaveBeenCalledWith(expect.stringContaining('select * from foo;'))
+    expect(mocks.createChat).not.toHaveBeenCalled()
+  })
+
   it('copies the same debug prompt text via the dropdown', async () => {
     const user = userEvent.setup()
     customRender(

--- a/apps/studio/components/interfaces/Explorer/QueryEditor/QueryResultError.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryEditor/QueryResultError.tsx
@@ -23,11 +23,16 @@ export const QueryResultError = ({
   autoLimit,
   sql,
   source,
+  onDebug,
 }: {
   error: NonNullable<QueryResult['error']>
   autoLimit?: QueryResult['autoLimit']
   sql?: string
   source?: SqlSnippetSource
+  /** Overrides the default "open a new debug chat" behavior — used when this query block
+   * is already rendered inside an open assistant conversation, so debugging should write
+   * into that conversation's composer instead of abandoning it for a new chat. */
+  onDebug?: (prompt: string) => void
 }) => {
   const { ref } = useParams()
 
@@ -61,7 +66,9 @@ export const QueryResultError = ({
   )
 
   const handleDebug = () =>
-    createChat({ name: 'Debug SQL snippet', initialMessage: buildDebugPrompt() })
+    onDebug
+      ? onDebug(buildDebugPrompt())
+      : createChat({ name: 'Debug SQL snippet', initialMessage: buildDebugPrompt() })
 
   const isTimeout =
     error.message?.includes('canceling statement due to statement timeout') ||

--- a/apps/studio/components/interfaces/Explorer/QueryEditor/QueryResultRenderer.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryEditor/QueryResultRenderer.tsx
@@ -12,6 +12,7 @@ interface QueryResultRendererProps {
   /** The query that produced `result`, used to build the "Debug with Assistant" prompt on error. */
   sql?: string
   source?: SqlSnippetSource
+  onDebug?: (prompt: string) => void
 }
 
 export const QueryResultRenderer = ({
@@ -20,6 +21,7 @@ export const QueryResultRenderer = ({
   chart,
   sql,
   source,
+  onDebug,
 }: QueryResultRendererProps) => {
   const { rows, error, autoLimit } = result ?? {}
 
@@ -28,7 +30,15 @@ export const QueryResultRenderer = ({
   }
 
   if (error) {
-    return <QueryResultError error={error} autoLimit={autoLimit} sql={sql} source={source} />
+    return (
+      <QueryResultError
+        error={error}
+        autoLimit={autoLimit}
+        sql={sql}
+        source={source}
+        onDebug={onDebug}
+      />
+    )
   }
 
   if ((rows ?? []).length === 0) {

--- a/apps/studio/components/interfaces/Explorer/QueryEditor/index.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryEditor/index.tsx
@@ -140,6 +140,7 @@ type QueryEditorProps = {
   onRowLimitChange?: (val: number) => void
   onDisplayChange?: (display: QueryDisplay) => void
   onRun?: () => void
+  onDebug?: (prompt: string) => void
 }
 
 /**
@@ -170,6 +171,7 @@ export const QueryEditor = forwardRef<QueryEditorHandle, QueryEditorProps>(funct
     onRowLimitChange,
     onDisplayChange,
     onRun,
+    onDebug,
   }: QueryEditorProps,
   ref
 ) {
@@ -609,6 +611,7 @@ export const QueryEditor = forwardRef<QueryEditorHandle, QueryEditorProps>(funct
             chart={display?.chart}
             sql={result?.sql}
             source={result?.source}
+            onDebug={onDebug}
           />
         </ExplorerQueryResults>
 

--- a/apps/studio/components/ui/AIAssistantPanel/AssistantQueryCell.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AssistantQueryCell.tsx
@@ -19,6 +19,7 @@ import {
   type QuerySourceTag,
 } from '@/data/query-sources/query-source-registry'
 import { useTrack } from '@/lib/telemetry/track'
+import { useAiAssistantState } from '@/state/ai-assistant-state'
 import { useLocalRoleImpersonationState } from '@/state/role-impersonation-state'
 
 interface AssistantQueryCellProps {
@@ -72,6 +73,7 @@ export const AssistantQueryCell = ({
 }: AssistantQueryCellProps) => {
   const track = useTrack()
   const roleImpersonationState = useLocalRoleImpersonationState()
+  const aiAssistantState = useAiAssistantState()
 
   const fallbackTitle =
     initialTitle?.trim() ||
@@ -180,6 +182,7 @@ export const AssistantQueryCell = ({
         }
         onDisplayChange={handleDisplayChange}
         onRun={handleRun}
+        onDebug={aiAssistantState.setInitialInput}
       />
     </Confirm>
   )

--- a/apps/studio/state/ai-assistant-state.tsx
+++ b/apps/studio/state/ai-assistant-state.tsx
@@ -426,6 +426,10 @@ export const createAiAssistantState = (): AiAssistantState => {
       state.model = model
     },
 
+    setInitialInput: (text: string) => {
+      state.initialInput = text
+    },
+
     // Chat management
     get activeChat(): ChatSession | undefined {
       return state.activeChatId ? state.chats[state.activeChatId] : undefined
@@ -716,6 +720,7 @@ export type AiAssistantState = AiAssistantData & {
   isInitialized: boolean
   setContext: (context: Partial<AiAssistantContext>) => void
   setModel: (model: AssistantModel) => void
+  setInitialInput: (text: string) => void
   createChat: (options?: CreateChatOptions) => string
   newChat: (options?: NewChatOptions) => string
   createBranch: (sourceChatId: string, messageId: string) => string | undefined


### PR DESCRIPTION
## Summary

* Query blocks embedded inside an active assistant conversation (`AssistantQueryCell`) reused the same "Debug with Assistant" handler as standalone query blocks (Explorer Query tab, notebook cells), which always opens a brand-new chat and navigates away.
* Clicking Debug on a block that's already part of the open conversation silently abandoned it for an unrelated new chat, which read as the button doing nothing.
* Added an optional `onDebug` override threaded through `QueryEditor` → `QueryResultRenderer` → `QueryResultError`; `AssistantQueryCell` now uses it to write the debug prompt into the currently active chat's composer (`ai-assistant-state`'s new `setInitialInput`) instead of creating a new chat. Standalone query blocks keep the existing "open a new chat" behavior since no `onDebug` override is passed there.
* `ExplorerChatTab` now wires `composerContext` into `AssistantChat` (it wasn't before), so the pre-filled prompt actually reaches the visible textarea on the Explorer chat route.

Fixes [FE-4319](https://linear.app/supabase/issue/FE-4319/debug-with-ai-assistant-does-seemingly-nothing-if-query-is-already).

## Test plan

- [X] `pnpm vitest run` on `QueryResultError.test.tsx` / `QueryResultError.selfhosted.test.tsx` / `ExplorerChatTab.test.tsx` / `AssistantQueryCell.utils.test.ts` — all pass, including new test asserting `onDebug` is called instead of `createChat`.
- [X] `pnpm exec eslint` on touched files — clean (only pre-existing unrelated warnings).
- [X] Manual check: run a query inside an assistant chat that errors, click "Debug with Assistant" on that block, confirm the debug prompt appears in the current chat's composer rather than opening a new chat.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Debug with Assistant” workflow that sends SQL error details to the AI Assistant as its initial input.
  * Preserved the existing behavior of opening a new debug chat when the Assistant panel is unavailable.

* **Tests**
  * Added coverage confirming that debugging invokes the Assistant callback without creating an additional chat.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->