### PR TITLE
docs: fix link to skip authorization checks

### DIFF
--- a/apps/docs/content/troubleshooting/edge-function-401-error-response.mdx
+++ b/apps/docs/content/troubleshooting/edge-function-401-error-response.mdx
@@ -10,7 +10,7 @@ message = "Invalid JWT"
 
 A 401 response from an Edge Function means either:
 
-- The function failed the [legacy auth verification check](/docs/guides/functions/development-tips#skipping-authorization-checks)
+- The function failed the [legacy auth verification check](/docs/guides/functions/function-configuration#skipping-authorization-checks)
 - Your function's logic deliberately returned a 401 response
 
 ## Quick triage


### PR DESCRIPTION
skip authorization checks section live in function-configuration.mdx

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

* YES/NO

## What kind of change does this PR introduce?

* docs fix

## What is the current behavior?

* redirection is NOT working properly in https://supabase.com/docs/guides/troubleshooting/edge-function-401-error-response, since it redirects to a content, which does NOT contain currently the skip authorization checks

## What is the new behavior?

* redirect to https://supabase.com/docs/guides/functions/function-configuration#skipping-authorization-checks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the troubleshooting guide link for skipping legacy authorization checks to point to the current function configuration documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->