### PR TITLE
Fix docs search request guards and subsection payloads

### DIFF
--- a/supabase/functions/search-embeddings/index.ts
+++ b/supabase/functions/search-embeddings/index.ts
@@ -7,6 +7,7 @@ import { ApplicationError, UserError } from '../common/errors.ts'
 const openAiKey = Deno.env.get('OPENAI_API_KEY')
 const supabaseUrl = Deno.env.get('SUPABASE_URL')
 const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
+const MAX_QUERY_LENGTH = 500
 
 export const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -18,6 +19,10 @@ Deno.serve(async (req) => {
     // Handle CORS
     if (req.method === 'OPTIONS') {
       return new Response('ok', { headers: corsHeaders })
+    }
+
+    if (req.method !== 'POST') {
+      throw new UserError('Method not allowed')
     }
 
     if (!openAiKey) {
@@ -40,14 +45,22 @@ Deno.serve(async (req) => {
 
     const { query, useAlternateSearchIndex } = requestData
 
-    if (!query) {
+    if (typeof query !== 'string') {
       throw new UserError('Missing query in request data')
     }
 
-    // Intentionally log the query
-    console.log({ query })
-
     const sanitizedQuery = query.trim()
+
+    if (!sanitizedQuery) {
+      throw new UserError('Missing query in request data')
+    }
+
+    if (sanitizedQuery.length > MAX_QUERY_LENGTH) {
+      throw new UserError('Query is too long')
+    }
+
+    // Intentionally log the query
+    console.log({ query: sanitizedQuery })
 
     const supabaseClient = createClient<Database>(supabaseUrl, supabaseServiceKey)
 

--- a/supabase/functions/search-embeddings/index.ts
+++ b/supabase/functions/search-embeddings/index.ts
@@ -22,7 +22,14 @@ Deno.serve(async (req) => {
     }
 
     if (req.method !== 'POST') {
-      throw new UserError('Method not allowed')
+      return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+        status: 405,
+        headers: {
+          ...corsHeaders,
+          Allow: 'POST, OPTIONS',
+          'Content-Type': 'application/json',
+        },
+      })
     }
 
     if (!openAiKey) {

--- a/supabase/migrations/20260906090000_fix_hybrid_search_subsections.sql
+++ b/supabase/migrations/20260906090000_fix_hybrid_search_subsections.sql
@@ -85,11 +85,14 @@ select
   public.get_full_content_url(page.type, page.path, null) as href,
   case when include_full_content then page.content else null end as content,
   page.meta as metadata,
-  array_agg(json_build_object(
-    'title', matched_section.heading,
-    'href', public.get_full_content_url(page.type, page.path, matched_section.slug),
-    'content', matched_section.content
-  )) filter (where matched_section.id is not null) as subsections
+  coalesce(
+    array_agg(json_build_object(
+      'title', matched_section.heading,
+      'href', public.get_full_content_url(page.type, page.path, matched_section.slug),
+      'content', matched_section.content
+    )) filter (where matched_section.id is not null),
+    array[]::json[]
+  ) as subsections
 from ranked_page
 join public.page on page.id = ranked_page.id
 left join matched_section on matched_section.page_id = page.id
@@ -182,11 +185,14 @@ select
   public.get_full_content_url(page_nimbus.type, page_nimbus.path, null) as href,
   case when include_full_content then page_nimbus.content else null end as content,
   page_nimbus.meta as metadata,
-  array_agg(json_build_object(
-    'title', matched_section.heading,
-    'href', public.get_full_content_url(page_nimbus.type, page_nimbus.path, matched_section.slug),
-    'content', matched_section.content
-  )) filter (where matched_section.id is not null) as subsections
+  coalesce(
+    array_agg(json_build_object(
+      'title', matched_section.heading,
+      'href', public.get_full_content_url(page_nimbus.type, page_nimbus.path, matched_section.slug),
+      'content', matched_section.content
+    )) filter (where matched_section.id is not null),
+    array[]::json[]
+  ) as subsections
 from ranked_page
 join public.page_nimbus on page_nimbus.id = ranked_page.id
 left join matched_section on matched_section.page_id = page_nimbus.id

--- a/supabase/migrations/20260906090000_fix_hybrid_search_subsections.sql
+++ b/supabase/migrations/20260906090000_fix_hybrid_search_subsections.sql
@@ -1,0 +1,195 @@
+-- Keep hybrid search subsection payloads limited to the sections that matched
+-- either the full-text or semantic branch.
+create or replace function search_content_hybrid(
+  query_text text,
+  query_embedding vector(1536),
+  max_result int default 30,
+  full_text_weight float default 1,
+  semantic_weight float default 1,
+  rrf_k int default 50,
+  match_threshold float default 0.78,
+  include_full_content boolean default false
+)
+returns table (
+  id bigint,
+  page_title text,
+  type text,
+  href text,
+  content text,
+  metadata json,
+  subsections json[]
+)
+language sql
+set search_path = ''
+as $$
+with full_text as (
+  select
+    id,
+    row_number() over(order by greatest(
+      least(10 * ts_rank(title_tokens, websearch_to_tsquery(query_text)), 1),
+      ts_rank(fts_tokens, websearch_to_tsquery(query_text))
+    ) desc) as rank_ix
+  from public.page
+  where title_tokens @@ websearch_to_tsquery(query_text) or fts_tokens @@ websearch_to_tsquery(query_text)
+  order by rank_ix
+  limit least(max_result, 30) * 2
+),
+semantic as (
+  select
+    id as section_id,
+    page_id as id,
+    row_number() over () as rank_ix
+  from public.match_embedding(query_embedding, match_threshold, max_result * 2)
+),
+rrf as (
+  select
+    coalesce(full_text.id, semantic.id) as id,
+    semantic.section_id,
+    coalesce(1.0 / (rrf_k + full_text.rank_ix), 0.0) * full_text_weight +
+    coalesce(1.0 / (rrf_k + semantic.rank_ix), 0.0) * semantic_weight as rrf_score
+  from full_text
+  full outer join semantic on full_text.id = semantic.id
+),
+ranked_page as (
+  select
+    id,
+    max(rrf_score) as rrf_score
+  from rrf
+  where rrf_score > 0
+  group by id
+  order by max(rrf_score) desc
+  limit max_result
+),
+matched_section as (
+  select distinct on (page_section.id)
+    page_section.id,
+    page_section.page_id,
+    page_section.heading,
+    page_section.slug,
+    page_section.content
+  from ranked_page
+  join public.page_section on page_section.page_id = ranked_page.id
+  left join rrf on rrf.id = ranked_page.id
+  where
+    rrf.section_id = page_section.id
+    or to_tsvector(
+      'english',
+      concat_ws(' ', page_section.heading, page_section.content)
+    ) @@ websearch_to_tsquery(query_text)
+  order by page_section.id
+)
+select
+  page.id,
+  page.meta ->> 'title' as page_title,
+  page.type,
+  public.get_full_content_url(page.type, page.path, null) as href,
+  case when include_full_content then page.content else null end as content,
+  page.meta as metadata,
+  array_agg(json_build_object(
+    'title', matched_section.heading,
+    'href', public.get_full_content_url(page.type, page.path, matched_section.slug),
+    'content', matched_section.content
+  )) filter (where matched_section.id is not null) as subsections
+from ranked_page
+join public.page on page.id = ranked_page.id
+left join matched_section on matched_section.page_id = page.id
+group by page.id, ranked_page.rrf_score
+order by ranked_page.rrf_score desc;
+$$;
+
+create or replace function search_content_hybrid_nimbus(
+  query_text text,
+  query_embedding vector(1536),
+  max_result int default 30,
+  full_text_weight float default 1,
+  semantic_weight float default 1,
+  rrf_k int default 50,
+  match_threshold float default 0.78,
+  include_full_content boolean default false
+)
+returns table (
+  id bigint,
+  page_title text,
+  type text,
+  href text,
+  content text,
+  metadata json,
+  subsections json[]
+)
+language sql
+set search_path = ''
+as $$
+with full_text as (
+  select
+    id,
+    row_number() over(order by greatest(
+      least(10 * ts_rank(title_tokens, websearch_to_tsquery(query_text)), 1),
+      ts_rank(fts_tokens, websearch_to_tsquery(query_text))
+    ) desc) as rank_ix
+  from public.page_nimbus
+  where title_tokens @@ websearch_to_tsquery(query_text) or fts_tokens @@ websearch_to_tsquery(query_text)
+  order by rank_ix
+  limit least(max_result, 30) * 2
+),
+semantic as (
+  select
+    id as section_id,
+    page_id as id,
+    row_number() over () as rank_ix
+  from public.match_embedding_nimbus(query_embedding, match_threshold, max_result * 2)
+),
+rrf as (
+  select
+    coalesce(full_text.id, semantic.id) as id,
+    semantic.section_id,
+    coalesce(1.0 / (rrf_k + full_text.rank_ix), 0.0) * full_text_weight +
+    coalesce(1.0 / (rrf_k + semantic.rank_ix), 0.0) * semantic_weight as rrf_score
+  from full_text
+  full outer join semantic on full_text.id = semantic.id
+),
+ranked_page as (
+  select
+    id,
+    max(rrf_score) as rrf_score
+  from rrf
+  where rrf_score > 0
+  group by id
+  order by max(rrf_score) desc
+  limit max_result
+),
+matched_section as (
+  select distinct on (page_section_nimbus.id)
+    page_section_nimbus.id,
+    page_section_nimbus.page_id,
+    page_section_nimbus.heading,
+    page_section_nimbus.slug,
+    page_section_nimbus.content
+  from ranked_page
+  join public.page_section_nimbus on page_section_nimbus.page_id = ranked_page.id
+  left join rrf on rrf.id = ranked_page.id
+  where
+    rrf.section_id = page_section_nimbus.id
+    or to_tsvector(
+      'english',
+      concat_ws(' ', page_section_nimbus.heading, page_section_nimbus.content)
+    ) @@ websearch_to_tsquery(query_text)
+  order by page_section_nimbus.id
+)
+select
+  page_nimbus.id,
+  page_nimbus.meta ->> 'title' as page_title,
+  page_nimbus.type,
+  public.get_full_content_url(page_nimbus.type, page_nimbus.path, null) as href,
+  case when include_full_content then page_nimbus.content else null end as content,
+  page_nimbus.meta as metadata,
+  array_agg(json_build_object(
+    'title', matched_section.heading,
+    'href', public.get_full_content_url(page_nimbus.type, page_nimbus.path, matched_section.slug),
+    'content', matched_section.content
+  )) filter (where matched_section.id is not null) as subsections
+from ranked_page
+join public.page_nimbus on page_nimbus.id = ranked_page.id
+left join matched_section on matched_section.page_id = page_nimbus.id
+group by page_nimbus.id, ranked_page.rrf_score
+order by ranked_page.rrf_score desc;
+$$;


### PR DESCRIPTION
## What changed
- Add request guards to the public search-embeddings edge function before it calls OpenAI or the database.
- Replace the regular and Nimbus hybrid search RPCs so subsection payloads include only semantically matched sections or sections whose own text matches the query, instead of every section on a matched page.

## Why
- Avoid unnecessary OpenAI/service-role work for unsupported methods, invalid query shapes, empty queries, and oversized queries.
- Keep hybrid search results focused and prevent unrelated sections from inflating response payloads.

## Verification
- Ran `git diff --check`.
- Could not run Deno/Supabase CLI checks in this environment: `deno` and `supabase` are not installed, and the checkout is sparse/filtered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved hybrid search by combining keyword and semantic matching for more relevant page-level results.
  - Search results now include only content sections relevant to the match, reducing unnecessary details.
  - Results with no matching sections now return an empty section list instead of missing data.

- **Bug Fixes**
  - Search requests now require a valid, trimmed query and reject empty or oversized input.
  - Non-POST requests are rejected with an appropriate method-not-allowed response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->