### PR TITLE
Update PostgresConf SJC 2026 contest page content

### DIFF
--- a/apps/www/_go/events/postgresconf-sjc-2026/contest.tsx
+++ b/apps/www/_go/events/postgresconf-sjc-2026/contest.tsx
@@ -39,7 +39,6 @@ const page: GoPageInput = {
     {
       type: 'single-column',
       title: 'Multigres: One stop PostgreSQL Management and Scaling',
-      description: 'Conference Talk: Thursday, April 23, 2026 2:30pm PDT',
       children: (
         <div className="flex flex-col items-center gap-8">
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-8 max-w-2xl">
@@ -86,8 +85,12 @@ const page: GoPageInput = {
           </div>
           <div className="flex flex-wrap items-center justify-center gap-3">
             <Button asChild variant="primary" size="medium">
-              <Link href="https://www.multigres.com" target="_blank" rel="noopener noreferrer">
-                Learn about Multigres
+              <Link
+                href="https://www.youtube.com/watch?v=ahhQ0n1SHiQ"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Watch the webinar
               </Link>
             </Button>
             <Button asChild variant="default" size="medium">
@@ -113,7 +116,7 @@ const page: GoPageInput = {
             <li>Create a Supabase account and note the email address you used</li>
             <li>Load data into a Supabase database</li>
             <li>Fill out the entry form below</li>
-            <li>Complete these steps by Monday, May 4, 2026 at 12:00 PM PST</li>
+            <li>Complete these steps by Monday, September 14, 2026 at 12:00 PM PST</li>
           </ol>
           <Button asChild variant="default" size="medium">
             <Link href="https://supabase.com/dashboard">Create your account</Link>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Content update to a `/go` landing page.

## What is the current behavior?

The PostgresConf San Jose 2026 contest page (`supabase.com/go/postgresconf-sjc-2026/contest`) shows a "Learn about Multigres" CTA linking to multigres.com, a "Conference Talk: Thursday, April 23, 2026 2:30pm PDT" line, and a contest entry deadline of Monday, May 4, 2026.

## What is the new behavior?

- Removed the outdated "Conference Talk" date/time line
- Changed the CTA to "Watch the webinar," linking to the recording (https://www.youtube.com/watch?v=ahhQ0n1SHiQ)
- Updated the contest entry deadline to Monday, September 14, 2026 at 12:00 PM PST

## Additional context

Content-only change to `apps/www/_go/events/postgresconf-sjc-2026/contest.tsx`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Content Updates**
  - Updated the event page to link to the webinar recording with a “Watch the webinar” label.
  - Changed the contest deadline to September 14, 2026, at 12:00 PM PST.
  - Removed the talk description from the event page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->