### PR TITLE
add github discussion link to explorer preview

### DIFF
--- a/apps/studio/components/interfaces/App/FeaturePreview/useFeaturePreviews.ts
+++ b/apps/studio/components/interfaces/App/FeaturePreview/useFeaturePreviews.ts
@@ -45,8 +45,7 @@ export const useFeaturePreviews = (): FeaturePreview[] => {
         key: LOCAL_STORAGE_KEYS.UI_PREVIEW_EXPLORER,
         name: 'Explorer & Notebooks',
         category: 'editors',
-        // [Joshen TODO] Update with proper URL once discussion is up
-        discussionsUrl: undefined,
+        discussionsUrl: 'https://github.com/orgs/supabase/discussions/49916',
         enabled: isExplorerEnabled,
         isNew: true,
         isPlatformOnly: true,


### PR DESCRIPTION
Adds the GitHub discussion link for Explorer feature preview.

Resolves FE-4256

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Explorer & Notebooks feature preview with a working link to its GitHub discussion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->