### PR TITLE
feat: Add Guides layout support, schema, and sample page

### DIFF
--- a/apps/kb/package.json
+++ b/apps/kb/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@astrojs/react": "^6.0.4",
     "astro": "^7.2.6",
+    "lucide-react": "*",
     "react": "catalog:",
     "react-dom": "catalog:",
     "ui": "workspace:*"

--- a/apps/kb/src/components/Nav.tsx
+++ b/apps/kb/src/components/Nav.tsx
@@ -30,7 +30,7 @@ const menus = [
 ]
 
 const triggerClass =
-  'h-(--header-height) p-2 border-transparent font-normal rounded-none text-foreground-light hover:text-foreground data-open:text-foreground! border-0 focus-ring focus-visible:text-foreground h-full focus-visible:rounded-sm shadow-none!'
+  'h-(--header-height) p-2 bg-transparent border-transparent font-normal rounded-none text-foreground-light hover:text-foreground data-open:text-foreground! border-0 focus-ring focus-visible:text-foreground h-full focus-visible:rounded-sm shadow-none!'
 // docs gates this at `md:absolute` (its own base component class) because its
 // nav is hidden entirely below `lg` in favor of a separate mobile menu. kb
 // doesn't have that split — the nav is always visible — so `absolute` is

--- a/apps/kb/src/content.config.ts
+++ b/apps/kb/src/content.config.ts
@@ -1,0 +1,18 @@
+import { defineCollection } from 'astro:content'
+import { glob } from 'astro/loaders'
+import { z } from 'astro/zod'
+
+// Every entry here is rendered through GuideLayout by
+// src/pages/guides/[...slug].astro — dropping a new file in
+// src/content/guides doesn't need any per-file layout wiring.
+const guides = defineCollection({
+  loader: glob({ pattern: '**/*.md', base: './src/content/guides' }),
+  schema: z.object({
+    title: z.string(),
+    description: z.string().optional(),
+    topics: z.array(z.string()).optional(),
+    github_url: z.string().optional(),
+  }),
+})
+
+export const collections = { guides }

--- a/apps/kb/src/content/guides/sample-guide.md
+++ b/apps/kb/src/content/guides/sample-guide.md
@@ -1,0 +1,81 @@
+---
+title: 'Markdown elements sample'
+description: 'A lorem ipsum sample guide exercising every base Markdown element supported by the guide layout.'
+topics: ['example', 'markdown']
+github_url: 'https://github.com/supabase/supabase/discussions/0000000'
+---
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor
+incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+
+## Heading level 2
+
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore
+eu fugiat nulla pariatur. This paragraph mixes **bold text**, _italic text_,
+**_bold italic text_**, ~~strikethrough text~~, and `inline code`.
+
+### Heading level 3
+
+Here's a [link to the Astro docs](https://docs.astro.build/en/basics/layouts/),
+followed by an unordered list with a nested list:
+
+- Excepteur sint occaecat cupidatat non proident
+- Sunt in culpa qui officia deserunt mollit anim id est laborum
+  - Nested item one
+  - Nested item two
+- Curabitur blandit tempus porttitor
+
+#### Heading level 4
+
+And an ordered list with a nested list:
+
+1. Lorem ipsum dolor sit amet
+2. Consectetur adipiscing elit
+   1. Nested step one
+   2. Nested step two
+3. Sed do eiusmod tempor incididunt
+
+##### Heading level 5
+
+> Neque porro quisquam est qui dolorem ipsum quia dolor sit amet,
+> consectetur, adipisci velit.
+>
+> > Nested blockquote: at vero eos et accusamus et iusto odio dignissimos.
+
+###### Heading level 6
+
+A fenced code block with a language tag:
+
+```js
+function add(a, b) {
+  return a + b
+}
+
+console.log(add(2, 3))
+```
+
+And another in a different language:
+
+```bash
+npm install
+npm run dev
+```
+
+A table:
+
+| Element  | Supported | Notes                        |
+| -------- | --------- | ---------------------------- |
+| Headings | Yes       | h2 through h6                |
+| Tables   | Yes       | via GitHub-flavored Markdown |
+| Images   | Yes       | see below                    |
+
+An image:
+
+![Placeholder image](https://placehold.co/800x400?text=Placeholder+Image)
+
+---
+
+Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium
+doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore
+veritatis et quasi architecto beatae vitae dicta sunt explicabo.

--- a/apps/kb/src/layouts/GuideLayout.astro
+++ b/apps/kb/src/layouts/GuideLayout.astro
@@ -1,0 +1,39 @@
+---
+import { Github } from 'lucide-react'
+import { Badge } from 'ui'
+
+import Layout from './Layout.astro'
+
+interface Props {
+	title: string
+	description?: string
+	topics?: string[]
+	github_url?: string
+}
+
+const { title, description, topics = [], github_url } = Astro.props
+---
+
+<Layout title={title} description={description}>
+	<article class="prose max-w-3xl mx-auto px-6 py-16">
+		<h1>{title}</h1>
+		{description && <p class="lead">{description}</p>}
+		{
+			topics.length > 0 && (
+				<div class="flex flex-wrap gap-2">
+					{topics.map((topic) => <Badge>{topic}</Badge>)}
+				</div>
+			)
+		}
+		<slot />
+		{
+			github_url && (
+				<p>
+					<a href={github_url} target="_blank" rel="noreferrer" class="inline-flex items-center gap-1.5">
+						<Github size={16} /> Go to the GitHub discussion
+					</a>
+				</p>
+			)
+		}
+	</article>
+</Layout>

--- a/apps/kb/src/layouts/Layout.astro
+++ b/apps/kb/src/layouts/Layout.astro
@@ -1,6 +1,13 @@
 ---
 import { Header } from '../components/Header'
 import '../styles/globals.css'
+
+interface Props {
+	title: string
+	description?: string
+}
+
+const { title, description } = Astro.props
 ---
 
 <!doctype html>
@@ -9,6 +16,7 @@ import '../styles/globals.css'
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width" />
 		<meta name="robots" content="noindex, nofollow" />
+		{description && <meta name="description" content={description} />}
 		<script is:inline>
 			// Set data-theme on <html> before first paint, so the page doesn't flash
 			// the wrong theme while this loads. Defaults to dark (no system-preference
@@ -50,7 +58,7 @@ import '../styles/globals.css'
 			rel="stylesheet"
 			href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Manrope:wght@400;500;600;700;800&display=swap"
 		/>
-		<title>Supabase Knowledge Base</title>
+		<title>{title} | Supabase Knowledge Base</title>
 	</head>
 	<body>
 		<Header client:load />

--- a/apps/kb/src/pages/guides/[...slug].astro
+++ b/apps/kb/src/pages/guides/[...slug].astro
@@ -1,0 +1,21 @@
+---
+import { getCollection, render } from 'astro:content'
+
+import GuideLayout from '../../layouts/GuideLayout.astro'
+
+export async function getStaticPaths() {
+	const guides = await getCollection('guides')
+	return guides.map((guide) => ({
+		params: { slug: guide.id },
+		props: { guide },
+	}))
+}
+
+const { guide } = Astro.props
+const { title, description, topics, github_url } = guide.data
+const { Content } = await render(guide)
+---
+
+<GuideLayout title={title} description={description} topics={topics} github_url={github_url}>
+	<Content />
+</GuideLayout>

--- a/apps/kb/src/pages/index.astro
+++ b/apps/kb/src/pages/index.astro
@@ -3,6 +3,6 @@ import { Hero } from '../components/Hero'
 import Layout from '../layouts/Layout.astro'
 ---
 
-<Layout>
+<Layout title="Home" description="In-depth guides, tutorials, and explainers for best practices for Supabase databases.">
 	<Hero />
 </Layout>

--- a/apps/kb/src/styles/globals.css
+++ b/apps/kb/src/styles/globals.css
@@ -72,3 +72,9 @@ h6:not(.font-mono),
 ::file-selector-button {
   border-color: var(--border-default, currentColor);
 }
+
+/* TEMPORARY UNTIL WE IMPLEMENT OUR OWN CODE COMPONENT */
+.prose pre code {
+  padding: 1rem;
+  display: inline-block;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -596,7 +596,7 @@ importers:
         version: 7.29.7(supports-color@8.1.1)
       '@graphiql/toolkit':
         specifier: ^0.9.1
-        version: 0.9.1(@types/node@22.13.14)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.21.3))(graphql@16.11.0)
+        version: 0.9.1(@types/node@22.13.14)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.21.0))(graphql@16.11.0)
       '@graphql-codegen/cli':
         specifier: 5.0.5
         version: 5.0.5(@parcel/watcher@2.5.6)(@types/node@22.13.14)(encoding@0.1.13)(graphql-sock@1.0.1(graphql@16.11.0))(graphql@16.11.0)(supports-color@8.1.1)(typescript@6.0.2)
@@ -677,7 +677,7 @@ importers:
         version: 13.2.2
       graphiql:
         specifier: ^4.0.2
-        version: 4.0.2(@codemirror/language@6.11.0)(@emotion/is-prop-valid@1.4.0)(@types/node@22.13.14)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.21.3))(graphql@16.11.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 4.0.2(@codemirror/language@6.11.0)(@emotion/is-prop-valid@1.4.0)(@types/node@22.13.14)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.21.0))(graphql@16.11.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
@@ -741,6 +741,9 @@ importers:
       astro:
         specifier: ^7.2.6
         version: 7.2.9(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@22.13.14)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.4.5))(ioredis@5.10.1(supports-color@8.1.1))(jiti@2.7.0)(sass@1.77.4)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0)
+      lucide-react:
+        specifier: '*'
+        version: 0.436.0(react@19.2.6)
       react:
         specifier: 'catalog:'
         version: 19.2.6
@@ -14714,10 +14717,6 @@ packages:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
 
-  mrmime@2.0.0:
-    resolution: {integrity: sha512-eu38+hdgojoyq63s+yTpN4XMBdt5l8HhMhc4VKLO9KM5caLIBvUm4thi7fFaxyTmCKeNnXZ5pAlBwCUnhA09uw==}
-    engines: {node: '>=10'}
-
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
@@ -20685,9 +20684,9 @@ snapshots:
 
   '@floating-ui/utils@0.2.9': {}
 
-  '@graphiql/plugin-doc-explorer@0.0.1(@codemirror/language@6.11.0)(@emotion/is-prop-valid@1.4.0)(@types/node@22.13.14)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.21.3))(graphql@16.11.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@graphiql/plugin-doc-explorer@0.0.1(@codemirror/language@6.11.0)(@emotion/is-prop-valid@1.4.0)(@types/node@22.13.14)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.21.0))(graphql@16.11.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@graphiql/react': 0.32.0(@codemirror/language@6.11.0)(@emotion/is-prop-valid@1.4.0)(@types/node@22.13.14)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.21.3))(graphql@16.11.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@graphiql/react': 0.32.0(@codemirror/language@6.11.0)(@emotion/is-prop-valid@1.4.0)(@types/node@22.13.14)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.21.0))(graphql@16.11.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@headlessui/react': 2.2.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       graphql: 16.11.0
       react: 19.2.6
@@ -20715,10 +20714,10 @@ snapshots:
       - immer
       - use-sync-external-store
 
-  '@graphiql/plugin-history@0.0.2(@codemirror/language@6.11.0)(@emotion/is-prop-valid@1.4.0)(@types/node@22.13.14)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.21.3))(graphql@16.11.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@graphiql/plugin-history@0.0.2(@codemirror/language@6.11.0)(@emotion/is-prop-valid@1.4.0)(@types/node@22.13.14)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.21.0))(graphql@16.11.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@graphiql/react': 0.32.0(@codemirror/language@6.11.0)(@emotion/is-prop-valid@1.4.0)(@types/node@22.13.14)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.21.3))(graphql@16.11.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@graphiql/toolkit': 0.11.3(@types/node@22.13.14)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.21.3))(graphql@16.11.0)
+      '@graphiql/react': 0.32.0(@codemirror/language@6.11.0)(@emotion/is-prop-valid@1.4.0)(@types/node@22.13.14)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.21.0))(graphql@16.11.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@graphiql/toolkit': 0.11.3(@types/node@22.13.14)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.21.0))(graphql@16.11.0)
       react: 19.2.6
       react-compiler-runtime: 19.1.0-rc.1(react@19.2.6)
       react-dom: 19.2.6(react@19.2.6)
@@ -20747,9 +20746,9 @@ snapshots:
       - immer
       - use-sync-external-store
 
-  '@graphiql/react@0.32.0(@codemirror/language@6.11.0)(@emotion/is-prop-valid@1.4.0)(@types/node@22.13.14)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.21.3))(graphql@16.11.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@graphiql/react@0.32.0(@codemirror/language@6.11.0)(@emotion/is-prop-valid@1.4.0)(@types/node@22.13.14)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.21.0))(graphql@16.11.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@graphiql/toolkit': 0.11.3(@types/node@22.13.14)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.21.3))(graphql@16.11.0)
+      '@graphiql/toolkit': 0.11.3(@types/node@22.13.14)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.21.0))(graphql@16.11.0)
       '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-dropdown-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-tooltip': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -20817,23 +20816,23 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@graphiql/toolkit@0.11.3(@types/node@22.13.14)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.21.3))(graphql@16.11.0)':
+  '@graphiql/toolkit@0.11.3(@types/node@22.13.14)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.21.0))(graphql@16.11.0)':
     dependencies:
       '@n1ru4l/push-pull-async-iterable-iterator': 3.2.0
       graphql: 16.11.0
       meros: 1.3.0(@types/node@22.13.14)
     optionalDependencies:
-      graphql-ws: 6.0.4(graphql@16.11.0)(ws@8.21.3)
+      graphql-ws: 6.0.4(graphql@16.11.0)(ws@8.21.0)
     transitivePeerDependencies:
       - '@types/node'
 
-  '@graphiql/toolkit@0.9.1(@types/node@22.13.14)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.21.3))(graphql@16.11.0)':
+  '@graphiql/toolkit@0.9.1(@types/node@22.13.14)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.21.0))(graphql@16.11.0)':
     dependencies:
       '@n1ru4l/push-pull-async-iterable-iterator': 3.2.0
       graphql: 16.11.0
       meros: 1.3.0(@types/node@22.13.14)
     optionalDependencies:
-      graphql-ws: 6.0.4(graphql@16.11.0)(ws@8.21.3)
+      graphql-ws: 6.0.4(graphql@16.11.0)(ws@8.21.0)
     transitivePeerDependencies:
       - '@types/node'
 
@@ -30306,11 +30305,11 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  graphiql@4.0.2(@codemirror/language@6.11.0)(@emotion/is-prop-valid@1.4.0)(@types/node@22.13.14)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.21.3))(graphql@16.11.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  graphiql@4.0.2(@codemirror/language@6.11.0)(@emotion/is-prop-valid@1.4.0)(@types/node@22.13.14)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.21.0))(graphql@16.11.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
-      '@graphiql/plugin-doc-explorer': 0.0.1(@codemirror/language@6.11.0)(@emotion/is-prop-valid@1.4.0)(@types/node@22.13.14)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.21.3))(graphql@16.11.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@graphiql/plugin-history': 0.0.2(@codemirror/language@6.11.0)(@emotion/is-prop-valid@1.4.0)(@types/node@22.13.14)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.21.3))(graphql@16.11.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@graphiql/react': 0.32.0(@codemirror/language@6.11.0)(@emotion/is-prop-valid@1.4.0)(@types/node@22.13.14)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.21.3))(graphql@16.11.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@graphiql/plugin-doc-explorer': 0.0.1(@codemirror/language@6.11.0)(@emotion/is-prop-valid@1.4.0)(@types/node@22.13.14)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.21.0))(graphql@16.11.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@graphiql/plugin-history': 0.0.2(@codemirror/language@6.11.0)(@emotion/is-prop-valid@1.4.0)(@types/node@22.13.14)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.21.0))(graphql@16.11.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@graphiql/react': 0.32.0(@codemirror/language@6.11.0)(@emotion/is-prop-valid@1.4.0)(@types/node@22.13.14)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.21.0))(graphql@16.11.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       graphql: 16.11.0
       react: 19.2.6
       react-compiler-runtime: 19.1.0-rc.1(react@19.2.6)
@@ -30408,13 +30407,6 @@ snapshots:
       graphql: 16.11.0
     optionalDependencies:
       ws: 8.21.0
-
-  graphql-ws@6.0.4(graphql@16.11.0)(ws@8.21.3):
-    dependencies:
-      graphql: 16.11.0
-    optionalDependencies:
-      ws: 8.21.3
-    optional: true
 
   graphql@16.11.0: {}
 
@@ -33085,8 +33077,6 @@ snapshots:
   motion-utils@12.9.4: {}
 
   mri@1.2.0: {}
-
-  mrmime@2.0.0: {}
 
   mrmime@2.0.1: {}
 
@@ -35996,7 +35986,7 @@ snapshots:
   sirv@3.0.2:
     dependencies:
       '@polka/url': 1.0.0-next.25
-      mrmime: 2.0.0
+      mrmime: 2.0.1
       totalist: 3.0.1
 
   sisteransi@1.0.5: {}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

In this PR we cover the basics for a simple guide page:
 - Set up _guides_ content collection, with schema definition.
 - Specific guides layout to be applied to all `content/guides` files.
 - Added support for multiple topics display on page.
 - Small fix to prevent menu navigation flash on theme change.
 
 _To test_
  - Open the `kb` preview
  - Go to `/kb/guides/sample-guide` ([link here](https://kb-git-jeremiasmenichelli-docs-1350-build-guide-df55d1-supabase.vercel.app/kb/guides/sample-guide))
  - Check the main content appears correctly

_Sample page_

<img width="786" height="6276" alt="Screenshot 2026-09-02 at 23-47-15 Markdown elements sample Supabase Knowledge Base" src="https://github.com/user-attachments/assets/509b399a-24fb-4ed1-8f23-cc3ceddf3090" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a documentation guides section with Markdown-based guide pages.
  - Guides now support titles, descriptions, topic badges, GitHub discussion links, images, code blocks, tables, lists, and other rich Markdown content.
  - Added page-specific titles and meta descriptions for improved navigation and sharing.
- **Style**
  - Updated navigation trigger styling for a transparent appearance.
  - Improved spacing and presentation of code blocks within guide content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->