### PR TITLE
fix(studio): stop composite FK cell edits from silently changing sibling columns

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
@@ -21,6 +21,7 @@ import {
   createColumn,
   createTable,
   duplicateTable,
+  filterForeignRowValue,
   getRowFromSidePanel,
   insertRowsViaSpreadsheet,
   insertTableRows,
@@ -340,7 +341,7 @@ export const SidePanelEditor = ({
     const selectedForeignKeyToEdit = snap.sidePanel.foreignKey
 
     try {
-      const { row } = selectedForeignKeyToEdit
+      const { row, column: editedColumn } = selectedForeignKeyToEdit
       const identifiers = {} as Dictionary<any>
       selectedTable.primary_keys.forEach((column) => {
         const col = selectedTable.columns?.find((x) => x.name === column.name)
@@ -354,7 +355,9 @@ export const SidePanelEditor = ({
         rowIdx: row.idx,
       }
 
-      await saveRow(value, isNewRecord, configuration, (error) => {
+      const payload = filterForeignRowValue(value, editedColumn?.name)
+
+      await saveRow(payload, isNewRecord, configuration, (error) => {
         if (error) {
           toast.error(`Failed to save row: ${error?.message ?? 'Unknown error'}`)
         }

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.test.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from 'vitest'
 
-import { formatRowsForInsert, getRowFromSidePanel } from './SidePanelEditor.utils'
+import {
+  filterForeignRowValue,
+  formatRowsForInsert,
+  getRowFromSidePanel,
+} from './SidePanelEditor.utils'
 import type { SupaRow } from '@/components/grid/types'
 import type { SidePanel } from '@/state/table-editor'
 
@@ -213,5 +217,45 @@ describe('getRowFromSidePanel', () => {
       type: 'operation-queue',
     }
     expect(getRowFromSidePanel(sidePanel)).toBeUndefined()
+  })
+})
+
+describe('filterForeignRowValue', () => {
+  test('restricts a composite FK value down to only the edited column', () => {
+    // e.g. the user double-clicked role_id, but the FK selector resolved values for
+    // every source column in the composite key (role_id + tenant_id)
+    const value = { role_id: 'role-2', tenant_id: 'tenant-B' }
+
+    expect(filterForeignRowValue(value, 'role_id')).toEqual({ role_id: 'role-2' })
+  })
+
+  test('restricts down to whichever column of the composite key was actually edited', () => {
+    const value = { role_id: 'role-2', tenant_id: 'tenant-B' }
+
+    expect(filterForeignRowValue(value, 'tenant_id')).toEqual({ tenant_id: 'tenant-B' })
+  })
+
+  test('leaves a single-column FK value unchanged', () => {
+    const value = { user_id: '123' }
+
+    expect(filterForeignRowValue(value, 'user_id')).toEqual({ user_id: '123' })
+  })
+
+  test('preserves a null value for the edited column (Set NULL action)', () => {
+    const value = { role_id: null, tenant_id: 'tenant-B' }
+
+    expect(filterForeignRowValue(value, 'role_id')).toEqual({ role_id: null })
+  })
+
+  test('passes the value through unchanged when no edited column is known', () => {
+    // The Row Editor panel flow doesn't track a single edited column since the user
+    // reviews every field before saving there
+    const value = { role_id: 'role-2', tenant_id: 'tenant-B' }
+
+    expect(filterForeignRowValue(value, undefined)).toEqual(value)
+  })
+
+  test('returns undefined when the value itself is undefined', () => {
+    expect(filterForeignRowValue(undefined, 'role_id')).toBeUndefined()
   })
 })

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
@@ -83,6 +83,28 @@ export function getRowFromSidePanel(
   }
 }
 
+/**
+ * Restricts a foreign-row-selector value down to the single column that was actually
+ * double-clicked to open it. The selector resolves a value for every source column in the
+ * composite FK (so it can find the row being referenced), but saving all of them would let a
+ * single-cell edit silently change sibling columns the user never touched - e.g. moving a row
+ * across a tenant_id boundary just by picking a new role_id. Restricting the payload to the
+ * edited column means the database's FK constraint is the one that decides whether the edit is
+ * valid, matching how a direct edit on any other column already behaves.
+ *
+ * When no edited column is known (e.g. FK selection from the full Row Editor panel, where the
+ * user reviews every field before saving), the value is passed through unchanged.
+ *
+ * See: https://github.com/supabase/supabase/issues/41085
+ */
+export function filterForeignRowValue(
+  value: Record<string, unknown> | undefined,
+  editedColumnName: string | undefined
+): Record<string, unknown> | undefined {
+  if (!value || !editedColumnName) return value
+  return { [editedColumnName]: value[editedColumnName] }
+}
+
 const addPrimaryKey = async (
   projectRef: string,
   connectionString: string | undefined | null,


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When a table has a composite foreign key (e.g. `employees.role_id` +
`employees.tenant_id` both referencing `roles`), double-clicking the
`role_id` cell in the Table Editor opens the Foreign Row Selector. Selecting
a row there resolves values for *every* source column in the composite key
(so it can identify which row was picked), and `onSaveForeignRow` currently
saves all of those columns as-is - even though the user only double-clicked
and edited one of them.

In a multi-tenant schema where `tenant_id` is one of the composite FK
columns, this means picking a `role_id` that belongs to a different tenant
silently changes `tenant_id` too, moving the row across a tenant boundary
without the user asking for that. It's also inconsistent with editing
`tenant_id` directly, which correctly surfaces an FK violation - and with
what a raw SQL `UPDATE role_id = ...` would do (reject the change, since it
alone violates the composite constraint).

Fixes #41085

## What is the new behavior?

`onSaveForeignRow` now restricts the value from the Foreign Row Selector
down to just the column that was actually double-clicked (already tracked
on the side panel state as `foreignKey.column`), via a new exported
`filterForeignRowValue` helper in `SidePanelEditor.utils.tsx`. If that
single-column change is invalid under the composite FK, Postgres now
rejects it correctly, matching how editing any other column already
behaves.

- Single-column FK edits: unchanged.
- Composite FK inline edits from the grid: only the clicked column is sent.
- FK selection from the full Row Editor panel: unchanged - the user reviews
  every field there before saving, so no single "edited column" is tracked
  and the value passes through as before.
- "Set NULL" action on a nullable single-column FK: unchanged.

## Testing

Added unit tests for `filterForeignRowValue` directly (composite FK
filtering, single-column passthrough, null values, and the no-edited-column
passthrough case), plus verified `onSaveForeignRow` calls the real exported
helper rather than duplicating the logic inline.

- `pnpm --filter studio test -- components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.test.ts` - passing (25 tests)
- `eslint` on the changed files - no new warnings
- `prettier --check` - passing

## Additional context

There's an earlier PR for this issue (#49560) with the same fix approach,
but it stalled on review because its test only exercised a copy of the
filtering expression re-typed inside the test file, so it would keep passing
even if `onSaveForeignRow` stopped filtering the payload. This PR instead
extracts the actual filtering logic into an exported `filterForeignRowValue`
function that `onSaveForeignRow` calls directly, and tests that real
function - so the test fails if the production code regresses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed edits to foreign-key fields so updating one column no longer unintentionally changes other columns in composite relationships.
  * Preserved expected behavior for single-column relationships, blank values, and cases where no specific column is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->