### PR TITLE
fix(pg-meta): fix invalid SQL when setting column default to NULL

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/InputWithSuggestions.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/InputWithSuggestions.tsx
@@ -106,6 +106,7 @@ const InputWithSuggestions = ({
                   <ButtonTooltip
                     variant="text"
                     size="tiny"
+                    className="px-1 mr-0.5"
                     tooltip={{
                       content: { text: suggestionsTooltip || 'Suggestions', side: 'bottom' },
                     }}
@@ -119,12 +120,12 @@ const InputWithSuggestions = ({
                   <DropdownMenuSeparator />
                   {filteredSuggestions.map((suggestion: Suggestion) => (
                     <DropdownMenuItem
-                      className="space-x-2"
+                      className="flex flex-col items-start"
                       key={suggestion.name}
                       onClick={() => onSelectSuggestion(suggestion)}
                     >
-                      <div>{suggestion.name}</div>
-                      <div className="text-foreground-lighter">{suggestion.description}</div>
+                      <p>{suggestion.name}</p>
+                      <p className="text-foreground-lighter">{suggestion.description}</p>
                     </DropdownMenuItem>
                   ))}
                 </DropdownMenuContent>

--- a/packages/pg-meta/src/pg-meta-columns.ts
+++ b/packages/pg-meta/src/pg-meta-columns.ts
@@ -168,6 +168,10 @@ function create({
   } else {
     if (defaultOptions.default_value === undefined) {
       // skip
+    } else if (defaultOptions.default_value === null) {
+      // NULL is the same literal regardless of format, and safeSql would
+      // otherwise silently drop a raw `null` expression fragment.
+      defaultValueClause = safeSql`DEFAULT ${literal(null)}`
     } else if (defaultOptions.default_value_format === 'expression') {
       defaultValueClause = safeSql`DEFAULT ${defaultOptions.default_value}`
     } else {
@@ -262,8 +266,14 @@ function update(
   } else if (default_value === undefined) {
     defaultValueSql = safeSql``
   } else {
+    // NULL is the same literal regardless of format, and safeSql would
+    // otherwise silently drop a raw `null` expression fragment.
     const defaultValue: SafeSqlFragment =
-      default_value_format === 'expression' ? default_value : literal(default_value)
+      default_value === null
+        ? literal(null)
+        : default_value_format === 'expression'
+          ? default_value
+          : literal(default_value)
     defaultValueSql = safeSql`ALTER TABLE ${ident(old.schema)}.${ident(old.table)} ALTER COLUMN ${ident(old.name)} SET DEFAULT ${defaultValue};`
   }
   // What identitySql does vary depending on the old and new values of

--- a/packages/pg-meta/test/columns.test.ts
+++ b/packages/pg-meta/test/columns.test.ts
@@ -294,6 +294,43 @@ withTestDatabase('retrieve, create, update, delete column', async ({ executeQuer
   expect(removedColumn).toBeUndefined()
 })
 
+withTestDatabase(
+  'update column default value to NULL via expression format',
+  async ({ executeQuery }) => {
+    // Create test table using pure SQL
+    await executeQuery('CREATE TABLE t ()')
+
+    // Create column with a non-null default
+    const { sql: createColumnSql } = pgMeta.columns.create({
+      schema: 'public',
+      table: 't',
+      name: 'c',
+      type: { name: 'text' },
+      default_value_format: 'literal',
+      default_value: 'a',
+    })
+    await executeQuery(createColumnSql)
+
+    const { sql: retrieveSql, zod: retrieveZod } = pgMeta.columns.retrieve({
+      schema: 'public',
+      table: 't',
+      name: 'c',
+    })
+    const column = retrieveZod.parse((await executeQuery(retrieveSql))[0])
+
+    // Mirrors the Studio Table Editor "Set as NULL" default value suggestion,
+    // which sets defaultValueFormat to 'expression' with a null value.
+    const { sql: updateSql } = pgMeta.columns.update(column!, {
+      default_value_format: 'expression',
+      default_value: null,
+    })
+    await executeQuery(updateSql)
+
+    const updated = retrieveZod.parse((await executeQuery(retrieveSql))[0])
+    expect(updated!.default_value).toBeNull()
+  }
+)
+
 withTestDatabase('enum column with quoted name', async ({ executeQuery }) => {
   await executeQuery('CREATE TYPE "T" AS ENUM (\'v\'); CREATE TABLE t ( c "T" );')
 


### PR DESCRIPTION
## Summary

- Fixes invalid SQL generation when setting a column's default value to NULL through Studio's Table Editor
- The bug occurred because raw `null` values bypassed literal serialization in the SQL builder
- Added special case handling in both `create()` and `update()` functions to use `literal(null)` regardless of format

## Details

Setting a column's default to NULL via the "Set as NULL" suggestion in Studio generated invalid SQL: `ALTER TABLE ... ALTER COLUMN ... SET DEFAULT ;` (missing the NULL keyword). This was caused by `default_value` being JS `null` and bypassing the literal() serialization function when `default_value_format === 'expression'`.

The fix ensures that when `default_value === null`, we always use `literal(null)` to produce the correct `SET DEFAULT NULL` clause.

## Test plan

- New regression test in `packages/pg-meta/test/columns.test.ts` ("update column default value to NULL via expression format") verifies the fix by:
  - Creating a text column with a literal default
  - Updating it using `default_value_format: 'expression', default_value: null` (exact payload from Studio)
  - Asserting the column's default value is null
- All 58 tests in `packages/pg-meta/test/columns.test.ts` pass
- TypeScript check (`tsc --noEmit`) passes

Fixes FE-4343

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed column creation and updates so explicitly setting a default value to `NULL` correctly preserves the `DEFAULT NULL` clause.
  - Ensured setting a column default to `NULL` through expression-based editing is reflected accurately when column details are retrieved.

- **Style**
  - Improved the column editor’s suggestion menu layout and spacing for clearer readability.

- **Tests**
  - Added coverage for updating a column default to `NULL`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->