### PR TITLE
Scoped PAT: improve error handling when showing a token details

### DIFF
--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/ViewTokenSheet.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/ViewTokenSheet.tsx
@@ -145,8 +145,8 @@ export function ViewTokenSheet({ visible, tokenId, onClose }: ViewTokenSheetProp
             'flex flex-col md:flex-row justify-between gap-4 items-start md:items-center border-b'
           )}
         >
-          <p className="truncate" title={`View access for ${token?.name}`}>
-            View access for {token?.name}
+          <p className="truncate" title={`View access for ${token?.name ?? 'Unknown'}`}>
+            View access for {token?.name ?? 'Unknown'}
           </p>
           <TokenDocsButtons />
         </SheetHeader>

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/ViewTokenSheet.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/ViewTokenSheet.tsx
@@ -22,6 +22,7 @@ import {
   type CapabilityLevelFilter,
 } from './TokenCapabilities/TokenCapabilities.utils'
 import { TokenDocsButtons } from './TokenDocsButtons'
+import { AlertError } from '@/components/ui/AlertError'
 import { useOrganizationsQuery } from '@/data/organizations/organizations-query'
 import { useProjectsInfiniteQuery } from '@/data/projects/projects-infinite-query'
 import {
@@ -161,11 +162,7 @@ export function ViewTokenSheet({ visible, tokenId, onClose }: ViewTokenSheetProp
             )}
 
             {tokenError && (
-              <div className="flex items-center justify-center py-8">
-                <p className="text-destructive">
-                  Error loading token information. Please try again.
-                </p>
-              </div>
+              <AlertError error={tokenError} subject="Error loading token information." />
             )}
 
             {token && (


### PR DESCRIPTION
We already have proper error handling on:

- the token list query
- token creation/deletion with toasts

We had custom error handling on the token permissions sheet. Replaced it with an `AlertError`:

<img width="798" height="371" alt="image" src="https://github.com/user-attachments/assets/24145308-b1cd-491f-8f54-0c628dd185ce" />

Question: should we do something about the sheet header when the token couldn't be loaded?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the access token loading error state with a clearer, consistent error display and “Please try again” guidance.
  * Added a fallback label of “Unknown” when an access token name is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->