### PR TITLE
chore(studio): update self-hosted MCP server to 0.12.0

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -71,7 +71,7 @@
     "@stripe/stripe-js": "9.1.0",
     "@stripe/sync-engine": "1.0.32",
     "@supabase/auth-js": "catalog:",
-    "@supabase/mcp-server-supabase": "^0.11.0",
+    "@supabase/mcp-server-supabase": "^0.12.0",
     "@supabase/pg-meta": "workspace:*",
     "@supabase/realtime-js": "catalog:",
     "@supabase/shared-types": "0.1.91",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1024,8 +1024,8 @@ importers:
         specifier: 'catalog:'
         version: 2.112.4
       '@supabase/mcp-server-supabase':
-        specifier: ^0.11.0
-        version: 0.11.0(@modelcontextprotocol/server@2.0.0)(zod@3.25.76)
+        specifier: ^0.12.0
+        version: 0.12.0(@modelcontextprotocol/server@2.0.0)(zod@3.25.76)
       '@supabase/pg-meta':
         specifier: workspace:*
         version: link:../../packages/pg-meta
@@ -8175,15 +8175,15 @@ packages:
     resolution: {integrity: sha512-DQ0aVH8wSQAccVqNoEkec62qCu2QRNyoGN53RqsVZ1k6F1zq4/v8scrlR6LNT2RJmT97apiTmORijPVhErCS2g==}
     engines: {node: '>=22.0.0'}
 
-  '@supabase/mcp-server-supabase@0.11.0':
-    resolution: {integrity: sha512-++eAgAmq3SAnj3nf2Ic0i2Si9oFmTn9ppEJOioABf7+DZ/w3blPuxLlSTSBZV5+Sf1SdueMpTvYvkKJh0zx+/Q==}
+  '@supabase/mcp-server-supabase@0.12.0':
+    resolution: {integrity: sha512-Rjh3k7pQel+vePiffG8m8DkqCT2y3pD9Z4dKejzjACfvrzGeFsaoRhgXoDeZio6kjgOvi8Wy7mgdezEwPklJhg==}
     hasBin: true
     peerDependencies:
       '@modelcontextprotocol/server': ^2.0.0
       zod: ^3.25.0 || ^4.0.0
 
-  '@supabase/mcp-utils@0.7.0':
-    resolution: {integrity: sha512-PDTPOn/0AEPWwAXc8I98wruYucGwNLCAfiCu0eZS1mE+E/e0xZhdSY3nfE2n+sh8p5aaep5Kqd9Wt0rThAKgdQ==}
+  '@supabase/mcp-utils@0.8.0':
+    resolution: {integrity: sha512-T3PpwysWEFBuvD7TMekFSv7xLqO6DjoUUh2ZHojyRdJD7UNaydffJx8ZGoUW2Ju9NOf5ffomfuzreioJUTFFcQ==}
     peerDependencies:
       '@modelcontextprotocol/server': ^2.0.0
       zod: ^3.25.0 || ^4.0.0
@@ -25190,18 +25190,18 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@supabase/mcp-server-supabase@0.11.0(@modelcontextprotocol/server@2.0.0)(zod@3.25.76)':
+  '@supabase/mcp-server-supabase@0.12.0(@modelcontextprotocol/server@2.0.0)(zod@3.25.76)':
     dependencies:
       '@mjackson/multipart-parser': 0.10.1
       '@modelcontextprotocol/server': 2.0.0
-      '@supabase/mcp-utils': 0.7.0(@modelcontextprotocol/server@2.0.0)(zod@3.25.76)
+      '@supabase/mcp-utils': 0.8.0(@modelcontextprotocol/server@2.0.0)(zod@3.25.76)
       common-tags: 1.8.2
       gqlmin: 0.3.1
       graphql: 16.11.0
       openapi-fetch: 0.13.8
       zod: 3.25.76
 
-  '@supabase/mcp-utils@0.7.0(@modelcontextprotocol/server@2.0.0)(zod@3.25.76)':
+  '@supabase/mcp-utils@0.8.0(@modelcontextprotocol/server@2.0.0)(zod@3.25.76)':
     dependencies:
       '@modelcontextprotocol/server': 2.0.0
       zod: 3.25.76


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Dependency update.

## What is the current behavior?

`apps/studio` depends on `@supabase/mcp-server-supabase` `^0.11.0`, which pulls in `@supabase/mcp-utils` `0.7.0` transitively.

## What is the new behavior?

- Bump `@supabase/mcp-server-supabase` to `^0.12.0`. The lockfile moves it to `0.12.0` and its `@supabase/mcp-utils` dep to `0.8.0` (still indirect). Nothing else in the lockfile changes.
- Peer deps are unchanged (`@modelcontextprotocol/server ^2.0.0`, `zod ^3.25.0 || ^4.0.0`).

No studio code change needed. 0.12.0 adds an optional `costConfirmation` server option for `create_project` / `create_branch`; the self-hosted route doesn't set it, and self-hosted never registers those tools in the first place. The exported tool set is the same 33 schemas, so the tool-name guard in `lib/ai/tools/mcp-tools.ts` still passes. `get_advisors` now groups lints inside its result, which studio forwards to the model without parsing. Release notes: [mcp-server-supabase v0.12.0](https://github.com/supabase/mcp/releases/tag/mcp-server-supabase-v0.12.0) and [mcp-utils v0.8.0](https://github.com/supabase/mcp/releases/tag/mcp-utils-v0.8.0).

## Additional context

[AI-1178](https://linear.app/supabase/issue/AI-1178/2b-update-self-hosted-remote-mcp-server)

Testing:
- `pnpm install --frozen-lockfile` passes.
- Studio `pnpm typecheck` is clean.
- MCP-related vitest files: 13 files, 108 tests passed.
- In-memory smoke of `createSupabaseMcpServer` with the self-hosted route's options reports `serverInfo.version` `0.12.0` and 11 tools.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Supabase MCP integration dependency to version 0.12.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->