### PR TITLE
fix(www): prevent State of Startups banner collision

### DIFF
--- a/apps/www/app/state-of-startups/components/StateOfStartupsAuroraHeader.tsx
+++ b/apps/www/app/state-of-startups/components/StateOfStartupsAuroraHeader.tsx
@@ -49,7 +49,7 @@ export function StateOfStartupsAuroraHeader() {
       />
 
       {/* Content — constrained to default container */}
-      <div className="relative z-10 max-w-240 mx-auto px-8 flex flex-col gap-4 justify-end pb-16 md:pb-18 min-h-[26rem] md:min-h-[50vh]">
+      <div className="relative z-10 max-w-240 mx-auto px-8 pt-36 md:pt-30 flex flex-col gap-4 justify-end pb-16 md:pb-18 min-h-[26rem] md:min-h-[50vh]">
         <p className="font-mono uppercase tracking-wide text-sm text-foreground-light">
           Supabase Presents
         </p>

--- a/apps/www/app/state-of-startups/components/StateOfStartupsAuroraHeader.tsx
+++ b/apps/www/app/state-of-startups/components/StateOfStartupsAuroraHeader.tsx
@@ -49,7 +49,7 @@ export function StateOfStartupsAuroraHeader() {
       />
 
       {/* Content — constrained to default container */}
-      <div className="relative z-10 max-w-240 mx-auto px-8 pt-36 md:pt-30 flex flex-col gap-4 justify-end pb-16 md:pb-18 min-h-[26rem] md:min-h-[50vh]">
+      <div className="relative z-10 max-w-240 mx-auto px-8 pt-40 md:pt-36 flex flex-col gap-4 justify-end pb-16 md:pb-18 min-h-[26rem] md:min-h-[50vh]">
         <p className="font-mono uppercase tracking-wide text-sm text-foreground-light">
           Supabase Presents
         </p>

--- a/apps/www/components/Nav/index.tsx
+++ b/apps/www/components/Nav/index.tsx
@@ -81,7 +81,7 @@ const Nav = ({ hideNavbar, stickyNavbar = true }: Props) => {
 
   return (
     <>
-      <AnnouncementBanner />
+      {!isStateOfStartupsPage && <AnnouncementBanner />}
       <div
         className={cn(
           'sticky top-0 z-40 transform',
@@ -91,6 +91,7 @@ const Nav = ({ hideNavbar, stickyNavbar = true }: Props) => {
         style={{ transform: 'translate3d(0,0,999px)' }}
         data-nav-transparent={isTransparent ? '' : undefined}
       >
+        {isStateOfStartupsPage && <AnnouncementBanner />}
         <div
           className={cn(
             'absolute inset-0 h-full w-full bg-background/90 dark:bg-background/95 transition-all duration-300',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

The Supabase Select 2026 announcement is rendered outside the fixed navigation stack on `/state-of-startups`, so the navigation overlaps the banner. At shorter viewport heights, the hero's viewport-based minimum height also lets its headline sit beneath the fixed banner and navigation.

## What is the new behavior?

On State of Startups routes, the announcement is rendered inside the fixed navigation stack. The hero content also reserves the stack's responsive height as its minimum top inset, keeping the headline clear when the viewport is short without shifting it at normal heights. Dismissing the banner moves the navigation back to the top without a hard-coded navigation offset. Other routes keep the existing announcement and sticky navigation layout.

| Before | After |
| --- | --- |
| <img width="1040" height="618" alt="State of Startups 2026  Supabase" src="https://github.com/user-attachments/assets/2dc42574-1485-465c-93b1-6690e44a26e4" /> | <img width="1040" height="618" alt="State of Startups 2026  Supabase" src="https://github.com/user-attachments/assets/626374cf-8a6b-4519-bbcd-21acfc822fa0" /> |

## To test

1. Open `/state-of-startups` on the deploy preview with the Supabase Select 2026 announcement visible.
2. Confirm the announcement sits above the navigation without overlap at desktop and mobile widths.
3. Reduce the viewport height to around 500px and confirm the State of Startups headline remains below the navigation.
4. Dismiss the announcement and confirm the navigation moves to the top of the viewport without leaving a gap.
5. Open another www route and confirm the announcement remains above the sticky navigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the announcement banner placement on State of Startups pages so it appears within the sticky navigation area.
  * Preserved the existing announcement banner placement on other pages.
  * Increased top spacing above the State of Startups header content across mobile and desktop layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->