### PR TITLE
fix(studio): drop resource-warnings staleTime to 5 minutes

### DIFF
--- a/apps/studio/data/usage/resource-warnings-query.ts
+++ b/apps/studio/data/usage/resource-warnings-query.ts
@@ -46,6 +46,6 @@ export const useResourceWarningsQuery = <TData = ResourceWarningsData>(
     queryFn: ({ signal }) => getResourceWarnings(variables, signal),
     enabled:
       IS_PLATFORM && enabled && (variables.ref !== undefined || variables.slug !== undefined),
-    staleTime: 1000 * 60 * 60,
+    staleTime: 1000 * 60 * 5,
     ...options,
   })


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

The disk space exhaustion banner can stick around for roughly two hours after the user has actually fixed the problem, which is long enough that people act on stale information and change the wrong thing.

Two caches stack:

- Studio caches resource warnings for an hour: `staleTime: 1000 * 60 * 60` in `useResourceWarningsQuery`
- The resource warnings endpoint independently only reports warnings raised in the last 60 minutes, and has no resolved signal, so a warning stops being reported by aging out rather than by being cleared

Worst case is that backend hour plus however much of the client hour the user happened to be sitting on.

Details in GROWTH-1190, split out of GROWTH-966.

## What is the new behavior?

Client `staleTime` drops to 5 minutes, which removes the client-side hour. Worst case goes from about two hours to about one.

No change to `refetchOnWindowFocus`, which already defaults to true in `apps/studio/data/query-client.ts`.

## Additional context

This deliberately only fixes the client half. The backend resolved signal, and the question of which banner should show for which disk, both stay on GROWTH-966.

Testing: unverified in the browser. It is a numeric literal on an existing field, so there is nothing new to typecheck, but I have not reproduced the stale banner locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resource warning information now refreshes more frequently, helping ensure displayed warnings are more up to date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->