### PR TITLE
feat(studio): additional events for scoped pat telemetry

### DIFF
--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/NewScopedTokenSuccess.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/NewScopedTokenSuccess.tsx
@@ -9,33 +9,27 @@ import { useTrack } from '@/lib/telemetry/track'
 interface TokenSuccessProps {
   tokenName: string
   tokenValue: string
-  tokenType: 'classic' | 'scoped'
   onClose: () => void
 }
 
-export const NewScopedTokenSuccess = ({
-  tokenName,
-  tokenValue,
-  tokenType,
-  onClose,
-}: TokenSuccessProps) => {
+export const NewScopedTokenSuccess = ({ tokenName, tokenValue, onClose }: TokenSuccessProps) => {
   const track = useTrack()
   const [keyCopied, setKeyCopied] = useState(false)
   const [hasCopiedToken, setHasCopiedToken] = useState(false)
 
   const handleCopy = () => {
     setHasCopiedToken(true)
-    track('access_token_copied', { tokenType })
+    track('access_token_copied', { tokenType: 'scoped' })
     toast.success('Token copied to clipboard')
   }
 
   const handleAcknowledge = (isChecked: boolean) => {
     setKeyCopied(isChecked)
-    track('access_token_stored_checkbox_clicked', { tokenType, isChecked })
+    track('access_token_stored_checkbox_clicked', { tokenType: 'scoped', isChecked })
   }
 
   const handleDone = () => {
-    track('access_token_done_button_clicked', { tokenType, hasCopiedToken })
+    track('access_token_done_button_clicked', { tokenType: 'scoped', hasCopiedToken })
     onClose()
   }
 

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/NewScopedTokenSuccess.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/NewScopedTokenSuccess.tsx
@@ -9,27 +9,33 @@ import { useTrack } from '@/lib/telemetry/track'
 interface TokenSuccessProps {
   tokenName: string
   tokenValue: string
+  tokenType: 'classic' | 'scoped'
   onClose: () => void
 }
 
-export const NewScopedTokenSuccess = ({ tokenName, tokenValue, onClose }: TokenSuccessProps) => {
+export const NewScopedTokenSuccess = ({
+  tokenName,
+  tokenValue,
+  tokenType,
+  onClose,
+}: TokenSuccessProps) => {
   const track = useTrack()
   const [keyCopied, setKeyCopied] = useState(false)
   const [hasCopiedToken, setHasCopiedToken] = useState(false)
 
   const handleCopy = () => {
     setHasCopiedToken(true)
-    track('access_token_copied', { tokenType: 'scoped' })
+    track('access_token_copied', { tokenType })
     toast.success('Token copied to clipboard')
   }
 
   const handleAcknowledge = (isChecked: boolean) => {
     setKeyCopied(isChecked)
-    track('access_token_stored_checkbox_clicked', { tokenType: 'scoped', isChecked })
+    track('access_token_stored_checkbox_clicked', { tokenType, isChecked })
   }
 
   const handleDone = () => {
-    track('access_token_done_button_clicked', { tokenType: 'scoped', hasCopiedToken })
+    track('access_token_done_button_clicked', { tokenType, hasCopiedToken })
     onClose()
   }
 

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/NewScopedTokenSuccess.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/NewScopedTokenSuccess.tsx
@@ -4,14 +4,40 @@ import { Button, Checkbox, ScrollArea, SheetFooter } from 'ui'
 import { Admonition } from 'ui-patterns/Admonition'
 import { Input } from 'ui-patterns/DataInputs/Input'
 
+import { useTrack } from '@/lib/telemetry/track'
+
 interface TokenSuccessProps {
   tokenName: string
   tokenValue: string
+  tokenType: 'classic' | 'scoped'
   onClose: () => void
 }
 
-export const NewScopedTokenSuccess = ({ tokenName, tokenValue, onClose }: TokenSuccessProps) => {
+export const NewScopedTokenSuccess = ({
+  tokenName,
+  tokenValue,
+  tokenType,
+  onClose,
+}: TokenSuccessProps) => {
+  const track = useTrack()
   const [keyCopied, setKeyCopied] = useState(false)
+  const [hasCopiedToken, setHasCopiedToken] = useState(false)
+
+  const handleCopy = () => {
+    setHasCopiedToken(true)
+    track('access_token_copied', { tokenType })
+    toast.success('Token copied to clipboard')
+  }
+
+  const handleAcknowledge = (isChecked: boolean) => {
+    setKeyCopied(isChecked)
+    track('access_token_stored_checkbox_clicked', { tokenType, isChecked })
+  }
+
+  const handleDone = () => {
+    track('access_token_done_button_clicked', { tokenType, hasCopiedToken })
+    onClose()
+  }
 
   return (
     <>
@@ -33,7 +59,7 @@ export const NewScopedTokenSuccess = ({ tokenName, tokenValue, onClose }: TokenS
             value={tokenValue}
             onChange={() => {}}
             aria-label={`${tokenName} token`}
-            onCopy={() => toast.success('Token copied to clipboard')}
+            onCopy={handleCopy}
           />
 
           <Admonition
@@ -46,7 +72,7 @@ export const NewScopedTokenSuccess = ({ tokenName, tokenValue, onClose }: TokenS
               <Checkbox
                 id="key-copied"
                 checked={keyCopied}
-                onCheckedChange={(v) => setKeyCopied(Boolean(v))}
+                onCheckedChange={(v) => handleAcknowledge(Boolean(v))}
               />
               <span className="text-sm text-warning cursor-pointer select-none">
                 I have copied the key and stored it securely
@@ -56,7 +82,7 @@ export const NewScopedTokenSuccess = ({ tokenName, tokenValue, onClose }: TokenS
         </div>
       </ScrollArea>
       <SheetFooter className="mt-auto flex w-full items-center justify-between! border-t py-4">
-        <Button className="ml-auto" disabled={!keyCopied} onClick={onClose}>
+        <Button className="ml-auto" disabled={!keyCopied} onClick={handleDone}>
           Done
         </Button>
       </SheetFooter>

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/NewScopedTokenSheet.test.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/NewScopedTokenSheet.test.tsx
@@ -235,8 +235,17 @@ describe('NewScopedTokenSheet', () => {
     await waitFor(async () =>
       expect(await window.navigator.clipboard.readText()).toEqual('a_token_value')
     )
+    expect(mockTrack).toHaveBeenCalledWith('access_token_copied', { tokenType: 'scoped' })
     fireEvent.click(await screen.findByLabelText('I have copied the key and stored it securely'))
+    expect(mockTrack).toHaveBeenCalledWith('access_token_stored_checkbox_clicked', {
+      tokenType: 'scoped',
+      isChecked: true,
+    })
     fireEvent.click(await screen.findByRole('button', { name: 'Done' }))
+    expect(mockTrack).toHaveBeenCalledWith('access_token_done_button_clicked', {
+      tokenType: 'scoped',
+      hasCopiedToken: true,
+    })
     // Dialog has been closed
     await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
   }, 10_000)
@@ -451,8 +460,13 @@ describe('NewScopedTokenSheet', () => {
       expiryPreset: '7d',
       resourceAccess: 'account',
     })
+    expect(mockTrack).toHaveBeenCalledWith('access_token_copied', { tokenType: 'classic' })
     fireEvent.click(await screen.findByLabelText('I have copied the key and stored it securely'))
     fireEvent.click(await screen.findByRole('button', { name: 'Done' }))
+    expect(mockTrack).toHaveBeenCalledWith('access_token_done_button_clicked', {
+      tokenType: 'classic',
+      hasCopiedToken: true,
+    })
     // Dialog has been closed
     await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
   })

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/NewScopedTokenSheet.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/NewScopedTokenSheet.tsx
@@ -106,10 +106,12 @@ export const NewScopedTokenSheet = ({ onCreateExperimentalToken }: NewScopedToke
   // as we need to make sure they copied the new token first
   const handleOpenChange = (open: boolean, isSafe = false) => {
     if (open === false && step === 'success' && !isSafe) return
-    track('access_token_creation_sheet_closed', {
-      tokenType: 'scoped',
-      step,
-    })
+    if (open === false) {
+      track('access_token_creation_sheet_closed', {
+        tokenType: 'scoped',
+        step,
+      })
+    }
     setStep('form')
     setIsOpen(open)
   }

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/NewScopedTokenSheet.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/NewScopedTokenSheet.tsx
@@ -106,6 +106,10 @@ export const NewScopedTokenSheet = ({ onCreateExperimentalToken }: NewScopedToke
   // as we need to make sure they copied the new token first
   const handleOpenChange = (open: boolean, isSafe = false) => {
     if (open === false && step === 'success' && !isSafe) return
+    track('access_token_creation_sheet_closed', {
+      tokenType: 'scoped',
+      step,
+    })
     setStep('form')
     setIsOpen(open)
   }
@@ -139,7 +143,6 @@ export const NewScopedTokenSheet = ({ onCreateExperimentalToken }: NewScopedToke
           <NewScopedTokenSuccess
             tokenName={createdToken.token.name}
             tokenValue={createdToken.token.token}
-            tokenType={createdToken.tokenType}
             onClose={() => handleOpenChange(false, true)}
           />
         ) : (

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/NewScopedTokenSheet.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/NewScopedTokenSheet.tsx
@@ -42,12 +42,15 @@ export const NewScopedTokenSheet = ({ onCreateExperimentalToken }: NewScopedToke
 
   const [step, setStep] = useState<'form' | 'success'>('form')
   const [createdToken, setCreatedToken] = useState<
-    NewScopedAccessToken | NewAccessToken | undefined
+    { token: NewScopedAccessToken | NewAccessToken; tokenType: 'classic' | 'scoped' } | undefined
   >()
 
-  const showCreatedToken = (data: NewScopedAccessToken | NewAccessToken) => {
+  const showCreatedToken = (
+    data: NewScopedAccessToken | NewAccessToken,
+    tokenType: 'classic' | 'scoped'
+  ) => {
     toast.success('Access token created successfully')
-    setCreatedToken(data)
+    setCreatedToken({ token: data, tokenType })
     setStep('success')
   }
 
@@ -66,7 +69,7 @@ export const NewScopedTokenSheet = ({ onCreateExperimentalToken }: NewScopedToke
               expiryPreset: values.expiresAt,
               resourceAccess: 'account',
             })
-            showCreatedToken(data)
+            showCreatedToken(data, 'classic')
           },
         }
       )
@@ -94,7 +97,7 @@ export const NewScopedTokenSheet = ({ onCreateExperimentalToken }: NewScopedToke
           resourceAccess: values.resourceAccess,
           permissionCount: permissions.length,
         })
-        showCreatedToken(data)
+        showCreatedToken(data, 'scoped')
       },
     })
   }
@@ -134,8 +137,9 @@ export const NewScopedTokenSheet = ({ onCreateExperimentalToken }: NewScopedToke
         </SheetHeader>
         {step === 'success' && createdToken ? (
           <NewScopedTokenSuccess
-            tokenName={createdToken.name}
-            tokenValue={createdToken.token}
+            tokenName={createdToken.token.name}
+            tokenValue={createdToken.token.token}
+            tokenType={createdToken.tokenType}
             onClose={() => handleOpenChange(false, true)}
           />
         ) : (

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/NewScopedTokenSheet.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/NewScopedTokenSheet.tsx
@@ -107,7 +107,7 @@ export const NewScopedTokenSheet = ({ onCreateExperimentalToken }: NewScopedToke
   const handleOpenChange = (open: boolean, isSafe = false) => {
     if (open === false && step === 'success' && !isSafe) return
     if (open === false) {
-      track('access_token_creation_sheet_closed', {
+      track('access_token_creation_sheet_dismissed', {
         // Can be non when users closes the sheet without completing the token creation
         tokenType: createdToken?.tokenType ?? 'none',
         step,

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/NewScopedTokenSheet.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/NewScopedTokenSheet.tsx
@@ -108,7 +108,8 @@ export const NewScopedTokenSheet = ({ onCreateExperimentalToken }: NewScopedToke
     if (open === false && step === 'success' && !isSafe) return
     if (open === false) {
       track('access_token_creation_sheet_closed', {
-        tokenType: 'scoped',
+        // Can be non when users closes the sheet without completing the token creation
+        tokenType: createdToken?.tokenType ?? 'none',
         step,
       })
     }
@@ -145,6 +146,7 @@ export const NewScopedTokenSheet = ({ onCreateExperimentalToken }: NewScopedToke
           <NewScopedTokenSuccess
             tokenName={createdToken.token.name}
             tokenValue={createdToken.token.token}
+            tokenType={createdToken.tokenType}
             onClose={() => handleOpenChange(false, true)}
           />
         ) : (

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -3543,7 +3543,7 @@ export interface AccessTokenCreatedEvent {
 export interface AccessTokenCreationSheetClosedEvent {
   action: 'access_token_creation_sheet_closed'
   properties: {
-    tokenType: 'classic' | 'scoped'
+    tokenType: 'classic' | 'scoped' | 'none'
     step: 'form' | 'success'
   }
   groups: Omit<TelemetryGroups, 'project'>

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -3534,6 +3534,22 @@ export interface AccessTokenCreatedEvent {
 }
 
 /**
+ * Triggered when an access token creation sheet is closed.
+ *
+ * @group Events
+ * @source studio
+ * @page /account/tokens
+ */
+export interface AccessTokenCreationSheetClosedEvent {
+  action: 'access_token_creation_sheet_closed'
+  properties: {
+    tokenType: 'classic' | 'scoped'
+    step: 'form' | 'success'
+  }
+  groups: Omit<TelemetryGroups, 'project'>
+}
+
+/**
  * Triggered when an access token is successfully deleted.
  *
  * @group Events
@@ -4059,6 +4075,7 @@ export type TelemetryEvent =
   | UpgradeCtaClickedEvent
   | PricingPanelPlanPresentationExperimentExposedEvent
   | AccessTokenCreatedEvent
+  | AccessTokenCreationSheetClosedEvent
   | AccessTokenRemovedEvent
   | AccessTokenCopiedEvent
   | AccessTokenStoredCheckboxClickedEvent

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -3540,8 +3540,8 @@ export interface AccessTokenCreatedEvent {
  * @source studio
  * @page /account/tokens
  */
-export interface AccessTokenCreationSheetClosedEvent {
-  action: 'access_token_creation_sheet_closed'
+export interface AccessTokenCreationSheetDismissedEvent {
+  action: 'access_token_creation_sheet_dismissed'
   properties: {
     tokenType: 'classic' | 'scoped' | 'none'
     step: 'form' | 'success'
@@ -4075,7 +4075,7 @@ export type TelemetryEvent =
   | UpgradeCtaClickedEvent
   | PricingPanelPlanPresentationExperimentExposedEvent
   | AccessTokenCreatedEvent
-  | AccessTokenCreationSheetClosedEvent
+  | AccessTokenCreationSheetDismissedEvent
   | AccessTokenRemovedEvent
   | AccessTokenCopiedEvent
   | AccessTokenStoredCheckboxClickedEvent

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -3549,6 +3549,57 @@ export interface AccessTokenRemovedEvent {
 }
 
 /**
+ * Triggered when the copy button is used on the token value shown after creation. The value is
+ * only ever displayed once, so this measures how many users leave with a usable token.
+ *
+ * @group Events
+ * @source studio
+ * @page /account/tokens (token created step of the generate token sheet)
+ */
+export interface AccessTokenCopiedEvent {
+  action: 'access_token_copied'
+  properties: {
+    tokenType: 'classic' | 'scoped'
+  }
+  groups: Omit<TelemetryGroups, 'project'>
+}
+
+/**
+ * Triggered when the "I have copied the key and stored it securely" checkbox is toggled on the
+ * token created step. `isChecked` is the resulting state, so unticking is tracked too.
+ *
+ * @group Events
+ * @source studio
+ * @page /account/tokens (token created step of the generate token sheet)
+ */
+export interface AccessTokenStoredCheckboxClickedEvent {
+  action: 'access_token_stored_checkbox_clicked'
+  properties: {
+    tokenType: 'classic' | 'scoped'
+    /** The state the checkbox was toggled into */
+    isChecked: boolean
+  }
+  groups: Omit<TelemetryGroups, 'project'>
+}
+
+/**
+ * Triggered when the "Done" button dismisses the token created step, completing the creation flow.
+ *
+ * @group Events
+ * @source studio
+ * @page /account/tokens (token created step of the generate token sheet)
+ */
+export interface AccessTokenDoneButtonClickedEvent {
+  action: 'access_token_done_button_clicked'
+  properties: {
+    tokenType: 'classic' | 'scoped'
+    /** Whether the copy button was used before finishing, as opposed to copying the value manually */
+    hasCopiedToken: boolean
+  }
+  groups: Omit<TelemetryGroups, 'project'>
+}
+
+/**
  * User clicked the "Upgrade to Pro" CTA. Fired from each CTA placement surface, with
  * `placement` identifying which one (the user dropdown or the org project-list usage card).
  *
@@ -4009,6 +4060,9 @@ export type TelemetryEvent =
   | PricingPanelPlanPresentationExperimentExposedEvent
   | AccessTokenCreatedEvent
   | AccessTokenRemovedEvent
+  | AccessTokenCopiedEvent
+  | AccessTokenStoredCheckboxClickedEvent
+  | AccessTokenDoneButtonClickedEvent
   | ResourceExhaustionBannerUpgradeClickedEvent
   | ResourceExhaustionBannerAiAssistantClickedEvent
   | UnifiedLogsRowClickedEvent


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Adds PostHog tracking to the final step of the scoped PAT creation flow, after `access_token_created` fires. The token value is only ever shown once, so this measures whether users actually leave with a usable token.

Three new events on the "Token created" step:

| Event | Properties |
| --- | --- |
| `access_token_copied` | `tokenType` |
| `access_token_stored_checkbox_clicked` | `tokenType`, `isChecked` |
| `access_token_done_button_clicked` | `tokenType`, `hasCopiedToken` |

- `isChecked` is the resulting state, so unticking the acknowledgement is captured too.
- `hasCopiedToken` records whether the Copy button was used before finishing. Done is gated on the checkbox, not on copying, so this separates "copied it" from "ticked the box and left."
- `tokenType` is threaded through from the sheet, which creates a classic token when resource access is `account` and a scoped one otherwise. It matches the existing `access_token_created` / `access_token_removed` property.

## Changes

- `packages/common/telemetry-constants.ts` — three event interfaces, added to the
`TelemetryEvent` union
- `NewScopedTokenSuccess.tsx` — `useTrack()` plus a new `tokenType` prop;
copy/acknowledge/done routed
- `NewScopedTokenSheet.tsx` — `createdToken` state now holds `{ token, tokenType }` so
the success step knows which
- `NewScopedTokenSheet.test.tsx` — extended the two tests that already walk the full
success flow with assertions  and classic paths)

## Testing

`pnpm test:studio` on `NewSco16 passing. Typecheck clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Analytics**
  * Added tracking for key access-token creation interactions, including copying tokens, selecting storage options, and completing the flow.
  * Tracking distinguishes between classic and scoped access tokens and records whether a token was copied before completion.
  * Added tracking when the access-token creation sheet is dismissed, including the current step.

* **Behavior**
  * Existing copy, storage-selection, notification, and completion actions continue to work as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->