### PR TITLE
docs: simplify troubleshooting landing page

### DIFF
--- a/apps/docs/app/guides/troubleshooting/page.tsx
+++ b/apps/docs/app/guides/troubleshooting/page.tsx
@@ -16,8 +16,6 @@ import { PROD_URL } from '~/lib/constants'
 import { getCustomContent } from '~/lib/custom-content/getCustomContent'
 import { mdAlternate } from '~/lib/md-alternates'
 import { type Metadata } from 'next'
-import Link from 'next/link'
-import { Admonition } from 'ui-patterns/Admonition'
 
 const { metadataTitle } = getCustomContent(['metadata:title'])
 
@@ -33,76 +31,6 @@ export default async function GlobalTroubleshootingPage() {
         <h1 className="text-4xl tracking-tight mb-7">Troubleshooting</h1>
         <p className="text-lg text-foreground-light">
           Search or browse our troubleshooting guides for solutions to common Supabase issues.
-        </p>
-        <p className="text-foreground-light mt-4">
-          Don&apos;t have a specific error yet? Start with{' '}
-          <Link href="/guides/observability/detecting" className="text-brand-link hover:underline">
-            Detecting
-          </Link>{' '}
-          to pick up a signal first. If you already have one, confirm one cause before you change
-          anything:
-        </p>
-        <ol className="list-decimal list-outside pl-5 text-foreground-light mt-4 space-y-1">
-          <li>
-            Capture the exact HTTP status, error code, and message. A <code>401</code> is not a{' '}
-            <code>403</code>; <code>PGRST002</code> is not <code>PGRST106</code>. If you use{' '}
-            <code>supabase-js</code>, errors are returned in <code>{'{ data, error }'}</code>, not
-            thrown. Inspect <code>error</code>; ignoring it hides the failure.
-          </li>
-          <li>
-            Query the{' '}
-            <Link
-              href="/guides/observability/advanced-log-filtering#logs-explorer"
-              className="text-brand-link hover:underline"
-            >
-              log source
-            </Link>{' '}
-            for that layer. When two layers could fit, start closer to the database.
-          </li>
-          <li>
-            Search below for that error. Each article confirms one cause, applies one fix, and tells
-            you how to verify it.
-          </li>
-          <li>
-            Re-run the failing operation. Keep the change only when the original symptom is gone. If
-            verification fails, reverse the change and look again.
-          </li>
-        </ol>
-        <p className="text-foreground-light mt-4">
-          For client-side or local debugging, see{' '}
-          <Link
-            href="/guides/auth/debugging/error-codes"
-            className="text-brand-link hover:underline"
-          >
-            Auth error codes
-          </Link>
-          ,{' '}
-          <Link href="/guides/storage/debugging/logs" className="text-brand-link hover:underline">
-            Storage logs
-          </Link>
-          , and{' '}
-          <Link
-            href="/guides/functions/debugging-tools"
-            className="text-brand-link hover:underline"
-          >
-            Edge Functions debugging tools
-          </Link>
-          .
-        </p>
-        <Admonition type="danger" className="mt-4">
-          Deleting data, disabling row-level security, weakening a policy, or terminating a database
-          process can cause data loss or a security incident. Do not let an automated routine
-          perform these changes.
-        </Admonition>
-        <p className="text-foreground-light mt-4">
-          Escalate to{' '}
-          <Link href="/dashboard/support/new" className="text-brand-link hover:underline">
-            Support
-          </Link>{' '}
-          when you cannot access the diagnostic source, the evidence points to a platform failure,
-          or a safe fix needs a permission you do not have. Include the project reference, timestamp
-          with time zone, error code, request ID, and sanitized evidence. Do not include passwords,
-          API keys, or personal data.
         </p>
         <hr className="my-7" aria-hidden />
         <TroubleshootingFilter


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update.

## What is the current behavior?

The troubleshooting landing page includes a lengthy diagnostic workflow, related debugging links, a destructive-action warning, and support escalation guidance before the search interface. This makes the troubleshooting catalog harder to scan.

## What is the new behavior?

The page returns to a concise catalog layout: title, short description, and the troubleshooting search and filters.

## Additional context

Validation completed:

- Prettier
- ESLint
- Git whitespace check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Streamlined the troubleshooting guide to focus on its heading, description, and search/browse troubleshooting interface.
  - Removed introductory debugging guidance, related-guide links, data-loss warning, and support-escalation information from the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->