### PR TITLE
docs(self-hosted): add a section about key rotation to docker guide

### DIFF
--- a/apps/docs/content/guides/self-hosting/docker.mdx
+++ b/apps/docs/content/guides/self-hosting/docker.mdx
@@ -492,6 +492,24 @@ The script generates a new password, updates all database roles, and modifies yo
 sh run.sh recreate
 ```
 
+### Rotating API keys
+
+Unlike the managed platform, where you rotate keys from the Dashboard, self-hosted API keys live in your `.env` file. To rotate the publishable and secret keys (`SUPABASE_PUBLISHABLE_KEY` and `SUPABASE_SECRET_KEY`) without changing the asymmetric signing key pair, run:
+
+```sh
+sh utils/rotate-new-api-keys.sh --update-env
+```
+
+Then restart the services and update your client applications with the new keys:
+
+```sh
+sh run.sh recreate
+```
+
+Rotating these keys does not invalidate existing user sessions tokens. You can also set a custom value by editing `SUPABASE_PUBLISHABLE_KEY` or `SUPABASE_SECRET_KEY` in `.env` directly, then recreating the services.
+
+For rotating versus fully regenerating the asymmetric key pair (which does affect active sessions), see [New API Keys and Asymmetric Authentication](/docs/guides/self-hosting/self-hosted-auth-keys#rotating-the-new-api-keys).
+
 ### Configuring secrets
 
 The `generate-keys.sh` script sets the following secrets automatically. You can also configure them manually in the `.env` file if needed:

--- a/apps/docs/content/guides/self-hosting/docker.mdx
+++ b/apps/docs/content/guides/self-hosting/docker.mdx
@@ -500,15 +500,15 @@ Unlike the managed platform, where you rotate keys from the Dashboard, self-host
 sh utils/rotate-new-api-keys.sh --update-env
 ```
 
-Then restart the services and update your client applications with the new keys:
+Then restart the services and update your applications with the new keys:
 
 ```sh
 sh run.sh recreate
 ```
 
-Rotating these keys does not invalidate existing user sessions tokens. You can also set a custom value by editing `SUPABASE_PUBLISHABLE_KEY` or `SUPABASE_SECRET_KEY` in `.env` directly, then recreating the services.
+Use the publishable key in client apps and the secret key only in trusted server-side environments. Rotating these keys does not invalidate existing user session tokens. You can also set a custom value by editing `SUPABASE_PUBLISHABLE_KEY` or `SUPABASE_SECRET_KEY` in `.env` directly, then recreating the services.
 
-For rotating versus fully regenerating the asymmetric key pair (which does affect active sessions), see [New API Keys and Asymmetric Authentication](/docs/guides/self-hosting/self-hosted-auth-keys#rotating-the-new-api-keys).
+For rotating versus fully regenerating the asymmetric key pair (which does affect active sessions), see [New API Keys and Asymmetric Authentication](/docs/guides/self-hosting/self-hosted-auth-keys#regenerating-asymmetric-key-pair).
 
 ### Configuring secrets
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Adds a section about new API key rotation to docker guide.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for rotating API keys in Docker self-hosted deployments.
  * Documented how to update environment values and restart services after rotation.
  * Clarified that key rotation does not invalidate existing user sessions.
  * Explained where to use publishable and secret keys safely.
  * Added information about custom key values and asymmetric key-pair regeneration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->