### PR TITLE
fix(ui-patterns): align badges and input in the tiny multi-select trigger

### DIFF
--- a/packages/ui-patterns/src/multi-select/multi-select.test.tsx
+++ b/packages/ui-patterns/src/multi-select/multi-select.test.tsx
@@ -50,12 +50,14 @@ function MultiSelectDemo() {
 describe('multi-select', () => {
   it('supports the tiny control size', () => {
     render(
-      <MultiSelector size="tiny" values={[]} onValuesChange={() => undefined}>
+      <MultiSelector size="tiny" values={['Apple']} onValuesChange={() => undefined}>
         <MultiSelectorTrigger label="Select fruits" />
       </MultiSelector>
     )
 
-    expect(screen.getByRole('combobox')).toHaveClass('h-[26px]', 'p-0.5')
+    const trigger = screen.getByRole('combobox')
+    expect(trigger).toHaveClass('h-[26px]', 'p-0.5')
+    expect(trigger.firstElementChild).toHaveClass('gap-0.5')
   })
 
   it('renders selected values with a custom label', () => {

--- a/packages/ui-patterns/src/multi-select/multi-select.tsx
+++ b/packages/ui-patterns/src/multi-select/multi-select.tsx
@@ -277,6 +277,7 @@ const MultiSelectorTrigger = React.forwardRef<HTMLButtonElement, MultiSelectorTr
     const IS_BADGE_LIMIT_WRAP = badgeLimit === 'wrap'
     const IS_NUMERIC_LIMIT = typeof badgeLimit === 'number'
     const IS_INLINE_MODE = mode === 'inline-combobox'
+    const isTiny = size === 'tiny'
 
     React.useEffect(() => {
       if (!inputRef?.current || !badgesRef.current) return
@@ -290,8 +291,10 @@ const MultiSelectorTrigger = React.forwardRef<HTMLButtonElement, MultiSelectorTr
       }
     }, [values, badgeLimit])
 
-    const badgeClasses =
-      'rounded-sm shrink-0 px-1.5 bg-surface-75 dark:bg-white/5 normal-case tracking-normal text-xs'
+    const badgeClasses = cn(
+      'rounded-sm shrink-0 px-1.5 bg-surface-75 dark:bg-white/5 normal-case tracking-normal text-xs',
+      isTiny && 'h-full py-0 leading-none'
+    )
 
     const handleTriggerClick: React.MouseEventHandler<HTMLButtonElement> = React.useCallback(
       (event) => {
@@ -326,7 +329,8 @@ const MultiSelectorTrigger = React.forwardRef<HTMLButtonElement, MultiSelectorTr
           type="button"
           role="combobox"
           className={cn(
-            'flex w-full min-w-[200px] items-center justify-between rounded-md border',
+            'flex w-full min-w-[200px] justify-between rounded-md border',
+            isTiny ? 'items-stretch' : 'items-center',
             'border-strong',
             // Empty: raised plate. Filled: sunk well for chips.
             values.length > 0 ? 'bg-field' : 'bg-control-raised',
@@ -343,8 +347,8 @@ const MultiSelectorTrigger = React.forwardRef<HTMLButtonElement, MultiSelectorTr
           <div
             ref={badgesRef}
             className={cn(
-              'flex gap-1 overflow-hidden flex-1',
-              size !== 'tiny' && '-ml-1',
+              'flex overflow-hidden flex-1 min-w-0',
+              isTiny ? 'h-full min-h-0 items-center gap-0.5' : 'gap-1 -ml-1',
               IS_BADGE_LIMIT_WRAP && 'flex-wrap',
               !IS_BADGE_LIMIT_WRAP &&
                 'overflow-x-auto scrollbar-thin scrollbar-track-transparent transition-colors scrollbar-thumb-muted-foreground dark:scrollbar-thumb-muted scrollbar-thumb-rounded-lg'
@@ -378,7 +382,8 @@ const MultiSelectorTrigger = React.forwardRef<HTMLButtonElement, MultiSelectorTr
             )}
             <span
               className={cn(
-                'text-foreground-muted whitespace-nowrap leading-5.5 ml-1 opacity-0 transition-opacity hidden',
+                'text-foreground-muted whitespace-nowrap opacity-0 transition-opacity hidden',
+                isTiny ? 'leading-none' : 'ml-1 leading-5.5',
                 !IS_INLINE_MODE &&
                   (persistLabel || values.length === 0) &&
                   'opacity-100 visible inline'
@@ -394,10 +399,11 @@ const MultiSelectorTrigger = React.forwardRef<HTMLButtonElement, MultiSelectorTr
                 placeholder={values.length === 0 ? label : undefined}
                 autoFocus={false}
                 wrapperClassName={cn(
-                  'px-0 flex-1 border-none truncate',
+                  'px-0 flex-1 border-none truncate min-w-0',
+                  isTiny && 'h-full',
                   IS_BADGE_LIMIT_WRAP && 'min-w-[85px]'
                 )}
-                className="py-0 px-1 truncate"
+                className={cn('py-0 truncate', isTiny ? 'h-full px-0' : 'px-1')}
               />
             )}
           </div>
@@ -406,7 +412,7 @@ const MultiSelectorTrigger = React.forwardRef<HTMLButtonElement, MultiSelectorTr
             <ChevronsUpDown
               size={16}
               strokeWidth={1.5}
-              className="text-foreground-lighter shrink-0 ml-1.5"
+              className={cn('text-foreground-lighter shrink-0 ml-1.5', isTiny && 'self-center')}
             />
           )}
         </button>
@@ -494,7 +500,7 @@ const MultiSelectorInput = React.forwardRef<
       wrapperClassName={wrapperClassName}
       className={cn(
         MultiSelectorInputVariants({ size }),
-        'text-sm bg-transparent h-full grow border-none outline-hidden placeholder:text-foreground-muted flex-1',
+        'bg-transparent h-full grow border-none outline-hidden placeholder:text-foreground-muted flex-1',
         activeIndex !== -1 && 'caret-transparent',
         className
       )}

--- a/packages/ui-patterns/src/multi-select/multi-select.tsx
+++ b/packages/ui-patterns/src/multi-select/multi-select.tsx
@@ -297,6 +297,21 @@ const MultiSelectorLabelVariants = cva(
   }
 )
 
+const MultiSelectorInlineInputWrapperVariants = cva('px-0 flex-1 border-none truncate min-w-0', {
+  variants: {
+    size: {
+      tiny: 'h-full',
+      small: '',
+      medium: '',
+      large: '',
+      xlarge: '',
+    },
+  },
+  defaultVariants: {
+    size: SIZE_VARIANTS_DEFAULT,
+  },
+})
+
 const MultiSelectorInlineInputVariants = cva('py-0 truncate', {
   variants: {
     size: {
@@ -460,7 +475,7 @@ const MultiSelectorTrigger = React.forwardRef<HTMLButtonElement, MultiSelectorTr
                 placeholder={values.length === 0 ? label : undefined}
                 autoFocus={false}
                 wrapperClassName={cn(
-                  'h-full px-0 flex-1 border-none truncate min-w-0',
+                  MultiSelectorInlineInputWrapperVariants({ size }),
                   IS_BADGE_LIMIT_WRAP && 'min-w-[85px]'
                 )}
                 className={MultiSelectorInlineInputVariants({ size })}

--- a/packages/ui-patterns/src/multi-select/multi-select.tsx
+++ b/packages/ui-patterns/src/multi-select/multi-select.tsx
@@ -360,6 +360,7 @@ const MultiSelectorTrigger = React.forwardRef<HTMLButtonElement, MultiSelectorTr
     const IS_BADGE_LIMIT_WRAP = badgeLimit === 'wrap'
     const IS_NUMERIC_LIMIT = typeof badgeLimit === 'number'
     const IS_INLINE_MODE = mode === 'inline-combobox'
+    const HAS_TINY_PLACEHOLDER = size === 'tiny' && values.length === 0
 
     React.useEffect(() => {
       if (!inputRef?.current || !badgesRef.current) return
@@ -460,6 +461,7 @@ const MultiSelectorTrigger = React.forwardRef<HTMLButtonElement, MultiSelectorTr
             <span
               className={cn(
                 MultiSelectorLabelVariants({ size }),
+                HAS_TINY_PLACEHOLDER && 'ml-2',
                 !IS_INLINE_MODE &&
                   (persistLabel || values.length === 0) &&
                   'opacity-100 visible inline'
@@ -478,7 +480,10 @@ const MultiSelectorTrigger = React.forwardRef<HTMLButtonElement, MultiSelectorTr
                   MultiSelectorInlineInputWrapperVariants({ size }),
                   IS_BADGE_LIMIT_WRAP && 'min-w-[85px]'
                 )}
-                className={MultiSelectorInlineInputVariants({ size })}
+                className={cn(
+                  MultiSelectorInlineInputVariants({ size }),
+                  HAS_TINY_PLACEHOLDER && 'pl-2'
+                )}
               />
             )}
           </div>

--- a/packages/ui-patterns/src/multi-select/multi-select.tsx
+++ b/packages/ui-patterns/src/multi-select/multi-select.tsx
@@ -229,14 +229,82 @@ export interface MultiSelectorTriggerProps extends React.HTMLAttributes<HTMLButt
   renderValue?: (value: string) => React.ReactNode
 }
 
+// The tiny control has no vertical padding to spare, so its children stretch to the
+// control height and drop their line-height; the larger sizes center normally.
 const MultiSelectorTriggerVariants = cva('', {
   variants: {
     size: {
-      tiny: 'h-[26px] p-0.5 text-xs',
-      small: 'min-h-[34px] px-3 py-1.5 text-sm',
-      medium: 'min-h-[38px] px-4 py-2 text-sm',
-      large: 'min-h-[42px] px-4 py-2 text-base',
-      xlarge: 'min-h-[50px] px-6 py-3 text-base',
+      tiny: 'h-[26px] p-0.5 text-xs items-stretch',
+      small: 'min-h-[34px] px-3 py-1.5 text-sm items-center',
+      medium: 'min-h-[38px] px-4 py-2 text-sm items-center',
+      large: 'min-h-[42px] px-4 py-2 text-base items-center',
+      xlarge: 'min-h-[50px] px-6 py-3 text-base items-center',
+    },
+  },
+  defaultVariants: {
+    size: SIZE_VARIANTS_DEFAULT,
+  },
+})
+
+const MultiSelectorBadgesVariants = cva('flex overflow-hidden flex-1 min-w-0', {
+  variants: {
+    size: {
+      tiny: 'h-full min-h-0 items-center gap-0.5',
+      small: 'gap-1 -ml-1',
+      medium: 'gap-1 -ml-1',
+      large: 'gap-1 -ml-1',
+      xlarge: 'gap-1 -ml-1',
+    },
+  },
+  defaultVariants: {
+    size: SIZE_VARIANTS_DEFAULT,
+  },
+})
+
+const MultiSelectorBadgeVariants = cva(
+  'rounded-sm shrink-0 px-1.5 bg-surface-75 dark:bg-white/5 normal-case tracking-normal text-xs',
+  {
+    variants: {
+      size: {
+        tiny: 'h-full py-0 leading-none',
+        small: '',
+        medium: '',
+        large: '',
+        xlarge: '',
+      },
+    },
+    defaultVariants: {
+      size: SIZE_VARIANTS_DEFAULT,
+    },
+  }
+)
+
+const MultiSelectorLabelVariants = cva(
+  'text-foreground-muted whitespace-nowrap opacity-0 transition-opacity hidden',
+  {
+    variants: {
+      size: {
+        tiny: 'leading-none',
+        small: 'ml-1 leading-5.5',
+        medium: 'ml-1 leading-5.5',
+        large: 'ml-1 leading-5.5',
+        xlarge: 'ml-1 leading-5.5',
+      },
+    },
+    defaultVariants: {
+      size: SIZE_VARIANTS_DEFAULT,
+    },
+  }
+)
+
+const MultiSelectorInlineInputVariants = cva('py-0 truncate', {
+  variants: {
+    size: {
+      tiny: 'px-0',
+      small: 'px-1',
+      medium: 'px-1',
+      large: 'px-1',
+      xlarge: 'px-1',
     },
   },
   defaultVariants: {
@@ -277,7 +345,6 @@ const MultiSelectorTrigger = React.forwardRef<HTMLButtonElement, MultiSelectorTr
     const IS_BADGE_LIMIT_WRAP = badgeLimit === 'wrap'
     const IS_NUMERIC_LIMIT = typeof badgeLimit === 'number'
     const IS_INLINE_MODE = mode === 'inline-combobox'
-    const isTiny = size === 'tiny'
 
     React.useEffect(() => {
       if (!inputRef?.current || !badgesRef.current) return
@@ -291,10 +358,7 @@ const MultiSelectorTrigger = React.forwardRef<HTMLButtonElement, MultiSelectorTr
       }
     }, [values, badgeLimit])
 
-    const badgeClasses = cn(
-      'rounded-sm shrink-0 px-1.5 bg-surface-75 dark:bg-white/5 normal-case tracking-normal text-xs',
-      isTiny && 'h-full py-0 leading-none'
-    )
+    const badgeClasses = MultiSelectorBadgeVariants({ size })
 
     const handleTriggerClick: React.MouseEventHandler<HTMLButtonElement> = React.useCallback(
       (event) => {
@@ -330,7 +394,6 @@ const MultiSelectorTrigger = React.forwardRef<HTMLButtonElement, MultiSelectorTr
           role="combobox"
           className={cn(
             'flex w-full min-w-[200px] justify-between rounded-md border',
-            isTiny ? 'items-stretch' : 'items-center',
             'border-strong',
             // Empty: raised plate. Filled: sunk well for chips.
             values.length > 0 ? 'bg-field' : 'bg-control-raised',
@@ -347,8 +410,7 @@ const MultiSelectorTrigger = React.forwardRef<HTMLButtonElement, MultiSelectorTr
           <div
             ref={badgesRef}
             className={cn(
-              'flex overflow-hidden flex-1 min-w-0',
-              isTiny ? 'h-full min-h-0 items-center gap-0.5' : 'gap-1 -ml-1',
+              MultiSelectorBadgesVariants({ size }),
               IS_BADGE_LIMIT_WRAP && 'flex-wrap',
               !IS_BADGE_LIMIT_WRAP &&
                 'overflow-x-auto scrollbar-thin scrollbar-track-transparent transition-colors scrollbar-thumb-muted-foreground dark:scrollbar-thumb-muted scrollbar-thumb-rounded-lg'
@@ -382,8 +444,7 @@ const MultiSelectorTrigger = React.forwardRef<HTMLButtonElement, MultiSelectorTr
             )}
             <span
               className={cn(
-                'text-foreground-muted whitespace-nowrap opacity-0 transition-opacity hidden',
-                isTiny ? 'leading-none' : 'ml-1 leading-5.5',
+                MultiSelectorLabelVariants({ size }),
                 !IS_INLINE_MODE &&
                   (persistLabel || values.length === 0) &&
                   'opacity-100 visible inline'
@@ -399,11 +460,10 @@ const MultiSelectorTrigger = React.forwardRef<HTMLButtonElement, MultiSelectorTr
                 placeholder={values.length === 0 ? label : undefined}
                 autoFocus={false}
                 wrapperClassName={cn(
-                  'px-0 flex-1 border-none truncate min-w-0',
-                  isTiny && 'h-full',
+                  'h-full px-0 flex-1 border-none truncate min-w-0',
                   IS_BADGE_LIMIT_WRAP && 'min-w-[85px]'
                 )}
-                className={cn('py-0 truncate', isTiny ? 'h-full px-0' : 'px-1')}
+                className={MultiSelectorInlineInputVariants({ size })}
               />
             )}
           </div>
@@ -412,7 +472,7 @@ const MultiSelectorTrigger = React.forwardRef<HTMLButtonElement, MultiSelectorTr
             <ChevronsUpDown
               size={16}
               strokeWidth={1.5}
-              className={cn('text-foreground-lighter shrink-0 ml-1.5', isTiny && 'self-center')}
+              className="text-foreground-lighter shrink-0 ml-1.5 self-center"
             />
           )}
         </button>


### PR DESCRIPTION


## What's changed

**Before**
<img width="467" height="353" alt="image" src="https://github.com/user-attachments/assets/4587d51a-8bbe-4da4-a3dd-dcaac6b17993" />

**After**
<img width="541" height="360" alt="image" src="https://github.com/user-attachments/assets/de66b229-54b0-4443-9c49-6f2ff0dd93aa" />

Independent of the Explorer/assistant stack.

`MultiSelectorTrigger` with `size="tiny"` had badges and the inline input overflowing the 26px control. The trigger now stretches its children (`items-stretch`), badges are `h-full py-0 leading-none` with a tighter `gap-0.5`, the input/label drop their extra padding and line-height, and the chevron self-centers. Other sizes are unchanged (`isTiny` guards every new class). Also drops a redundant `text-sm` from `MultiSelectorInput`, which `MultiSelectorInputVariants` already sets per size.

## How to test

1. Design system (`pnpm dev:design-system`) or anywhere Studio uses `<MultiSelector size="tiny">` (e.g. Logs filters): with 1–3 values selected the badges sit inside the 26px control with no clipping; the placeholder and chevron are vertically centered.
2. `size="small"` / default still look the same as on `master`.
3. `pnpm --filter ui-patterns exec vitest --run src/multi-select` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved the compact multi-select control layout, including spacing, alignment, selected-value badges, input sizing, and dropdown indicator positioning.
  - Adjusted placeholder spacing when the tiny control has no selected values.

- **Tests**
  - Updated coverage to verify compact spacing and sizing when the tiny multi-select control displays a selected value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->