### PR TITLE
fix(studio): prevent stale redirect after unmounting SignInPartner

### DIFF
--- a/apps/studio/components/interfaces/SignIn/SignInPartner.tsx
+++ b/apps/studio/components/interfaces/SignIn/SignInPartner.tsx
@@ -15,6 +15,12 @@ export const SignInPartner = () => {
   const trackFunnelError = useTrackFunnelError()
 
   useEffect(() => {
+    // The sign-in exchange below is async, so the user can navigate away (or the
+    // component can otherwise unmount) before it settles. Without this guard the
+    // redirects at the bottom still fire on the stale mount and yank the user back
+    // to /sign-in-mfa or /sign-in regardless of where they've since navigated to.
+    let isMounted = true
+
     ;(async () => {
       const params = new URLSearchParams(window.location.hash.substring(1))
 
@@ -38,12 +44,16 @@ export const SignInPartner = () => {
             trackFunnelError('signin', classifyApiError('signin', error), 'form')
           }
         } finally {
-          router.replace({ pathname: '/sign-in-mfa', query: { method } })
+          if (isMounted) router.replace({ pathname: '/sign-in-mfa', query: { method } })
         }
       } else {
-        router.replace({ pathname: '/sign-in' })
+        if (isMounted) router.replace({ pathname: '/sign-in' })
       }
     })()
+
+    return () => {
+      isMounted = false
+    }
   }, [])
 
   return (

--- a/apps/studio/tests/components/interfaces/SignIn/SignInPartner.test.tsx
+++ b/apps/studio/tests/components/interfaces/SignIn/SignInPartner.test.tsx
@@ -1,0 +1,84 @@
+import { waitFor } from '@testing-library/dom'
+import { describe, expect, test, vi } from 'vitest'
+
+import { SignInPartner } from '@/components/interfaces/SignIn/SignInPartner'
+import { auth } from '@/lib/gotrue'
+import { customRender } from '@/tests/lib/custom-render'
+
+const routerReplaceMock = vi.fn()
+
+vi.mock('next/router', () => ({
+  useRouter: () => ({
+    replace: routerReplaceMock,
+  }),
+}))
+
+vi.mock('@/lib/gotrue', () => ({
+  auth: {
+    getSession: vi.fn(),
+    signInWithIdToken: vi.fn(),
+  },
+}))
+
+type GetSessionResult = Awaited<ReturnType<typeof auth.getSession>>
+type SignInWithIdTokenResult = Awaited<ReturnType<typeof auth.signInWithIdToken>>
+
+describe('SignInPartner', () => {
+  test('does not redirect if the component unmounts before sign-in resolves', async () => {
+    let resolveSignIn: (value: SignInWithIdTokenResult) => void = () => {}
+
+    vi.mocked(auth.getSession).mockResolvedValue({
+      data: { session: null },
+    } as GetSessionResult)
+    vi.mocked(auth.signInWithIdToken).mockImplementation(
+      () => new Promise<SignInWithIdTokenResult>((resolve) => (resolveSignIn = resolve))
+    )
+
+    window.location.hash = '#partner=github&id_token=test-token'
+
+    const { unmount } = customRender(<SignInPartner />)
+
+    // Wait until the component has actually kicked off the sign-in exchange -
+    // otherwise unmounting here proves nothing, since router.replace was never
+    // going to be reachable yet regardless of the mount guard.
+    await waitFor(() => {
+      expect(auth.signInWithIdToken).toHaveBeenCalledWith({
+        provider: 'github',
+        token: 'test-token',
+      })
+    })
+
+    unmount()
+
+    // Resolve the pending sign-in after the component has already unmounted -
+    // this is the exact race the guard needs to catch.
+    resolveSignIn({ data: { session: null, user: null }, error: null } as SignInWithIdTokenResult)
+
+    // Flush the microtasks queued by the resolved promise so the effect's
+    // `finally` block runs before we assert.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(routerReplaceMock).not.toHaveBeenCalled()
+  })
+
+  test('still redirects normally when the component stays mounted', async () => {
+    vi.mocked(auth.getSession).mockResolvedValue({
+      data: { session: null },
+    } as GetSessionResult)
+    vi.mocked(auth.signInWithIdToken).mockResolvedValue({
+      data: { session: null, user: null },
+      error: null,
+    } as SignInWithIdTokenResult)
+
+    window.location.hash = '#partner=github&id_token=test-token'
+
+    customRender(<SignInPartner />)
+
+    await waitFor(() => {
+      expect(routerReplaceMock).toHaveBeenCalledWith({
+        pathname: '/sign-in-mfa',
+        query: { method: 'github' },
+      })
+    })
+  })
+})


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`SignInPartner` kicks off an async sign-in exchange (`auth.getSession()`, then
`auth.signInWithIdToken()`) inside a `useEffect` with no unmount guard at all.
If the user navigates away while that exchange is still pending - for
example on a slow connection, or by clicking a link before the partner
sign-in has resolved - the effect still runs to completion and calls
`router.replace()` once it settles. That yanks the user back to
`/sign-in-mfa` or `/sign-in`, overriding wherever they've actually navigated
to in the meantime.

Fixes #46593

## What is the new behavior?

The effect now sets an `isMounted` flag that's cleared in its cleanup
function, and both `router.replace()` calls are guarded on it. If the
component has unmounted by the time the sign-in exchange resolves, the
redirect is simply skipped - the sign-in call itself still runs to
completion either way, so nothing about the actual auth flow changes.

- Added a regression test that lets the sign-in promise resolve *after*
  unmounting, and asserts the router is never called.
- Added a second test confirming the normal (still-mounted) redirect path is
  unaffected.

## Testing

- `pnpm --filter studio test -- tests/components/interfaces/SignIn/SignInPartner.test.tsx` - passing
- `eslint` on the changed files - no new warnings
- `prettier --check` - passing

## Additional context

There's an earlier PR for this issue (#49175) that took the same guard
approach but stalled because its test unmounted before the mocked
`signInWithIdToken` call had even been made, so the assertion passed without
actually exercising the guard, and it introduced `any` casts that fail lint.
This PR's test explicitly waits for `signInWithIdToken` to be called first,
then unmounts, then resolves the pending promise - so it fails without the
fix and passes with it - and uses properly typed mock return values instead
of `any`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented delayed partner sign-in redirects from navigating users away after leaving the sign-in page.
  * Preserved expected redirects to MFA when partner authentication completes successfully.

* **Tests**
  * Added coverage for both normal partner sign-in redirects and interrupted sign-in flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->