### PR TITLE
fix(studio): suppress shortcut tooltip while the invite-disabled warning shows

### DIFF
--- a/apps/studio/components/interfaces/Organization/TeamSettings/InviteMemberButton.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/InviteMemberButton.tsx
@@ -123,6 +123,13 @@ export const InviteMemberButton = () => {
       )
     )
 
+  // When the button is disabled because inviting is unavailable, the
+  // ButtonTooltip below renders the reason. The keyboard-shortcut tooltip from
+  // <Shortcut> attaches to the same trigger, so both would open at once and
+  // overlap (#49859) — and advertising the shortcut while it cannot fire is
+  // misleading. Suppress the shortcut tooltip whenever the warning is shown.
+  const showInviteDisabledWarning = !organizationMembersCreationEnabled || !canInviteMembers
+
   const { mutateAsync: inviteMemberAsync, isPending: isInviting } =
     useOrganizationCreateInvitationMutation()
 
@@ -260,7 +267,7 @@ export const InviteMemberButton = () => {
             if (canInviteMembers) setIsOpen(true)
           }}
           side="bottom"
-          tooltipOpen={isOpen ? false : undefined}
+          tooltipOpen={isOpen || showInviteDisabledWarning ? false : undefined}
         >
           <ButtonTooltip
             variant="primary"
@@ -271,11 +278,11 @@ export const InviteMemberButton = () => {
             tooltip={{
               content: {
                 side: 'bottom',
-                text: !organizationMembersCreationEnabled
-                  ? 'Inviting members is currently disabled'
-                  : !canInviteMembers
-                    ? 'You need additional permissions to invite members to this organization'
-                    : undefined,
+                text: showInviteDisabledWarning
+                  ? !organizationMembersCreationEnabled
+                    ? 'Inviting members is currently disabled'
+                    : 'You need additional permissions to invite members to this organization'
+                  : undefined,
               },
             }}
           >

--- a/apps/studio/tests/components/Organization/TeamSettings/InviteMemberButton.test.tsx
+++ b/apps/studio/tests/components/Organization/TeamSettings/InviteMemberButton.test.tsx
@@ -77,10 +77,7 @@ vi.mock('@/hooks/misc/useCheckEntitlements', () => ({
 }))
 
 vi.mock('@/components/interfaces/Organization/TeamSettings/TeamSettings.utils', () => ({
-  useGetRolesManagementPermissions: () => ({
-    rolesAddable: [1, 2, 3, 4],
-    rolesRemovable: [1, 2, 3, 4],
-  }),
+  useGetRolesManagementPermissions: (...args: unknown[]) => mockRolesPermissions(...(args as [])),
 }))
 
 const mockInvite = vi.fn().mockResolvedValue({ succeeded: [], failed: [] })
@@ -89,6 +86,11 @@ vi.mock('@/data/organization-members/organization-invitation-create-mutation', (
     mutateAsync: mockInvite,
     isPending: false,
   }),
+}))
+
+const mockRolesPermissions = vi.fn(() => ({
+  rolesAddable: [1, 2, 3, 4] as unknown as number[],
+  rolesRemovable: [1, 2, 3, 4] as unknown as number[],
 }))
 
 vi.mock('@/hooks/ui/useConfirmOnClose', () => ({
@@ -120,6 +122,10 @@ describe('InviteMemberButton', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockInvite.mockResolvedValue({ succeeded: [], failed: [] })
+    mockRolesPermissions.mockReturnValue({
+      rolesAddable: [1, 2, 3, 4] as unknown as number[],
+      rolesRemovable: [1, 2, 3, 4] as unknown as number[],
+    })
   })
 
   it('renders an enabled Invite members button', () => {
@@ -288,6 +294,44 @@ describe('InviteMemberButton', () => {
       expect(toast.error).toHaveBeenCalledWith(
         'Failed to invite bob@example.com: Domain not allowed'
       )
+    })
+  })
+
+  describe('tooltips (#49859)', () => {
+    it('shows only the warning tooltip when the user cannot invite (no shortcut tooltip overlap)', () => {
+      mockRolesPermissions.mockReturnValue({
+        rolesAddable: [] as unknown as number[],
+        rolesRemovable: [] as unknown as number[],
+      })
+      customRender(<InviteMemberButton />)
+
+      const button = screen.getByRole('button', { name: /invite members/i })
+      expect(button).toBeDisabled()
+
+      fireEvent.mouseEnter(button)
+      fireEvent.focus(button)
+
+      // The warning tooltip must be present (Radix renders the text in the
+      // visible bubble and again in a screen-reader-only span)...
+      expect(screen.getAllByText(/you need additional permissions/i).length).toBeGreaterThan(0)
+      // ...and the keyboard-shortcut tooltip must not render alongside it.
+      // ShortcutTooltip renders "<label> <pills>"; the button label is also
+      // "Invite members", so assert on the Shift+N pill instead.
+      expect(screen.queryByText('⇧N')).not.toBeInTheDocument()
+    })
+
+    it('shows the shortcut tooltip when the user can invite (normal path intact)', () => {
+      customRender(<InviteMemberButton />)
+
+      const button = screen.getByRole('button', { name: /invite members/i })
+      expect(button).toBeEnabled()
+
+      fireEvent.mouseEnter(button)
+      fireEvent.focus(button)
+
+      // With no warning to show, the shortcut tooltip renders its pills.
+      expect(screen.getAllByText('⇧N').length).toBeGreaterThan(0)
+      expect(screen.queryByText(/you need additional permissions/i)).not.toBeInTheDocument()
     })
   })
 })


### PR DESCRIPTION
Fixes #49859.

## Root cause

The **"Invite members"** button in Organization → Team is wrapped in **two nested tooltips on the same trigger**:

1. `<Shortcut>` — renders the keyboard-shortcut tooltip (`Invite members ⇧N`)
2. `<ButtonTooltip>` — renders the reason the button is disabled when invite permission is missing ("You need additional permissions…" / "Inviting members is currently disabled")

When the button is disabled, both tooltips open on hover and overlap, making both unreadable (screenshot in the issue).

There's a second, subtler problem: the shortcut tooltip advertises `⇧N` even while the button is disabled — but the `onTrigger` handler no-ops without invite permission, so the shortcut doesn't actually work. Advertising it is misleading.

## Fix

Compute `showInviteDisabledWarning = !organizationMembersCreationEnabled || !canInviteMembers` once and use it for both consumers:

- `ButtonTooltip` shows the warning text (unchanged behavior)
- `<Shortcut tooltipOpen={isOpen || showInviteDisabledWarning ? false : undefined}>` — the shortcut tooltip is forced closed whenever the warning is showing (and while the invite sheet is open, as before)

Result: a disabled button shows exactly one tooltip — the reason. An enabled button shows exactly one tooltip — the shortcut. No merged-tooltip component needed, no behavior change for enabled users.

## Tests

Two regression tests added to the existing `InviteMemberButton` suite (15/15 passing):

1. **cannot invite** → warning tooltip renders, and the `⇧N` shortcut pill does **not** (this test fails on the unfixed component — both render — verified by stashing the fix)
2. **can invite** → shortcut pill renders, no warning text (normal path intact)

Supporting change in the test file: `useGetRolesManagementPermissions` was converted from a static mock to a `vi.fn()` (defaulting to the same values in `beforeEach`) so the `rolesAddable: []` case — which disables the button — can be simulated per-test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved invite-member button tooltips when member creation is disabled or the user lacks permission to invite members.
  * Suppressed the keyboard-shortcut tooltip when an invitation warning is displayed, ensuring users see only the relevant guidance.

* **Tests**
  * Added coverage for permission-based warning tooltips and the keyboard shortcut shown when inviting members is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->