### PR TITLE
feat(studio): gate health advisor behind flag

### DIFF
--- a/apps/studio/components/interfaces/ProjectHome/AdvisorSection.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/AdvisorSection.tsx
@@ -1,4 +1,4 @@
-import { useParams } from 'common'
+import { useFlag, useParams } from 'common'
 import { Shield } from 'lucide-react'
 import { useCallback, useMemo } from 'react'
 import { AiIconAnimation, Badge, Button, Card, CardContent, CardHeader, CardTitle, cn } from 'ui'
@@ -35,6 +35,7 @@ export const AdvisorSection = ({ showEmptyState = false }: { showEmptyState?: bo
   const snap = useAiAssistantStateSnapshot()
   const { openSidebar } = useSidebarManagerSnapshot()
   const { setSelectedItem } = useAdvisorStateSnapshot()
+  const isHealthAdvisorEnabled = useFlag('healthAdvisor') === true
 
   const { data: lints, isLoading: isLoadingLints } = useProjectLintsQuery(
     { projectRef },
@@ -43,7 +44,7 @@ export const AdvisorSection = ({ showEmptyState = false }: { showEmptyState?: bo
 
   const { data: healthLints } = useProjectHealthLintsQuery(
     { projectRef },
-    { enabled: !showEmptyState }
+    { enabled: !showEmptyState && isHealthAdvisorEnabled }
   )
 
   const { data: signalItems } = useAdvisorSignals({ projectRef, enabled: !showEmptyState })
@@ -51,11 +52,11 @@ export const AdvisorSection = ({ showEmptyState = false }: { showEmptyState?: bo
   const advisorItems = useMemo<AdvisorItem[]>(() => {
     const criticalLintItems = createAdvisorLintItems([
       ...(lints ?? []),
-      ...(healthLints ?? []),
+      ...(isHealthAdvisorEnabled ? (healthLints ?? []) : []),
     ]).filter((item) => item.source === 'lint' && item.original.level === LINTER_LEVELS.ERROR)
 
     return sortAdvisorItems([...criticalLintItems, ...signalItems])
-  }, [lints, healthLints, signalItems])
+  }, [lints, healthLints, isHealthAdvisorEnabled, signalItems])
 
   const visibleAdvisorItems = useMemo(
     () => advisorItems.slice(0, MAX_HOMEPAGE_ADVISOR_ITEMS),
@@ -229,19 +230,21 @@ export const AdvisorSection = ({ showEmptyState = false }: { showEmptyState?: bo
           )}
         </>
       ) : (
-        <EmptyState />
+        <EmptyState isHealthAdvisorEnabled={isHealthAdvisorEnabled} />
       )}
     </div>
   )
 }
 
-function EmptyState() {
+function EmptyState({ isHealthAdvisorEnabled }: { isHealthAdvisorEnabled: boolean }) {
   return (
     <Card className="bg-transparent h-64">
       <CardContent className="flex flex-col items-center justify-center gap-2 p-16 h-full">
         <Shield size={20} strokeWidth={1.5} className="text-foreground-muted" />
         <p className="text-sm text-foreground-light text-center">
-          No security, performance or health issues found
+          {isHealthAdvisorEnabled
+            ? 'No security, performance or health issues found'
+            : 'No security or performance issues found'}
         </p>
       </CardContent>
     </Card>

--- a/apps/studio/components/layouts/AdvisorsLayout/Advisors.Commands.tsx
+++ b/apps/studio/components/layouts/AdvisorsLayout/Advisors.Commands.tsx
@@ -1,4 +1,4 @@
-import { useParams } from 'common'
+import { useFlag, useParams } from 'common'
 import type { CommandOptions } from 'ui-patterns/CommandMenu'
 import { useRegisterCommands } from 'ui-patterns/CommandMenu'
 import type { IRouteCommand } from 'ui-patterns/CommandMenu/internal/types'
@@ -9,11 +9,12 @@ import { IS_PLATFORM } from '@/lib/constants'
 export function useAdvisorsGoToCommands(options?: CommandOptions) {
   let { ref } = useParams()
   ref ||= '_'
+  const isHealthAdvisorEnabled = useFlag('healthAdvisor') === true
 
   useRegisterCommands(
     COMMAND_MENU_SECTIONS.NAVIGATE,
     [
-      ...(IS_PLATFORM
+      ...(IS_PLATFORM && isHealthAdvisorEnabled
         ? [
             {
               id: 'nav-advisors-health',
@@ -36,6 +37,6 @@ export function useAdvisorsGoToCommands(options?: CommandOptions) {
         defaultHidden: true,
       },
     ],
-    { ...options, deps: [ref] }
+    { ...options, deps: [ref, isHealthAdvisorEnabled] }
   )
 }

--- a/apps/studio/components/layouts/AdvisorsLayout/AdvisorsMenu.utils.test.ts
+++ b/apps/studio/components/layouts/AdvisorsLayout/AdvisorsMenu.utils.test.ts
@@ -7,6 +7,7 @@ describe('generateAdvisorsMenu', () => {
     const [advisors] = generateAdvisorsMenu({
       ref: 'abc',
       isAdvisorRulesEnabled: false,
+      isHealthAdvisorEnabled: true,
       isPlatform: true,
     })
 
@@ -23,7 +24,23 @@ describe('generateAdvisorsMenu', () => {
     const [advisors] = generateAdvisorsMenu({
       ref: 'abc',
       isAdvisorRulesEnabled: false,
+      isHealthAdvisorEnabled: false,
       isPlatform: false,
+    })
+
+    expect(advisors.items.map((item) => item.key)).toEqual([
+      'security',
+      'performance',
+      'query-performance',
+    ])
+  })
+
+  it('omits Health Advisor when the flag is disabled', () => {
+    const [advisors] = generateAdvisorsMenu({
+      ref: 'abc',
+      isAdvisorRulesEnabled: false,
+      isHealthAdvisorEnabled: false,
+      isPlatform: true,
     })
 
     expect(advisors.items.map((item) => item.key)).toEqual([

--- a/apps/studio/components/layouts/AdvisorsLayout/AdvisorsMenu.utils.tsx
+++ b/apps/studio/components/layouts/AdvisorsLayout/AdvisorsMenu.utils.tsx
@@ -1,4 +1,4 @@
-import { useParams } from 'common'
+import { useFlag, useParams } from 'common'
 import { ArrowUpRight } from 'lucide-react'
 
 import { useIsAdvisorRulesEnabled } from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
@@ -12,14 +12,16 @@ import { SHORTCUT_IDS } from '@/state/shortcuts/registry'
 export const generateAdvisorsMenu = ({
   ref,
   isAdvisorRulesEnabled,
+  isHealthAdvisorEnabled,
   isPlatform,
 }: {
   ref: string | undefined
   isAdvisorRulesEnabled: boolean
+  isHealthAdvisorEnabled: boolean
   isPlatform: boolean
 }): ProductMenuGroup[] => {
   const advisorItems: ProductMenuGroupItem[] = [
-    ...(isPlatform
+    ...(isPlatform && isHealthAdvisorEnabled
       ? [
           {
             name: 'Health Advisor',
@@ -80,10 +82,12 @@ export const generateAdvisorsMenu = ({
 export const useGenerateAdvisorsMenu = (): ProductMenuGroup[] => {
   const { ref } = useParams()
   const isAdvisorRulesEnabled = useIsAdvisorRulesEnabled()
+  const isHealthAdvisorEnabled = useFlag('healthAdvisor') === true
 
   return generateAdvisorsMenu({
     ref,
     isAdvisorRulesEnabled,
+    isHealthAdvisorEnabled,
     isPlatform: IS_PLATFORM,
   })
 }

--- a/apps/studio/components/ui/AdvisorPanel/AdvisorFilters.tsx
+++ b/apps/studio/components/ui/AdvisorPanel/AdvisorFilters.tsx
@@ -46,6 +46,7 @@ interface AdvisorFiltersProps {
   onStatusFiltersChange: (filters: string[]) => void
   onClose: () => void
   isPlatform?: boolean
+  isHealthAdvisorEnabled?: boolean
 }
 
 export const AdvisorFilters = ({
@@ -57,10 +58,11 @@ export const AdvisorFilters = ({
   onStatusFiltersChange,
   onClose,
   isPlatform = false,
+  isHealthAdvisorEnabled = false,
 }: AdvisorFiltersProps) => {
-  const categoryOptions = (isPlatform ? platformCategories : selfHostedCategories).map(
-    (category) => ({ label: advisorCategoryLabels[category], value: category })
-  )
+  const categoryOptions = (isPlatform ? platformCategories : selfHostedCategories)
+    .filter((category) => isHealthAdvisorEnabled || category !== 'health')
+    .map((category) => ({ label: advisorCategoryLabels[category], value: category }))
 
   return (
     <div className="border-b overflow-x-auto">

--- a/apps/studio/components/ui/AdvisorPanel/AdvisorPanel.tsx
+++ b/apps/studio/components/ui/AdvisorPanel/AdvisorPanel.tsx
@@ -1,3 +1,4 @@
+import { useFlag } from 'common'
 import { useMemo, useRef } from 'react'
 
 import { AdvisorDetail } from './AdvisorDetail'
@@ -42,19 +43,24 @@ export const AdvisorPanel = () => {
   } = useAdvisorStateSnapshot()
   const { data: project } = useSelectedProjectQuery()
   const { activeSidebar, closeSidebar } = useSidebarManagerSnapshot()
+  const isHealthAdvisorEnabled = useFlag('healthAdvisor') === true
 
   const isSidebarOpen = activeSidebar?.id === SIDEBAR_KEYS.ADVISOR_PANEL
   const markedRead = useRef<string[]>([])
   const hasProjectRef = !!project?.ref
+  const visibleCategoryFilters = isHealthAdvisorEnabled
+    ? categoryFilters
+    : categoryFilters.filter((category) => category !== 'health')
   const isCategorySelected = (category: AdvisorCategory) =>
-    categoryFilters.length === 0 || categoryFilters.includes(category)
+    visibleCategoryFilters.length === 0 || visibleCategoryFilters.includes(category)
   // Each source is fetched only when a category it can produce items for is selected, so
   // filtering down to one category doesn't run the checks behind the others. Health in
   // particular hits live infrastructure, and signals only ever produce security items.
   const canLoadProjectData = isSidebarOpen && hasProjectRef
   const shouldLoadLints =
     canLoadProjectData && (isCategorySelected('security') || isCategorySelected('performance'))
-  const shouldLoadHealthLints = canLoadProjectData && isCategorySelected('health')
+  const shouldLoadHealthLints =
+    isHealthAdvisorEnabled && canLoadProjectData && isCategorySelected('health')
   const shouldLoadSignals = canLoadProjectData && isCategorySelected('security')
 
   const {
@@ -132,8 +138,11 @@ export const AdvisorPanel = () => {
   }
 
   const lintItems = useMemo<AdvisorItem[]>(() => {
-    return createAdvisorLintItems([...(lintData ?? []), ...(healthLintData ?? [])])
-  }, [lintData, healthLintData])
+    return createAdvisorLintItems([
+      ...(lintData ?? []),
+      ...(isHealthAdvisorEnabled ? (healthLintData ?? []) : []),
+    ])
+  }, [lintData, healthLintData, isHealthAdvisorEnabled])
 
   const notificationItems = useMemo<AdvisorItem[]>(() => {
     if (!IS_PLATFORM) return []
@@ -149,9 +158,11 @@ export const AdvisorPanel = () => {
       // Notifications are the only items that exist without a project
       if (!hasProjectRef && item.source !== 'notification') return false
 
-      return categoryFilters.length === 0 || categoryFilters.includes(item.category)
+      return (
+        visibleCategoryFilters.length === 0 || visibleCategoryFilters.includes(item.category)
+      )
     })
-  }, [combinedItems, categoryFilters, hasProjectRef])
+  }, [combinedItems, visibleCategoryFilters, hasProjectRef])
 
   const filteredItems = useMemo<AdvisorItem[]>(() => {
     if (severityFilters.length === 0) return itemsFilteredByCategory
@@ -171,7 +182,10 @@ export const AdvisorPanel = () => {
   // Health checks hit live infrastructure and are the slowest of the three. They only block
   // the list when health is all the user asked for — otherwise health items just fill in
   // once they arrive, rather than holding up everything else.
-  const isShowingHealthOnly = categoryFilters.length === 1 && categoryFilters[0] === 'health'
+  const isShowingHealthOnly =
+    isHealthAdvisorEnabled &&
+    visibleCategoryFilters.length === 1 &&
+    visibleCategoryFilters[0] === 'health'
   const isHealthLintsActuallyLoading =
     shouldLoadHealthLints && isHealthLintsLoading && isShowingHealthOnly
 
@@ -256,7 +270,7 @@ export const AdvisorPanel = () => {
       ) : (
         <>
           <AdvisorFilters
-            categoryFilters={[...categoryFilters]}
+            categoryFilters={[...visibleCategoryFilters]}
             onCategoryFiltersChange={(categories) => {
               setCategoryFilters(categories)
               setSelectedItem(undefined)
@@ -274,13 +288,14 @@ export const AdvisorPanel = () => {
             }}
             onClose={handleClose}
             isPlatform={IS_PLATFORM}
+            isHealthAdvisorEnabled={isHealthAdvisorEnabled}
           />
           <div className="flex-1 overflow-y-auto">
             <AdvisorPanelBody
               isLoading={isLoading}
               isError={isError}
               filteredItems={filteredItems}
-              categoryFilters={[...categoryFilters]}
+              categoryFilters={[...visibleCategoryFilters]}
               severityFilters={[...severityFilters]}
               onItemClick={handleItemClick}
               onClearFilters={clearFilters}
@@ -289,6 +304,7 @@ export const AdvisorPanel = () => {
               hasAnyFilters={hasNarrowingFilters}
               hasProjectRef={hasProjectRef}
               projectNameByRef={projectNameByRef}
+              isHealthAdvisorEnabled={isHealthAdvisorEnabled}
             />
           </div>
         </>

--- a/apps/studio/components/ui/AdvisorPanel/AdvisorPanelBody.tsx
+++ b/apps/studio/components/ui/AdvisorPanel/AdvisorPanelBody.tsx
@@ -16,14 +16,18 @@ import { EmptyAdvisor } from './EmptyAdvisor'
 import type { Notification } from '@/data/notifications/notifications-v2-query'
 import type { AdvisorCategory, AdvisorSeverity } from '@/state/advisor-state'
 
-const NoProjectNotice = () => {
+const NoProjectNotice = ({ isHealthAdvisorEnabled }: { isHealthAdvisorEnabled: boolean }) => {
+  const advisorCategories = isHealthAdvisorEnabled
+    ? 'security, performance and health'
+    : 'security and performance'
+
   return (
     <div className="absolute top-28 px-6 flex flex-col items-center justify-center w-full gap-y-2">
       <Inbox className="text-foreground-muted" strokeWidth={1} />
       <div className="text-center">
         <p className="heading-default">Project required</p>
         <p className="text-foreground-light text-sm">
-          Select a project to view its security, performance and health advisories
+          Select a project to view its {advisorCategories} advisories
         </p>
       </div>
     </div>
@@ -43,6 +47,7 @@ interface AdvisorPanelBodyProps {
   hasAnyFilters: boolean
   hasProjectRef?: boolean
   projectNameByRef?: ReadonlyMap<string, string>
+  isHealthAdvisorEnabled: boolean
 }
 
 export const AdvisorPanelBody = ({
@@ -58,13 +63,14 @@ export const AdvisorPanelBody = ({
   hasAnyFilters,
   hasProjectRef = true,
   projectNameByRef,
+  isHealthAdvisorEnabled,
 }: AdvisorPanelBodyProps) => {
   // Notifications are the only items that exist without a project, so the notice replaces
   // the list whenever the user has narrowed to categories that need one.
   const needsProject =
     categoryFilters.length > 0 && categoryFilters.every((category) => category !== 'messages')
   if (!hasProjectRef && needsProject) {
-    return <NoProjectNotice />
+    return <NoProjectNotice isHealthAdvisorEnabled={isHealthAdvisorEnabled} />
   }
 
   if (isLoading) {

--- a/apps/studio/data/lint/health-lints-query.ts
+++ b/apps/studio/data/lint/health-lints-query.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import type { components } from 'api-types'
+import { useFlag } from 'common'
 
 import { lintKeys } from './keys'
 import type { Lint } from './lint-query'
@@ -75,12 +76,14 @@ export const useProjectHealthLintsQuery = <TData = ProjectHealthLintsData>(
   }: UseCustomQueryOptions<ProjectHealthLintsData, ProjectHealthLintsError, TData> = {}
 ) => {
   const { data: project } = useSelectedProjectQuery()
+  const isHealthAdvisorEnabled = useFlag('healthAdvisor') === true
   const isActive = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY
 
   return useQuery<ProjectHealthLintsData, ProjectHealthLintsError, TData>({
     queryKey: lintKeys.healthLints(projectRef),
     queryFn: ({ signal }) => getProjectHealthLints({ projectRef }, signal),
-    enabled: enabled && IS_PLATFORM && typeof projectRef !== 'undefined' && isActive,
+    enabled:
+      enabled && isHealthAdvisorEnabled && IS_PLATFORM && typeof projectRef !== 'undefined' && isActive,
     // Every run costs a live database connection plus a metrics and a logs query, so keep
     // repeat mounts (homepage row, advisor panel) on one result and don't retry failures.
     staleTime: 60_000,

--- a/apps/studio/pages/project/[ref]/advisors/health.tsx
+++ b/apps/studio/pages/project/[ref]/advisors/health.tsx
@@ -41,7 +41,7 @@ const ProjectHealthLints: NextPageWithLayout = () => {
   const isFlagLoading = IS_PLATFORM && !flagsLoaded
 
   useEffect(() => {
-    if (!isFlagLoading && !isHealthAdvisorEnabled) {
+    if (!isFlagLoading && !isHealthAdvisorEnabled && ref) {
       router.replace(`/project/${ref}/advisors/security`)
     }
   }, [isFlagLoading, isHealthAdvisorEnabled, ref, router])

--- a/apps/studio/pages/project/[ref]/advisors/health.tsx
+++ b/apps/studio/pages/project/[ref]/advisors/health.tsx
@@ -1,5 +1,6 @@
-import { useParams } from 'common'
-import { useMemo, useState } from 'react'
+import { useFeatureFlags, useFlag, useParams } from 'common'
+import { useRouter } from 'next/router'
+import { useEffect, useMemo, useState } from 'react'
 import { LoadingLine } from 'ui'
 
 import { LINTER_LEVELS } from '@/components/interfaces/Linter/Linter.constants'
@@ -18,8 +19,11 @@ import { IS_PLATFORM } from '@/lib/constants'
 import type { NextPageWithLayout } from '@/types'
 
 const ProjectHealthLints: NextPageWithLayout = () => {
-  const { preset, id } = useParams()
+  const router = useRouter()
+  const { preset, id, ref } = useParams()
   const { data: project } = useSelectedProjectQuery()
+  const { hasLoaded: flagsLoaded } = useFeatureFlags()
+  const isHealthAdvisorEnabled = useFlag('healthAdvisor') === true
 
   const [filters, setFilters] = useState<{ level: LINTER_LEVELS; filters: string[] }[]>([
     { level: LINTER_LEVELS.ERROR, filters: [] },
@@ -29,9 +33,20 @@ const ProjectHealthLints: NextPageWithLayout = () => {
   const [currentTab, setCurrentTab] = useState<LINTER_LEVELS>(
     parseLinterLevel(preset) ?? LINTER_LEVELS.ERROR
   )
-  const { data, isPending, isRefetching, refetch } = useProjectHealthLintsQuery({
-    projectRef: project?.ref,
-  })
+  const { data, isPending, isRefetching, refetch } = useProjectHealthLintsQuery(
+    { projectRef: project?.ref },
+    { enabled: isHealthAdvisorEnabled }
+  )
+
+  const isFlagLoading = IS_PLATFORM && !flagsLoaded
+
+  useEffect(() => {
+    if (!isFlagLoading && !isHealthAdvisorEnabled) {
+      router.replace(`/project/${ref}/advisors/security`)
+    }
+  }, [isFlagLoading, isHealthAdvisorEnabled, ref, router])
+
+  if (isFlagLoading || !isHealthAdvisorEnabled) return null
 
   // Health checks are platform-only. If this page is opened self-hosted the query stays
   // disabled, and `isPending` would otherwise spin forever.

--- a/apps/studio/pages/project/[ref]/advisors/health.tsx
+++ b/apps/studio/pages/project/[ref]/advisors/health.tsx
@@ -20,23 +20,9 @@ import type { NextPageWithLayout } from '@/types'
 
 const ProjectHealthLints: NextPageWithLayout = () => {
   const router = useRouter()
-  const { preset, id, ref } = useParams()
-  const { data: project } = useSelectedProjectQuery()
+  const { ref } = useParams()
   const { hasLoaded: flagsLoaded } = useFeatureFlags()
   const isHealthAdvisorEnabled = useFlag('healthAdvisor') === true
-
-  const [filters, setFilters] = useState<{ level: LINTER_LEVELS; filters: string[] }[]>([
-    { level: LINTER_LEVELS.ERROR, filters: [] },
-    { level: LINTER_LEVELS.WARN, filters: [] },
-    { level: LINTER_LEVELS.INFO, filters: [] },
-  ])
-  const [currentTab, setCurrentTab] = useState<LINTER_LEVELS>(
-    parseLinterLevel(preset) ?? LINTER_LEVELS.ERROR
-  )
-  const { data, isPending, isRefetching, refetch } = useProjectHealthLintsQuery(
-    { projectRef: project?.ref },
-    { enabled: isHealthAdvisorEnabled }
-  )
 
   const isFlagLoading = IS_PLATFORM && !flagsLoaded
 
@@ -47,6 +33,25 @@ const ProjectHealthLints: NextPageWithLayout = () => {
   }, [isFlagLoading, isHealthAdvisorEnabled, ref, router])
 
   if (isFlagLoading || !isHealthAdvisorEnabled) return null
+
+  return <ProjectHealthLintsContent />
+}
+
+const ProjectHealthLintsContent = () => {
+  const { preset, id } = useParams()
+  const { data: project } = useSelectedProjectQuery()
+
+  const [filters, setFilters] = useState<{ level: LINTER_LEVELS; filters: string[] }[]>([
+    { level: LINTER_LEVELS.ERROR, filters: [] },
+    { level: LINTER_LEVELS.WARN, filters: [] },
+    { level: LINTER_LEVELS.INFO, filters: [] },
+  ])
+  const [currentTab, setCurrentTab] = useState<LINTER_LEVELS>(
+    parseLinterLevel(preset) ?? LINTER_LEVELS.ERROR
+  )
+  const { data, isPending, isRefetching, refetch } = useProjectHealthLintsQuery({
+    projectRef: project?.ref,
+  })
 
   // Health checks are platform-only. If this page is opened self-hosted the query stays
   // disabled, and `isPending` would otherwise spin forever.

--- a/apps/studio/tests/pages/health-advisor.test.tsx
+++ b/apps/studio/tests/pages/health-advisor.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import ProjectHealthLints from '@/pages/project/[ref]/advisors/health'
+
+const mocks = vi.hoisted(() => ({
+  flags: { hasLoaded: false, enabled: false },
+  router: { replace: vi.fn() },
+  query: vi.fn(),
+  shortcuts: vi.fn(),
+}))
+
+vi.mock('common', () => ({
+  useFeatureFlags: () => ({ hasLoaded: mocks.flags.hasLoaded }),
+  useFlag: () => mocks.flags.enabled,
+  useParams: () => ({ ref: 'test-project' }),
+}))
+vi.mock('next/router', () => ({ useRouter: () => mocks.router }))
+vi.mock('@/lib/constants', () => ({ IS_PLATFORM: true }))
+vi.mock('@/hooks/misc/useSelectedProject', () => ({
+  useSelectedProjectQuery: () => ({ data: { ref: 'test-project' } }),
+}))
+vi.mock('@/data/lint/health-lints-query', () => ({
+  useProjectHealthLintsQuery: mocks.query,
+}))
+vi.mock('@/components/interfaces/Linter/useAdvisorPageShortcuts', () => ({
+  useAdvisorPageShortcuts: mocks.shortcuts,
+}))
+vi.mock('@/components/interfaces/Linter/Linter.utils', () => ({
+  lintInfoMap: [],
+  parseLinterLevel: () => undefined,
+}))
+vi.mock('@/components/interfaces/Linter/LinterDataGrid', () => ({
+  LinterDataGrid: () => null,
+}))
+vi.mock('@/components/interfaces/Linter/LinterFilters', () => ({ default: () => null }))
+vi.mock('@/components/interfaces/Linter/LintPageTabs', () => ({ default: () => null }))
+vi.mock('@/components/layouts/AdvisorsLayout/AdvisorsLayout', () => ({ default: () => null }))
+vi.mock('@/components/layouts/DefaultLayout', () => ({ DefaultLayout: () => null }))
+vi.mock('@/components/ui/Forms/FormHeader', () => ({
+  FormHeader: ({ title }: { title: string }) => <h1>{title}</h1>,
+}))
+vi.mock('ui', () => ({ LoadingLine: () => null }))
+
+describe('Health Advisor feature flag', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.flags.hasLoaded = false
+    mocks.flags.enabled = false
+    mocks.query.mockReturnValue({
+      data: [],
+      isPending: false,
+      isRefetching: false,
+      refetch: vi.fn(),
+    })
+  })
+
+  it('renders after the flag loads without changing hook order', () => {
+    const { rerender } = render(<ProjectHealthLints />)
+
+    expect(screen.queryByRole('heading', { name: 'Health Advisor' })).not.toBeInTheDocument()
+    expect(mocks.router.replace).not.toHaveBeenCalled()
+    expect(mocks.query).not.toHaveBeenCalled()
+    expect(mocks.shortcuts).not.toHaveBeenCalled()
+
+    mocks.flags.hasLoaded = true
+    mocks.flags.enabled = true
+    rerender(<ProjectHealthLints />)
+
+    expect(screen.getByRole('heading', { name: 'Health Advisor' })).toBeInTheDocument()
+    expect(mocks.query).toHaveBeenCalled()
+    expect(mocks.shortcuts).toHaveBeenCalled()
+    expect(mocks.router.replace).not.toHaveBeenCalled()
+
+    mocks.flags.enabled = false
+    rerender(<ProjectHealthLints />)
+
+    expect(screen.queryByRole('heading', { name: 'Health Advisor' })).not.toBeInTheDocument()
+    expect(mocks.router.replace).toHaveBeenCalledWith('/project/test-project/advisors/security')
+  })
+
+  it('redirects when the loaded flag is disabled without mounting health functionality', () => {
+    mocks.flags.hasLoaded = true
+    render(<ProjectHealthLints />)
+
+    expect(mocks.router.replace).toHaveBeenCalledWith('/project/test-project/advisors/security')
+    expect(mocks.query).not.toHaveBeenCalled()
+    expect(mocks.shortcuts).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Problem

Health Advisor runs live infrastructure checks whenever its surfaces load. It needs a controlled rollout and a quick way to stop those requests.

## Fix

Gate every Health Advisor entry point behind the ConfigCat healthAdvisor flag, including the shared query hook, homepage cards, Advisor panel, navigation, command menu, and direct route. The flag defaults off until ConfigCat provides it.

## How to test

- Set healthAdvisor to false in ConfigCat and open Project Home and Advisor Center.
- Expected result: no Health Advisor navigation, filter, cards, or health-check request appears; direct Health Advisor URLs redirect to Security Advisor.
- Set healthAdvisor to true and reload.
- Expected result: all Health Advisor surfaces and checks are available.