### PR TITLE
fix(docs): table bottom border color missing

### DIFF
--- a/packages/config/typography.config.js
+++ b/packages/config/typography.config.js
@@ -114,7 +114,7 @@ module.exports = {
               border: '1px solid var(--border-default)',
               borderRadius: 'var(--radius-lg)',
             },
-            td: {
+            'tbody tr:not(:last-child) td': {
               borderBottom: '1px solid var(--background-surface-200)',
             },
             code: {


### PR DESCRIPTION
## What kind of change does this PR introduce?

bug fix on table ui in docs

## What is the current behavior?

currently a recent change in [#47288](https://github.com/supabase/supabase/pull/47288/changes#diff-57e15cf799459c10344c86d8ec797a16f0d3e824386e85552cb653594f7e616aR118) made table bottom border color dimmed down vs others.

## What is the new behavior?

- fixes bottom border by targeting only border within the table (if that was the initial intent?)

| state | preview |
| -------|------|
| before | <img width="787" height="320" alt="image" src="https://github.com/user-attachments/assets/70eac743-255d-4848-9488-752e91a8793e" /> |
| after | <img width="787" height="320" alt="image" src="https://github.com/user-attachments/assets/e307dc33-6247-4f36-89d0-75d1eb1aef4e" /> | 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined table styling so bottom borders appear only between body rows, removing the border from the final row.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->