### PR TITLE
fix(ui): admonition component parity

### DIFF
--- a/apps/docs/app/contributing/ContributingToC.tsx
+++ b/apps/docs/app/contributing/ContributingToC.tsx
@@ -1,12 +1,11 @@
 'use client'
 
+import { Feedback } from '~/components/Feedback'
+import { useBreakpoint } from 'common'
 import { Menu } from 'lucide-react'
 import type { HTMLAttributes } from 'react'
 import { useEffect, useState } from 'react'
-
-import { useBreakpoint } from 'common'
 import { cn, Separator, Sheet, SheetContent, SheetHeader, SheetTrigger } from 'ui'
-import { Feedback } from '~/components/Feedback'
 
 interface TocItem extends HTMLAttributes<HTMLElement> {
   label: string
@@ -19,7 +18,9 @@ export function ContributingToc({ className }: { className?: string }) {
 
   useEffect(() => {
     const headings = [
-      ...document.querySelectorAll('article.prose > h2,h3:not(#feedback-title)'),
+      ...document.querySelectorAll(
+        'article.prose > h2:not(#feedback-title),h3:not(#feedback-title)'
+      ),
     ] as Array<HTMLHeadingElement>
     const tocItems = headings
       .filter((heading) => !!heading.id && heading.textContent)

--- a/apps/docs/components/Feedback/Feedback.tsx
+++ b/apps/docs/components/Feedback/Feedback.tsx
@@ -141,9 +141,9 @@ function Feedback({ className }: { className?: string }) {
 
   return (
     <section className={cn('@container', className)} aria-labelledby="feedback-title">
-      <h3 id="feedback-title" className="block font-mono text-xs text-foreground-light mb-3">
+      <h2 id="feedback-title" className="block font-mono text-xs text-foreground-light mb-3">
         Is this helpful?
-      </h3>
+      </h2>
       <div className="relative flex flex-col gap-2 @[12rem]:gap-4 @[12rem]:flex-row @[12rem]:items-center">
         <div
           style={{ '--container-flex-gap': '0.5rem' } as CSSProperties}

--- a/apps/docs/content/guides/database/metabase.mdx
+++ b/apps/docs/content/guides/database/metabase.mdx
@@ -43,7 +43,7 @@ hideToc: true
     - On your project dashboard, click [Connect](/dashboard/project/_?showConnect=true)
     - View parameters under "Session pooler"
 
-    <Admonition type="note" title="connection notice">
+    <Admonition type="note" title="Connection notice">
 
             If you're in an [IPv6 environment](/docs/guides/platform/ipv4-address#checking-your-network-ipv6-support) or have the [IPv4 Add-On](/docs/guides/platform/ipv4-address#understanding-ip-addresses), you can use the direct connection string instead of Supavisor in Session mode.
 

--- a/apps/docs/content/guides/database/prisma.mdx
+++ b/apps/docs/content/guides/database/prisma.mdx
@@ -19,7 +19,7 @@ If you plan to solely use Prisma instead of the Supabase Data API (PostgREST), t
     <StepHikeCompact.Details title="Create a custom user for Prisma">
       - In the [SQL Editor](/dashboard/project/_/sql/new), create a Prisma DB user with full privileges on the public schema.
       - This gives you better control over Prisma's access and makes it easier to monitor using Supabase tools like the [Query Performance Dashboard](/dashboard/project/_/advisors/query-performance) and [Log Explorer](/dashboard/project/_/logs/explorer).
-      <Admonition type="note" title="password manager">
+      <Admonition type="note" title="Password manager">
 
         For security, consider using a [password generator](https://bitwarden.com/password-generator/) for the Prisma role.
 
@@ -325,7 +325,7 @@ If you plan to solely use Prisma instead of the Supabase Data API (PostgREST), t
               --to-schema prisma/schema.prisma \
               --script > prisma/migrations/0_init_supabase/migration.sql
             ```
-            <Admonition type="note" title="conflict management">
+            <Admonition type="note" title="Conflict management">
 
               If there are any conflicts, reference [Prisma's official doc](https://www.prisma.io/docs/orm/prisma-migrate/getting-started#work-around-features-not-supported-by-prisma-schema-language) or the [trouble shooting guide](/docs/guides/database/prisma/prisma-troubleshooting) for more details
 
@@ -354,7 +354,7 @@ If you plan to solely use Prisma instead of the Supabase Data API (PostgREST), t
               --to-schema prisma/schema.prisma \
               --script > prisma/migrations/0_init_supabase/migration.sql
             ```
-            <Admonition type="note" title="conflict management">
+            <Admonition type="note" title="Conflict management">
 
               If there are any conflicts, reference [Prisma's official doc](https://www.prisma.io/docs/orm/prisma-migrate/getting-started#work-around-features-not-supported-by-prisma-schema-language) or the [trouble shooting guide](/docs/guides/database/prisma/prisma-troubleshooting) for more details
 
@@ -383,7 +383,7 @@ If you plan to solely use Prisma instead of the Supabase Data API (PostgREST), t
               --to-schema prisma/schema.prisma \
               --script > prisma/migrations/0_init_supabase/migration.sql
             ```
-            <Admonition type="note" title="conflict management">
+            <Admonition type="note" title="Conflict management">
 
               If there are any conflicts, reference [Prisma's official doc](https://www.prisma.io/docs/orm/prisma-migrate/getting-started#work-around-features-not-supported-by-prisma-schema-language) or the [trouble shooting guide](/docs/guides/database/prisma/prisma-troubleshooting) for more details
 
@@ -412,7 +412,7 @@ If you plan to solely use Prisma instead of the Supabase Data API (PostgREST), t
               --to-schema prisma/schema.prisma \
               --script > prisma/migrations/0_init_supabase/migration.sql
             ```
-            <Admonition type="note" title="conflict management">
+            <Admonition type="note" title="Conflict management">
 
               If there are any conflicts, reference [Prisma's official doc](https://www.prisma.io/docs/orm/prisma-migrate/getting-started#work-around-features-not-supported-by-prisma-schema-language) or the [trouble shooting guide](/docs/guides/database/prisma/prisma-troubleshooting) for more details
 

--- a/apps/docs/features/docs/MdxBase.shared.tsx
+++ b/apps/docs/features/docs/MdxBase.shared.tsx
@@ -44,8 +44,8 @@ import { AiPrompt } from '../ui/AiPrompt'
 import { ErrorCodes } from '../ui/ErrorCodes'
 import { McpConfigPanel } from '../ui/McpConfigPanel'
 
-// Wrap Admonition for Docs-specific styling (within MDX prose, requires a margin-bottom)
-const AdmonitionWithMargin = (props: AdmonitionProps) => {
+// Admonition as it appears in docs pages: sits in MDX prose, so it needs a margin-bottom.
+const DocsAdmonition = (props: AdmonitionProps) => {
   return <Admonition {...props} className="mb-8" />
 }
 
@@ -68,7 +68,7 @@ const Pre = (props: any) => {
 const components = {
   Accordion,
   AccordionItem,
-  Admonition: AdmonitionWithMargin,
+  Admonition: DocsAdmonition,
   AgentPluginsPanel,
   AgentSetup,
   AgentWatchSchedule,

--- a/apps/docs/styles/globals.css
+++ b/apps/docs/styles/globals.css
@@ -281,10 +281,6 @@ pre[class*='language-'] {
   }
 }
 
-.admonition-content > p {
-  @apply m-0;
-}
-
 /* format <code> inside <p> */
 h2 code,
 h3 code,
@@ -299,13 +295,6 @@ h4 code {
   &::after {
     display: none;
   }
-}
-
-/* code inside admonitions */
-.admonition-content p code {
-  @apply bg-control;
-  word-break: keep-all !important;
-  white-space: nowrap !important;
 }
 
 article p strong {

--- a/apps/docs/styles/globals.css
+++ b/apps/docs/styles/globals.css
@@ -160,11 +160,16 @@ h6:not(.font-mono),
   @apply font-heading font-semibold;
 }
 
+/* Alert set its own type scale to prevent drift in docs */
 .prose
   :where(p, li, a, figcaption):not(:where([class~='not-prose'], [class~='not-prose'] *)):not(
     :where(h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6) *
-  ) {
+  ):not(:where([data-slot='alert'] *)) {
   @apply text-base leading-7;
+}
+
+.prose :where([data-slot='alert'] ol > li)::before {
+  top: 0;
 }
 
 .prose :where(h1, .h1):not(:where([class~='not-prose'], [class~='not-prose'] *)) {

--- a/packages/ui-patterns/src/Admonition/Admonition.test.tsx
+++ b/packages/ui-patterns/src/Admonition/Admonition.test.tsx
@@ -77,7 +77,7 @@ describe('Admonition', () => {
     expect(note).toHaveTextContent('Review ownership before exposing this function.')
   })
 
-  it('renders success styling', () => {
+  it('renders the success icon', () => {
     render(
       <Admonition
         type="success"
@@ -89,8 +89,6 @@ describe('Admonition', () => {
     const note = screen.getByRole('alert', { name: 'Success' })
     expect(note).toHaveTextContent('Connection confirmed')
     expect(note).toHaveTextContent('You can now close this tab.')
-    expect(note).toHaveClass('bg-brand-400/15')
-    expect(note).toHaveClass('border-brand-400')
     expect(note.querySelector('svg path')?.getAttribute('d')).toContain('M10.5 19.5')
   })
 
@@ -128,18 +126,6 @@ describe('Admonition', () => {
     expect(note.querySelector('h1, h2, h3, h4, h5, h6')).not.toBeInTheDocument()
     expect(title.tagName).toBe('P')
     expect(title).toHaveAttribute('data-slot', 'alert-title')
-    expect(title).toHaveClass('!mt-0', 'mb-0.5', 'font-medium')
-  })
-
-  it('wraps a string description in a paragraph', () => {
-    render(<Admonition type="note" description="Body copy." />)
-
-    const note = screen.getByRole('alert', { name: 'Note' })
-    const description = within(note).getByText('Body copy.')
-
-    expect(description.tagName).toBe('P')
-    expect(description.parentElement).toHaveClass('!mb-0')
-    expect(description.parentElement?.parentElement).toHaveClass('my-0.5')
   })
 
   it('wraps MDX children in AlertDescription', () => {
@@ -153,26 +139,6 @@ describe('Admonition', () => {
     const paragraph = within(note).getByText('Children body copy.')
 
     expect(paragraph.tagName).toBe('P')
-    expect(paragraph.parentElement).toHaveClass('text-sm', '!mb-0')
     expect(paragraph.parentElement).toHaveAttribute('data-slot', 'alert-description')
-    expect(paragraph.parentElement?.parentElement).not.toHaveClass('my-0.5')
-  })
-
-  it('does not offset titled content', () => {
-    render(<Admonition type="note" title="Manual approval required" description="Body copy." />)
-
-    const note = screen.getByRole('alert', { name: 'Note' })
-    const title = within(note).getByText('Manual approval required')
-
-    expect(title.parentElement).not.toHaveClass('my-0.5')
-  })
-
-  it('does not offset titleless content when the icon is hidden', () => {
-    render(<Admonition type="note" showIcon={false} description="Body copy." />)
-
-    const note = screen.getByRole('alert', { name: 'Note' })
-    const description = within(note).getByText('Body copy.')
-
-    expect(description.parentElement?.parentElement).not.toHaveClass('my-0.5')
   })
 })

--- a/packages/ui-patterns/src/Admonition/Admonition.tsx
+++ b/packages/ui-patterns/src/Admonition/Admonition.tsx
@@ -7,8 +7,13 @@ import { AdmonitionTypeIcon } from './AdmonitionIcons'
 
 export type { AdmonitionLayout, AdmonitionProps, AdmonitionType }
 
-const admonitionBodyClassName =
-  '!mb-0 [&_p]:!mt-0 [&_p]:!mb-1.5 [&_p:last-child]:!mb-0 [&_ul]:!my-1.5 [&_ol]:!my-1.5 [&_li]:!my-0.5'
+const admonitionBodyClassName = [
+  'text-sm leading-relaxed [&_code]:text-[0.75rem]',
+  'mb-0 [&_p]:mt-0 [&_p]:mb-1.5 [&_p:last-child]:mb-0',
+  '[&_ul]:my-1.5 [&_ol]:my-1.5 [&_li]:my-0.5',
+  '[&_ul]:list-none [&_ol]:list-decimal [&_ul]:pl-4 [&_ol]:pl-4',
+  '[&_ul>li]:relative [&_ul>li]:before:absolute [&_ul>li]:before:left-[-1rem] [&_ul>li]:before:top-2.5 [&_ul>li]:before:h-0.5 [&_ul>li]:before:w-2 [&_ul>li]:before:rounded [&_ul>li]:before:bg-border-strong [&_ul>li]:before:content-[""]',
+].join(' ')
 
 export const Admonition = forwardRef<
   React.ComponentRef<typeof Alert>,
@@ -43,7 +48,7 @@ export const Admonition = forwardRef<
         aria-label={label}
         variant={TYPE_TO_VARIANT[type]}
         className={cn(
-          'overflow-hidden',
+          'overflow-hidden text-sm leading-normal',
           layout === 'responsive' && '@container',
           type === 'success' && [
             'bg-brand-400/15 dark:bg-brand/10',
@@ -69,11 +74,15 @@ export const Admonition = forwardRef<
               ]
             )}
           >
-            <div className={cn(showIcon && !title && description && 'my-0.5')}>
+            <div
+              className={cn(
+                showIcon && (title || description || children) && (title ? 'mt-0.75' : 'mt-0.5')
+              )}
+            >
               {title && (
                 <AlertTitle
                   {...childProps?.title}
-                  className={cn('text-foreground', childProps?.title?.className)}
+                  className={cn('!mt-0 text-foreground', childProps?.title?.className)}
                 >
                   {title}
                 </AlertTitle>
@@ -99,6 +108,7 @@ export const Admonition = forwardRef<
               <div
                 className={cn(
                   'flex flex-row gap-2',
+                  '[&_button]:text-xs [&_a]:text-xs',
                   layout === 'vertical' && 'mt-3 items-start',
                   layout === 'horizontal' && 'items-center',
                   layout === 'responsive' && 'mt-3 items-start @md:mt-0 @md:items-center'


### PR DESCRIPTION
## what is the current behavior?

admonition icon <> text not optically aligned + rendered differently in docs and the design system _ docs showed admonition text at 15px/28px because the page's prose styles reached inside the component, while the same callout was 13px in the design system _ lists

## what is the new behavior?

- the title offset is now conditional. a title and body copy have different line heights, so they need different nudges to sit level with the icon.
- fixes list markers and the ordered-list chip alignment inside callouts.
- removes `.admonition-content` css that nothing referenced
- fixes 5 admonition titles that were not capitalized.

| state | preview |
| -------|------|
| before | <img width="902" height="279" alt="image" src="https://github.com/user-attachments/assets/2fffb183-81e2-4eff-8f0d-8a07649390e8" /> |
| after | <img width="902" height="279" alt="image" src="https://github.com/user-attachments/assets/22abe3ed-fd6d-49ac-aa37-4292bca5850a" /> | 

## follow ups

- better composition: title, description and actions are still props _ a compound api (`Admonition.Title`, `Admonition.Actions`) would remove the `childProps` escape hatch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved capitalization of note and warning titles in the Metabase and Prisma guides for consistency.
  * Updated the contributing guide’s table of contents to exclude feedback headings.
  * Improved heading structure for the documentation feedback section.

* **UI Improvements**
  * Refined admonition and alert typography, spacing, list formatting, and ordered-list alignment.
  * Improved content spacing when titles, descriptions, or icons are present.
  * Updated action links and buttons for more consistent sizing.
  * Adjusted alert content styling for a clearer presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->