### PR TITLE
fix(www): preserve blog category filter when loading more posts

### DIFF
--- a/apps/www/app/blog/BlogClient.test.tsx
+++ b/apps/www/app/blog/BlogClient.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+
+import { act, createElement, type ReactNode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import BlogClient from './BlogClient'
+
+const observers: MockIntersectionObserver[] = []
+
+class MockIntersectionObserver {
+  callback: (entries: IntersectionObserverEntry[]) => void
+
+  constructor(callback: (entries: IntersectionObserverEntry[]) => void) {
+    this.callback = callback
+    observers.push(this)
+  }
+
+  observe() {}
+
+  unobserve() {}
+}
+
+vi.mock('components/Blog/BlogFilters', () => ({
+  default: ({ onFilterChange }: { onFilterChange: (category?: string) => void }) =>
+    createElement('button', { onClick: () => onFilterChange('postgres') }, 'Filter'),
+}))
+
+vi.mock('components/Blog/BlogGridItem', () => ({
+  default: () => createElement('div', null, 'Grid post'),
+}))
+
+vi.mock('components/Blog/BlogListItem', () => ({
+  default: () => createElement('div', null, 'List post'),
+}))
+
+vi.mock('../../components/Layouts/SectionContainerWithCn', () => ({
+  default: ({ children }: { children: ReactNode }) => createElement('div', null, children),
+}))
+
+vi.mock('@/components/Layouts/SectionContainer', () => ({
+  default: ({ children }: { children: ReactNode }) => createElement('div', null, children),
+}))
+
+describe('BlogClient', () => {
+  const fetchMock = vi.fn()
+  const roots: Array<ReturnType<typeof createRoot>> = []
+
+  beforeEach(() => {
+    observers.length = 0
+    fetchMock.mockReset()
+    vi.stubGlobal('fetch', fetchMock)
+    window.fetch = fetchMock
+    vi.stubGlobal('IntersectionObserver', MockIntersectionObserver)
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true)
+  })
+
+  afterEach(() => {
+    roots.forEach((root) => root.unmount())
+    roots.length = 0
+    vi.unstubAllGlobals()
+  })
+
+  it('preserves the category when loading more filtered posts', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        json: async () => ({
+          success: true,
+          posts: Array.from({ length: 25 }, (_, index) => ({ slug: `postgres-${index}` })),
+          total: 30,
+        }),
+      })
+      .mockResolvedValueOnce({
+        json: async () => ({
+          success: true,
+          posts: Array.from({ length: 5 }, (_, index) => ({ slug: `postgres-more-${index}` })),
+          total: 30,
+        }),
+      })
+
+    const container = document.createElement('div')
+    document.body.append(container)
+    const root = createRoot(container)
+    roots.push(root)
+    act(() => {
+      root.render(
+        createElement(BlogClient, { initialBlogs: [], totalPosts: 0, initialView: 'list' })
+      )
+    })
+
+    act(() => {
+      container.querySelector('button')?.click()
+    })
+
+    await act(async () => {
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1), { timeout: 5000 })
+    })
+
+    const firstRequest = new URL(fetchMock.mock.calls[0][0], 'http://localhost')
+    expect(firstRequest.searchParams.get('category')).toBe('postgres')
+
+    await act(async () => {
+      await vi.waitFor(() => expect(observers.length).toBeGreaterThan(0), { timeout: 5000 })
+    })
+    const observer = observers.at(-1)
+    expect(observer).toBeDefined()
+
+    await act(async () => {
+      observer?.callback([{ isIntersecting: true } as IntersectionObserverEntry])
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2), { timeout: 5000 })
+    })
+
+    const secondRequest = new URL(fetchMock.mock.calls[1][0], 'http://localhost')
+    expect(secondRequest.searchParams.get('offset')).toBe('25')
+    expect(secondRequest.searchParams.get('limit')).toBe('25')
+    expect(secondRequest.searchParams.get('category')).toBe('postgres')
+  })
+})

--- a/apps/www/app/blog/BlogClient.tsx
+++ b/apps/www/app/blog/BlogClient.tsx
@@ -81,6 +81,9 @@ export default function BlogClient({ initialBlogs, totalPosts, initialView }: Bl
         limit: limit.toString(),
       })
 
+      if (filterParams.category && filterParams.category !== 'all') {
+        params.set('category', filterParams.category)
+      }
       if (filterParams.search) {
         params.set('q', filterParams.search)
       }

--- a/apps/www/vitest.config.ts
+++ b/apps/www/vitest.config.ts
@@ -2,6 +2,9 @@ import tsconfigPaths from 'vite-tsconfig-paths'
 import { configDefaults, defineConfig } from 'vitest/config'
 
 export default defineConfig({
+  oxc: {
+    jsx: 'automatic',
+  },
   plugins: [
     tsconfigPaths({
       projects: ['.'],


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

Closes https://github.com/supabase/supabase/issues/50108

## What is the current behavior?

When a user selects a category on the blog page, the initial request includes the category filter.

However, subsequent requests triggered by infinite scrolling only preserve the search query and omit the selected category. This can append posts from other categories to the filtered results.

The regression was introduced in #47236, which removed the category parameter from `fetchMorePosts()`.

## What is the new behavior?

Paginated blog requests preserve the selected category filter.

For example, loading the second page of the `postgres` category now requests:

`/api-v2/blog-posts?offset=25&limit=25&category=postgres`

Added a regression test covering the initial filtered request and the subsequent infinite-scroll request.

## Additional context

The implementation change is limited to restoring the missing `category` query parameter in `fetchMorePosts()`.

No visual changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Infinite scrolling now preserves the selected blog category when loading additional posts, keeping results consistent with the active filter.

* **Tests**
  * Added coverage verifying category-filtered pagination and intersection-based loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->