### PR TITLE
fix(ui): let command dropdowns scroll on touch inside overlays

### DIFF
--- a/apps/studio/components/interfaces/Auth/Hooks/CreateHookSheet.tsx
+++ b/apps/studio/components/interfaces/Auth/Hooks/CreateHookSheet.tsx
@@ -410,7 +410,6 @@ revoke execute on function ${ident(schema)}.${ident(functionName)} from authenti
                           <SchemaSelector
                             size="small"
                             showError={false}
-                            stopScrollPropagation
                             selectedSchemaName={field.value}
                             onSelectSchema={(name) => field.onChange(name)}
                             disabled={field.disabled}
@@ -435,7 +434,6 @@ revoke execute on function ${ident(schema)}.${ident(functionName)} from authenti
                             size="small"
                             schema={postgresValues.schema}
                             value={field.value}
-                            stopScrollPropagation
                             onChange={field.onChange}
                             disabled={field.disabled}
                             filterFunction={(func) => {

--- a/apps/studio/components/interfaces/ConnectButton/ConnectButton.tsx
+++ b/apps/studio/components/interfaces/ConnectButton/ConnectButton.tsx
@@ -41,6 +41,7 @@ export const ConnectButton = ({
       >
         <Button
           variant={buttonVariant}
+          aria-label="Connect"
           disabled={!isActiveHealthy}
           className={cn('rounded-full', className)}
           icon={<Plug className="rotate-90" />}
@@ -50,7 +51,7 @@ export const ConnectButton = ({
             setShowConnect(true)
           }}
         >
-          <span className={cn({ 'sr-only': iconOnly })}>Connect</span>
+          {!iconOnly && <span>Connect</span>}
         </Button>
       </ShortcutTooltip>
     )

--- a/apps/studio/components/interfaces/ConnectSheet/ConnectConfigSection.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/ConnectConfigSection.tsx
@@ -193,6 +193,7 @@ export function ConnectConfigSection({
                 <MultiSelector
                   values={Array.isArray(value) ? value : []}
                   onValuesChange={(v) => onFieldChange(field.id, v)}
+                  modal
                 >
                   <MultiSelectorTrigger
                     id={`connect-${field.id}`}

--- a/apps/studio/components/interfaces/ConnectSheet/ConnectConfigSection.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/ConnectConfigSection.tsx
@@ -193,7 +193,6 @@ export function ConnectConfigSection({
                 <MultiSelector
                   values={Array.isArray(value) ? value : []}
                   onValuesChange={(v) => onFieldChange(field.id, v)}
-                  modal
                 >
                   <MultiSelectorTrigger
                     id={`connect-${field.id}`}

--- a/apps/studio/components/interfaces/Integrations/CronJobs/SqlFunctionSection.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/SqlFunctionSection.tsx
@@ -24,7 +24,6 @@ export const SqlFunctionSection = ({ form }: SqlFunctionSectionProps) => {
               size="small"
               className="w-56 2xl:w-full"
               selectedSchemaName={field.value}
-              stopScrollPropagation
               onSelectSchema={(name) => {
                 field.onChange(name)
                 // deselect the selected function when the schema is changed
@@ -45,7 +44,6 @@ export const SqlFunctionSection = ({ form }: SqlFunctionSectionProps) => {
               className="w-56 2xl:w-full"
               schema={schema}
               value={field.value}
-              stopScrollPropagation
               onChange={(name) => field.onChange(name)}
             />
           </FormItemLayout>

--- a/apps/studio/components/layouts/DefaultLayout.tsx
+++ b/apps/studio/components/layouts/DefaultLayout.tsx
@@ -6,7 +6,7 @@ import { SkipToContent } from 'ui-patterns/SkipToContent'
 
 import { BannerStack } from '../ui/BannerStack/BannerStack'
 import { LayoutHeader } from './Navigation/LayoutHeader/LayoutHeader'
-import MobileNavigationBar from './Navigation/NavigationBar/MobileNavigationBar'
+import { MobileNavigationBar } from './Navigation/NavigationBar/MobileNavigationBar'
 import { MobileSheetProvider } from './Navigation/NavigationBar/MobileSheetContext'
 import { StudioMobileSheetNav } from './Navigation/NavigationBar/StudioMobileSheetNav'
 import { LayoutSidebar } from './ProjectLayout/LayoutSidebar'

--- a/apps/studio/components/layouts/Navigation/NavigationBar/MobileNavigationBar.tsx
+++ b/apps/studio/components/layouts/Navigation/NavigationBar/MobileNavigationBar.tsx
@@ -21,7 +21,7 @@ import { IS_PLATFORM } from '@/lib/constants'
 export const ICON_SIZE = 20
 export const ICON_STROKE_WIDTH = 1.5
 
-const MobileNavigationBar = ({
+export const MobileNavigationBar = ({
   hideMobileMenu,
   backToDashboardURL,
 }: {
@@ -73,6 +73,7 @@ const MobileNavigationBar = ({
           {IS_PLATFORM ? <UserDropdown /> : <LocalDropdown />}
           {!hideMobileMenu && (
             <Button
+              aria-label="Open menu"
               title="Menu dropdown button"
               variant="default"
               className="flex lg:hidden border-default bg-surface-100/75 text-foreground-light rounded-md min-w-[30px] w-[30px] h-[30px] data-open:bg-overlay-hover/30"
@@ -89,5 +90,3 @@ const MobileNavigationBar = ({
     </div>
   )
 }
-
-export default MobileNavigationBar

--- a/apps/studio/components/ui/FunctionSelector.tsx
+++ b/apps/studio/components/ui/FunctionSelector.tsx
@@ -37,7 +37,6 @@ interface FunctionSelectorProps {
   value: string
   onChange: (value: string) => void
   disabled?: boolean
-  stopScrollPropagation?: boolean
   // used to filter the functions by a criteria
   filterFunction?: (func: DatabaseFunction) => boolean
   noResultsLabel?: React.ReactNode
@@ -51,7 +50,6 @@ const FunctionSelector = ({
   schema,
   value,
   onChange,
-  stopScrollPropagation = false,
   filterFunction = () => true,
   noResultsLabel = <span>No functions found in this schema.</span>,
 }: FunctionSelectorProps) => {
@@ -123,9 +121,7 @@ const FunctionSelector = ({
           <PopoverContent className="p-0" side="bottom" align="start" sameWidthAsTrigger>
             <Command>
               <CommandInput placeholder="Search functions..." />
-              <CommandList
-                onWheel={stopScrollPropagation ? (event) => event.stopPropagation() : undefined}
-              >
+              <CommandList>
                 <CommandEmpty>No functions found</CommandEmpty>
                 <CommandGroup>
                   <ScrollArea className={(functions || []).length > 7 ? 'h-[210px]' : ''}>

--- a/apps/studio/components/ui/SchemaSelector.tsx
+++ b/apps/studio/components/ui/SchemaSelector.tsx
@@ -34,7 +34,6 @@ type SchemaSelectorProps = Omit<ComponentPropsWithoutRef<'div'>, 'onSelect'> & {
   placeholderLabel?: string
   supportSelectAll?: boolean
   excludedSchemas?: string[]
-  stopScrollPropagation?: boolean
   onSelectSchema: (name: string) => void
   onSelectCreateSchema?: () => void
   align?: 'start' | 'end'
@@ -55,7 +54,6 @@ export const SchemaSelector = forwardRef<HTMLDivElement, SchemaSelectorProps>(
       placeholderLabel = 'Choose a schema...',
       supportSelectAll = false,
       excludedSchemas = DEFAULT_EXCLUDED_SCHEMAS,
-      stopScrollPropagation = false,
       onSelectSchema,
       onSelectCreateSchema,
       align = 'start',
@@ -172,9 +170,7 @@ export const SchemaSelector = forwardRef<HTMLDivElement, SchemaSelectorProps>(
             >
               <Command>
                 <CommandInput className="text-xs" placeholder="Find schema..." />
-                <CommandList
-                  onWheel={stopScrollPropagation ? (event) => event.stopPropagation() : undefined}
-                >
+                <CommandList>
                   <CommandEmpty>No schemas found</CommandEmpty>
                   <CommandGroup>
                     <ScrollArea className={(schemas || []).length > 7 ? 'h-[210px]' : ''}>

--- a/packages/ui-patterns/src/multi-select/multi-select.tsx
+++ b/packages/ui-patterns/src/multi-select/multi-select.tsx
@@ -669,11 +669,6 @@ const MultiSelectorList = React.forwardRef<
         style={{
           maxHeight: `min(${dropdownMaxHeight}px, calc(var(--radix-popover-content-available-height) - ${DROPDOWN_BORDER_HEIGHT}px))`,
         }}
-        // A dialog or sheet locks scrolling by cancelling wheel and touch events that land
-        // outside it, and this dropdown portals to the body. Keeping both off the document is
-        // what lets the list scroll with a trackpad and with a finger.
-        onWheel={(e) => e.stopPropagation()}
-        onTouchMove={(e) => e.stopPropagation()}
         {...props}
       >
         <SelectionListState

--- a/packages/ui-patterns/src/multi-select/multi-select.tsx
+++ b/packages/ui-patterns/src/multi-select/multi-select.tsx
@@ -78,6 +78,13 @@ type MultiSelectorProps = {
   onValuesChange: (value: string[]) => void
   onOpenChange?: (open: boolean) => void
   disabled?: boolean
+  /**
+   * Set this when the multi-select lives inside a dialog or sheet. Those lock scrolling and
+   * cancel wheel and touch events outside themselves, which leaves the dropdown unscrollable
+   * because it portals to the body. A modal dropdown traps focus, so leave it off for
+   * `mode="inline-combobox"`, where the search input sits in the trigger.
+   */
+  modal?: boolean
 } & React.ComponentPropsWithoutRef<typeof Command> &
   VariantProps<typeof MultiSelectorVariants>
 
@@ -91,6 +98,7 @@ function MultiSelector({
   className,
   children,
   id: idProp,
+  modal = false,
   ...props
 }: MultiSelectorProps) {
   const ref = React.useRef(null)
@@ -202,7 +210,7 @@ function MultiSelector({
         dropdownMaxHeight,
       }}
     >
-      <Popover open={open} onOpenChange={handleOpenChange}>
+      <Popover open={open} onOpenChange={handleOpenChange} modal={modal}>
         <Command
           id={id}
           ref={ref}

--- a/packages/ui-patterns/src/multi-select/multi-select.tsx
+++ b/packages/ui-patterns/src/multi-select/multi-select.tsx
@@ -78,13 +78,6 @@ type MultiSelectorProps = {
   onValuesChange: (value: string[]) => void
   onOpenChange?: (open: boolean) => void
   disabled?: boolean
-  /**
-   * Set this when the multi-select lives inside a dialog or sheet. Those lock scrolling and
-   * cancel wheel and touch events outside themselves, which leaves the dropdown unscrollable
-   * because it portals to the body. A modal dropdown traps focus, so leave it off for
-   * `mode="inline-combobox"`, where the search input sits in the trigger.
-   */
-  modal?: boolean
 } & React.ComponentPropsWithoutRef<typeof Command> &
   VariantProps<typeof MultiSelectorVariants>
 
@@ -98,7 +91,6 @@ function MultiSelector({
   className,
   children,
   id: idProp,
-  modal = false,
   ...props
 }: MultiSelectorProps) {
   const ref = React.useRef(null)
@@ -210,7 +202,7 @@ function MultiSelector({
         dropdownMaxHeight,
       }}
     >
-      <Popover open={open} onOpenChange={handleOpenChange} modal={modal}>
+      <Popover open={open} onOpenChange={handleOpenChange}>
         <Command
           id={id}
           ref={ref}
@@ -677,7 +669,11 @@ const MultiSelectorList = React.forwardRef<
         style={{
           maxHeight: `min(${dropdownMaxHeight}px, calc(var(--radix-popover-content-available-height) - ${DROPDOWN_BORDER_HEIGHT}px))`,
         }}
+        // A dialog or sheet locks scrolling by cancelling wheel and touch events that land
+        // outside it, and this dropdown portals to the body. Keeping both off the document is
+        // what lets the list scroll with a trackpad and with a finger.
         onWheel={(e) => e.stopPropagation()}
+        onTouchMove={(e) => e.stopPropagation()}
         {...props}
       >
         <SelectionListState

--- a/packages/ui/src/components/shadcn/ui/command.tsx
+++ b/packages/ui/src/components/shadcn/ui/command.tsx
@@ -90,10 +90,21 @@ CommandInput.displayName = CommandPrimitive.Input.displayName
 const CommandList = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.List>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.List>
->(({ className, ...props }, ref) => (
+>(({ className, onWheel, onTouchMove, ...props }, ref) => (
   <CommandPrimitive.List
     ref={ref}
     className={cn('max-h-full overflow-y-auto overflow-x-hidden', className)}
+    // A dialog or sheet locks scrolling by cancelling wheel and touch events that land outside
+    // it, and a dropdown portals to the body. Keeping both off the document is what lets the
+    // list scroll with a trackpad and with a finger while an overlay is open.
+    onWheel={(event) => {
+      event.stopPropagation()
+      onWheel?.(event)
+    }}
+    onTouchMove={(event) => {
+      event.stopPropagation()
+      onTouchMove?.(event)
+    }}
     {...props}
   />
 ))


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

A command dropdown cannot be scrolled by touch when it sits inside a dialog or sheet.

Radix wraps a modal dialog's overlay in a scroll lock that cancels wheel and touch events whose target is not inside the sheet. A dropdown portals to the body, so it falls outside that boundary and its scroll events get cancelled.

Callers have been rediscovering this one at a time and fixing only half of it. `MultiSelectorList` stops wheel events reaching the document, and `SchemaSelector` and `FunctionSelector` expose a `stopScrollPropagation` prop that does the same. None of them handle touch, so the desktop symptom is fixed everywhere and the mobile one is fixed nowhere.

## What is the new behavior?

`CommandList` keeps wheel and touch events off the document itself. That covers every command dropdown in the monorepo, in an overlay or not, with no call-site changes. A caller's own `onWheel` or `onTouchMove` still runs.

The workarounds this replaces are removed: the handler in `MultiSelectorList`, and the `stopScrollPropagation` prop on `SchemaSelector` and `FunctionSelector` along with its four call sites.

One behavior change worth naming: overscrolling past the end of a dropdown no longer scrolls the page behind it. That is what a dropdown should do, and it is what the four `stopScrollPropagation` call sites were already opting into.

#50072 depends on this. It swaps two selects for comboboxes, and Radix Select brings its own scroll lock, so without this the swap would regress touch scrolling.

## To test

- On the deploy preview, [open a project's Connect sheet](https://studio-staging-git-dnywh-fix-multi-select-scrol-63608b-supabase.vercel.app/dashboard/project/_) and pick the MCP tab.
- Narrow the window to phone width and switch on touch emulation in devtools.
- Open the features dropdown and drag the list. It should scroll, and the sheet behind it should stay put.
- Repeat with a mouse wheel to confirm desktop scrolling still works.
- [Open Authentication > Hooks](https://studio-staging-git-dnywh-fix-multi-select-scrol-63608b-supabase.vercel.app/dashboard/project/_/auth/hooks) > Create hook, open the schema picker, and confirm it still scrolls by wheel now that `stopScrollPropagation` is gone.
- [Open the SQL editor](https://studio-staging-git-dnywh-fix-multi-select-scrol-63608b-supabase.vercel.app/dashboard/project/_/sql/new)'s schema picker on a page with no overlay and confirm the list scrolls normally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved wheel and touch scrolling behavior in command lists, selectors, and multi-select menus.
  - Reduced unwanted scroll-lock interference when using selectors inside overlays such as dialogs and sheets.
  - Preserved support for supplied scroll event callbacks.

- **Accessibility**
  - Added clearer accessible labels to the Connect and mobile navigation menu buttons.
  - Updated the Connect button text behavior for icon-only and standard presentations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
