### PR TITLE
fix(studio): point the Warehouse table picker at the v2 publication API

### DIFF
--- a/apps/studio/components/interfaces/ConnectSheet/WarehouseModePanel/WarehouseSchemaTablePicker.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/WarehouseModePanel/WarehouseSchemaTablePicker.tsx
@@ -17,7 +17,7 @@ import {
 } from './WarehouseModePanel.utils'
 import { AlertError } from '@/components/ui/AlertError'
 import { useSchemasQuery } from '@/data/database/schemas-query'
-import { useReplicationPublicationsQuery } from '@/data/replication/publications-query'
+import { useReplicationPublicationQuery } from '@/data/replication/publication-query'
 import { useReplicationSourcesQuery } from '@/data/replication/sources-query'
 import { useTablesQuery } from '@/data/tables/tables-query'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
@@ -71,23 +71,25 @@ export const WarehouseSchemaTablePicker = ({
   const sourceId = sourcesData?.sources.find((source) => source.name === projectRef)?.id
 
   const {
-    data: publications,
+    data: publication,
     isError: isPublicationsError,
     error: publicationsError,
-  } = useReplicationPublicationsQuery({ projectRef, sourceId })
+  } = useReplicationPublicationQuery({
+    projectRef,
+    sourceId,
+    publicationName: WAREHOUSE_PUBLICATION_NAME,
+  })
 
   // Derived from data presence rather than fetch status, so there's no render gap between the
-  // publications query becoming enabled and it actually starting to fetch.
+  // publication query becoming enabled and it actually starting to fetch.
   const isSelectionPending =
     isSourcesLoading ||
-    (sourceId !== undefined && publications === undefined && !isPublicationsError)
+    (sourceId !== undefined && publication === undefined && !isPublicationsError)
 
-  const initialSelection = useMemo(() => {
-    const warehousePublication = publications?.find(
-      (publication) => publication.name === WAREHOUSE_PUBLICATION_NAME
-    )
-    return buildSelectionFromPublicationTables(warehousePublication?.tables ?? [])
-  }, [publications])
+  const initialSelection = useMemo(
+    () => buildSelectionFromPublicationTables(publication?.tables ?? []),
+    [publication]
+  )
 
   const selection = selectionOverride ?? initialSelection
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix. Master is currently red, so this needs to land before anything else can go green.

## What is the current behavior?

`WarehouseSchemaTablePicker` still imports `@/data/replication/publications-query`, which #49844 removed. Studio does not typecheck on master, which takes typecheck, knip, unit tests, E2E, the Studio Docker build and both Studio Vercel deployments down with it.

```
WarehouseSchemaTablePicker.tsx(20,49): error TS2307: Cannot find module '@/data/replication/publications-query'
WarehouseSchemaTablePicker.tsx(87,8): error TS7006: Parameter 'publication' implicitly has an 'any' type
```

## What is the new behavior?

The picker reads the `supabase_warehouse` publication through `useReplicationPublicationQuery`, matching how `TableCopySelection` and `DestinationForm` were migrated. It only ever needed that one publication, and it needs the publication's tables, which the v2 list endpoint no longer returns.

Behavior is unchanged. A missing publication still resolves to an empty selection during first-time setup, and a failed lookup still only blocks when editing an already-enabled Warehouse.

## To test

- Confirm CI goes green here.
- On the Studio deploy preview, open a project's Connect sheet and pick the Warehouse mode.
- With Warehouse not yet enabled, the schema and table list renders with nothing checked.
- With Warehouse already enabled, reopen the picker and confirm the previously replicated tables come back checked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved warehouse schema table selection by loading the Warehouse publication directly.
  - Table selections now initialize correctly from the returned publication.
  - Preserved loading and error handling for publication retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->