### PR TITLE
Bump reviewdog action misspell

### DIFF
--- a/.github/workflows/avoid-typos.yml
+++ b/.github/workflows/avoid-typos.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           persist-credentials: false
       - name: misspell
-        uses: reviewdog/action-misspell@9daa94af4357dddb6fd3775de806bc0a8e98d3e4 # v1.26.3
+        uses: reviewdog/action-misspell@dfb5c728e60546aca47282343e9d090cf75e9e63 # v1.28.0
         with:
           github_token: ${{ secrets.github_token }}
           locale: 'US'

--- a/.github/workflows/avoid-typos.yml
+++ b/.github/workflows/avoid-typos.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           persist-credentials: false
       - name: misspell
-        uses: reviewdog/action-misspell@dfb5c728e60546aca47282343e9d090cf75e9e63 # v1.28.0
+        uses: reviewdog/action-misspell@ba7ac4030fa6812f8c8b2d4e516af8bc99553c32 # v1.28.0
         with:
           github_token: ${{ secrets.github_token }}
           locale: 'US'


### PR DESCRIPTION
## Context

Our `avoid-typos` GHA which uses `reviewdog/action-misspell` is currently failing with a 404 while fetching some files to build the Docker container as per [here](https://github.com/supabase/supabase/actions/runs/34074954209/job/101604888827) for example.
```E: Failed to fetch http://deb.debian.org/debian-security/.../perl-modules-5.32...  404  Not Found```

Happening as v1.26.3's Dockerfile builds on `debian:bullseye-slim`, which is now EOL as of 31st Aug 2026 ([ref](https://www.debian.org/News/2026/20260831)). `bullseye-security` apt mirror has dropped the pinned perl package version, so the action's Docker image can no longer build

[v1.28.0](https://github.com/reviewdog/action-misspell/releases/tag/v1.28.0) (Published on 6th Sept) switches the base image to `debian:bookworm-slim`, which resolves this

## Changes involved:
- Bumps reviewdog/action-misspell from v1.26.3 to v1.28.0 in `avoid-typos.yml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Corrected the pinned revision used by automated spelling checks.
  * No changes to application functionality or end-user behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->