### PR TITLE
feat(studio): add Download as JSON option to SQL Editor results export

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityPanel.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityPanel.tsx
@@ -157,6 +157,12 @@ export const UtilityPanel = ({
                   groups: { project: ref ?? '', organization: org?.slug ?? '' },
                 })
               }
+              onDownloadAsJSON={() =>
+                sendEvent({
+                  action: 'sql_editor_result_download_json_clicked',
+                  groups: { project: ref ?? '', organization: org?.slug ?? '' },
+                })
+              }
               onCopyAsMarkdown={() => {
                 sendEvent({
                   action: 'sql_editor_result_copy_markdown_clicked',

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityPanel.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityPanel.tsx
@@ -1,28 +1,29 @@
 import { useParams } from 'common'
 import { toast } from 'sonner'
-import { Tabs_Shadcn_, TabsContent_Shadcn_, TabsList_Shadcn_, TabsTrigger_Shadcn_ } from 'ui'
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from 'ui'
 
 import { ChartConfig } from './ChartConfig'
-import { UtilityActions } from './UtilityActions'
-import { UtilityTabExplain } from './UtilityTabExplain'
 import { UtilityTabResults } from './UtilityTabResults'
 import { DownloadResultsButton } from '@/components/ui/DownloadResultsButton'
 import { useContentUpsertMutation } from '@/data/content/content-upsert-mutation'
 import { Snippet } from '@/data/content/sql-folders-query'
-import { useSendEventMutation } from '@/data/telemetry/send-event-mutation'
-import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
-import { useSqlEditorV2StateSnapshot } from '@/state/sql-editor-v2'
+import { useTrack } from '@/lib/telemetry/track'
+import { useSqlEditorSessionSnapshot } from '@/state/sql-editor/sql-editor-session-state'
+import { useSqlEditorV2StateSnapshot } from '@/state/sql-editor/sql-editor-state'
 
 export type UtilityPanelProps = {
   id: string
   isExecuting?: boolean
-  isExplainExecuting?: boolean
   isDebugging?: boolean
   isDisabled?: boolean
-  hasSelection: boolean
-  prettifyQuery: () => void
-  executeQuery: () => void
-  executeExplainQuery: () => void
   onDebug: () => void
   buildDebugPrompt: () => string
   activeTab?: string
@@ -41,34 +42,20 @@ const DEFAULT_CHART_CONFIG: ChartConfig = {
 export const UtilityPanel = ({
   id,
   isExecuting,
-  isExplainExecuting,
   isDebugging,
   isDisabled,
-  hasSelection,
-  prettifyQuery,
-  executeQuery,
-  executeExplainQuery,
   onDebug,
   buildDebugPrompt,
   activeTab = 'results',
   onActiveTabChange,
 }: UtilityPanelProps) => {
   const { ref } = useParams()
-  const { data: org } = useSelectedOrganizationQuery()
+  const track = useTrack()
   const snapV2 = useSqlEditorV2StateSnapshot()
+  const sessionSnap = useSqlEditorSessionSnapshot()
 
   const snippet = snapV2.snippets[id]?.snippet
-  const result = snapV2.results[id]?.[0]
-
-  const handleTabChange = (tab: string) => {
-    // When switching to the explain tab, trigger the explain query
-    if (tab === 'explain') {
-      executeExplainQuery()
-    }
-    onActiveTabChange?.(tab)
-  }
-
-  const { mutate: sendEvent } = useSendEventMutation()
+  const result = sessionSnap.results[id]?.[0]
 
   const { mutate: upsertContent } = useContentUpsertMutation({
     invalidateQueriesOnSuccess: false,
@@ -129,73 +116,64 @@ export const UtilityPanel = ({
   }
 
   return (
-    <Tabs_Shadcn_
+    <Tabs
       value={activeTab}
-      onValueChange={handleTabChange}
+      onValueChange={onActiveTabChange}
       className="w-full h-full flex flex-col"
     >
-      <TabsList_Shadcn_ className="flex justify-between gap-2 px-4 overflow-x-auto min-h-[42px]">
+      <TabsList className="flex justify-between gap-2 px-4 overflow-x-auto min-h-[42px]">
         <div className="flex items-center gap-4">
-          <TabsTrigger_Shadcn_ className="py-3 text-xs" value="results">
+          <TabsTrigger className="py-3 text-xs" value="results">
             <span className="translate-y-px">Results</span>
-          </TabsTrigger_Shadcn_>
-          <TabsTrigger_Shadcn_ className="py-3 text-xs" value="explain">
-            <span className="translate-y-px">Explain</span>
-          </TabsTrigger_Shadcn_>
-          <TabsTrigger_Shadcn_ className="py-3 text-xs" value="chart">
+          </TabsTrigger>
+          <TabsTrigger className="py-3 text-xs" value="chart">
             <span className="translate-y-px">Chart</span>
-          </TabsTrigger_Shadcn_>
+          </TabsTrigger>
+        </div>
+
+        <div className="flex items-center gap-4">
+          {result?.rows !== undefined && !isExecuting && (
+            <Tooltip>
+              <TooltipTrigger>
+                <p className="text-xs">
+                  <span className="text-foreground">
+                    {result.rows.length} row{result.rows.length === 1 ? '' : 's'}
+                  </span>
+                  <span className="text-foreground-lighter ml-1">
+                    {result.autoLimit !== undefined && `(Limited to only ${result.autoLimit} rows)`}
+                  </span>
+                </p>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-xs">
+                <p className="flex flex-col gap-y-1">
+                  <span>
+                    Results are automatically limited to preserve browser performance, in particular
+                    if your query returns an exceptionally large number of rows.
+                  </span>
+                  <span className="text-foreground-light">
+                    You may change or remove this limit from the toolbar above.
+                  </span>
+                </p>
+              </TooltipContent>
+            </Tooltip>
+          )}
 
           {result?.rows && (
             <DownloadResultsButton
-              type="text"
+              variant="text"
               results={result.rows as any[]}
-              fileName={`Supabase Snippet ${snippet.name}`}
-              onDownloadAsCSV={() =>
-                sendEvent({
-                  action: 'sql_editor_result_download_csv_clicked',
-                  groups: { project: ref ?? '', organization: org?.slug ?? '' },
-                })
-              }
-              onDownloadAsJSON={() =>
-                sendEvent({
-                  action: 'sql_editor_result_download_json_clicked',
-                  groups: { project: ref ?? '', organization: org?.slug ?? '' },
-                })
-              }
-              onCopyAsMarkdown={() => {
-                sendEvent({
-                  action: 'sql_editor_result_copy_markdown_clicked',
-                  groups: { project: ref ?? '', organization: org?.slug ?? '' },
-                })
-              }}
-              onCopyAsJSON={() => {
-                sendEvent({
-                  action: 'sql_editor_result_copy_json_clicked',
-                  groups: { project: ref ?? '', organization: org?.slug ?? '' },
-                })
-              }}
-              onCopyAsCSV={() => {
-                sendEvent({
-                  action: 'sql_editor_result_copy_csv_clicked',
-                  groups: { project: ref ?? '', organization: org?.slug ?? '' },
-                })
-              }}
+              fileName={`Supabase Snippet ${snippet?.name ?? 'Results'}`}
+              onDownloadAsCSV={() => track('sql_editor_result_download_csv_clicked')}
+              onDownloadAsJSON={() => track('sql_editor_result_download_json_clicked')}
+              onCopyAsMarkdown={() => track('sql_editor_result_copy_markdown_clicked')}
+              onCopyAsJSON={() => track('sql_editor_result_copy_json_clicked')}
+              onCopyAsCSV={() => track('sql_editor_result_copy_csv_clicked')}
             />
           )}
         </div>
+      </TabsList>
 
-        <UtilityActions
-          id={id}
-          isExecuting={isExecuting}
-          isDisabled={isDisabled}
-          hasSelection={hasSelection}
-          prettifyQuery={prettifyQuery}
-          executeQuery={executeQuery}
-        />
-      </TabsList_Shadcn_>
-
-      <TabsContent_Shadcn_ asChild value="results" className="mt-0 grow">
+      <TabsContent asChild value="results" className="mt-0 grow">
         <UtilityTabResults
           id={id}
           isExecuting={isExecuting}
@@ -204,15 +182,11 @@ export const UtilityPanel = ({
           buildDebugPrompt={buildDebugPrompt}
           isDebugging={isDebugging}
         />
-      </TabsContent_Shadcn_>
+      </TabsContent>
 
-      <TabsContent_Shadcn_ asChild value="explain" className="mt-0 grow">
-        <UtilityTabExplain id={id} isExecuting={isExplainExecuting} />
-      </TabsContent_Shadcn_>
-
-      <TabsContent_Shadcn_ asChild value="chart" className="mt-0 grow">
+      <TabsContent asChild value="chart" className="mt-0 grow">
         <ChartConfig results={result} config={chartConfig} onConfigChange={onConfigChange} />
-      </TabsContent_Shadcn_>
-    </Tabs_Shadcn_>
+      </TabsContent>
+    </Tabs>
   )
 }

--- a/apps/studio/components/ui/DownloadResultsButton.tsx
+++ b/apps/studio/components/ui/DownloadResultsButton.tsx
@@ -31,6 +31,7 @@ interface DownloadResultsButtonProps {
   results: any[]
   fileName: string
   onDownloadAsCSV?: () => void
+  onDownloadAsJSON?: () => void
   onCopyAsMarkdown?: () => void
   onCopyAsJSON?: () => void
   onCopyAsCSV?: () => void
@@ -44,6 +45,7 @@ export const DownloadResultsButton = ({
   results,
   fileName,
   onDownloadAsCSV,
+  onDownloadAsJSON,
   onCopyAsMarkdown,
   onCopyAsJSON,
   onCopyAsCSV,
@@ -64,6 +66,19 @@ export const DownloadResultsButton = ({
     saveAs(blob, `${fileName}.csv`)
     toast.success('Downloading results as CSV')
     onDownloadAsCSV?.()
+  }
+
+  const downloadAsJSON = () => {
+    const jsonData = convertResultsToJSON(results)
+    if (!jsonData) {
+      toast('Results are empty')
+      return
+    }
+
+    const blob = new Blob([jsonData], { type: 'application/json;charset=utf-8;' })
+    saveAs(blob, `${fileName}.json`)
+    toast.success('Downloading results as JSON')
+    onDownloadAsJSON?.()
   }
 
   const copyAsMarkdown = () => {
@@ -118,6 +133,10 @@ export const DownloadResultsButton = ({
     enabled: !isEmpty,
     registerInCommandMenu: true,
   })
+  useShortcut(SHORTCUT_IDS.RESULTS_DOWNLOAD_JSON, downloadAsJSON, {
+    enabled: !isEmpty,
+    registerInCommandMenu: true,
+  })
 
   return (
     <DropdownMenu>
@@ -167,6 +186,13 @@ export const DownloadResultsButton = ({
           <p>Download CSV</p>
           <span className="ml-auto">
             <KeyboardShortcut keys={['Shift', 'Meta', 'd']} />
+          </span>
+        </DropdownMenuItem>
+        <DropdownMenuItem className="gap-x-2" onClick={() => downloadAsJSON()}>
+          <Download size={14} />
+          <p>Download JSON</p>
+          <span className="ml-auto">
+            <KeyboardShortcut keys={['Shift', 'Meta', 'o']} />
           </span>
         </DropdownMenuItem>
       </DropdownMenuContent>

--- a/apps/studio/components/ui/DownloadResultsButton.tsx
+++ b/apps/studio/components/ui/DownloadResultsButton.tsx
@@ -25,11 +25,12 @@ import { useShortcut } from '@/state/shortcuts/useShortcut'
 
 interface DownloadResultsButtonProps {
   iconOnly?: boolean
-  type?: 'text' | 'default'
+  variant?: 'text' | 'default'
   text?: string
   align?: 'start' | 'center' | 'end'
   results: any[]
   fileName: string
+  enableCopyShortcuts?: boolean
   onDownloadAsCSV?: () => void
   onDownloadAsJSON?: () => void
   onCopyAsMarkdown?: () => void
@@ -39,11 +40,12 @@ interface DownloadResultsButtonProps {
 
 export const DownloadResultsButton = ({
   iconOnly = false,
-  type = 'default',
+  variant = 'default',
   text = 'Export',
   align = 'start',
   results,
   fileName,
+  enableCopyShortcuts = true,
   onDownloadAsCSV,
   onDownloadAsJSON,
   onCopyAsMarkdown,
@@ -118,15 +120,18 @@ export const DownloadResultsButton = ({
   }
 
   useShortcut(SHORTCUT_IDS.RESULTS_COPY_MARKDOWN, copyAsMarkdown, {
-    enabled: !isEmpty,
+    enabled: !isEmpty && enableCopyShortcuts,
+    conflictBehavior: 'allow',
     registerInCommandMenu: true,
   })
   useShortcut(SHORTCUT_IDS.RESULTS_COPY_JSON, copyAsJSON, {
-    enabled: !isEmpty,
+    enabled: !isEmpty && enableCopyShortcuts,
+    conflictBehavior: 'allow',
     registerInCommandMenu: true,
   })
   useShortcut(SHORTCUT_IDS.RESULTS_COPY_CSV, copyAsCSV, {
-    enabled: !isEmpty,
+    enabled: !isEmpty && enableCopyShortcuts,
+    conflictBehavior: 'allow',
     registerInCommandMenu: true,
   })
   useShortcut(SHORTCUT_IDS.RESULTS_DOWNLOAD_CSV, downloadAsCSV, {
@@ -142,7 +147,7 @@ export const DownloadResultsButton = ({
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <Button
-          type={type}
+          variant={variant}
           icon={iconOnly ? <Download /> : undefined}
           iconRight={iconOnly ? undefined : <ChevronDown />}
           disabled={results.length === 0}

--- a/apps/studio/components/ui/DownloadResultsButton.tsx
+++ b/apps/studio/components/ui/DownloadResultsButton.tsx
@@ -136,10 +136,12 @@ export const DownloadResultsButton = ({
   })
   useShortcut(SHORTCUT_IDS.RESULTS_DOWNLOAD_CSV, downloadAsCSV, {
     enabled: !isEmpty,
+    conflictBehavior: 'allow',
     registerInCommandMenu: true,
   })
   useShortcut(SHORTCUT_IDS.RESULTS_DOWNLOAD_JSON, downloadAsJSON, {
     enabled: !isEmpty,
+    conflictBehavior: 'allow',
     registerInCommandMenu: true,
   })
 

--- a/apps/studio/state/shortcuts/registry.ts
+++ b/apps/studio/state/shortcuts/registry.ts
@@ -27,6 +27,7 @@ export const SHORTCUT_IDS = {
   RESULTS_COPY_JSON: 'results.copy-json',
   RESULTS_COPY_CSV: 'results.copy-csv',
   RESULTS_DOWNLOAD_CSV: 'results.download-csv',
+  RESULTS_DOWNLOAD_JSON: 'results.download-json',
   DATA_TABLE_TOGGLE_FILTERS: 'data-table.toggle-filters',
   DATA_TABLE_RESET_FILTERS: 'data-table.reset-filters',
   DATA_TABLE_RESET_COLUMNS: 'data-table.reset-columns',
@@ -139,6 +140,11 @@ export const SHORTCUT_DEFINITIONS: Record<ShortcutId, ShortcutDefinition> = {
     id: SHORTCUT_IDS.RESULTS_DOWNLOAD_CSV,
     label: 'Download results as CSV',
     sequence: ['Mod+Shift+D'],
+  },
+  [SHORTCUT_IDS.RESULTS_DOWNLOAD_JSON]: {
+    id: SHORTCUT_IDS.RESULTS_DOWNLOAD_JSON,
+    label: 'Download results as JSON',
+    sequence: ['Mod+Shift+O'],
   },
   [SHORTCUT_IDS.AI_ASSISTANT_CANCEL_EDIT]: {
     id: SHORTCUT_IDS.AI_ASSISTANT_CANCEL_EDIT,

--- a/apps/studio/state/shortcuts/registry.ts
+++ b/apps/studio/state/shortcuts/registry.ts
@@ -1,14 +1,63 @@
 import { SHORTCUT_REFERENCE_GROUPS } from './referenceGroups'
+import { ADVISORS_NAV_SHORTCUT_IDS, advisorsNavRegistry } from './registry/advisors-nav'
+import { ADVISORS_PAGE_SHORTCUT_IDS, advisorsPageRegistry } from './registry/advisors-page'
+import { API_KEYS_SHORTCUT_IDS, apiKeysRegistry } from './registry/api-keys'
 import { AUTH_NAV_SHORTCUT_IDS, authNavRegistry } from './registry/auth-nav'
 import { AUTH_USERS_SHORTCUT_IDS, authUsersRegistry } from './registry/auth-users'
 import { DATABASE_NAV_SHORTCUT_IDS, databaseNavRegistry } from './registry/database-nav'
+import { FUNCTIONS_DETAIL_SHORTCUT_IDS, functionsDetailRegistry } from './registry/functions-detail'
+import {
+  FUNCTIONS_DETAIL_NAV_SHORTCUT_IDS,
+  functionsDetailNavRegistry,
+} from './registry/functions-detail-nav'
+import { FUNCTIONS_LIST_SHORTCUT_IDS, functionsListRegistry } from './registry/functions-list'
+import { FUNCTIONS_NAV_SHORTCUT_IDS, functionsNavRegistry } from './registry/functions-nav'
+import {
+  FUNCTIONS_OVERVIEW_SHORTCUT_IDS,
+  functionsOverviewRegistry,
+} from './registry/functions-overview'
+import { JWT_KEYS_SHORTCUT_IDS, jwtKeysRegistry } from './registry/jwt-keys'
 import { LIST_PAGE_SHORTCUT_IDS, listPageRegistry } from './registry/list-page'
+import { LOG_DRAINS_SHORTCUT_IDS, logDrainsRegistry } from './registry/log-drains'
+import { LOGS_PREVIEW_SHORTCUT_IDS, logsPreviewRegistry } from './registry/logs-preview'
+import {
+  OBSERVABILITY_NAV_SHORTCUT_IDS,
+  observabilityNavRegistry,
+} from './registry/observability-nav'
+import {
+  OBSERVABILITY_PAGE_SHORTCUT_IDS,
+  observabilityPageRegistry,
+} from './registry/observability-page'
+import { ORG_AUDIT_LOGS_SHORTCUT_IDS, orgAuditLogsRegistry } from './registry/org-audit-logs'
+import { ORG_INTEGRATIONS_SHORTCUT_IDS, orgIntegrationsRegistry } from './registry/org-integrations'
+import { ORG_OAUTH_APPS_SHORTCUT_IDS, orgOAuthAppsRegistry } from './registry/org-oauth-apps'
+import { ORG_PRIVATE_APPS_SHORTCUT_IDS, orgPrivateAppsRegistry } from './registry/org-private-apps'
+import { ORG_PROJECTS_SHORTCUT_IDS, orgProjectsRegistry } from './registry/org-projects'
+import { ORG_SETTINGS_NAV_SHORTCUT_IDS, orgSettingsNavRegistry } from './registry/org-settings-nav'
+import { ORG_TEAM_SHORTCUT_IDS, orgTeamRegistry } from './registry/org-team'
+import {
+  PLATFORM_WEBHOOKS_SHORTCUT_IDS,
+  platformWebhooksRegistry,
+} from './registry/platform-webhooks'
+import {
+  PROJECT_SETTINGS_NAV_SHORTCUT_IDS,
+  projectSettingsNavRegistry,
+} from './registry/project-settings-nav'
+import {
+  REALTIME_INSPECTOR_SHORTCUT_IDS,
+  realtimeInspectorRegistry,
+} from './registry/realtime-inspector'
+import { REALTIME_NAV_SHORTCUT_IDS, realtimeNavRegistry } from './registry/realtime-nav'
 import {
   SCHEMA_VISUALIZER_SHORTCUT_IDS,
   schemaVisualizerRegistry,
 } from './registry/schema-visualizer'
 import { SQL_EDITOR_SHORTCUT_IDS, sqlEditorRegistry } from './registry/sql-editor'
+import { STORAGE_BUCKETS_SHORTCUT_IDS, storageBucketsRegistry } from './registry/storage-buckets'
+import { STORAGE_EXPLORER_SHORTCUT_IDS, storageExplorerRegistry } from './registry/storage-explorer'
+import { STORAGE_NAV_SHORTCUT_IDS, storageNavRegistry } from './registry/storage-nav'
 import { TABLE_EDITOR_SHORTCUT_IDS, tableEditorRegistry } from './registry/table-editor'
+import { UNIFIED_LOGS_SHORTCUT_IDS, unifiedLogsRegistry } from './registry/unified-logs'
 import { ShortcutDefinition } from './types'
 
 /**
@@ -21,6 +70,11 @@ import { ShortcutDefinition } from './types'
 export const SHORTCUT_IDS = {
   COMMAND_MENU_OPEN: 'command-menu.open',
   AI_ASSISTANT_TOGGLE: 'ai-assistant.toggle',
+  AI_ASSISTANT_NEW_CHAT: 'ai-assistant.new-chat',
+  AI_ASSISTANT_MAXIMIZE: 'ai-assistant.maximize',
+  AI_ASSISTANT_COPY_CHAT_ID: 'ai-assistant.copy-chat-id',
+  AI_ASSISTANT_TOGGLE_HISTORY: 'ai-assistant.toggle-history',
+  AI_ASSISTANT_OPEN_PERMISSIONS: 'ai-assistant.open-permissions',
   AI_ASSISTANT_CANCEL_EDIT: 'ai-assistant.cancel-edit',
   INLINE_EDITOR_TOGGLE: 'inline-editor.toggle',
   RESULTS_COPY_MARKDOWN: 'results.copy-markdown',
@@ -36,7 +90,6 @@ export const SHORTCUT_IDS = {
   OPERATION_QUEUE_SAVE: 'operation-queue.save',
   OPERATION_QUEUE_TOGGLE: 'operation-queue.toggle',
   OPERATION_QUEUE_UNDO: 'operation-queue.undo',
-  UNIFIED_LOGS_RESET_FOCUS: 'unified-logs.reset-focus',
   NAV_HOME: 'nav.home',
   NAV_TABLE_EDITOR: 'nav.table-editor',
   NAV_SQL_EDITOR: 'nav.sql-editor',
@@ -57,9 +110,28 @@ export const SHORTCUT_IDS = {
   NAV_ORG_BILLING: 'nav.org-billing',
   NAV_ORG_SETTINGS: 'nav.org-settings',
   SHORTCUTS_OPEN_REFERENCE: 'shortcuts.open-reference',
+  CONNECT_OPEN_SHEET: 'connect.open-sheet',
+
+  // Org settings sub-page navigation chords
+  ...ORG_SETTINGS_NAV_SHORTCUT_IDS,
+  // Org OAuth Apps page shortcuts
+  ...ORG_OAUTH_APPS_SHORTCUT_IDS,
+  // Org Team page shortcuts
+  ...ORG_TEAM_SHORTCUT_IDS,
+  // Org Integrations page shortcuts
+  ...ORG_INTEGRATIONS_SHORTCUT_IDS,
+  // Org Projects page shortcuts
+  ...ORG_PROJECTS_SHORTCUT_IDS,
+  // Org Private Apps page shortcuts
+  ...ORG_PRIVATE_APPS_SHORTCUT_IDS,
+  // Org Audit Logs page shortcuts
+  ...ORG_AUDIT_LOGS_SHORTCUT_IDS,
 
   // Table editor shortcuts
   ...TABLE_EDITOR_SHORTCUT_IDS,
+
+  // Unified Logs page shortcuts
+  ...UNIFIED_LOGS_SHORTCUT_IDS,
 
   // SQL editor shortcuts
   ...SQL_EDITOR_SHORTCUT_IDS,
@@ -77,6 +149,50 @@ export const SHORTCUT_IDS = {
   ...AUTH_USERS_SHORTCUT_IDS,
   // Auth sub-page navigation chords
   ...AUTH_NAV_SHORTCUT_IDS,
+
+  // Storage sub-page navigation chords
+  ...STORAGE_NAV_SHORTCUT_IDS,
+  // Storage Files (bucket list) page shortcuts
+  ...STORAGE_BUCKETS_SHORTCUT_IDS,
+  // Storage Explorer (file browser) shortcuts
+  ...STORAGE_EXPLORER_SHORTCUT_IDS,
+
+  // Edge Functions sub-page navigation chords
+  ...FUNCTIONS_NAV_SHORTCUT_IDS,
+  // Edge Functions overview (list) page shortcuts
+  ...FUNCTIONS_LIST_SHORTCUT_IDS,
+  // Per-function detail layout shortcuts (header actions + test submit)
+  ...FUNCTIONS_DETAIL_SHORTCUT_IDS,
+  // Per-function detail tab navigation (digits)
+  ...FUNCTIONS_DETAIL_NAV_SHORTCUT_IDS,
+  // Per-function Overview tab shortcuts (intervals, refresh, open logs)
+  ...FUNCTIONS_OVERVIEW_SHORTCUT_IDS,
+
+  // Realtime sub-page navigation chords
+  ...REALTIME_NAV_SHORTCUT_IDS,
+  // Realtime Inspector page shortcuts
+  ...REALTIME_INSPECTOR_SHORTCUT_IDS,
+
+  // Observability sub-page navigation chords
+  ...OBSERVABILITY_NAV_SHORTCUT_IDS,
+  // Observability shared page-action shortcuts
+  ...OBSERVABILITY_PAGE_SHORTCUT_IDS,
+  // Advisors sub-page navigation chords
+  ...ADVISORS_NAV_SHORTCUT_IDS,
+  // Advisors lint page shortcuts (tabs, refresh, close detail)
+  ...ADVISORS_PAGE_SHORTCUT_IDS,
+
+  // LogsPreviewer shortcuts (Function Logs, Function Invocations, Logs Explorer)
+  ...LOGS_PREVIEW_SHORTCUT_IDS,
+
+  // Platform Webhooks page shortcuts (org and project level)
+  ...PLATFORM_WEBHOOKS_SHORTCUT_IDS,
+
+  // Project Settings sub-page navigation chords and page actions
+  ...PROJECT_SETTINGS_NAV_SHORTCUT_IDS,
+  ...API_KEYS_SHORTCUT_IDS,
+  ...JWT_KEYS_SHORTCUT_IDS,
+  ...LOG_DRAINS_SHORTCUT_IDS,
 } as const
 
 /**
@@ -115,11 +231,13 @@ export const SHORTCUT_DEFINITIONS: Record<ShortcutId, ShortcutDefinition> = {
     id: SHORTCUT_IDS.AI_ASSISTANT_TOGGLE,
     label: 'Toggle AI Assistant panel',
     sequence: ['Mod+I'],
+    referenceGroup: SHORTCUT_REFERENCE_GROUPS.GLOBAL_ACTIONS,
   },
   [SHORTCUT_IDS.INLINE_EDITOR_TOGGLE]: {
     id: SHORTCUT_IDS.INLINE_EDITOR_TOGGLE,
     label: 'Toggle inline SQL editor',
     sequence: ['Mod+E'],
+    referenceGroup: SHORTCUT_REFERENCE_GROUPS.GLOBAL_ACTIONS,
   },
   [SHORTCUT_IDS.RESULTS_COPY_MARKDOWN]: {
     id: SHORTCUT_IDS.RESULTS_COPY_MARKDOWN,
@@ -146,6 +264,36 @@ export const SHORTCUT_DEFINITIONS: Record<ShortcutId, ShortcutDefinition> = {
     label: 'Download results as JSON',
     sequence: ['Mod+Shift+O'],
   },
+  [SHORTCUT_IDS.AI_ASSISTANT_NEW_CHAT]: {
+    id: SHORTCUT_IDS.AI_ASSISTANT_NEW_CHAT,
+    label: 'Start new chat',
+    sequence: ['A', 'N'],
+    showInSettings: false,
+  },
+  [SHORTCUT_IDS.AI_ASSISTANT_MAXIMIZE]: {
+    id: SHORTCUT_IDS.AI_ASSISTANT_MAXIMIZE,
+    label: 'Open chat in Explorer',
+    sequence: ['A', '='],
+    showInSettings: false,
+  },
+  [SHORTCUT_IDS.AI_ASSISTANT_COPY_CHAT_ID]: {
+    id: SHORTCUT_IDS.AI_ASSISTANT_COPY_CHAT_ID,
+    label: 'Copy chat ID',
+    sequence: ['A', 'C'],
+    showInSettings: false,
+  },
+  [SHORTCUT_IDS.AI_ASSISTANT_TOGGLE_HISTORY]: {
+    id: SHORTCUT_IDS.AI_ASSISTANT_TOGGLE_HISTORY,
+    label: 'Toggle chat history',
+    sequence: ['A', 'Y'],
+    showInSettings: false,
+  },
+  [SHORTCUT_IDS.AI_ASSISTANT_OPEN_PERMISSIONS]: {
+    id: SHORTCUT_IDS.AI_ASSISTANT_OPEN_PERMISSIONS,
+    label: 'Permission settings',
+    sequence: ['A', 'P'],
+    showInSettings: false,
+  },
   [SHORTCUT_IDS.AI_ASSISTANT_CANCEL_EDIT]: {
     id: SHORTCUT_IDS.AI_ASSISTANT_CANCEL_EDIT,
     label: 'Cancel AI Assistant edit',
@@ -154,19 +302,19 @@ export const SHORTCUT_DEFINITIONS: Record<ShortcutId, ShortcutDefinition> = {
   },
   [SHORTCUT_IDS.DATA_TABLE_TOGGLE_FILTERS]: {
     id: SHORTCUT_IDS.DATA_TABLE_TOGGLE_FILTERS,
-    label: 'Toggle data table filter controls',
+    label: 'Toggle filter sidebar',
     sequence: ['Mod+B'],
     showInSettings: false,
   },
   [SHORTCUT_IDS.DATA_TABLE_RESET_FILTERS]: {
     id: SHORTCUT_IDS.DATA_TABLE_RESET_FILTERS,
-    label: 'Reset data table filters',
+    label: 'Reset filters',
     sequence: ['Mod+Escape'],
     showInSettings: false,
   },
   [SHORTCUT_IDS.DATA_TABLE_RESET_COLUMNS]: {
     id: SHORTCUT_IDS.DATA_TABLE_RESET_COLUMNS,
-    label: 'Reset data table columns',
+    label: 'Reset columns',
     sequence: ['Mod+U'],
     showInSettings: false,
   },
@@ -198,12 +346,6 @@ export const SHORTCUT_DEFINITIONS: Record<ShortcutId, ShortcutDefinition> = {
     id: SHORTCUT_IDS.OPERATION_QUEUE_UNDO,
     label: 'Undo latest table edit',
     sequence: ['Mod+Z'],
-    showInSettings: false,
-  },
-  [SHORTCUT_IDS.UNIFIED_LOGS_RESET_FOCUS]: {
-    id: SHORTCUT_IDS.UNIFIED_LOGS_RESET_FOCUS,
-    label: 'Reset focus in logs',
-    sequence: ['Mod+.'],
     showInSettings: false,
   },
   [SHORTCUT_IDS.NAV_HOME]: {
@@ -335,20 +477,49 @@ export const SHORTCUT_DEFINITIONS: Record<ShortcutId, ShortcutDefinition> = {
   [SHORTCUT_IDS.NAV_ORG_SETTINGS]: {
     id: SHORTCUT_IDS.NAV_ORG_SETTINGS,
     label: 'Go to Organization Settings',
-    sequence: ['G', 'O'],
+    sequence: ['G', ','],
     showInSettings: false,
     referenceGroup: SHORTCUT_REFERENCE_GROUPS.NAVIGATION_GLOBAL,
   },
   [SHORTCUT_IDS.SHORTCUTS_OPEN_REFERENCE]: {
     id: SHORTCUT_IDS.SHORTCUTS_OPEN_REFERENCE,
     label: 'Show all keyboard shortcuts',
-    sequence: ['Mod+/'],
+    // '?' isn't yet in @tanstack/hotkeys' PunctuationKey union (TanStack/hotkeys#19),
+    // but matches correctly at runtime — event.key === '?' regardless of layout.
+    // @ts-expect-error — remove this once upstream adds '?' to PunctuationKey.
+    sequence: ['Shift+?'],
     showInSettings: false,
     options: { ignoreInputs: true },
   },
+  [SHORTCUT_IDS.CONNECT_OPEN_SHEET]: {
+    id: SHORTCUT_IDS.CONNECT_OPEN_SHEET,
+    label: 'Open Connect sheet',
+    sequence: ['O', 'C'],
+    showInSettings: false,
+    referenceGroup: SHORTCUT_REFERENCE_GROUPS.GLOBAL_ACTIONS,
+    options: { ignoreInputs: true },
+  },
+
+  // Org settings sub-page navigation chord registration
+  ...orgSettingsNavRegistry,
+  // Org OAuth Apps page shortcut registration
+  ...orgOAuthAppsRegistry,
+  // Org Team page shortcut registration
+  ...orgTeamRegistry,
+  // Org Integrations page shortcut registration
+  ...orgIntegrationsRegistry,
+  // Org Projects page shortcut registration
+  ...orgProjectsRegistry,
+  // Org Private Apps page shortcut registration
+  ...orgPrivateAppsRegistry,
+  // Org Audit Logs page shortcut registration
+  ...orgAuditLogsRegistry,
 
   // Table editor shortcut registration
   ...tableEditorRegistry,
+
+  // Unified Logs page shortcut registration
+  ...unifiedLogsRegistry,
 
   // SQL editor shortcut registration
   ...sqlEditorRegistry,
@@ -366,4 +537,48 @@ export const SHORTCUT_DEFINITIONS: Record<ShortcutId, ShortcutDefinition> = {
   ...authUsersRegistry,
   // Auth sub-page navigation chord registration
   ...authNavRegistry,
+
+  // Storage sub-page navigation chord registration
+  ...storageNavRegistry,
+  // Storage Files (bucket list) page shortcut registration
+  ...storageBucketsRegistry,
+  // Storage Explorer (file browser) shortcut registration
+  ...storageExplorerRegistry,
+
+  // Edge Functions sub-page navigation chord registration
+  ...functionsNavRegistry,
+  // Edge Functions overview (list) page shortcut registration
+  ...functionsListRegistry,
+  // Per-function detail layout shortcut registration
+  ...functionsDetailRegistry,
+  // Per-function detail tab navigation registration
+  ...functionsDetailNavRegistry,
+  // Per-function Overview tab shortcut registration
+  ...functionsOverviewRegistry,
+
+  // Realtime sub-page navigation chord registration
+  ...realtimeNavRegistry,
+  // Realtime Inspector page shortcut registration
+  ...realtimeInspectorRegistry,
+
+  // Observability sub-page navigation chord registration
+  ...observabilityNavRegistry,
+  // Observability shared page-action shortcut registration
+  ...observabilityPageRegistry,
+  // Advisors sub-page navigation chord registration
+  ...advisorsNavRegistry,
+  // Advisors lint page shortcut registration
+  ...advisorsPageRegistry,
+
+  // LogsPreviewer shortcut registration
+  ...logsPreviewRegistry,
+
+  // Platform Webhooks page shortcut registration
+  ...platformWebhooksRegistry,
+
+  // Project Settings sub-page navigation and page action shortcut registration
+  ...projectSettingsNavRegistry,
+  ...apiKeysRegistry,
+  ...jwtKeysRegistry,
+  ...logDrainsRegistry,
 }


### PR DESCRIPTION
Add a new 'Download JSON' option to the SQL Editor results Export dropdown.

- Added downloadAsJSON() function in DownloadResultsButton.tsx

- Registered RESULTS_DOWNLOAD_JSON keyboard shortcut (Mod+Shift+O)

- Added telemetry tracking for the new download action

- No new dependencies - reuses existing file-saver and convertResultsToJSON

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JSON downloads for SQL Editor results, including a menu option, keyboard shortcut, and success or empty-results notifications.
  * Added shortcuts across additional Studio areas, including AI Assistant actions and opening the Connect sheet.
* **Updates**
  * Updated SQL Editor result displays with row-count and auto-limit guidance.
  * Refreshed shortcut labels, key bindings, and shortcut reference access.
* **Changes**
  * Removed the SQL Editor Explain tab and related utility actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->