### PR TITLE
fix(studio): show 'Query ran successfully' for DML without RETURNING in SQL Editor

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityPanel.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityPanel.tsx
@@ -15,6 +15,7 @@ import { UtilityTabResults } from './UtilityTabResults'
 import { DownloadResultsButton } from '@/components/ui/DownloadResultsButton'
 import { useContentUpsertMutation } from '@/data/content/content-upsert-mutation'
 import { Snippet } from '@/data/content/sql-folders-query'
+import { isNonReturningDml } from '@/data/sql/utils'
 import { useTrack } from '@/lib/telemetry/track'
 import { useSqlEditorSessionSnapshot } from '@/state/sql-editor/sql-editor-session-state'
 import { useSqlEditorV2StateSnapshot } from '@/state/sql-editor/sql-editor-state'
@@ -56,6 +57,8 @@ export const UtilityPanel = ({
 
   const snippet = snapV2.snippets[id]?.snippet
   const result = sessionSnap.results[id]?.[0]
+  const snippetSql = snippet?.type === 'sql' ? (snippet.content?.unchecked_sql ?? '') : ''
+  const isDmlWithoutReturn = isNonReturningDml(snippetSql)
 
   const { mutate: upsertContent } = useContentUpsertMutation({
     invalidateQueriesOnSuccess: false,
@@ -132,7 +135,7 @@ export const UtilityPanel = ({
         </div>
 
         <div className="flex items-center gap-4">
-          {result?.rows !== undefined && !isExecuting && (
+          {result?.rows !== undefined && !isExecuting && !isDmlWithoutReturn && (
             <Tooltip>
               <TooltipTrigger>
                 <p className="text-xs">

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityPanel.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityPanel.tsx
@@ -58,7 +58,8 @@ export const UtilityPanel = ({
   const snippet = snapV2.snippets[id]?.snippet
   const result = sessionSnap.results[id]?.[0]
   const snippetSql = snippet?.type === 'sql' ? (snippet.content?.unchecked_sql ?? '') : ''
-  const isDmlWithoutReturn = isNonReturningDml(snippetSql)
+  const sql = result?.sql ?? snippetSql
+  const isDmlWithoutReturn = isNonReturningDml(sql)
 
   const { mutate: upsertContent } = useContentUpsertMutation({
     invalidateQueriesOnSuccess: false,

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabResults.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabResults.tsx
@@ -37,7 +37,7 @@ export const UtilityTabResults = forwardRef<HTMLDivElement, UtilityTabResultsPro
     const [, setShowConnect] = useQueryState('showConnect', parseAsBoolean.withDefault(false))
 
     const result = sessionSnap.results[id]?.[0]
-    const sql = snapV2.snippets[id]?.snippet.content?.unchecked_sql ?? ''
+    const sql = result?.sql ?? snapV2.snippets[id]?.snippet.content?.unchecked_sql ?? ''
     const { data: subscription } = useOrgSubscriptionQuery({ orgSlug: organization?.slug })
 
     // Customers on HIPAA plans should not have access to Supabase AI
@@ -183,8 +183,10 @@ export const UtilityTabResults = forwardRef<HTMLDivElement, UtilityTabResultsPro
     } else if (result.rows.length <= 0) {
       return (
         <div className="bg-table-header-light in-data-[theme*=dark]:bg-table-header-dark overflow-y-auto">
-          <p className="m-0 border-0 px-6 py-4 font-mono text-sm">
-            {isNonReturningDml(sql) ? 'Success. Query ran successfully.' : 'Success. No rows returned'}
+          <p role="status" aria-live="polite" className="m-0 border-0 px-6 py-4 font-mono text-sm">
+            {isNonReturningDml(sql)
+              ? 'Success. Query ran successfully.'
+              : 'Success. No rows returned'}
           </p>
         </div>
       )

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabResults.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabResults.tsx
@@ -25,11 +25,14 @@ export type UtilityTabResultsProps = {
   onDebug: () => void
   buildDebugPrompt: () => string
   isDebugging?: boolean
-}
+} & React.HTMLAttributes<HTMLDivElement>
 
 export const UtilityTabResults = forwardRef<HTMLDivElement, UtilityTabResultsProps>(
-  ({ id, isExecuting, isDisabled, isDebugging, onDebug, buildDebugPrompt }) => {
-    const { ref } = useParams()
+  (
+    { id, isExecuting, isDisabled, isDebugging, onDebug, buildDebugPrompt, className, ...props },
+    forwardedRef
+  ) => {
+    const { ref: projectRef } = useParams()
     const state = useDatabaseSelectorStateSnapshot()
     const { data: organization } = useSelectedOrganizationQuery()
     const sessionSnap = useSqlEditorSessionSnapshot()
@@ -41,7 +44,7 @@ export const UtilityTabResults = forwardRef<HTMLDivElement, UtilityTabResultsPro
     const { data: subscription } = useOrgSubscriptionQuery({ orgSlug: organization?.slug })
 
     // Customers on HIPAA plans should not have access to Supabase AI
-    const { data: projectSettings } = useProjectSettingsV2Query({ projectRef: ref })
+    const { data: projectSettings } = useProjectSettingsV2Query({ projectRef })
     const hasHipaaAddon = subscriptionHasHipaaAddon(subscription) && projectSettings?.is_sensitive
 
     const isTimeout =
@@ -51,148 +54,172 @@ export const UtilityTabResults = forwardRef<HTMLDivElement, UtilityTabResultsPro
 
     const isNetWorkError = result?.error?.message?.includes('EHOSTUNREACH')
 
-    if (isExecuting) {
-      return (
-        <div className="flex items-center gap-x-4 px-6 py-4 bg-table-header-light in-data-[theme*=dark]:bg-table-header-dark">
-          <Loader2 size={14} className="animate-spin" />
-          <p className="m-0 border-0 font-mono text-sm">Running...</p>
-        </div>
-      )
-    } else if (result?.error) {
-      const errorLines = getSqlErrorLines(result.error)
-      const readReplicaError =
-        state.selectedDatabaseId !== ref &&
-        result.error.message.includes('in a read-only transaction')
-      const payloadTooLargeError = result.error.message.includes(
-        'Query is too large to be run via the SQL Editor'
-      )
+    const statusMessage = isExecuting
+      ? 'Running query...'
+      : result?.error
+        ? `Error: ${result.error.message}`
+        : result && result.rows.length <= 0
+          ? isNonReturningDml(sql)
+            ? 'Success. Query ran successfully.'
+            : 'Success. No rows returned'
+          : ''
 
-      return (
-        <div className="bg-table-header-light in-data-[theme*=dark]:bg-table-header-dark overflow-y-auto">
-          <div className="flex flex-row justify-between items-start py-4 px-6 gap-x-4">
-            {isTimeout ? (
-              <div className="flex flex-col gap-y-1">
-                <p className="font-mono text-sm tracking-tight">
-                  Error: SQL query ran into an upstream timeout
-                </p>
-                <p className="text-sm text-foreground-light">
-                  You can either{' '}
-                  <InlineLink
-                    href={`${DOCS_URL}/guides/platform/performance#examining-query-performance`}
-                  >
-                    optimize your query
-                  </InlineLink>
-                  , or{' '}
-                  <InlineLink href={`${DOCS_URL}/guides/database/timeouts`}>
-                    increase the statement timeout
-                  </InlineLink>
-                  {' or '}
-                  <span
-                    className={cn(InlineLinkClassName, 'cursor-pointer')}
-                    onClick={() => setShowConnect(true)}
-                  >
-                    connect to your database directly
-                  </span>
-                  .
-                </p>
-              </div>
-            ) : (
-              <div className="flex flex-col gap-y-1">
-                {errorLines.length > 0 ? (
-                  errorLines.map((x: string, i: number) => (
-                    <pre key={`error-${i}`} className="font-mono text-sm text-wrap">
-                      {x}
-                    </pre>
-                  ))
-                ) : (
-                  <p className="font-mono text-sm tracking-tight">Error: {result.error?.message}</p>
-                )}
-                {!isTimeout && !isNetWorkError && result.autoLimit && (
-                  <p className="text-sm text-foreground-light">
-                    Note: A limit of {result.autoLimit} was applied to your query. If this was the
-                    cause of a syntax error, try selecting "No limit" instead and re-run the query.
+    const renderContent = () => {
+      if (isExecuting) {
+        return (
+          <div className="flex items-center gap-x-4 px-6 py-4 bg-table-header-light in-data-[theme*=dark]:bg-table-header-dark">
+            <Loader2 size={14} className="animate-spin" />
+            <p className="m-0 border-0 font-mono text-sm">Running...</p>
+          </div>
+        )
+      } else if (result?.error) {
+        const errorLines = getSqlErrorLines(result.error)
+        const readReplicaError =
+          state.selectedDatabaseId !== projectRef &&
+          result.error.message.includes('in a read-only transaction')
+        const payloadTooLargeError = result.error.message.includes(
+          'Query is too large to be run via the SQL Editor'
+        )
+
+        return (
+          <div className="bg-table-header-light in-data-[theme*=dark]:bg-table-header-dark overflow-y-auto">
+            <div className="flex flex-row justify-between items-start py-4 px-6 gap-x-4">
+              {isTimeout ? (
+                <div className="flex flex-col gap-y-1">
+                  <p className="font-mono text-sm tracking-tight">
+                    Error: SQL query ran into an upstream timeout
                   </p>
-                )}
-                {readReplicaError && (
                   <p className="text-sm text-foreground-light">
-                    Note: Read replicas are for read only queries. Run write queries on the primary
-                    database instead.
-                  </p>
-                )}
-                {payloadTooLargeError && (
-                  <p className="text-sm text-foreground-light flex items-center gap-x-1">
-                    Run this query by{' '}
-                    <span
-                      onClick={() => setShowConnect(true)}
-                      className={cn(InlineLinkClassName, 'flex items-center gap-x-1')}
+                    You can either{' '}
+                    <InlineLink
+                      href={`${DOCS_URL}/guides/platform/performance#examining-query-performance`}
                     >
-                      connecting to your database directly
-                      <ExternalLink size={12} />
+                      optimize your query
+                    </InlineLink>
+                    , or{' '}
+                    <InlineLink href={`${DOCS_URL}/guides/database/timeouts`}>
+                      increase the statement timeout
+                    </InlineLink>
+                    {' or '}
+                    <span
+                      className={cn(InlineLinkClassName, 'cursor-pointer')}
+                      onClick={() => setShowConnect(true)}
+                    >
+                      connect to your database directly
                     </span>
                     .
                   </p>
+                </div>
+              ) : (
+                <div className="flex flex-col gap-y-1">
+                  {errorLines.length > 0 ? (
+                    errorLines.map((x: string, i: number) => (
+                      <pre key={`error-${i}`} className="font-mono text-sm text-wrap">
+                        {x}
+                      </pre>
+                    ))
+                  ) : (
+                    <p className="font-mono text-sm tracking-tight">
+                      Error: {result.error?.message}
+                    </p>
+                  )}
+                  {!isTimeout && !isNetWorkError && result.autoLimit && (
+                    <p className="text-sm text-foreground-light">
+                      Note: A limit of {result.autoLimit} was applied to your query. If this was the
+                      cause of a syntax error, try selecting "No limit" instead and re-run the
+                      query.
+                    </p>
+                  )}
+                  {readReplicaError && (
+                    <p className="text-sm text-foreground-light">
+                      Note: Read replicas are for read only queries. Run write queries on the
+                      primary database instead.
+                    </p>
+                  )}
+                  {payloadTooLargeError && (
+                    <p className="text-sm text-foreground-light flex items-center gap-x-1">
+                      Run this query by{' '}
+                      <span
+                        onClick={() => setShowConnect(true)}
+                        className={cn(InlineLinkClassName, 'flex items-center gap-x-1')}
+                      >
+                        connecting to your database directly
+                        <ExternalLink size={12} />
+                      </span>
+                      .
+                    </p>
+                  )}
+                </div>
+              )}
+
+              <div className="flex items-center gap-x-2">
+                {readReplicaError && (
+                  <Button
+                    className="py-2"
+                    variant="default"
+                    onClick={() => {
+                      state.setSelectedDatabaseId(projectRef)
+                      sessionSnap.resetResult(id)
+                    }}
+                  >
+                    Switch to primary database
+                  </Button>
+                )}
+                {errorLines.length > 0 && (
+                  <Tooltip>
+                    <TooltipTrigger>
+                      <CopyButton iconOnly variant="default" text={errorLines.join('\n')} />
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom" align="center">
+                      <span>Copy error</span>
+                    </TooltipContent>
+                  </Tooltip>
+                )}
+                {!hasHipaaAddon && (
+                  <AiAssistantDropdown
+                    label="Debug with Assistant"
+                    buildPrompt={buildDebugPrompt}
+                    onOpenAssistant={onDebug}
+                    telemetrySource="sql_debug"
+                    disabled={!!isDisabled || isDebugging}
+                    loading={isDebugging}
+                  />
                 )}
               </div>
-            )}
-
-            <div className="flex items-center gap-x-2">
-              {readReplicaError && (
-                <Button
-                  className="py-2"
-                  variant="default"
-                  onClick={() => {
-                    state.setSelectedDatabaseId(ref)
-                    sessionSnap.resetResult(id)
-                  }}
-                >
-                  Switch to primary database
-                </Button>
-              )}
-              {errorLines.length > 0 && (
-                <Tooltip>
-                  <TooltipTrigger>
-                    <CopyButton iconOnly variant="default" text={errorLines.join('\n')} />
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom" align="center">
-                    <span>Copy error</span>
-                  </TooltipContent>
-                </Tooltip>
-              )}
-              {!hasHipaaAddon && (
-                <AiAssistantDropdown
-                  label="Debug with Assistant"
-                  buildPrompt={buildDebugPrompt}
-                  onOpenAssistant={onDebug}
-                  telemetrySource="sql_debug"
-                  disabled={!!isDisabled || isDebugging}
-                  loading={isDebugging}
-                />
-              )}
             </div>
           </div>
-        </div>
-      )
-    } else if (!result) {
-      return (
-        <div className="bg-table-header-light in-data-[theme*=dark]:bg-table-header-dark overflow-y-auto">
-          <p className="m-0 border-0 px-4 py-4 text-sm text-foreground-light">
-            Click <code className="text-code-inline">Run</code> to execute your query
-          </p>
-        </div>
-      )
-    } else if (result.rows.length <= 0) {
-      return (
-        <div className="bg-table-header-light in-data-[theme*=dark]:bg-table-header-dark overflow-y-auto">
-          <p role="status" aria-live="polite" className="m-0 border-0 px-6 py-4 font-mono text-sm">
-            {isNonReturningDml(sql)
-              ? 'Success. Query ran successfully.'
-              : 'Success. No rows returned'}
-          </p>
-        </div>
-      )
+        )
+      } else if (!result) {
+        return (
+          <div className="bg-table-header-light in-data-[theme*=dark]:bg-table-header-dark overflow-y-auto">
+            <p className="m-0 border-0 px-4 py-4 text-sm text-foreground-light">
+              Click <code className="text-code-inline">Run</code> to execute your query
+            </p>
+          </div>
+        )
+      } else if (result.rows.length <= 0) {
+        return (
+          <div className="bg-table-header-light in-data-[theme*=dark]:bg-table-header-dark overflow-y-auto">
+            <p className="m-0 border-0 px-6 py-4 font-mono text-sm">
+              {isNonReturningDml(sql)
+                ? 'Success. Query ran successfully.'
+                : 'Success. No rows returned'}
+            </p>
+          </div>
+        )
+      }
+
+      return <DataGridResults rows={result.rows} />
     }
 
-    return <DataGridResults rows={result.rows} />
+    return (
+      <div ref={forwardedRef} className={cn('h-full flex flex-col', className)} {...props}>
+        <span role="status" aria-live="polite" className="sr-only">
+          {statusMessage}
+        </span>
+        {renderContent()}
+      </div>
+    )
   }
 )
 

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabResults.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabResults.tsx
@@ -10,12 +10,13 @@ import CopyButton from '@/components/ui/CopyButton'
 import { DataGridResults } from '@/components/ui/DataGridResults'
 import { InlineLink, InlineLinkClassName } from '@/components/ui/InlineLink'
 import { useProjectSettingsV2Query } from '@/data/config/project-settings-v2-query'
-import { getSqlErrorLines } from '@/data/sql/utils'
+import { getSqlErrorLines, isNonReturningDml } from '@/data/sql/utils'
 import { useOrgSubscriptionQuery } from '@/data/subscriptions/org-subscription-query'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 import { DOCS_URL } from '@/lib/constants'
 import { useDatabaseSelectorStateSnapshot } from '@/state/database-selector'
 import { useSqlEditorSessionSnapshot } from '@/state/sql-editor/sql-editor-session-state'
+import { useSqlEditorV2StateSnapshot } from '@/state/sql-editor/sql-editor-state'
 
 export type UtilityTabResultsProps = {
   id: string
@@ -32,9 +33,11 @@ export const UtilityTabResults = forwardRef<HTMLDivElement, UtilityTabResultsPro
     const state = useDatabaseSelectorStateSnapshot()
     const { data: organization } = useSelectedOrganizationQuery()
     const sessionSnap = useSqlEditorSessionSnapshot()
+    const snapV2 = useSqlEditorV2StateSnapshot()
     const [, setShowConnect] = useQueryState('showConnect', parseAsBoolean.withDefault(false))
 
     const result = sessionSnap.results[id]?.[0]
+    const sql = snapV2.snippets[id]?.snippet.content?.unchecked_sql ?? ''
     const { data: subscription } = useOrgSubscriptionQuery({ orgSlug: organization?.slug })
 
     // Customers on HIPAA plans should not have access to Supabase AI
@@ -180,7 +183,9 @@ export const UtilityTabResults = forwardRef<HTMLDivElement, UtilityTabResultsPro
     } else if (result.rows.length <= 0) {
       return (
         <div className="bg-table-header-light in-data-[theme*=dark]:bg-table-header-dark overflow-y-auto">
-          <p className="m-0 border-0 px-6 py-4 font-mono text-sm">Success. No rows returned</p>
+          <p className="m-0 border-0 px-6 py-4 font-mono text-sm">
+            {isNonReturningDml(sql) ? 'Success. Query ran successfully.' : 'Success. No rows returned'}
+          </p>
         </div>
       )
     }

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabResults.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabResults.tsx
@@ -27,6 +27,12 @@ export type UtilityTabResultsProps = {
   isDebugging?: boolean
 } & React.HTMLAttributes<HTMLDivElement>
 
+/**
+ * Renders the Results tab in the SQL Editor Utility Panel.
+ *
+ * Displays query execution states (running, error, empty/successful DML,
+ * and table results grid) with an accessible live region for screen readers.
+ */
 export const UtilityTabResults = forwardRef<HTMLDivElement, UtilityTabResultsProps>(
   (
     { id, isExecuting, isDisabled, isDebugging, onDebug, buildDebugPrompt, className, ...props },

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabResults.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabResults.tsx
@@ -60,15 +60,19 @@ export const UtilityTabResults = forwardRef<HTMLDivElement, UtilityTabResultsPro
 
     const isNetWorkError = result?.error?.message?.includes('EHOSTUNREACH')
 
+    const successMessage = isNonReturningDml(sql)
+      ? 'Success. Query ran successfully.'
+      : 'Success. No rows returned'
+
     const statusMessage = isExecuting
       ? 'Running query...'
       : result?.error
         ? `Error: ${result.error.message}`
         : result && result.rows.length <= 0
-          ? isNonReturningDml(sql)
-            ? 'Success. Query ran successfully.'
-            : 'Success. No rows returned'
-          : ''
+          ? successMessage
+          : result
+            ? `Success. ${result.rows.length} row${result.rows.length === 1 ? '' : 's'} returned`
+            : ''
 
     const renderContent = () => {
       if (isExecuting) {
@@ -206,11 +210,7 @@ export const UtilityTabResults = forwardRef<HTMLDivElement, UtilityTabResultsPro
       } else if (result.rows.length <= 0) {
         return (
           <div className="bg-table-header-light in-data-[theme*=dark]:bg-table-header-dark overflow-y-auto">
-            <p className="m-0 border-0 px-6 py-4 font-mono text-sm">
-              {isNonReturningDml(sql)
-                ? 'Success. Query ran successfully.'
-                : 'Success. No rows returned'}
-            </p>
+            <p className="m-0 border-0 px-6 py-4 font-mono text-sm">{successMessage}</p>
           </div>
         )
       }

--- a/apps/studio/components/interfaces/SQLEditor/useSqlEditorExecution.ts
+++ b/apps/studio/components/interfaces/SQLEditor/useSqlEditorExecution.ts
@@ -65,7 +65,7 @@ export function useSqlEditorExecution({
   const { mutate: execute, isPending: isExecuting } = useExecuteSqlMutation({
     onSuccess(data, vars) {
       if (id) {
-        sessionSnap.addResult(id, data.result, vars.autoLimit)
+        sessionSnap.addResult(id, data.result, vars.autoLimit, vars.sql)
       }
 
       // revalidate lint query
@@ -75,7 +75,7 @@ export function useSqlEditorExecution({
     onError(error: any, vars) {
       if (id) {
         editor.highlightErrorLine(error, hasSelection)
-        sessionSnap.addResultError(id, error, vars.autoLimit)
+        sessionSnap.addResultError(id, error, vars.autoLimit, vars.sql)
       }
 
       refocusEditorAfterRunIfNeeded()

--- a/apps/studio/data/sql/__tests__/utils.test.ts
+++ b/apps/studio/data/sql/__tests__/utils.test.ts
@@ -314,6 +314,139 @@ update users set deleted = true where id = 1`)
     })
   })
 
+  describe('handles CTEs (WITH clauses)', () => {
+    it('classifies WITH ... UPDATE without RETURNING as non-returning DML', () => {
+      expect(
+        isNonReturningDml(`
+          WITH regional_sales AS (
+            SELECT region, SUM(amount) AS total_sales
+            FROM orders
+            GROUP BY region
+          )
+          UPDATE orders
+          SET discount = 0.1
+          WHERE region IN (SELECT region FROM regional_sales WHERE total_sales > 1000)
+        `)
+      ).toBe(true)
+    })
+
+    it('classifies WITH ... UPDATE with RETURNING as returning', () => {
+      expect(
+        isNonReturningDml(`
+          WITH cte AS (SELECT id FROM users)
+          UPDATE profile SET active = true WHERE user_id IN (SELECT id FROM cte)
+          RETURNING user_id
+        `)
+      ).toBe(false)
+    })
+
+    it('classifies WITH ... DELETE without RETURNING as non-returning DML', () => {
+      expect(
+        isNonReturningDml(`
+          WITH old_records AS (
+            SELECT id FROM logs WHERE created_at < NOW() - INTERVAL '30 days'
+          )
+          DELETE FROM logs WHERE id IN (SELECT id FROM old_records)
+        `)
+      ).toBe(true)
+    })
+
+    it('classifies WITH ... DELETE with RETURNING as returning', () => {
+      expect(
+        isNonReturningDml(`
+          WITH old_records AS (
+            SELECT id FROM logs WHERE created_at < NOW() - INTERVAL '30 days'
+          )
+          DELETE FROM logs WHERE id IN (SELECT id FROM old_records)
+          RETURNING id
+        `)
+      ).toBe(false)
+    })
+
+    it('classifies WITH ... INSERT without RETURNING as non-returning DML', () => {
+      expect(
+        isNonReturningDml(`
+          WITH new_data AS (
+            SELECT 1 AS a, 2 AS b
+          )
+          INSERT INTO target (a, b) SELECT a, b FROM new_data
+        `)
+      ).toBe(true)
+    })
+
+    it('classifies WITH ... INSERT with RETURNING as returning', () => {
+      expect(
+        isNonReturningDml(`
+          WITH new_data AS (
+            SELECT 1 AS a, 2 AS b
+          )
+          INSERT INTO target (a, b) SELECT a, b FROM new_data
+          RETURNING *
+        `)
+      ).toBe(false)
+    })
+
+    it('classifies WITH ... SELECT as returning (not non-returning DML)', () => {
+      expect(
+        isNonReturningDml(`
+          WITH data AS (
+            SELECT id, name FROM users
+          )
+          SELECT * FROM data
+        `)
+      ).toBe(false)
+    })
+
+    it('handles WITH RECURSIVE', () => {
+      expect(
+        isNonReturningDml(`
+          WITH RECURSIVE subordinates AS (
+            SELECT employee_id, manager_id FROM employees WHERE employee_id = 1
+            UNION ALL
+            SELECT e.employee_id, e.manager_id FROM employees e
+            JOIN subordinates s ON e.manager_id = s.employee_id
+          )
+          UPDATE employees SET reviewed = true WHERE employee_id IN (SELECT employee_id FROM subordinates)
+        `)
+      ).toBe(true)
+    })
+
+    it('classifies data-modifying CTE followed by non-returning main DML correctly', () => {
+      expect(
+        isNonReturningDml(`
+          WITH archived AS (
+            DELETE FROM logs WHERE created_at < NOW() - INTERVAL '30 days'
+            RETURNING *
+          )
+          INSERT INTO logs_archive SELECT * FROM archived
+        `)
+      ).toBe(true)
+    })
+
+    it('classifies data-modifying CTE followed by SELECT as returning', () => {
+      expect(
+        isNonReturningDml(`
+          WITH deleted AS (
+            DELETE FROM logs WHERE created_at < NOW() - INTERVAL '30 days'
+            RETURNING *
+          )
+          SELECT count(*) FROM deleted
+        `)
+      ).toBe(false)
+    })
+
+    it('handles CTEs with column aliases', () => {
+      expect(
+        isNonReturningDml(`
+          WITH cte(col1, col2) AS (
+            SELECT 1, 2
+          )
+          UPDATE target SET a = 1
+        `)
+      ).toBe(true)
+    })
+  })
+
   describe('handles string literals, quoted identifiers, and comments safely', () => {
     it('preserves RETURNING clause when -- is inside a string literal', () => {
       expect(isNonReturningDml("UPDATE t SET note = '--' RETURNING id")).toBe(false)

--- a/apps/studio/data/sql/__tests__/utils.test.ts
+++ b/apps/studio/data/sql/__tests__/utils.test.ts
@@ -1,7 +1,12 @@
 import { safeSql } from '@supabase/pg-meta'
 import { describe, expect, it, test } from 'vitest'
 
-import { applyAutoLimit, getSqlErrorLines, trimTrailingSemicolons } from '../utils'
+import {
+  applyAutoLimit,
+  getSqlErrorLines,
+  isNonReturningDml,
+  trimTrailingSemicolons,
+} from '../utils'
 
 describe('getSqlErrorLines', () => {
   it('returns formattedError lines when present', () => {
@@ -240,8 +245,6 @@ select * from cities`
   })
 })
 
-import { isNonReturningDml } from '../utils'
-
 describe('isNonReturningDml', () => {
   describe('returns true for DML statements without RETURNING', () => {
     it('detects a plain UPDATE', () => {
@@ -295,9 +298,9 @@ update users set deleted = true where id = 1`)
 
   describe('returns false when a RETURNING clause is present', () => {
     it('UPDATE … RETURNING', () => {
-      expect(
-        isNonReturningDml('update users set name = $1 where id = $2 returning id, name')
-      ).toBe(false)
+      expect(isNonReturningDml('update users set name = $1 where id = $2 returning id, name')).toBe(
+        false
+      )
     })
 
     it('DELETE … RETURNING', () => {
@@ -305,9 +308,45 @@ update users set deleted = true where id = 1`)
     })
 
     it('INSERT … RETURNING', () => {
-      expect(
-        isNonReturningDml("insert into users (name) values ('Alice') returning id")
-      ).toBe(false)
+      expect(isNonReturningDml("insert into users (name) values ('Alice') returning id")).toBe(
+        false
+      )
+    })
+  })
+
+  describe('handles string literals, quoted identifiers, and comments safely', () => {
+    it('preserves RETURNING clause when -- is inside a string literal', () => {
+      expect(isNonReturningDml("UPDATE t SET note = '--' RETURNING id")).toBe(false)
+    })
+
+    it('preserves RETURNING clause when /* */ is inside a string literal', () => {
+      expect(isNonReturningDml("UPDATE t SET note = '/* comment */' RETURNING id")).toBe(false)
+    })
+
+    it('does not treat returning inside a string literal as a RETURNING clause', () => {
+      expect(isNonReturningDml("UPDATE t SET note = 'returning this tomorrow'")).toBe(true)
+    })
+
+    it('does not treat returning inside a quoted identifier as a RETURNING clause', () => {
+      expect(isNonReturningDml('UPDATE "returning" SET id = 1')).toBe(true)
+    })
+
+    it('does not treat returning inside a dollar-quoted body as a RETURNING clause', () => {
+      expect(isNonReturningDml('UPDATE t SET note = $$ returning $$ WHERE id = 1')).toBe(true)
+    })
+
+    it('does not treat returning inside a tagged dollar-quoted body as a RETURNING clause', () => {
+      expect(isNonReturningDml('UPDATE t SET note = $tag$ returning $tag$ WHERE id = 1')).toBe(true)
+    })
+
+    it('handles nested block comments', () => {
+      expect(isNonReturningDml('/* outer /* inner */ */ UPDATE users SET id = 1')).toBe(true)
+    })
+
+    it('respects word boundaries so function names starting with DML keywords do not match', () => {
+      expect(isNonReturningDml('update_stats()')).toBe(false)
+      expect(isNonReturningDml('insert_audit_log()')).toBe(false)
+      expect(isNonReturningDml('delete_old_records()')).toBe(false)
     })
   })
 

--- a/apps/studio/data/sql/__tests__/utils.test.ts
+++ b/apps/studio/data/sql/__tests__/utils.test.ts
@@ -481,6 +481,20 @@ update users set deleted = true where id = 1`)
       expect(isNonReturningDml('insert_audit_log()')).toBe(false)
       expect(isNonReturningDml('delete_old_records()')).toBe(false)
     })
+
+    it('does not treat an identifier suffix like nonreturning as a RETURNING clause', () => {
+      expect(isNonReturningDml('UPDATE jobs SET nonreturning = true')).toBe(true)
+    })
+
+    it('treats backslashes as literal in standard-conforming ordinary strings', () => {
+      expect(isNonReturningDml("UPDATE files SET path = 'C:\\' RETURNING id")).toBe(false)
+      expect(isNonReturningDml("UPDATE files SET path = 'C:\\'")).toBe(true)
+    })
+
+    it('handles escaped quotes in E-prefixed escape strings', () => {
+      expect(isNonReturningDml("UPDATE t SET x = E'a\\'b' RETURNING id")).toBe(false)
+      expect(isNonReturningDml("UPDATE t SET x = E'a\\'b'")).toBe(true)
+    })
   })
 
   describe('returns false for non-DML statements', () => {

--- a/apps/studio/data/sql/__tests__/utils.test.ts
+++ b/apps/studio/data/sql/__tests__/utils.test.ts
@@ -239,3 +239,101 @@ select * from cities`
     expect(formattedSql).toBe(sql)
   })
 })
+
+import { isNonReturningDml } from '../utils'
+
+describe('isNonReturningDml', () => {
+  describe('returns true for DML statements without RETURNING', () => {
+    it('detects a plain UPDATE', () => {
+      expect(isNonReturningDml('update users set name = $1 where id = $2')).toBe(true)
+    })
+
+    it('detects a plain DELETE', () => {
+      expect(isNonReturningDml('delete from users where id = 1')).toBe(true)
+    })
+
+    it('detects a plain INSERT', () => {
+      expect(isNonReturningDml("insert into users (name) values ('Alice')")).toBe(true)
+    })
+
+    it('detects MERGE', () => {
+      expect(isNonReturningDml('merge into target using source on target.id = source.id')).toBe(
+        true
+      )
+    })
+
+    it('detects CALL', () => {
+      expect(isNonReturningDml('call my_procedure(1, 2, 3)')).toBe(true)
+    })
+
+    it('detects DO (anonymous block)', () => {
+      expect(isNonReturningDml("do $$ begin raise notice 'hi'; end $$")).toBe(true)
+    })
+
+    it('handles leading whitespace and mixed case', () => {
+      expect(isNonReturningDml('  UPDATE users SET active = false ')).toBe(true)
+    })
+
+    it('handles multi-line SQL', () => {
+      expect(
+        isNonReturningDml(`
+          update
+            position_log
+          set notes = notes
+          where id = (select id from position_log limit 1)
+        `)
+      ).toBe(true)
+    })
+
+    it('strips line comments before checking keyword', () => {
+      expect(
+        isNonReturningDml(`-- delete old rows
+update users set deleted = true where id = 1`)
+      ).toBe(true)
+    })
+  })
+
+  describe('returns false when a RETURNING clause is present', () => {
+    it('UPDATE … RETURNING', () => {
+      expect(
+        isNonReturningDml('update users set name = $1 where id = $2 returning id, name')
+      ).toBe(false)
+    })
+
+    it('DELETE … RETURNING', () => {
+      expect(isNonReturningDml('delete from users where id = 1 returning *')).toBe(false)
+    })
+
+    it('INSERT … RETURNING', () => {
+      expect(
+        isNonReturningDml("insert into users (name) values ('Alice') returning id")
+      ).toBe(false)
+    })
+  })
+
+  describe('returns false for non-DML statements', () => {
+    it('plain SELECT', () => {
+      expect(isNonReturningDml('select * from users')).toBe(false)
+    })
+
+    it('CREATE TABLE', () => {
+      expect(isNonReturningDml('create table foo (id int)')).toBe(false)
+    })
+
+    it('ALTER TABLE', () => {
+      expect(isNonReturningDml('alter table foo add column bar text')).toBe(false)
+    })
+
+    it('DROP TABLE', () => {
+      expect(isNonReturningDml('drop table foo')).toBe(false)
+    })
+
+    it('empty string', () => {
+      expect(isNonReturningDml('')).toBe(false)
+    })
+
+    it('only whitespace', () => {
+      expect(isNonReturningDml('   \n\t  ')).toBe(false)
+    })
+  })
+})

--- a/apps/studio/data/sql/utils.ts
+++ b/apps/studio/data/sql/utils.ts
@@ -44,6 +44,40 @@ export function trimTrailingSemicolons(sql: SafeSqlFragment): SafeSqlFragment {
 // rather than gluing raw template-literal text onto the fragment and casting
 // the result, so the only new content this function ever stamps safe is an
 // internally-generated integer literal, never arbitrary concatenated text.
+/**
+ * Returns true when the SQL is a DML statement (INSERT/UPDATE/DELETE/MERGE/CALL/DO)
+ * that does *not* include a RETURNING clause.
+ *
+ * When this is the case the empty-row result is expected — the query may still have
+ * modified rows — so the UI should say "Query ran successfully" rather than the
+ * misleading "No rows returned".
+ *
+ * This is intentionally conservative (plain regex, no full parse):
+ * - False negatives (DML with RETURNING detected as non-returning) → safe: we just
+ *   fall through to the standard "No rows returned" message.
+ * - False positives (SELECT detected as DML) → safe: we'd show a slightly odd
+ *   "Query ran successfully" for a SELECT that genuinely returned 0 rows. This can't
+ *   happen here because we explicitly exclude SELECT-starting queries.
+ */
+export function isNonReturningDml(sql: string): boolean {
+  const cleaned = sql.trim().replace(/--[^\n]*/g, '').replace(/\/\*[\s\S]*?\*\//g, '').trim()
+  const lower = cleaned.toLowerCase()
+
+  const isDml =
+    lower.startsWith('insert') ||
+    lower.startsWith('update') ||
+    lower.startsWith('delete') ||
+    lower.startsWith('merge') ||
+    lower.startsWith('call') ||
+    lower.startsWith('do')
+
+  if (!isDml) return false
+
+  // A RETURNING clause means Postgres will send back rows, so the empty-row
+  // result would correctly mean "0 matched", not "statement ran without output".
+  return !lower.includes('returning')
+}
+
 export function applyAutoLimit(
   sql: SafeSqlFragment,
   limit: number = 0

--- a/apps/studio/data/sql/utils.ts
+++ b/apps/studio/data/sql/utils.ts
@@ -45,6 +45,110 @@ export function trimTrailingSemicolons(sql: SafeSqlFragment): SafeSqlFragment {
 // the result, so the only new content this function ever stamps safe is an
 // internally-generated integer literal, never arbitrary concatenated text.
 /**
+ * Strips comments and replaces string literals, dollar-quoted blocks,
+ * and quoted identifiers with whitespace. This allows matching executable
+ * SQL keywords without false positives from comments or text literals.
+ *
+ * @param sql - Raw SQL query text
+ * @returns Sanitized SQL containing only executable tokens and whitespace
+ */
+export function stripSqlCommentsAndLiterals(sql: string): string {
+  let result = ''
+  let i = 0
+  const len = sql.length
+
+  while (i < len) {
+    // Single-line comment: -- ... until newline
+    if (sql[i] === '-' && sql[i + 1] === '-') {
+      i += 2
+      while (i < len && sql[i] !== '\n' && sql[i] !== '\r') {
+        i++
+      }
+      result += ' '
+      continue
+    }
+
+    // Multi-line comment: /* ... */ with support for nested comments in Postgres
+    if (sql[i] === '/' && sql[i + 1] === '*') {
+      i += 2
+      let depth = 1
+      while (i < len && depth > 0) {
+        if (sql[i] === '/' && sql[i + 1] === '*') {
+          depth++
+          i += 2
+        } else if (sql[i] === '*' && sql[i + 1] === '/') {
+          depth--
+          i += 2
+        } else {
+          i++
+        }
+      }
+      result += ' '
+      continue
+    }
+
+    // Dollar-quoted string: $tag$...$tag$ or $$...$$
+    if (sql[i] === '$') {
+      const match = sql.slice(i).match(/^\$([a-zA-Z0-9_]*)\$/)
+      if (match) {
+        const tag = match[0]
+        const closeIndex = sql.indexOf(tag, i + tag.length)
+        if (closeIndex !== -1) {
+          i = closeIndex + tag.length
+          result += ' '
+          continue
+        }
+      }
+    }
+
+    // Single-quoted string literal: '...' (supports '' escape and \' escape)
+    if (sql[i] === "'") {
+      i++
+      while (i < len) {
+        if (sql[i] === "'") {
+          if (sql[i + 1] === "'") {
+            i += 2
+          } else {
+            i++
+            break
+          }
+        } else if (sql[i] === '\\') {
+          i += 2
+        } else {
+          i++
+        }
+      }
+      result += ' '
+      continue
+    }
+
+    // Double-quoted identifier: "..." (supports "" escape)
+    if (sql[i] === '"') {
+      i++
+      while (i < len) {
+        if (sql[i] === '"') {
+          if (sql[i + 1] === '"') {
+            i += 2
+          } else {
+            i++
+            break
+          }
+        } else {
+          i++
+        }
+      }
+      result += ' '
+      continue
+    }
+
+    result += sql[i]
+    i++
+  }
+
+  return result
+}
+
+/**
  * Returns true when the SQL is a DML statement (INSERT/UPDATE/DELETE/MERGE/CALL/DO)
  * that does *not* include a RETURNING clause.
  *
@@ -52,30 +156,21 @@ export function trimTrailingSemicolons(sql: SafeSqlFragment): SafeSqlFragment {
  * modified rows — so the UI should say "Query ran successfully" rather than the
  * misleading "No rows returned".
  *
- * This is intentionally conservative (plain regex, no full parse):
- * - False negatives (DML with RETURNING detected as non-returning) → safe: we just
- *   fall through to the standard "No rows returned" message.
- * - False positives (SELECT detected as DML) → safe: we'd show a slightly odd
- *   "Query ran successfully" for a SELECT that genuinely returned 0 rows. This can't
- *   happen here because we explicitly exclude SELECT-starting queries.
+ * Comments, quoted literals, and identifiers are stripped prior to keyword checking
+ * to prevent false positives (e.g. 'returning' inside a string literal or '--' inside text).
+ *
+ * @param sql - The SQL statement to inspect
+ * @returns True if the statement is DML without a RETURNING clause
  */
 export function isNonReturningDml(sql: string): boolean {
-  const cleaned = sql.trim().replace(/--[^\n]*/g, '').replace(/\/\*[\s\S]*?\*\//g, '').trim()
-  const lower = cleaned.toLowerCase()
+  const cleaned = stripSqlCommentsAndLiterals(sql).trim()
 
-  const isDml =
-    lower.startsWith('insert') ||
-    lower.startsWith('update') ||
-    lower.startsWith('delete') ||
-    lower.startsWith('merge') ||
-    lower.startsWith('call') ||
-    lower.startsWith('do')
-
+  const isDml = /^\s*(?:insert|update|delete|merge|call|do)\b/i.test(cleaned)
   if (!isDml) return false
 
   // A RETURNING clause means Postgres will send back rows, so the empty-row
   // result would correctly mean "0 matched", not "statement ran without output".
-  return !lower.includes('returning')
+  return !/\breturning\b/i.test(cleaned)
 }
 
 export function applyAutoLimit(

--- a/apps/studio/data/sql/utils.ts
+++ b/apps/studio/data/sql/utils.ts
@@ -178,6 +178,9 @@ export function extractMainStatement(sql: string): string {
   let hasClosedCte = false
   const len = sql.length
 
+  const asRe = /\bas\b/iy
+  const matRe = /\s*(?:not\s+)?materialized\s*/iy
+
   while (i < len) {
     const ch = sql[i]
 
@@ -190,11 +193,12 @@ export function extractMainStatement(sql: string): string {
         hasClosedCte = true
       }
     } else if (depth === 0) {
-      if (/^\bas\b/i.test(sql.slice(i))) {
+      asRe.lastIndex = i
+      if (asRe.test(sql)) {
         i += 2
         // Skip whitespace and optional [NOT] MATERIALIZED
-        const rest = sql.slice(i)
-        const matMatch = rest.match(/^\s*(?:not\s+)?materialized\s*/i)
+        matRe.lastIndex = i
+        const matMatch = matRe.exec(sql)
         if (matMatch) {
           i += matMatch[0].length
         }
@@ -226,6 +230,7 @@ export function extractMainStatement(sql: string): string {
 export function hasTopLevelReturning(sql: string): boolean {
   let depth = 0
   const len = sql.length
+  const returningRe = /returning\b/iy
 
   for (let i = 0; i < len; i++) {
     const ch = sql[i]
@@ -236,8 +241,11 @@ export function hasTopLevelReturning(sql: string): boolean {
     } else if (depth === 0) {
       // Must have a valid left token boundary to prevent matching identifiers like "nonreturning"
       const hasLeftBoundary = i === 0 || !/[a-zA-Z0-9_]/.test(sql[i - 1])
-      if (hasLeftBoundary && /^returning\b/i.test(sql.slice(i))) {
-        return true
+      if (hasLeftBoundary) {
+        returningRe.lastIndex = i
+        if (returningRe.test(sql)) {
+          return true
+        }
       }
     }
   }

--- a/apps/studio/data/sql/utils.ts
+++ b/apps/studio/data/sql/utils.ts
@@ -101,9 +101,20 @@ export function stripSqlCommentsAndLiterals(sql: string): string {
       }
     }
 
-    // Single-quoted string literal: '...' (supports '' escape and \' escape)
-    if (sql[i] === "'") {
-      i++
+    // String literal: ordinary '...' (standard conforming: '' escape only)
+    // or E-prefixed escape string E'...' / e'...' (supports \' and \\ escapes)
+    const isEscapeStringPrefix =
+      (sql[i] === 'E' || sql[i] === 'e') &&
+      sql[i + 1] === "'" &&
+      (i === 0 || !/[a-zA-Z0-9_]/.test(sql[i - 1]))
+
+    if (isEscapeStringPrefix || sql[i] === "'") {
+      const isEscapeString = isEscapeStringPrefix
+      if (isEscapeString) {
+        i++ // advance past 'E' / 'e'
+      }
+      i++ // advance past opening quote "'"
+
       while (i < len) {
         if (sql[i] === "'") {
           if (sql[i + 1] === "'") {
@@ -112,7 +123,7 @@ export function stripSqlCommentsAndLiterals(sql: string): string {
             i++
             break
           }
-        } else if (sql[i] === '\\') {
+        } else if (isEscapeString && sql[i] === '\\') {
           i += 2
         } else {
           i++
@@ -223,7 +234,9 @@ export function hasTopLevelReturning(sql: string): boolean {
     } else if (ch === ')') {
       depth--
     } else if (depth === 0) {
-      if (/^returning\b/i.test(sql.slice(i))) {
+      // Must have a valid left token boundary to prevent matching identifiers like "nonreturning"
+      const hasLeftBoundary = i === 0 || !/[a-zA-Z0-9_]/.test(sql[i - 1])
+      if (hasLeftBoundary && /^returning\b/i.test(sql.slice(i))) {
         return true
       }
     }

--- a/apps/studio/data/sql/utils.ts
+++ b/apps/studio/data/sql/utils.ts
@@ -149,8 +149,92 @@ export function stripSqlCommentsAndLiterals(sql: string): string {
 }
 
 /**
+ * Extracts the top-level main statement from a SQL query, skipping any leading
+ * CTE (Common Table Expression / WITH clause) definitions.
+ *
+ * Assumes the SQL has already been stripped of comments and literals.
+ *
+ * @param sql - Cleaned SQL string
+ * @returns The main top-level statement following the CTEs, or the original SQL if not a CTE
+ */
+export function extractMainStatement(sql: string): string {
+  const withMatch = sql.match(/^\s*with\b(?:\s+recursive\b)?/i)
+  if (!withMatch) return sql
+
+  let i = withMatch[0].length
+  let depth = 0
+  let inCteBody = false
+  let hasClosedCte = false
+  const len = sql.length
+
+  while (i < len) {
+    const ch = sql[i]
+
+    if (ch === '(') {
+      depth++
+    } else if (ch === ')') {
+      depth--
+      if (depth === 0 && inCteBody) {
+        inCteBody = false
+        hasClosedCte = true
+      }
+    } else if (depth === 0) {
+      if (/^\bas\b/i.test(sql.slice(i))) {
+        i += 2
+        // Skip whitespace and optional [NOT] MATERIALIZED
+        const rest = sql.slice(i)
+        const matMatch = rest.match(/^\s*(?:not\s+)?materialized\s*/i)
+        if (matMatch) {
+          i += matMatch[0].length
+        }
+        inCteBody = true
+        continue
+      }
+
+      if (hasClosedCte) {
+        if (ch === ',') {
+          hasClosedCte = false
+        } else if (!/\s/.test(ch)) {
+          return sql.slice(i)
+        }
+      }
+    }
+    i++
+  }
+
+  return sql
+}
+
+/**
+ * Checks if a SQL statement contains a RETURNING clause at the top level
+ * (i.e. not nested inside subquery parentheses).
+ *
+ * @param sql - Cleaned SQL statement
+ * @returns True if a top-level RETURNING clause is present
+ */
+export function hasTopLevelReturning(sql: string): boolean {
+  let depth = 0
+  const len = sql.length
+
+  for (let i = 0; i < len; i++) {
+    const ch = sql[i]
+    if (ch === '(') {
+      depth++
+    } else if (ch === ')') {
+      depth--
+    } else if (depth === 0) {
+      if (/^returning\b/i.test(sql.slice(i))) {
+        return true
+      }
+    }
+  }
+
+  return false
+}
+
+/**
  * Returns true when the SQL is a DML statement (INSERT/UPDATE/DELETE/MERGE/CALL/DO)
- * that does *not* include a RETURNING clause.
+ * that does *not* include a RETURNING clause, even when preceded by a CTE (WITH clause).
  *
  * When this is the case the empty-row result is expected — the query may still have
  * modified rows — so the UI should say "Query ran successfully" rather than the
@@ -164,13 +248,14 @@ export function stripSqlCommentsAndLiterals(sql: string): string {
  */
 export function isNonReturningDml(sql: string): boolean {
   const cleaned = stripSqlCommentsAndLiterals(sql).trim()
+  const main = extractMainStatement(cleaned).trim()
 
-  const isDml = /^\s*(?:insert|update|delete|merge|call|do)\b/i.test(cleaned)
+  const isDml = /^\s*(?:insert|update|delete|merge|call|do)\b/i.test(main)
   if (!isDml) return false
 
-  // A RETURNING clause means Postgres will send back rows, so the empty-row
+  // A top-level RETURNING clause means Postgres will send back rows, so the empty-row
   // result would correctly mean "0 matched", not "statement ran without output".
-  return !/\breturning\b/i.test(cleaned)
+  return !hasTopLevelReturning(main)
 }
 
 export function applyAutoLimit(

--- a/apps/studio/state/sql-editor/sql-editor-session-state.test.ts
+++ b/apps/studio/state/sql-editor/sql-editor-session-state.test.ts
@@ -12,22 +12,24 @@ beforeEach(() => {
 
 describe('sqlEditorSessionState', () => {
   describe('results', () => {
-    it('addResult stores rows (and optional autoLimit) keyed by snippet id', () => {
-      sqlEditorSessionState.addResult('a', [{ x: 1 }], 50)
+    it('addResult stores rows (and optional autoLimit and sql) keyed by snippet id', () => {
+      sqlEditorSessionState.addResult('a', [{ x: 1 }], 50, 'UPDATE users SET x = 1')
 
       const result = sqlEditorSessionState.results['a']?.[0]
       expect(result?.rows).toEqual([{ x: 1 }])
       expect(result?.autoLimit).toBe(50)
+      expect(result?.sql).toBe('UPDATE users SET x = 1')
       expect(result?.error).toBeUndefined()
     })
 
-    it('addResultError stores the error with empty rows', () => {
-      sqlEditorSessionState.addResultError('a', { message: 'boom' }, 25)
+    it('addResultError stores the error with empty rows and optional sql', () => {
+      sqlEditorSessionState.addResultError('a', { message: 'boom' }, 25, 'SELECT * FROM invalid')
 
       const result = sqlEditorSessionState.results['a']?.[0]
       expect(result?.rows).toEqual([])
       expect(result?.error).toEqual({ message: 'boom' })
       expect(result?.autoLimit).toBe(25)
+      expect(result?.sql).toBe('SELECT * FROM invalid')
     })
 
     it('resetResult clears the rows for a snippet', () => {

--- a/apps/studio/state/sql-editor/sql-editor-session-state.ts
+++ b/apps/studio/state/sql-editor/sql-editor-session-state.ts
@@ -44,6 +44,14 @@ export const sqlEditorSessionState = proxy({
     sqlEditorSessionState.logRange[id] = range
   },
 
+  /**
+   * Stores successful execution results for a SQL snippet.
+   *
+   * @param id - The snippet identifier
+   * @param results - Array of result row objects
+   * @param autoLimit - Optional auto-limit applied to the query
+   * @param sql - Optional executed SQL string
+   */
   addResult: (id: string, results: any[], autoLimit?: number, sql?: string) => {
     // Use ref() to prevent Valtio from creating proxies for each row object.
     // This is critical for large result sets - without ref(), Valtio wraps every
@@ -53,10 +61,23 @@ export const sqlEditorSessionState = proxy({
     sqlEditorSessionState.results[id] = [{ rows: ref(results), autoLimit, sql }]
   },
 
+  /**
+   * Stores execution error state for a SQL snippet.
+   *
+   * @param id - The snippet identifier
+   * @param error - The execution error object
+   * @param autoLimit - Optional auto-limit applied to the query
+   * @param sql - Optional executed SQL string
+   */
   addResultError: (id: string, error: any, autoLimit?: number, sql?: string) => {
     sqlEditorSessionState.results[id] = [{ rows: ref([]), error, autoLimit, sql }]
   },
 
+  /**
+   * Clears the current results for a SQL snippet.
+   *
+   * @param id - The snippet identifier
+   */
   resetResult: (id: string) => {
     sqlEditorSessionState.results[id] = []
   },

--- a/apps/studio/state/sql-editor/sql-editor-session-state.ts
+++ b/apps/studio/state/sql-editor/sql-editor-session-state.ts
@@ -19,6 +19,7 @@ export const sqlEditorSessionState = proxy({
       rows: any[]
       error?: any
       autoLimit?: number
+      sql?: string
     }[]
   },
 
@@ -43,17 +44,17 @@ export const sqlEditorSessionState = proxy({
     sqlEditorSessionState.logRange[id] = range
   },
 
-  addResult: (id: string, results: any[], autoLimit?: number) => {
+  addResult: (id: string, results: any[], autoLimit?: number, sql?: string) => {
     // Use ref() to prevent Valtio from creating proxies for each row object.
     // This is critical for large result sets - without ref(), Valtio wraps every
     // row and nested property in a Proxy, causing massive memory overhead.
     // Alright to use ref() in this case as the data is meant to be read-only and we
     // don't need to track changes to the underlying data
-    sqlEditorSessionState.results[id] = [{ rows: ref(results), autoLimit }]
+    sqlEditorSessionState.results[id] = [{ rows: ref(results), autoLimit, sql }]
   },
 
-  addResultError: (id: string, error: any, autoLimit?: number) => {
-    sqlEditorSessionState.results[id] = [{ rows: ref([]), error, autoLimit }]
+  addResultError: (id: string, error: any, autoLimit?: number, sql?: string) => {
+    sqlEditorSessionState.results[id] = [{ rows: ref([]), error, autoLimit, sql }]
   },
 
   resetResult: (id: string) => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Closes #48862

When a user runs an `UPDATE`, `DELETE`, `INSERT`, `MERGE`, `CALL`, or `DO` statement **without** a `RETURNING` clause in the SQL Editor, the results panel shows:

- Tab header: **"0 rows"**
- Results pane: **"Success. No rows returned"**

Both messages suggest nothing happened. In reality the statement may have updated, deleted, or inserted many rows — they just weren't selected back. `psql` and most other SQL clients display the Postgres command tag (e.g. `UPDATE 1`) in this case.

**Before:**
```sql
update position_log
set notes = notes
where id = (select id from position_log limit 1);
-- Results panel: "0 rows" · "Success. No rows returned"
```

## What is the new behavior?

The SQL Editor detects non-returning DML at the display layer and adjusts both messages:

- Tab header: the "0 rows" badge is **hidden** (it's meaningless for writes with no RETURNING)
- Results pane: **"Success. Query ran successfully."**

Statements that include a `RETURNING` clause continue to work exactly as before — if the clause matches zero rows the display correctly stays "No rows returned".

**After:**
```sql
update position_log
set notes = notes
where id = (select id from position_log limit 1);
-- Results panel: "Success. Query ran successfully."
```

## Implementation

All changes are client-side in `apps/studio`:

| File | Change |
|------|--------|
| `data/sql/utils.ts` | `isNonReturningDml(sql)` with tokenizer `stripSqlCommentsAndLiterals`, CTE unwrapping `extractMainStatement`, and `hasTopLevelReturning` to classify writes vs returning queries accurately without false positives |
| `state/sql-editor/sql-editor-session-state.ts` | Store executed SQL string alongside results so evaluation is always grounded in the query that generated the result, rather than live-edited editor contents |
| `components/interfaces/SQLEditor/useSqlEditorExecution.ts` | Forward executed `vars.sql` to `sessionSnap.addResult` and `addResultError` |
| `UtilityPanel/UtilityTabResults.tsx` | Use executed SQL to switch message for non-returning DML; keep `role="status"` and `aria-live="polite"` region persistently mounted across loading and result transitions for screen-reader accessibility |
| `UtilityPanel/UtilityPanel.tsx` | Suppress the "0 rows" count badge in the tab header for non-returning DML |
| `data/sql/__tests__/utils.test.ts` | 75 unit tests covering all DML statements, CTEs (`WITH` clauses), `RETURNING` detection, comments, string literals (including Windows paths and E-strings), dollar-quoted blocks, quoted identifiers, word boundaries, and non-DML exclusion |
| `state/sql-editor/sql-editor-session-state.test.ts` | Verify SQL storage and retrieval in session results |

## Additional context

The platform `/platform/pg-meta/{ref}/query` endpoint currently returns only the result rows array (no command tag or `rowCount` field), so this is addressed client-side without requiring a backend change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - SQL results are now classified using the SQL that was actually executed, preventing later edits from affecting existing results.
  - Improved detection of statements that do not return rows, including queries with CTEs, comments, literals, and nested clauses.
  - Empty-result messaging is more accurate for complex SQL statements.

- **Accessibility**
  - Added persistent screen-reader status updates for query execution, errors, empty results, and returned row counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->