### PR TITLE
docs(api): note db.schema generic requirement for TS

### DIFF
--- a/apps/docs/content/guides/api/using-custom-schemas.mdx
+++ b/apps/docs/content/guides/api/using-custom-schemas.mdx
@@ -58,7 +58,7 @@ const { data: todos, error } = await supabase.schema('myschema').from('todos').s
 
 <Admonition type="note">
 
-With generated `Database` types, `createClient<Database>(...)` type-checks `db.schema` against nothing but `public` unless the schema name is also passed as the second generic: `createClient<Database, 'myschema'>(...)`. `supabase.schema('myschema').from(...)` infers its schema per call and needs no second generic.
+With generated `Database` types that include `public`, `createClient<Database>(...)` type-checks `db.schema` against `public` only, unless the schema name is also passed as the second generic: `createClient<Database, 'myschema'>(...)`. `supabase.schema('myschema').from(...)` infers its schema per call and needs no second generic. In both cases `myschema` has to be present in the generated `Database` type.
 
 </Admonition>
 

--- a/apps/docs/content/guides/api/using-custom-schemas.mdx
+++ b/apps/docs/content/guides/api/using-custom-schemas.mdx
@@ -56,6 +56,12 @@ const { data: todos, error } = await supabase.from('todos').select('*')
 const { data: todos, error } = await supabase.schema('myschema').from('todos').select('*')
 ```
 
+<Admonition type="note">
+
+With generated `Database` types, `createClient<Database>(...)` type-checks `db.schema` against nothing but `public` unless the schema name is also passed as the second generic: `createClient<Database, 'myschema'>(...)`. `supabase.schema('myschema').from(...)` infers its schema per call and needs no second generic.
+
+</Admonition>
+
 </TabPanel>
 <$Show if="sdk:dart">
 <TabPanel id="dart" label="Dart">


### PR DESCRIPTION
Adds a note to the "Using Custom Schemas" guide: `createClient<Database>(...)` needs the schema passed as the second generic (`createClient<Database, 'myschema'>(...)`) to type-check `db.schema` against anything but `public`. `supabase.schema('myschema').from(...)` is the per-call alternative that needs no second generic.

Related to supabase/supabase-js#969 — the existing JS example has no type parameters so it never surfaces this, and TypeScript users extending it with `<Database>` hit a confusing compile error with no pointer to the fix.

supabase-js companion: supabase/supabase-js#2662

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance to the custom schemas guide explaining TypeScript typing behavior when using non-public schemas.
  * Clarified how to specify a schema explicitly and when schema types are inferred automatically.
  * Noted that custom schemas must be included in the generated `Database` type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->