### PR TITLE
Scoped PAT: ensure innaccessible resources are distinguishable

### DIFF
--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/ResourceAccessPills.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/ResourceAccessPills.tsx
@@ -14,31 +14,27 @@ export interface ResourceAccessPillItem {
 export const OrganizationAccessPill = ({
   slug,
   organization,
-  isInaccessible = false,
 }: {
   slug: string
   organization: OrganizationsData[number] | undefined
-  isInaccessible?: boolean
-}) => (
-  <div
-    className={cn(
-      'flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full border bg-surface-75 text-foreground-light px-3 py-1 text-xs',
-      isInaccessible ? 'border-destructive-500 text-destructive' : 'border-strong text-foreground'
-    )}
-  >
-    <Boxes size={14} strokeWidth={1.5} className="shrink-0 text-foreground-lighter" />
-    {organization?.name ?? slug}
-  </div>
-)
-
-export const ProjectAccessPill = ({
-  projectRef,
-  isInaccessible = false,
-}: {
-  projectRef: string
-  isInaccessible?: boolean
 }) => {
+  const isInaccessible = organization == null
+  return (
+    <div
+      className={cn(
+        'flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full border bg-surface-75 text-foreground-light px-3 py-1 text-xs',
+        isInaccessible ? 'border-destructive-500 text-destructive' : 'border-strong text-foreground'
+      )}
+    >
+      <Boxes size={14} strokeWidth={1.5} className="shrink-0 text-foreground-lighter" />
+      {organization?.name ?? slug}
+    </div>
+  )
+}
+
+export const ProjectAccessPill = ({ projectRef }: { projectRef: string }) => {
   const { data } = useProjectDetailQuery({ ref: projectRef })
+  const isInaccessible = data == null
   return (
     <div
       className={cn(

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/ResourceAccessPills.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/ResourceAccessPills.tsx
@@ -22,12 +22,12 @@ export const OrganizationAccessPill = ({
   return (
     <Badge
       variant={isInaccessible ? 'destructive' : 'default'}
-      className={cn('normal-case text-xs font-normal tracking-normal', {
+      className={cn('normal-case text-xs font-normal tracking-normal pr-2', {
         'border-destructive-500': isInaccessible,
         'text-foreground': !isInaccessible,
       })}
     >
-      <Box
+      <Boxes
         size={14}
         strokeWidth={1.5}
         className={cn('shrink-0', {
@@ -46,7 +46,7 @@ export const ProjectAccessPill = ({ projectRef }: { projectRef: string }) => {
   return (
     <Badge
       variant={isInaccessible ? 'destructive' : 'default'}
-      className={cn('normal-case text-xs font-normal tracking-normal', {
+      className={cn('normal-case text-xs font-normal tracking-normal pr-2', {
         'border-destructive-500': isInaccessible,
         'text-foreground': !isInaccessible,
       })}

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/ResourceAccessPills.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/ResourceAccessPills.tsx
@@ -27,7 +27,8 @@ export const OrganizationAccessPill = ({
       )}
     >
       <Boxes size={14} strokeWidth={1.5} className="shrink-0 text-foreground-lighter" />
-      {organization?.name ?? slug} <span className="sr-only">(innaccessible)</span>
+      {organization?.name ?? slug}{' '}
+      {isInaccessible ? <span className="sr-only">(innaccessible)</span> : null}
     </div>
   )
 }
@@ -43,7 +44,8 @@ export const ProjectAccessPill = ({ projectRef }: { projectRef: string }) => {
       )}
     >
       <Box size={14} strokeWidth={1.5} className="shrink-0 text-foreground-lighter" />
-      {data?.name ?? projectRef} <span className="sr-only">(innaccessible)</span>
+      {data?.name ?? projectRef}{' '}
+      {isInaccessible ? <span className="sr-only">(innaccessible)</span> : null}
     </div>
   )
 }

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/ResourceAccessPills.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/ResourceAccessPills.tsx
@@ -27,7 +27,7 @@ export const OrganizationAccessPill = ({
       )}
     >
       <Boxes size={14} strokeWidth={1.5} className="shrink-0 text-foreground-lighter" />
-      {organization?.name ?? slug}
+      {organization?.name ?? slug} <span className="sr-only">(innaccessible)</span>
     </div>
   )
 }
@@ -43,7 +43,7 @@ export const ProjectAccessPill = ({ projectRef }: { projectRef: string }) => {
       )}
     >
       <Box size={14} strokeWidth={1.5} className="shrink-0 text-foreground-lighter" />
-      {data?.name ?? projectRef}
+      {data?.name ?? projectRef} <span className="sr-only">(innaccessible)</span>
     </div>
   )
 }

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/ResourceAccessPills.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/ResourceAccessPills.tsx
@@ -35,7 +35,7 @@ export const OrganizationAccessPill = ({
         })}
       />
       {organization?.name ?? slug}
-      {isInaccessible ? <span> - revoked</span> : null}
+      {isInaccessible ? <span role="status"> - revoked</span> : null}
     </Badge>
   )
 }
@@ -59,7 +59,7 @@ export const ProjectAccessPill = ({ projectRef }: { projectRef: string }) => {
         })}
       />
       {project?.name ?? projectRef}
-      {isInaccessible ? <span> - revoked</span> : null}
+      {isInaccessible ? <span role="status"> - revoked</span> : null}
     </Badge>
   )
 }

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/ResourceAccessPills.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/ResourceAccessPills.tsx
@@ -1,6 +1,6 @@
 import { Box, Boxes } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
-import { cn } from 'ui'
+import { Badge, cn } from 'ui'
 
 import { OrganizationsData } from '@/data/organizations/organizations-query'
 import { useProjectDetailQuery } from '@/data/projects/project-detail-query'
@@ -20,33 +20,47 @@ export const OrganizationAccessPill = ({
 }) => {
   const isInaccessible = organization == null
   return (
-    <div
-      className={cn(
-        'flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full border bg-surface-75 text-foreground-light px-3 py-1 text-xs',
-        isInaccessible ? 'border-destructive-500 text-destructive' : 'border-strong text-foreground'
-      )}
+    <Badge
+      variant={isInaccessible ? 'destructive' : 'default'}
+      className={cn('normal-case text-xs font-normal tracking-normal', {
+        'border-destructive-500': isInaccessible,
+        'text-foreground': !isInaccessible,
+      })}
     >
-      <Boxes size={14} strokeWidth={1.5} className="shrink-0 text-foreground-lighter" />
-      {organization?.name ?? slug}{' '}
-      {isInaccessible ? <span className="sr-only">(innaccessible)</span> : null}
-    </div>
+      <Box
+        size={14}
+        strokeWidth={1.5}
+        className={cn('shrink-0', {
+          'text-foreground-lighter': !isInaccessible,
+        })}
+      />
+      {organization?.name ?? slug}
+      {isInaccessible ? <span> - revoked</span> : null}
+    </Badge>
   )
 }
 
 export const ProjectAccessPill = ({ projectRef }: { projectRef: string }) => {
-  const { data, isPending } = useProjectDetailQuery({ ref: projectRef })
-  const isInaccessible = data == null && !isPending
+  const { data: project, isPending } = useProjectDetailQuery({ ref: projectRef })
+  const isInaccessible = project == null && !isPending
   return (
-    <div
-      className={cn(
-        'flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full border bg-surface-75 text-foreground-light px-3 py-1 text-xs',
-        isInaccessible ? 'border-destructive-500 text-destructive' : 'border-strong text-foreground'
-      )}
+    <Badge
+      variant={isInaccessible ? 'destructive' : 'default'}
+      className={cn('normal-case text-xs font-normal tracking-normal', {
+        'border-destructive-500': isInaccessible,
+        'text-foreground': !isInaccessible,
+      })}
     >
-      <Box size={14} strokeWidth={1.5} className="shrink-0 text-foreground-lighter" />
-      {data?.name ?? projectRef}{' '}
-      {isInaccessible ? <span className="sr-only">(innaccessible)</span> : null}
-    </div>
+      <Box
+        size={14}
+        strokeWidth={1.5}
+        className={cn('shrink-0', {
+          'text-foreground-lighter': !isInaccessible,
+        })}
+      />
+      {project?.name ?? projectRef}
+      {isInaccessible ? <span> - revoked</span> : null}
+    </Badge>
   )
 }
 

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/ResourceAccessPills.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/ResourceAccessPills.tsx
@@ -33,8 +33,8 @@ export const OrganizationAccessPill = ({
 }
 
 export const ProjectAccessPill = ({ projectRef }: { projectRef: string }) => {
-  const { data } = useProjectDetailQuery({ ref: projectRef })
-  const isInaccessible = data == null
+  const { data, isPending } = useProjectDetailQuery({ ref: projectRef })
+  const isInaccessible = data == null && !isPending
   return (
     <div
       className={cn(


### PR DESCRIPTION
## Problem

When users don't have access to some resources targeted by a token, we show those resources slugs or refs. However, they are not distinguishable enough.

## Solution

- Make them distinguishable by applying the _destructive_ color
- Cleaned up unused code (`isInaccessible` prop wasn't used anymore after last refactoring but we forgot to remove it)

## How to test

1. Invite another user to one of your projects
2. As this other user, create a scoped pat targeting the project
3. As the initial user, remove the invited user from the project
4. As the invited user, check the token permissions: you should see an admonition at the top and the project should be displayed in red with only its ref (not its name)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Access token resource indicators now accurately show when an organization or project is inaccessible.
  - Inaccessible resources are clearly labeled as “revoked,” reducing ambiguity about their access status.

- **Style**
  - Organization and project access indicators now use consistent badge styling, spacing, and icon treatments.

- **Accessibility**
  - Revoked status messages are now announced more clearly to assistive technologies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->