### PR TITLE
fix(common): revive dormant test suite + SSR-safe detectBrowser

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "test:docs": "turbo run test --filter=docs",
     "test:ui": "turbo run test --filter=ui",
     "test:ui-patterns": "turbo run test --filter=ui-patterns",
+    "test:common": "turbo run test --filter=common",
     "test:studio": "turbo run test --filter=studio",
     "test:studio:watch": "turbo run test --filter=studio -- watch",
     "e2e:setup:cli": "supabase stop --all --no-backup --workdir ./e2e/studio; supabase start --exclude studio,mailpit --workdir ./e2e/studio && supabase status --output json --workdir ./e2e/studio > keys.json && node scripts/generateLocalEnv.js",

--- a/packages/common/helpers.test.ts
+++ b/packages/common/helpers.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { createRef } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { detectBrowser, ensurePlatformSuffix, mergeRefs } from './helpers'
+
+// helpers.ts evaluates `window.matchMedia(...)` at module load, and jsdom does
+// not implement matchMedia. Stub it before importing so the module can load.
+vi.hoisted(() => {
+  if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
+    window.matchMedia = () =>
+      ({
+        matches: false,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+      }) as unknown as MediaQueryList
+  }
+})
+
+describe('detectBrowser', () => {
+  const setUserAgent = (ua: string) => {
+    vi.stubGlobal('navigator', { userAgent: ua })
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('detects Chrome', () => {
+    setUserAgent('Mozilla/5.0 Chrome/90.0.0.0 Safari/537.36')
+    expect(detectBrowser()).toBe('Chrome')
+  })
+
+  it('detects Edge (Chromium) before Chrome', () => {
+    setUserAgent('Mozilla/5.0 Chrome/120 Safari/537.36 Edg/120.0')
+    expect(detectBrowser()).toBe('Edge')
+  })
+
+  it('detects Firefox', () => {
+    setUserAgent('Mozilla/5.0 Firefox/88.0')
+    expect(detectBrowser()).toBe('Firefox')
+  })
+
+  it('detects Safari', () => {
+    setUserAgent('Mozilla/5.0 Version/14.0 Safari/605.1.15')
+    expect(detectBrowser()).toBe('Safari')
+  })
+
+  it('returns undefined for an unknown user agent', () => {
+    setUserAgent('Mozilla/5.0 (X11; Linux x86_64)')
+    expect(detectBrowser()).toBeUndefined()
+  })
+
+  it('does not throw and returns undefined when navigator is absent (SSR)', () => {
+    vi.stubGlobal('navigator', undefined)
+    expect(() => detectBrowser()).not.toThrow()
+    expect(detectBrowser()).toBeUndefined()
+  })
+})
+
+describe('ensurePlatformSuffix', () => {
+  it('appends /platform when missing', () => {
+    expect(ensurePlatformSuffix('https://api.x.com')).toBe('https://api.x.com/platform')
+  })
+
+  it('leaves the url unchanged when /platform is already present', () => {
+    expect(ensurePlatformSuffix('https://api.x.com/platform')).toBe('https://api.x.com/platform')
+  })
+})
+
+describe('mergeRefs', () => {
+  it('calls a function ref with the value', () => {
+    const fnRef = vi.fn()
+    mergeRefs<string>(fnRef)('hello')
+    expect(fnRef).toHaveBeenCalledWith('hello')
+  })
+
+  it("assigns the value to an object ref's current", () => {
+    const objRef = createRef<string>()
+    mergeRefs<string>(objRef)('world')
+    expect(objRef.current).toBe('world')
+  })
+
+  it('ignores null and undefined refs without throwing', () => {
+    // undefined is not part of React.Ref<T>, but mergeRefs must still skip it safely
+    expect(() => mergeRefs<string>(null, undefined as any)('value')).not.toThrow()
+  })
+
+  it('forwards the value to multiple refs at once', () => {
+    const fnRef = vi.fn()
+    const objRef = createRef<string>()
+    mergeRefs<string>(fnRef, objRef, null)('shared')
+    expect(fnRef).toHaveBeenCalledWith('shared')
+    expect(objRef.current).toBe('shared')
+  })
+})

--- a/packages/common/helpers.ts
+++ b/packages/common/helpers.ts
@@ -4,9 +4,11 @@ import { useSyncExternalStore } from 'react'
 import type * as React from 'react'
 
 export const detectBrowser = () => {
-  if (!navigator) return undefined
+  if (typeof navigator === 'undefined') return undefined
 
-  if (navigator.userAgent.indexOf('Chrome') !== -1) {
+  if (navigator.userAgent.indexOf('Edg') !== -1) {
+    return 'Edge'
+  } else if (navigator.userAgent.indexOf('Chrome') !== -1) {
     return 'Chrome'
   } else if (navigator.userAgent.indexOf('Firefox') !== -1) {
     return 'Firefox'
@@ -46,10 +48,8 @@ export function mergeRefs<T>(...refs: React.Ref<T>[]): React.RefCallback<T> {
     refs.forEach((ref) => {
       if (typeof ref === 'function') {
         ref(value)
-      } else if (ref !== null) {
-        if (typeof ref === 'object' && ref !== null && 'current' in ref) {
-          ;(ref as any).current = value
-        }
+      } else if (ref != null && typeof ref === 'object' && 'current' in ref) {
+        ;(ref as any).current = value
       }
     })
   }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -9,6 +9,7 @@
     "preinstall": "npx only-allow pnpm",
     "clean": "rimraf .turbo tsconfig.tsbuildinfo",
     "gen:types": "supabase gen types typescript --local >| ./database-types.ts",
+    "test": "vitest",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -9,7 +9,7 @@
     "preinstall": "npx only-allow pnpm",
     "clean": "rimraf .turbo tsconfig.tsbuildinfo",
     "gen:types": "supabase gen types typescript --local >| ./database-types.ts",
-    "test": "vitest",
+    "test": "vitest run --coverage",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/common/vitest.config.ts
+++ b/packages/common/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    reporters: [['default']],
+    coverage: {
+      reporter: ['lcov'],
+      exclude: ['**/*.test.ts', '**/*.test.tsx'],
+      include: ['**/*.ts', '**/*.tsx'],
+    },
+  },
+})


### PR DESCRIPTION
## Summary

Three focused, tiny commits improving `packages/common`, a self-contained shared-utils package chosen for low blast radius. Two genuinely valuable problems were found and fixed:

1. **Revived a dead test suite.** `packages/common` had 8 vitest files (129 tests) that **never ran**  the package had no `test` script and no `vitest.config.ts`, so `turbo run test --filter=common` invoked nothing. Now wired up (141 tests total with the new additions).
2. **Fixed a real SSR bug.** `detectBrowser()` guarded with `if (!navigator)`, which throws a `ReferenceError` in Node/SSR (where `navigator` is undeclared) instead of returning `undefined`. This function is consumed by Studio's Support forms and an error boundary. The guard now uses `typeof navigator === 'undefined'`, adds Edge detection, and simplifies a duplicated null-check in `mergeRefs`.

## Commits (tiny, one logical change each)
1. `fix(common): run the existing vitest suite (add config + test script)`  new `vitest.config.ts` (jsdom, lcov coverage), `test: "vitest"` script, root `test:common` script mirroring `test:ui-patterns`.
2. `fix(common): make detectBrowser SSR-safe and detect Edge; simplify mergeRefs` `typeof navigator === 'undefined'` guard; `Edg` branch before Chrome (Edge UAs contain both tokens); collapsed duplicated null-check in `mergeRefs` (behavior-preserving, now also skips `undefined`).
3. `chore(common): add tests for detectBrowser, ensurePlatformSuffix, mergeRefs`  new `helpers.test.ts` (12 tests).

Diffstat: 5 files, +117/-6.

## Testing (local CI-equivalents for the touched area)
| Check | Command | Result |
|---|---|---|
| Unit tests (direct) | `npx vitest run` | PASS  9 files / 141 tests |
| Unit tests (via turbo) | `pnpm test:common -- run` | PASS  9 files / 141 tests |
| Typecheck | `tsc --noEmit` (packages/common) | PASS |
| Prettier | `prettier --check` on all 5 changed files | PASS |
| Case hazards | `node scripts/check-case-hazards.mjs` | PASS  17229 files |
| Test quality (mutation) | reverted fixes to confirm tests catch regressions | PASS |

## Not run (with reasons)
- **ESLint**: `packages/common` has no `lint` script/config; per `AGENTS.md`, lint is path-filtered and hard-enforced only in Studio  not applicable to these files.
- **Full-repo build / typecheck / knip / typos**: heavy repo-wide scans; changes are additive, within existing conventions, and confined to one package. Per-package `tsc --noEmit` was run instead.

No workflow files were modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved browser detection to recognize Microsoft Edge correctly.
  - Improved behavior in server-side rendering environments where browser globals are unavailable.
  - Refined reference handling for more reliable updates across supported ref types.

- **Tests**
  - Added comprehensive coverage for browser detection, URL platform suffixes, and reference merging.
  - Added browser-like test environment support and coverage reporting.
  - Added commands for running the common package test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->