### PR TITLE
docs: add Windows venv activation command to Flask quickstart

### DIFF
--- a/apps/docs/content/guides/getting-started/quickstarts/flask.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/flask.mdx
@@ -15,7 +15,11 @@ Create a new directory for your Python app and set up a virtual environment.
 ```bash
 mkdir my-app && cd my-app
 python3 -m venv venv
+# On macOS/Linux
 source venv/bin/activate
+
+# On Windows
+venv\Scripts\activate
 ```
 
 ## 4. Set up AI tooling (optional)

--- a/apps/docs/content/guides/getting-started/quickstarts/flask.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/flask.mdx
@@ -18,8 +18,11 @@ python3 -m venv venv
 # On macOS/Linux
 source venv/bin/activate
 
-# On Windows
-venv\Scripts\activate
+# On Windows (Command Prompt)
+venv\Scripts\activate.bat
+
+# On Windows (PowerShell)
+.\venv\Scripts\Activate.ps1
 ```
 
 ## 4. Set up AI tooling (optional)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.
YES

## What kind of change does this PR introduce?
Docs update

## What is the current behavior?
The Flask quickstart only shows macOS/Linux venv activation (`source venv/bin/activate`) with no guidance for Windows users.

## What is the new behavior?
Added Windows-specific activation command (`venv\Scripts\activate`) alongside the existing macOS/Linux command.

## Additional context
Consistent with the existing pattern in the guide — the bottom of the page already includes a macOS-specific note about port 5000.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Flask quickstart with shell-specific Windows virtual environment activation commands for Command Prompt and PowerShell.
  * Replaced the generic Windows activation command with the appropriate command for each supported shell.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->