### PR TITLE
fix(docs): keep code block line numbers sticky while scrolling

### DIFF
--- a/apps/docs/features/ui/CodeBlock/CodeBlock.client.tsx
+++ b/apps/docs/features/ui/CodeBlock/CodeBlock.client.tsx
@@ -99,6 +99,7 @@ function CrossfadeIcon({
     cn(
       'absolute inset-0 m-auto text-lighter group-hover/btn:text-foreground',
       'transition-[opacity,scale,filter,color] duration-300 [transition-timing-function:cubic-bezier(0.2,0,0,1)]',
+      'motion-reduce:transition-none',
       shown ? 'opacity-100 scale-100 blur-none' : 'opacity-0 scale-[0.25] blur-[4px]'
     )
 

--- a/apps/docs/features/ui/CodeBlock/CodeBlock.client.tsx
+++ b/apps/docs/features/ui/CodeBlock/CodeBlock.client.tsx
@@ -1,12 +1,10 @@
 'use client'
 
-import { ArrowRightFromLine, Check, Copy, WrapText } from 'lucide-react'
+import { ArrowRightFromLine, Check, Copy, WrapText, type LucideIcon } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState, type MouseEvent } from 'react'
 import { type ThemedToken } from 'shiki'
 import { type NodeHover } from 'twoslash'
-import { cn, copyToClipboard, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
-
-import { getFontStyle } from './CodeBlock.utils'
+import { Button, cn, copyToClipboard, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 
 export function AnnotatedSpan({
   token,
@@ -88,8 +86,39 @@ function Annotation({ annotation }: { annotation: NodeHover }) {
   )
 }
 
+function CrossfadeIcon({
+  active,
+  activeIcon: ActiveIcon,
+  inactiveIcon: InactiveIcon,
+}: {
+  active: boolean
+  activeIcon: LucideIcon
+  inactiveIcon: LucideIcon
+}) {
+  const iconClass = (shown: boolean) =>
+    cn(
+      'absolute inset-0 m-auto text-lighter group-hover/btn:text-foreground',
+      'transition-[opacity,scale,filter,color] duration-300 [transition-timing-function:cubic-bezier(0.2,0,0,1)]',
+      shown ? 'opacity-100 scale-100 blur-none' : 'opacity-0 scale-[0.25] blur-[4px]'
+    )
+
+  return (
+    <span className="relative block size-3.5">
+      <ActiveIcon size={14} aria-hidden="true" className={iconClass(active)} />
+      <InactiveIcon size={14} aria-hidden="true" className={iconClass(!active)} />
+    </span>
+  )
+}
+
 export function CodeCopyButton({ className, content }: { className?: string; content: string }) {
   const [copied, setCopied] = useState(false)
+
+  useEffect(() => {
+    if (!copied) return
+
+    const timeout = window.setTimeout(() => setCopied(false), 2000)
+    return () => window.clearTimeout(timeout)
+  }, [copied])
 
   const handleCopy = async () => {
     copyToClipboard(content, () => {
@@ -108,26 +137,23 @@ export function CodeCopyButton({ className, content }: { className?: string; con
       </span>
       <Tooltip>
         <TooltipTrigger asChild>
-          <button
+          <Button
+            variant="outline"
             tabIndex={0}
             onClick={handleCopy}
             onBlur={resetStatus}
             className={cn(
-              'cursor-pointer border rounded-md p-1',
-              copied && 'bg-selection',
-              'hover:bg-selection transition',
+              'group/btn size-6 p-1 cursor-pointer bg-200 hover:border-strong',
+              copied && 'bg-[var(--btn-active)]',
+              'hover:bg-[var(--btn-active)]',
               className
             )}
             aria-label="Copy code"
             // Tooltip repeats the label; the description would read the name twice
             aria-describedby={undefined}
           >
-            {copied ? (
-              <Check size={14} className="text-lighter" />
-            ) : (
-              <Copy size={14} className="text-lighter" />
-            )}
-          </button>
+            <CrossfadeIcon active={copied} activeIcon={Check} inactiveIcon={Copy} />
+          </Button>
         </TooltipTrigger>
         <TooltipContent>Copy code</TooltipContent>
       </Tooltip>
@@ -159,27 +185,34 @@ export function CodeBlockControls({ content }: { content: string }) {
   return (
     <div
       ref={wrapperRef}
-      className="opacity-0 flex group-hover:opacity-100 group-focus-within:opacity-100 absolute top-2 right-2 gap-1"
+      className={cn(
+        'opacity-0 flex group-hover:opacity-100 group-focus-within:opacity-100 absolute top-[9.5px] right-[9.5px] gap-1',
+        '[--btn-active:color-mix(in_srgb,var(--foreground)_4%,var(--background-200))]'
+      )}
     >
       <span className="sr-only" aria-live="polite">
         {wrapStatus}
       </span>
       <Tooltip>
         <TooltipTrigger asChild>
-          <button
+          <Button
+            variant="outline"
             tabIndex={0}
             onClick={toggleWrap}
-            className={cn('cursor-pointer border rounded-md p-1', 'hover:bg-selection transition')}
+            className={cn(
+              'group/btn size-6 p-1 cursor-pointer bg-200 hover:border-strong',
+              'hover:bg-[var(--btn-active)]'
+            )}
             aria-label={isWrapped ? 'Disable word wrap' : 'Enable word wrap'}
             // Tooltip repeats the label; the description would read the name twice
             aria-describedby={undefined}
           >
-            {isWrapped ? (
-              <ArrowRightFromLine size={14} className="text-lighter" />
-            ) : (
-              <WrapText size={14} className="text-lighter" />
-            )}
-          </button>
+            <CrossfadeIcon
+              active={isWrapped}
+              activeIcon={ArrowRightFromLine}
+              inactiveIcon={WrapText}
+            />
+          </Button>
         </TooltipTrigger>
         <TooltipContent>{isWrapped ? 'Disable word wrap' : 'Enable word wrap'}</TooltipContent>
       </Tooltip>

--- a/apps/docs/features/ui/CodeBlock/CodeBlock.tsx
+++ b/apps/docs/features/ui/CodeBlock/CodeBlock.tsx
@@ -1,4 +1,4 @@
-import { Fragment, type PropsWithChildren } from 'react'
+import { type PropsWithChildren } from 'react'
 import { bundledLanguages, createHighlighter, type BundledLanguage, type ThemedToken } from 'shiki'
 import { createTwoslasher, type ExtraFiles, type NodeHover } from 'twoslash'
 import { cn } from 'ui'
@@ -64,7 +64,7 @@ export async function CodeBlock({
         'not-prose',
         'w-full',
         'border border-default rounded-lg',
-        'bg-200',
+        'bg-200 shadow-codeblock',
         'text-sm',
         className
       )}
@@ -72,7 +72,7 @@ export async function CodeBlock({
       <div
         className={cn(
           'code-scroll',
-          'w-full overflow-x-auto rounded-lg',
+          'w-full overflow-x-auto overscroll-x-none rounded-lg',
           'focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring'
         )}
         role="group"
@@ -81,33 +81,40 @@ export async function CodeBlock({
         tabIndex={0}
       >
         <pre>
-          <code className={lineNumbers ? 'grid grid-cols-[auto_1fr]' : ''}>
+          <code
+            className={cn(
+              lineNumbers && 'grid grid-cols-[auto_1fr] w-fit min-w-full py-3',
+              '[--row-rest:var(--background-200)]',
+              '[--row-hover:color-mix(in_srgb,var(--foreground)_3%,var(--background-200))]'
+            )}
+          >
             {lineNumbers ? (
-              <>
-                {tokens.map((line, idx) => (
-                  <Fragment key={idx}>
-                    <div
-                      aria-hidden="true"
-                      className={cn(
-                        'select-none text-right text-muted bg-control px-2 min-h-5 leading-5',
-                        idx === 0 && 'pt-6',
-                        idx === tokens.length - 1 && 'pb-6'
-                      )}
-                    >
-                      {idx + 1}
-                    </div>
-                    <div
-                      className={cn(
-                        'code-content min-h-5 leading-5 pl-6 pr-6',
-                        idx === 0 && 'pt-6',
-                        idx === tokens.length - 1 && 'pb-6'
-                      )}
-                    >
-                      <CodeLine tokens={line} twoslash={twoslashed?.get(idx)} />
-                    </div>
-                  </Fragment>
-                ))}
-              </>
+              tokens.map((line, idx) => (
+                <div key={idx} className="group/row contents">
+                  <div
+                    aria-hidden="true"
+                    className={cn(
+                      'select-none text-right text-muted/70 pl-3 pr-2 min-h-5 leading-5',
+                      'bg-[var(--row-rest)]',
+                      'sticky left-0 z-10',
+                      'group-hover/row:text-muted group-hover/row:bg-[var(--row-hover)]',
+                      'after:pointer-events-none after:absolute after:inset-y-0 after:left-full after:w-4',
+                      '[--gutter-fade:var(--row-rest)] group-hover/row:[--gutter-fade:var(--row-hover)]',
+                      'after:bg-[image:linear-gradient(to_right,var(--gutter-fade)_0%,color-mix(in_srgb,var(--gutter-fade)_85%,transparent)_25%,color-mix(in_srgb,var(--gutter-fade)_50%,transparent)_50%,color-mix(in_srgb,var(--gutter-fade)_15%,transparent)_75%,transparent_100%)]'
+                    )}
+                  >
+                    {idx + 1}
+                  </div>
+                  <div
+                    className={cn(
+                      'code-content min-h-5 leading-5 pl-3 pr-18',
+                      'group-hover/row:bg-[var(--row-hover)]'
+                    )}
+                  >
+                    <CodeLine tokens={line} twoslash={twoslashed?.get(idx)} />
+                  </div>
+                </div>
+              ))
             ) : (
               <div className="code-content p-6">
                 {tokens.map((line, idx) => (

--- a/apps/docs/styles/globals.css
+++ b/apps/docs/styles/globals.css
@@ -433,6 +433,8 @@ th code {
   --code-token-number: #ffffff;
   --code-token-property: #3ecf8e;
   --code-highlight-color: #232323;
+  --shadow-codeblock:
+    0 0 0 0 var(--border-default), 0 1px 2px 0 rgba(0, 0, 0, 0.3), 0 1px 3px 0 rgba(0, 0, 0, 0.3);
 }
 [data-theme='light'],
 .light {
@@ -459,4 +461,8 @@ th code {
 .shiki[data-wrapped='true'] .code-content {
   white-space: pre-wrap !important;
   word-break: break-word !important;
+}
+
+.shadow-codeblock {
+  box-shadow: var(--shadow-codeblock, none);
 }

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -20,7 +20,8 @@ const buttonVariants = cva(
   ease-out
   duration-200
   rounded-md
-  transition-colors
+  transition-[background-color,border-color,color,scale]
+  motion-safe:active:scale-[0.97]
   focus-ring
   border
   `,


### PR DESCRIPTION
## What kind of change does this PR introduce?

bug fix + some ui polish on the docs code block

## What is the current behavior?

line numbers scroll away with the code _ so you lose your place in any block wide enough to scroll _ the gutter is also see-through so scrolled code renders interleaved with the numbers

## What is the new behavior?

- makes gutter sticky and stays pinned while the code scrolls (no rubber)
- fixes gutter, row hover, and button backgrounds as opaque so nothing bleeds through
- adds gutter right edge fades vs bg
- adds right padding so line endings clear the buttons
- adds press feedback on the shared in-house `Button` gated behind `motion-safe`

| state | preview |
| -------|------|
| before | <img width="566" height="263" alt="image" src="https://github.com/user-attachments/assets/81778815-1f15-4ea5-a647-ed48418210e8" /> |
| after | <img width="566" height="259" alt="image" src="https://github.com/user-attachments/assets/b7d770c5-4156-491f-93c8-b0d900b7dc85" /> | 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Refined code block controls with consistent styling, active states, animated icons, and automatic copy-status reset.
  * Improved code block line-number presentation with hover effects, sticky gutters, spacing, shadows, and smoother horizontal scrolling.
  * Added smoother button transitions and a subtle pressed-state animation.
  * Respect reduced-motion preferences by disabling icon animations when requested.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->