### PR TITLE
fix(studio): escape SQL identifiers in row export

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/TableEntity.utils.test.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/TableEntity.utils.test.ts
@@ -29,6 +29,26 @@ describe('TableEntity.utils: formatTableRowsToSQL', () => {
     expect(result).toBe(expected)
   })
 
+  it('should quote embedded double quotes in SQL identifiers', () => {
+    const table: SupaTable = {
+      id: 1,
+      type: ENTITY_TYPE.TABLE,
+      columns: [
+        { name: 'customer"id', dataType: 'text', format: 'text', position: 0 },
+        { name: 'display"name', dataType: 'text', format: 'text', position: 1 },
+      ],
+      name: 'customer"profile',
+      schema: 'public"data',
+      comment: undefined,
+      estimateRowCount: 1,
+    }
+    const rows = [{ 'customer"id': 'cus_1', 'display"name': 'Customer 1' }]
+
+    const result = formatTableRowsToSQL(table, rows)
+    const expected = `INSERT INTO "public""data"."customer""profile" ("customer""id", "display""name") VALUES ('cus_1', 'Customer 1');`
+    expect(result).toBe(expected)
+  })
+
   it('should not stringify null values', () => {
     const table: SupaTable = {
       id: 1,

--- a/apps/studio/components/interfaces/TableGridEditor/TableEntity.utils.test.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/TableEntity.utils.test.ts
@@ -49,6 +49,20 @@ describe('TableEntity.utils: formatTableRowsToSQL', () => {
     expect(result).toBe(expected)
   })
 
+  it('should return an empty string when the table schema is missing', () => {
+    const table: SupaTable = {
+      id: 1,
+      type: ENTITY_TYPE.TABLE,
+      columns: [{ name: 'id', dataType: 'bigint', format: 'int8', position: 0 }],
+      name: 'people',
+      schema: null,
+      comment: undefined,
+      estimateRowCount: 1,
+    }
+
+    expect(formatTableRowsToSQL(table, [{ id: 1 }])).toBe('')
+  })
+
   it('should not stringify null values', () => {
     const table: SupaTable = {
       id: 1,

--- a/apps/studio/components/interfaces/TableGridEditor/TableEntity.utils.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/TableEntity.utils.ts
@@ -37,7 +37,7 @@ export const getTablePoliciesUrl = (
 const quoteIdentifier = (identifier: string): string => `"${identifier.replaceAll('"', '""')}"`
 
 export const formatTableRowsToSQL = (table: SupaTable, rows: any[]) => {
-  if (rows.length === 0) return ''
+  if (rows.length === 0 || table.schema == null) return ''
 
   const columns = table.columns.map((col) => quoteIdentifier(col.name)).join(', ')
 

--- a/apps/studio/components/interfaces/TableGridEditor/TableEntity.utils.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/TableEntity.utils.ts
@@ -34,10 +34,12 @@ export const getTablePoliciesUrl = (
   )}&schema=${encodeURIComponent(schema ?? '')}`
 }
 
+const quoteIdentifier = (identifier: string): string => `"${identifier.replaceAll('"', '""')}"`
+
 export const formatTableRowsToSQL = (table: SupaTable, rows: any[]) => {
   if (rows.length === 0) return ''
 
-  const columns = table.columns.map((col) => `"${col.name}"`).join(', ')
+  const columns = table.columns.map((col) => quoteIdentifier(col.name)).join(', ')
 
   const valuesSets = rows
     .map((row) => {
@@ -78,7 +80,7 @@ export const formatTableRowsToSQL = (table: SupaTable, rows: any[]) => {
     })
     .join(', ')
 
-  return `INSERT INTO "${table.schema}"."${table.name}" (${columns}) VALUES ${valuesSets};`
+  return `INSERT INTO ${quoteIdentifier(table.schema)}.${quoteIdentifier(table.name)} (${columns}) VALUES ${valuesSets};`
 }
 
 /**


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

`formatTableRowsToSQL` wraps schema, table, and column names in double quotes but does not escape embedded double quotes. PostgreSQL permits identifiers containing `"`, so Studio's Copy as SQL / Export as SQL can generate invalid SQL for valid identifiers.

For example, a table named `customer"profile` currently produces invalid SQL.

Fixes #49977

## What is the new behavior?

SQL identifier quoting is centralized in `quoteIdentifier()`, which doubles embedded `"` characters as required by PostgreSQL delimited identifiers.

The formatter also now returns an empty string when table metadata has no schema, avoiding malformed SQL and satisfying the nullable `SupaTable.schema` type.

Regression tests cover embedded quotes in the schema, table, and column names, plus missing schema metadata.

## Testing

Added focused regression coverage in `TableEntity.utils.test.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SQL generated from table data now safely escapes double quotes in schema, table, and column names.
  * SQL generation now returns no output when the table schema is unavailable or no rows are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->