### PR TITLE
docs(auth): make hashedNonce reachable in Google nonce example

### DIFF
--- a/apps/docs/content/guides/auth/social-login/auth-google.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-google.mdx
@@ -352,10 +352,9 @@ Most web apps and websites can use Google's [personalized sign-in buttons](https
    const nonce = btoa(String.fromCharCode(...crypto.getRandomValues(new Uint8Array(32))))
    const encoder = new TextEncoder()
    const encodedNonce = encoder.encode(nonce)
-   crypto.subtle.digest('SHA-256', encodedNonce).then((hashBuffer) => {
-     const hashArray = Array.from(new Uint8Array(hashBuffer))
-     const hashedNonce = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')
-   })
+   const hashBuffer = await crypto.subtle.digest('SHA-256', encodedNonce)
+   const hashArray = Array.from(new Uint8Array(hashBuffer))
+   const hashedNonce = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')
 
    // Use 'hashedNonce' when making the authentication request to Google
    // Use 'nonce' when invoking the supabase.auth.signInWithIdToken() method

--- a/apps/docs/content/guides/auth/social-login/auth-google.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-google.mdx
@@ -348,13 +348,19 @@ Most web apps and websites can use Google's [personalized sign-in buttons](https
 
    ```js
    // Adapted from https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest#converting_a_digest_to_a_hex_string
+   async function generateNonce() {
+     const nonce = btoa(String.fromCharCode(...crypto.getRandomValues(new Uint8Array(32))))
+     const encoder = new TextEncoder()
+     const encodedNonce = encoder.encode(nonce)
+     const hashBuffer = await crypto.subtle.digest('SHA-256', encodedNonce)
+     const hashArray = Array.from(new Uint8Array(hashBuffer))
+     const hashedNonce = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')
 
-   const nonce = btoa(String.fromCharCode(...crypto.getRandomValues(new Uint8Array(32))))
-   const encoder = new TextEncoder()
-   const encodedNonce = encoder.encode(nonce)
-   const hashBuffer = await crypto.subtle.digest('SHA-256', encodedNonce)
-   const hashArray = Array.from(new Uint8Array(hashBuffer))
-   const hashedNonce = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')
+     return [nonce, hashedNonce]
+   }
+
+   // In your initialization / setup:
+   const [nonce, hashedNonce] = await generateNonce()
 
    // Use 'hashedNonce' when making the authentication request to Google
    // Use 'nonce' when invoking the supabase.auth.signInWithIdToken() method


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

In the "Google pre-built" sign-in section of the Google social login guide (`apps/docs/content/guides/auth/social-login/auth-google.mdx`), `hashedNonce` is declared inside a `.then()` callback:

```js
crypto.subtle.digest('SHA-256', encodedNonce).then((hashBuffer) => {
  const hashArray = Array.from(new Uint8Array(hashBuffer))
  const hashedNonce = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')
})

// Use 'hashedNonce' when making the authentication request to Google
// Use 'nonce' when invoking the supabase.auth.signInWithIdToken() method
```

Because `hashedNonce` is scoped inside the callback, attempting to use it as instructed immediately below fails with `ReferenceError: hashedNonce is not defined`.

Fixes #49406

## What is the new behavior?

The example awaits `crypto.subtle.digest` directly:

```js
const hashBuffer = await crypto.subtle.digest('SHA-256', encodedNonce)
const hashArray = Array.from(new Uint8Array(hashBuffer))
const hashedNonce = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')

// Use 'hashedNonce' when making the authentication request to Google
// Use 'nonce' when invoking the supabase.auth.signInWithIdToken() method
```

This keeps `hashedNonce` accessible in the surrounding scope, matching the working implementation in the `generateNonce` helper right below in the "One-tap with Next.js" section.

## Additional context

Documentation code snippet fix only; matches the surrounding guide patterns.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the Google sign-in application code example to use clearer `async`/`await` syntax when hashing the nonce.
  - Preserved the existing SHA-256 hashing behavior and output.
  - The example now shows nonce generation and hashed-nonce retrieval as a complete asynchronous operation, making the sign-in flow easier to follow without changing its behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->