### PR TITLE
fix(studio): close popover menu when dragging block (FE-4301)

### DIFF
--- a/apps/studio/components/ui/SortableSection.tsx
+++ b/apps/studio/components/ui/SortableSection.tsx
@@ -27,7 +27,10 @@ export const SortableSection = ({
 
   useDndMonitor({
     onDragStart: (event) => {
-      if (event.active.id === id) isDraggingRef.current = true
+      if (event.active.id === id) {
+        isDraggingRef.current = true
+        setMenuOpen(false)
+      }
     },
     onDragEnd: (event) => {
       if (event.active.id === id) isDraggingRef.current = false

--- a/apps/studio/components/ui/SortableSection.tsx
+++ b/apps/studio/components/ui/SortableSection.tsx
@@ -29,6 +29,7 @@ export const SortableSection = ({
     onDragStart: (event) => {
       if (event.active.id === id) {
         isDraggingRef.current = true
+        clearTimeout(openTimeoutRef.current)
         setMenuOpen(false)
       }
     },


### PR DESCRIPTION
## Summary

* Closes the block options popover (grip dropdown menu) when a drag operation starts on that block
* Fixes the issue where the menu would remain visible during the drag if it was already open

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Section action menus now remain closed when dragging begins, preventing delayed reopening and keeping the editing interface clear and focused.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->