### PR TITLE
refactor(studio): remove `USE_REMOTE_MCP` gate, always use remote MCP server

### DIFF
--- a/apps/studio/lib/ai/supabase-mcp.ts
+++ b/apps/studio/lib/ai/supabase-mcp.ts
@@ -81,17 +81,16 @@ export async function createSupabaseMCPClient({
 }
 
 /**
- * Legacy in-process MCP client — the pre-migration behavior, kept as a fallback
- * behind the `USE_REMOTE_MCP` gate (see `tools/mcp-tools.ts`).
+ * In-process MCP client used by the eval harness (`getMockTools`,
+ * `evals/preflight.ts`) so evals stay hermetic — no live remote endpoint or
+ * real access token needed. Not used by the production assistant, which always
+ * talks to the remote MCP server (`createSupabaseMCPClient`).
  *
  * Instantiates `@supabase/mcp-server-supabase` in-process and connects to it over
  * an in-memory transport. The heavy server package is imported dynamically so it
- * is code-split into its own chunk and stays out of the (default, post-migration)
- * remote path's bundle.
+ * is code-split into its own chunk and stays out of the remote path's bundle.
  *
- * TODO(AI-897): remove in process mcp — delete this once every environment has
- * been flipped to the remote MCP server and has been stable. Tracked alongside
- * the `USE_REMOTE_MCP` rollout.
+ * TODO(AI-897): point evals at the remote MCP server instead and delete this.
  */
 export async function createInProcessSupabaseMCPClient({
   accessToken,
@@ -100,8 +99,9 @@ export async function createInProcessSupabaseMCPClient({
   accessToken: string
   projectRef: string
 }) {
-  // Dynamic imports keep the in-process server + its transport out of the remote
-  // path's bundle (loaded only when this fallback is actually taken).
+  // Dynamic imports keep the in-process server + its transport out of the
+  // production assistant bundle, so they're loaded only when the eval harness
+  // actually calls this function.
   // `.js` is required for esbuild ESM resolution.
   const { InMemoryTransport } = await import('@modelcontextprotocol/sdk/inMemory.js')
   const { createSupabaseMcpServer } = await import('@supabase/mcp-server-supabase')

--- a/apps/studio/lib/ai/tools/index.ts
+++ b/apps/studio/lib/ai/tools/index.ts
@@ -54,10 +54,9 @@ export const getTools = async ({
     }
   } else if (accessToken) {
     // If platform, fetch MCP and other platform specific tools. The MCP tools
-    // may be fetched from the remote MCP server over the network (see
-    // `USE_REMOTE_MCP`), so a failure there (outage, timeout, auth) should
-    // degrade gracefully to the remaining tools rather than break the entire
-    // assistant.
+    // are fetched from the remote MCP server over the network, so a failure
+    // there (outage, timeout, auth) should degrade gracefully to the remaining
+    // tools rather than break the entire assistant.
     let mcpTools: ToolSet = {}
     try {
       mcpTools = await getMcpTools({

--- a/apps/studio/lib/ai/tools/mcp-tools.test.ts
+++ b/apps/studio/lib/ai/tools/mcp-tools.test.ts
@@ -1,11 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { createInProcessSupabaseMCPClient, createSupabaseMCPClient } from '../supabase-mcp'
+import { createSupabaseMCPClient } from '../supabase-mcp'
 import { getMcpTools } from './mcp-tools'
 
 vi.mock('../supabase-mcp', () => ({
   createSupabaseMCPClient: vi.fn(),
-  createInProcessSupabaseMCPClient: vi.fn(),
 }))
 
 const BASE_PARAMS = {
@@ -36,8 +35,6 @@ describe('ai/tools/mcp-tools getMcpTools', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    // These tests exercise the remote transport; pin the migration gate to it.
-    process.env.USE_REMOTE_MCP = 'true'
     consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     close = vi.fn().mockResolvedValue(undefined)
     tools = vi.fn().mockResolvedValue({ ...FULL_REMOTE_TOOLS })
@@ -45,7 +42,6 @@ describe('ai/tools/mcp-tools getMcpTools', () => {
   })
 
   afterEach(() => {
-    delete process.env.USE_REMOTE_MCP
     consoleErrorSpy.mockRestore()
   })
 
@@ -121,52 +117,5 @@ describe('ai/tools/mcp-tools getMcpTools', () => {
 
     await expect(getMcpTools(BASE_PARAMS)).rejects.toThrow('MCP tools validation failed')
     expect(close).toHaveBeenCalledTimes(1)
-  })
-})
-
-describe('ai/tools/mcp-tools getMcpTools transport selection', () => {
-  let close: ReturnType<typeof vi.fn>
-  let tools: ReturnType<typeof vi.fn>
-  let consoleErrorSpy: ReturnType<typeof vi.spyOn>
-
-  beforeEach(() => {
-    vi.clearAllMocks()
-    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-    close = vi.fn().mockResolvedValue(undefined)
-    tools = vi.fn().mockResolvedValue({ ...FULL_REMOTE_TOOLS })
-    vi.mocked(createSupabaseMCPClient).mockResolvedValue({ tools, close } as any)
-    vi.mocked(createInProcessSupabaseMCPClient).mockResolvedValue({ tools, close } as any)
-  })
-
-  afterEach(() => {
-    delete process.env.USE_REMOTE_MCP
-    consoleErrorSpy.mockRestore()
-  })
-
-  it('uses the remote client when USE_REMOTE_MCP is "true"', async () => {
-    process.env.USE_REMOTE_MCP = 'true'
-
-    await getMcpTools(BASE_PARAMS)
-
-    expect(createSupabaseMCPClient).toHaveBeenCalledTimes(1)
-    expect(createInProcessSupabaseMCPClient).not.toHaveBeenCalled()
-  })
-
-  it('falls back to the in-process client when USE_REMOTE_MCP is unset (default)', async () => {
-    delete process.env.USE_REMOTE_MCP
-
-    await getMcpTools(BASE_PARAMS)
-
-    expect(createInProcessSupabaseMCPClient).toHaveBeenCalledTimes(1)
-    expect(createSupabaseMCPClient).not.toHaveBeenCalled()
-  })
-
-  it('uses the in-process client for any non-"true" value', async () => {
-    process.env.USE_REMOTE_MCP = 'false'
-
-    await getMcpTools(BASE_PARAMS)
-
-    expect(createInProcessSupabaseMCPClient).toHaveBeenCalledTimes(1)
-    expect(createSupabaseMCPClient).not.toHaveBeenCalled()
   })
 })

--- a/apps/studio/lib/ai/tools/mcp-tools.ts
+++ b/apps/studio/lib/ai/tools/mcp-tools.ts
@@ -2,7 +2,7 @@
 import type * as SupabaseMcp from '@supabase/mcp-server-supabase'
 import type { ToolSet } from 'ai'
 
-import { createInProcessSupabaseMCPClient, createSupabaseMCPClient } from '../supabase-mcp'
+import { createSupabaseMCPClient } from '../supabase-mcp'
 import { filterToolsByOptInLevel, toolSetValidationSchema } from '../tool-filter'
 import type { AiOptInLevel } from '@/hooks/misc/useOrgOptedIntoAi'
 
@@ -50,22 +50,12 @@ export const getMcpTools = async ({
   // when the request ends. The caller owns that lifecycle via this signal.
   signal: AbortSignal
 }) => {
-  // Connect to the MCP server and fetch its tools, which replace the old local
-  // tools. `USE_REMOTE_MCP` gates the transport: the remote HTTP server (target
-  // state) or the legacy in-process server (fallback during the migration),
-  // defaulting to in-process until an environment opts in. Flip it per
-  // environment (staging → prod → Nimbus) once each one's prerequisites are met
-  // (dashboard-token support on the MCP API, remote MCP enabled for Nimbus);
-  // unset to roll back on the next deploy. Both transports expose the same tool
-  // surface, so the filtering, drift detection, and lifecycle handling below are
-  // transport-agnostic.
-  //
-  // TODO(AI-897): remove in process mcp — once every environment has been
-  // flipped and is stable, delete `createInProcessSupabaseMCPClient` and this
-  // fallback branch.
-  const useRemoteMcp = process.env.USE_REMOTE_MCP === 'true'
-  const createClient = useRemoteMcp ? createSupabaseMCPClient : createInProcessSupabaseMCPClient
-  const mcpClient = await createClient({
+  // Connect to the remote MCP server over HTTP and fetch its tools, which
+  // replace the old local tools. The legacy in-process server is no longer a
+  // production transport (eval-only now, see `createInProcessSupabaseMCPClient`),
+  // so this is unconditional. A remote failure (outage, timeout, auth) degrades
+  // to the remaining tools in `getTools` rather than breaking the assistant.
+  const mcpClient = await createSupabaseMCPClient({
     accessToken,
     projectRef,
   })

--- a/apps/studio/lib/ai/tools/mock-tools.ts
+++ b/apps/studio/lib/ai/tools/mock-tools.ts
@@ -599,10 +599,10 @@ export async function getMockTools(overrides: MockToolOverrides | undefined, sig
 
   // Every tool here is a deterministic mock except `search_docs`, which uses the
   // real implementation. We source it from an in-process MCP server directly
-  // (rather than `getMcpTools`) so the eval harness stays hermetic and decoupled
-  // from the assistant's transport gate (`USE_REMOTE_MCP`): the in-process server
-  // needs no live remote endpoint or real access token. See AI-897 for how to
-  // point evals at the remote MCP server instead.
+  // (rather than `getMcpTools`, which always talks to the remote server) so the
+  // eval harness stays hermetic: the in-process server needs no live remote
+  // endpoint or real access token. See AI-897 for how to point evals at the
+  // remote MCP server instead.
   const mcpClient = await createInProcessSupabaseMCPClient({
     accessToken: 'mock-access-token',
     projectRef: 'mock-project-ref',

--- a/apps/studio/turbo.jsonc
+++ b/apps/studio/turbo.jsonc
@@ -71,9 +71,6 @@
         "OPENAI_API_KEY",
         "BRAINTRUST_API_KEY",
         "BRAINTRUST_PROJECT_ID",
-        // Gates the dashboard assistant between the remote MCP server and the
-        // legacy in-process one (see lib/ai/tools/mcp-tools.ts).
-        "USE_REMOTE_MCP",
         "AUTH_JWT_SECRET",
         "LOGFLARE_API_KEY",
         "LOGFLARE_PUBLIC_ACCESS_TOKEN",


### PR DESCRIPTION
## Summary
- Removes the `USE_REMOTE_MCP` env-var gate from the dashboard assistant: `getMcpTools` now always connects to the remote MCP server (the rollout from #47479 has been stable ~2 months and is enabled in prod).
- Drops the var from `apps/studio/turbo.jsonc` and deletes the now-obsolete transport-selection tests.
- The legacy in-process client (`createInProcessSupabaseMCPClient`) stays, re-scoped to the hermetic eval harness (`mock-tools.ts`, `evals/preflight.ts`); removing it is tracked by AI-897.

## Verification
- `pnpm exec tsc --noEmit` in apps/studio: no errors in any changed file (one pre-existing unrelated error in `packages/ui-patterns/.../InstructionBlocks.tsx`).
- `mcp-tools.test.ts` (7), `mock-tools.test.ts` (15), `tools/index.test.ts` (6), `supabase-mcp.test.ts` (11) all pass. 

## Risk
Low. Remote failure already degrades to non-MCP tools in `getTools`; rollback = revert this PR (or re-add the gate).

## Follow-up
After this lands in prod, `USE_REMOTE_MCP` can be removed from the Vercel env vars — nothing in the repo reads it anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * AI tools now consistently use the remote service when retrieving available tools.
  * If the remote service is unavailable, times out, or cannot authenticate, the assistant continues operating with the tools that remain available.
  * Evaluation and development behavior now more closely reflects the remote service experience.

* **Maintenance**
  * Updated supporting documentation and automated coverage to reflect the streamlined tool connection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->