### PR TITLE
fix: use correct Notion database ID for VIP dinner RSVPs

### DIFF
--- a/apps/www/_go/events/select-2026/vip-dinner.tsx
+++ b/apps/www/_go/events/select-2026/vip-dinner.tsx
@@ -175,7 +175,7 @@ const page: GoPageInput = {
             'By submitting this form, I confirm that I have read and understood the Privacy Policy.',
         },
         notion: {
-          database_id: '37d5004b775f80c585c7fc15377098dc',
+          database_id: '37d5004b775f809e8cc4e29fdec302aa',
           columnMap: {
             first_name: 'First Name',
             last_name: 'Last Name',


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Submitting the `/go/select-2026/vip-dinner` form fails with a Notion 400:

`Provided ID 37d5004b-775f-80c5-85c7-fc15377098dc is a page, not a database.`

The form was writing to the Notion page that contains the RSVP database, not the database itself.

## What is the new behavior?

RSVPs now write to the VIP dinner Notion database (`37d5004b775f809e8cc4e29fdec302aa`).

## Additional context

No visual changes. This only updates the Notion `database_id` on the VIP dinner go page.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the VIP dinner RSVP form’s backend configuration to ensure submissions are directed to the correct destination.
  * No changes were made to the form fields, configuration, or CRM mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->