### PR TITLE
Add GH token for fetchAgentSkills to mitigate rate limits

### DIFF
--- a/apps/www/scripts/fetchAgentSkills.mjs
+++ b/apps/www/scripts/fetchAgentSkills.mjs
@@ -8,7 +8,8 @@
  * URLs — no rewriting needed on this side.
  *
  * Spec: https://github.com/agentskills/agentskills/pull/254
- * Runs unauthenticated — public repo, build-time only.
+ * Uses AGENT_SKILLS_GITHUB_TOKEN if set to avoid GitHub's unauthenticated
+ * rate limit (60 req/hr per IP, shared across Vercel build machines).
  */
 
 import { promises as fs } from 'node:fs'
@@ -20,7 +21,11 @@ const OUT_DIR = join(__dirname, '..', 'public', '.well-known', 'agent-skills')
 const REPO = 'supabase/agent-skills'
 
 async function fetchJson(url) {
-  const res = await fetch(url, { headers: { 'User-Agent': 'supabase-www-build' } })
+  const headers = { 'User-Agent': 'supabase-www-build' }
+  if (process.env.AGENT_SKILLS_GITHUB_TOKEN) {
+    headers['Authorization'] = `Bearer ${process.env.AGENT_SKILLS_GITHUB_TOKEN}`
+  }
+  const res = await fetch(url, { headers })
   if (!res.ok) throw new Error(`GET ${url} → ${res.status}`)
   return res.json()
 }

--- a/apps/www/turbo.jsonc
+++ b/apps/www/turbo.jsonc
@@ -76,6 +76,7 @@
         "FORCE_ASSET_CDN",
         "ASSET_CDN_S3_ENDPOINT",
         "SITE_NAME",
+        "AGENT_SKILLS_GITHUB_TOKEN",
         "LUMA_API_KEY",
         "LUMA_HACKATHONS_API_KEY",
         "NEXT_RUNTIME",


### PR DESCRIPTION
## Context

As per PR title - just a nice to have as our `www` preview builds occasionally fail, likely due to rate limits on the GH API

Env var `AGENT_SKILLS_GITHUB_TOKEN` has been added to the `www` app on Vercel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added optional GitHub authentication support for retrieving agent skills.
  * Preserved existing request behavior when no authentication token is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->