### PR TITLE
feat(kb): Apply supabase theme to code blocks

### DIFF
--- a/apps/kb/astro.config.mjs
+++ b/apps/kb/astro.config.mjs
@@ -6,6 +6,8 @@ import react from '@astrojs/react'
 import tailwindcss from '@tailwindcss/vite'
 import { defineConfig } from 'astro/config'
 
+import supabaseTheme from '../learn/lib/themes/supabase-2.json' with { type: 'json' }
+
 // Absolute dir of lodash-es, for the SSR-only lodash alias below (same fix
 // apps/studio/vite.config.ts uses). `packages/ui`'s clipboard util does
 // `import { noop } from 'lodash'` — under Vite's dev-mode SSR module runner,
@@ -44,5 +46,24 @@ export default defineConfig({
       noExternal: ['lodash'],
     },
     plugins: [tailwindcss(), ssrLodashEs],
+  },
+  markdown: {
+    shikiConfig: {
+      theme: supabaseTheme,
+      // Match the docs app's CodeBlock component (border + rounded-lg on the
+      // outer element), since Astro's own markdown pipeline renders code
+      // blocks straight to a `<pre>` with no wrapper we can add classes to.
+      transformers: [
+        {
+          name: 'kb-code-block-classes',
+          pre(node) {
+            this.addClassToHast(node, 'border border-default rounded-lg')
+          },
+          code(node) {
+            this.addClassToHast(node, 'inline-block p-6')
+          },
+        },
+      ],
+    },
   },
 })

--- a/apps/kb/src/styles/globals.css
+++ b/apps/kb/src/styles/globals.css
@@ -105,4 +105,3 @@ h6:not(.font-mono),
   --code-token-property: #15593b;
   --code-highlight-color: #1c1c1c;
 }
-

--- a/apps/kb/src/styles/globals.css
+++ b/apps/kb/src/styles/globals.css
@@ -73,8 +73,36 @@ h6:not(.font-mono),
   border-color: var(--border-default, currentColor);
 }
 
-/* TEMPORARY UNTIL WE IMPLEMENT OUR OWN CODE COMPONENT */
-.prose pre code {
-  padding: 1rem;
-  display: inline-block;
+/* Code block theme colors for use with Supabase Theme */
+[data-theme='dark'] {
+  --code-token-keyword: #bda4ff;
+  --code-foreground: #ffffff;
+  --code-token-constant: #3ecf8e;
+  --code-token-string: #ffcda1;
+  --code-token-comment: #949494;
+  --code-token-parameter: #ffffff;
+  --code-token-function: #3ecf8e;
+  --code-token-string-expression: #ffcda1;
+  --code-token-punctuation: #ffffff;
+  --code-token-link: #ffffff;
+  --code-token-number: #ffffff;
+  --code-token-property: #3ecf8e;
+  --code-highlight-color: #232323;
 }
+
+[data-theme='light'] {
+  --code-token-keyword: #5f2fc4;
+  --code-foreground: oklch(from var(--foreground-light) l c h / 1);
+  --code-token-constant: #15593b;
+  --code-token-string: #9a5200;
+  --code-token-comment: #6a6a6a;
+  --code-token-parameter: oklch(from var(--foreground-light) l c h / 1);
+  --code-token-function: #15593b;
+  --code-token-string-expression: #9a5200;
+  --code-token-punctuation: oklch(from var(--foreground-light) l c h / 1);
+  --code-token-link: oklch(from var(--foreground-light) l c h / 1);
+  --code-token-number: oklch(from var(--foreground-light) l c h / 1);
+  --code-token-property: #15593b;
+  --code-highlight-color: #1c1c1c;
+}
+


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Adding Supabase Theme highlighting to code blocks in KB.

Astro supports Shiki out-of-the-box which makes things really easy in this case.

_Light_
<img width="1440" height="340" alt="Screen Shot 2026-09-03 at 15 01 59" src="https://github.com/user-attachments/assets/0e49fd5b-1008-4063-9e1e-979e8c71de8f" />

_Dark_
<img width="1440" height="340" alt="Screen Shot 2026-09-03 at 15 02 09" src="https://github.com/user-attachments/assets/b9e9fd70-1b2f-470b-92a2-a7de61cf645b" />

To test:
 - Go to the preview of KB site
 - Open the `/kb/guides/sample-guide` route
 - Check the code blocks present have the Supabase Theme applied.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved code block syntax highlighting with dedicated dark and light theme colors.
  - Code examples now better match the selected site theme for improved readability.
  - Updated code block styling for a more consistent presentation across the knowledge base.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->