### PR TITLE
docs: remove unused `@rneui/themed` from the React Native quickstart

### DIFF
--- a/apps/docs/content/guides/auth/quickstarts/react-native.mdx
+++ b/apps/docs/content/guides/auth/quickstarts/react-native.mdx
@@ -56,7 +56,7 @@ hideToc: true
     <StepHikeCompact.Code>
 
       ```bash name=Terminal
-      cd my-app && npx expo install @supabase/supabase-js @react-native-async-storage/async-storage @rneui/themed react-native-url-polyfill
+      cd my-app && npx expo install @supabase/supabase-js @react-native-async-storage/async-storage react-native-url-polyfill
       ```
 
     </StepHikeCompact.Code>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The React Native auth quickstart tells readers to install `@rneui/themed`, but the sign-in component it embeds (`examples/auth/quickstarts/react-native/components/Auth.tsx`) has used only core React Native components since #42269 replaced the React Native Elements `Input` and `Button`. Readers following the quickstart install a UI kit that nothing in the guide uses.

## What is the new behavior?

The quickstart's `npx expo install` command no longer includes `@rneui/themed`.

## Additional context

Follow-up to #42269, which dropped the dependency from the example app but left the install command on the docs page.
