### PR TITLE
docs: add omp (oh-my-pi) to supported clients in MCP and plugin guides

### DIFF
--- a/apps/docs/data/content-listings/ai-tools.data.ts
+++ b/apps/docs/data/content-listings/ai-tools.data.ts
@@ -19,6 +19,7 @@ const ICON_ASSETS: Record<string, { icon: string; hasLightIcon?: boolean }> = {
   'gemini-cli': { icon: '/docs/img/icons/agent-gemini-cli-icon', hasLightIcon: false },
   'github-copilot': { icon: '/docs/img/icons/agent-copilot-icon', hasLightIcon: true },
   kimi: { icon: '/docs/img/icons/agent-kimi-icon', hasLightIcon: true },
+  omp: { icon: '/docs/img/icons/agent-omp-icon', hasLightIcon: false },
   vscode: { icon: '/docs/img/icons/agent-vscode-icon', hasLightIcon: false },
   antigravity: { icon: '/docs/img/icons/agent-antigravity-icon', hasLightIcon: false },
   windsurf: { icon: '/docs/img/icons/agent-devin-icon', hasLightIcon: true },
@@ -46,6 +47,7 @@ const TAGLINES: Record<string, string> = {
   goose: 'Your native open source AI agent — desktop app, CLI, and API.',
   kimi: 'Engineered to drop into any dev workflow and get programming tasks done fast.',
   kiro: 'Move beyond AI coding to agentic engineering.',
+  omp: 'A coding agent with the IDE wired in.',
   opencode: 'The open source AI coding agent.',
   vscode: 'The open source AI code editor — your home for multi-agent development.',
   // Pre-acquisition tagline (Cognition/Devin acquired Windsurf in 2025) — see "Open questions".

--- a/apps/docs/features/ui/AgentPluginsPanel.data.ts
+++ b/apps/docs/features/ui/AgentPluginsPanel.data.ts
@@ -64,6 +64,14 @@ export const PLUGIN_CLIENTS: PluginClient[] = [
     docsUrl: 'https://www.kimi.com/code/docs/en/kimi-code-cli/customization/plugins.html',
   },
   {
+    key: 'omp',
+    label: 'omp',
+    icon: 'omp',
+    repoUrl: 'https://github.com/supabase-community/supabase-plugin',
+    docsUrl: 'https://github.com/can1357/oh-my-pi/blob/main/docs/marketplace.md',
+    docsLinkText: 'View omp plugin docs',
+  },
+  {
     key: 'vscode',
     label: 'VS Code',
     icon: 'vscode',

--- a/apps/docs/features/ui/AgentPluginsPanel.tsx
+++ b/apps/docs/features/ui/AgentPluginsPanel.tsx
@@ -169,6 +169,38 @@ function PluginInstructions({ client }: { client: PluginClient }) {
       </div>
     )
   }
+  if (client.key === 'omp') {
+    return (
+      <div className="space-y-3">
+        <p className="text-sm text-foreground-light">
+          omp reads the Claude Code plugin format, so install the Supabase plugin from the{' '}
+          <a
+            href="https://github.com/anthropics/claude-plugins-official"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-brand-link hover:underline"
+          >
+            official Anthropic marketplace
+          </a>
+          :
+        </p>
+        <CodeBlock
+          value={`omp plugin marketplace add anthropics/claude-plugins-official\nomp plugin install supabase@claude-plugins-official`}
+          language="bash"
+          focusable={false}
+          className="block"
+        />
+        <p className="text-xs text-foreground-lighter">
+          Installs with <code>--scope user</code> by default, making it available across all your
+          projects. Use <code>--scope project</code> to install it for the current project only.
+        </p>
+        <p className="text-xs text-foreground-lighter">
+          Inside a session, run <code>/marketplace</code> to browse plugins, then{' '}
+          <code>/reload-plugins</code> after installing to load the skills and MCP server.
+        </p>
+      </div>
+    )
+  }
 
   if (client.key === 'vscode') {
     return (

--- a/apps/docs/public/img/icons/agent-omp-icon.svg
+++ b/apps/docs/public/img/icons/agent-omp-icon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="omp-mark" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#ed4abf" />
+      <stop offset=".5" stop-color="#9b4dff" />
+      <stop offset="1" stop-color="#5ad8e6" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="12" fill="#0f0a14" />
+  <path fill="url(#omp-mark)" d="M14 16h36v8H40v32h-8V24h-6v22h-8V24h-4z" />
+</svg>

--- a/packages/ui-patterns/src/McpUrlBuilder/assets/omp-icon.svg
+++ b/packages/ui-patterns/src/McpUrlBuilder/assets/omp-icon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="omp-mark" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#ed4abf" />
+      <stop offset=".5" stop-color="#9b4dff" />
+      <stop offset="1" stop-color="#5ad8e6" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="12" fill="#0f0a14" />
+  <path fill="url(#omp-mark)" d="M14 16h36v8H40v32h-8V24h-6v22h-8V24h-4z" />
+</svg>

--- a/packages/ui-patterns/src/McpUrlBuilder/clients.data.ts
+++ b/packages/ui-patterns/src/McpUrlBuilder/clients.data.ts
@@ -13,6 +13,7 @@ import type {
   McpClientConfig,
   McpClientDeepLinkOptions,
   McpFeatureGroup,
+  OmpMcpConfig,
   OpenCodeMcpConfig,
   VSCodeMcpConfig,
   WindsurfMcpConfig,
@@ -361,6 +362,23 @@ export const MCP_CLIENT_DATA: McpClientData[] = [
     },
   },
   {
+    key: 'omp',
+    label: 'omp',
+    icon: 'omp',
+    configFile: '.omp/mcp.json',
+    externalDocsUrl: 'https://github.com/can1357/oh-my-pi/blob/main/docs/mcp-config.md',
+    transformConfig: (config): OmpMcpConfig => {
+      return {
+        mcpServers: {
+          supabase: {
+            type: 'http',
+            url: config.mcpServers.supabase.url,
+          },
+        },
+      }
+    },
+  },
+  {
     key: 'kiro',
     label: 'Kiro',
     icon: 'kiro',
@@ -449,6 +467,7 @@ export const MCP_CLIENT_GROUPS = [
       'opencode',
       'factory',
       'fx',
+      'omp',
     ],
   },
   {

--- a/packages/ui-patterns/src/McpUrlBuilder/clients.instructions.md.tsx
+++ b/packages/ui-patterns/src/McpUrlBuilder/clients.instructions.md.tsx
@@ -275,6 +275,32 @@ export const MCP_CLIENT_INSTRUCTIONS: Record<string, McpClientInstructions> = {
       </>
     ),
   },
+  omp: {
+    primary: () => (
+      <>
+        <paragraph>
+          Start <inlineCode value="omp" /> and add the Supabase MCP server with the guided setup:
+        </paragraph>
+        <code lang="bash" value="/mcp add" />
+      </>
+    ),
+    alternate: () => (
+      <>
+        <paragraph>
+          That path is project-scoped. To use the server in every project, add the same entry to{' '}
+          <inlineCode value="~/.omp/agent/mcp.json" /> instead.
+        </paragraph>
+        <paragraph>
+          If a session is already open, pick up the change with <inlineCode value="/mcp reload" />.
+          omp opens your browser to complete the Supabase OAuth flow the first time it connects.
+        </paragraph>
+        <paragraph>
+          Confirm the server is connected with <inlineCode value="/mcp list" />, or authorize again
+          with a different account using <inlineCode value="/mcp reauth supabase" />.
+        </paragraph>
+      </>
+    ),
+  },
   kiro: {
     deepLinkDescription: (
       <paragraph>

--- a/packages/ui-patterns/src/McpUrlBuilder/types.ts
+++ b/packages/ui-patterns/src/McpUrlBuilder/types.ts
@@ -214,6 +214,19 @@ export interface KimiMcpConfig extends McpClientBaseConfig {
     }
   }
 }
+/**
+ * Configuration format for the omp CLI MCP client.
+ * omp keys servers under `mcpServers` and requires an explicit `type: "http"`:
+ * an entry with a `url` but no `type` is validated as stdio and rejected.
+ */
+export interface OmpMcpConfig extends McpClientBaseConfig {
+  mcpServers: {
+    supabase: {
+      type: 'http'
+      url: string
+    }
+  }
+}
 
 // Union of all possible config types
 export type McpClientConfig =
@@ -230,6 +243,7 @@ export type McpClientConfig =
   | GrokMcpConfig
   | KimiMcpConfig
   | McpClientBaseConfig
+  | OmpMcpConfig
   | OpenCodeMcpConfig
   | OtherMcpConfig
   | VSCodeMcpConfig

--- a/packages/ui-patterns/src/McpUrlBuilder/utils/mcpIconAssets.ts
+++ b/packages/ui-patterns/src/McpUrlBuilder/utils/mcpIconAssets.ts
@@ -20,6 +20,7 @@ import grokIcon from '../assets/grok-icon.svg'
 import kimiDarkIcon from '../assets/kimi-icon-dark.svg'
 import kimiIcon from '../assets/kimi-icon.svg'
 import kiroIcon from '../assets/kiro-icon.svg'
+import ompIcon from '../assets/omp-icon.svg'
 import openaiDarkIcon from '../assets/openai-icon-dark.svg'
 import openaiIcon from '../assets/openai-icon.svg'
 import opencodeDarkIcon from '../assets/opencode-icon-dark.svg'
@@ -52,6 +53,7 @@ const MCP_CLIENT_ICON_ASSETS = {
   grok: { light: grokIcon, dark: grokDarkIcon },
   kimi: { light: kimiIcon, dark: kimiDarkIcon },
   kiro: { light: kiroIcon, dark: kiroIcon },
+  omp: { light: ompIcon, dark: ompIcon },
   openai: { light: openaiIcon, dark: openaiDarkIcon },
   opencode: { light: opencodeIcon, dark: opencodeDarkIcon },
   perplexity: { light: perplexityIcon, dark: perplexityDarkIcon },


### PR DESCRIPTION
## What this does

Adds **omp** (oh-my-pi) across the Supabase AI-tools docs.

- **Plugin docs** (`AgentPluginsPanel`) — omp client + Anthropic marketplace install: `omp plugin marketplace add anthropics/claude-plugins-official`, then `omp plugin install supabase@claude-plugins-official`.
- **MCP docs** (`McpUrlBuilder`) — omp under "AI Agent CLI": `.omp/mcp.json` / `~/.omp/agent/mcp.json` (JSON), `/mcp add` guided setup, project vs user scope.
- **"Pick your agent" grid** — add the omp logo and tagline ("A coding agent with the IDE wired in.").

No CLI command mapping entry — omp has no `omp mcp …` subcommand, so the page documents file-based setup (`/mcp add` wizard or direct JSON edit). Matches other file-configured clients like kiro.

## Testing

Verified against omp 18.1.11: written `.omp/mcp.json` parsed by runtime, `/mcp list` shows server connected; `omp plugin marketplace add/install supabase@claude-plugins-official` works; `omp plugin list` confirms installed.

## Preview

### Agent Plugin page

<img width="1128" height="706" alt="image" src="https://github.com/user-attachments/assets/1f06895b-2d45-4b64-b9ab-c1670201c370" />


### MCP page

<img width="1128" height="706" alt="image" src="https://github.com/user-attachments/assets/30a9a823-0e78-4c3b-aeeb-3a6a7aa40ed6" />


### AI Tools main page

<img width="1128" height="706" alt="image" src="https://github.com/user-attachments/assets/064a3234-9f4d-4f0a-9598-fbb2a465266f" />


Closes AI-1184

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added OMP as a supported AI coding agent across documentation and integrations.
  - Added OMP installation guidance, including marketplace setup, scope options, session reloads, and authentication.
  - Added support for configuring the Supabase MCP server through OMP.
  - Added OMP branding, icon, tagline, repository, and documentation links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->