### PR TITLE
fix(ui): restore accordion trigger layout

### DIFF
--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/AdvancedSettings.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/AdvancedSettings.tsx
@@ -46,10 +46,10 @@ export const AdvancedSettings = ({
     }
 
   return (
-    <div className="px-5">
+    <div className="w-full">
       <Accordion type="single" collapsible>
         <AccordionItem value="item-1" className="border-none">
-          <AccordionTrigger className="font-normal gap-2 justify-between text-sm py-3 hover:no-underline">
+          <AccordionTrigger className="font-normal gap-2 justify-between px-5 py-3 text-sm hover:no-underline">
             <div className="flex flex-col items-start gap-0.5">
               <span className="text-sm font-medium">Advanced settings</span>
               <span className="text-sm text-foreground-lighter font-normal">
@@ -57,7 +57,7 @@ export const AdvancedSettings = ({
               </span>
             </div>
           </AccordionTrigger>
-          <AccordionContent className="pb-0! pt-3 [&>div]:flex [&>div]:flex-col [&>div]:gap-y-4">
+          <AccordionContent className="pb-0! pt-3 [&>div]:flex [&>div]:flex-col [&>div]:gap-y-4 [&>div]:px-5">
             <FormField
               control={form.control}
               name="maxFillMs"

--- a/apps/studio/components/interfaces/Integrations/Integration/IntegrationOverviewTabV2/InstallIntegrationSheet/AdvancedSettings.tsx
+++ b/apps/studio/components/interfaces/Integrations/Integration/IntegrationOverviewTabV2/InstallIntegrationSheet/AdvancedSettings.tsx
@@ -60,13 +60,13 @@ export const AdvancedSettings = ({
   )
 
   return (
-    <SheetSection>
+    <SheetSection className="px-0">
       <Accordion type="single" collapsible>
         <AccordionItem value="advanced-settings" className="border-none">
-          <AccordionTrigger className="font-normal gap-2 py-0 justify-between text-sm hover:no-underline">
+          <AccordionTrigger className="font-normal gap-2 px-5 py-0 justify-between text-sm hover:no-underline">
             Advanced settings
           </AccordionTrigger>
-          <AccordionContent className="pb-0! pt-3 [&>div]:flex [&>div]:flex-col [&>div]:gap-y-4">
+          <AccordionContent className="pb-0! pt-3 [&>div]:flex [&>div]:flex-col [&>div]:gap-y-4 [&>div]:px-5">
             <p className="text-foreground-light">
               Select which schemas to install the database extensions under
             </p>

--- a/packages/ui/src/components/shadcn/ui/accordion.test.tsx
+++ b/packages/ui/src/components/shadcn/ui/accordion.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 import { Accordion, AccordionItem, AccordionTrigger } from './accordion'
 
 describe('AccordionTrigger', () => {
-  it('provides rounded geometry and the shared inset focus ring', () => {
+  it('fills its container without adding horizontal padding', () => {
     render(
       <Accordion type="single" collapsible>
         <AccordionItem value="advanced">
@@ -14,7 +14,9 @@ describe('AccordionTrigger', () => {
     )
 
     const trigger = screen.getByRole('button', { name: 'Advanced settings' })
-    expect(trigger).toHaveClass('px-2', 'relative', 'focus-inset')
+    expect(trigger.parentElement).toHaveClass('flex', 'w-full')
+    expect(trigger).toHaveClass('flex-1', 'relative', 'focus-inset')
+    expect(trigger).not.toHaveClass('px-2')
     expect(trigger).not.toHaveClass('rounded-md')
     expect(trigger).not.toHaveClass('focus-ring')
     expect(trigger).not.toHaveClass('transition-colors')

--- a/packages/ui/src/components/shadcn/ui/accordion.tsx
+++ b/packages/ui/src/components/shadcn/ui/accordion.tsx
@@ -32,11 +32,11 @@ const AccordionTrigger = React.forwardRef<
 
     return (
       <AccordionPrimitive.Header asChild>
-        <div className="flex">
+        <div className="flex w-full">
           <AccordionPrimitive.Trigger
             ref={ref}
             className={cn(
-              'cursor-pointer flex flex-1 gap-2 items-center justify-between px-2 py-4 text-left',
+              'cursor-pointer flex flex-1 gap-2 items-center justify-between py-4 text-left',
               'font-medium hover:underline',
               '[&[data-state=open]>svg]:rotate-180',
               focusVariant === 'ring' && 'rounded-md',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix. Follow-up to #49660.

## What is the current behavior?

`AccordionTrigger` adds horizontal padding at the shared primitive level. This shifts content at call sites that already own their spacing. In the Studio Advanced settings sections, padding around the whole accordion also constrains the trigger and its hit area instead of letting it fill the row.

## What is the new behavior?

The shared trigger no longer adds horizontal padding and its header explicitly fills its container. Both Studio Advanced settings sections now apply their padding inside the full-width trigger and content, keeping the text aligned while extending the focus outline and hit area across the row.

The inset focus treatment from #49660 is unchanged.

| Before | After |
| --- | --- |
| <img width="1334" height="286" alt="CleanShot 2026-09-08 at 16 18 57@2x" src="https://github.com/user-attachments/assets/3a057b45-1eb4-4928-ae69-2d636b0c4678" /> | <img width="1302" height="278" alt="CleanShot 2026-09-08 at 16 18 12@2x" src="https://github.com/user-attachments/assets/0454493e-4fbc-4ad2-a9fd-1b9dc1d486dc" /> |

## To test

### Studio replication destination

1. Open the [Studio staging preview](https://studio-staging-git-dnywh-fixaccordion-trigger-width-supabase.vercel.app) and select a project with Pipelines enabled.
2. Go to **Database > Replication**. Under **Destinations**, click **Add destination**.
3. Tab to **Advanced settings** and press Enter to expand it.
4. Confirm the text aligns with the form content, the focus outline spans the full row between the sheet edges, and clicking near the far right of the row toggles it.

### Studio access-token permissions

1. In the [Studio staging preview](https://studio-staging-git-dnywh-fixaccordion-trigger-width-supabase.vercel.app), go to **Account > Access Tokens**.
2. Click **Generate new token** and scroll to **Permissions**.
3. Tab to any permission category, then click near the far right of its row.
4. Confirm the focus outline fills the category row, the label keeps its existing inset, and the full row toggles the category.

### Pricing FAQs

1. Open the [Pricing preview](https://zone-www-dot-com-git-dnywh-fixaccordion-trigger-width-supabase.vercel.app/pricing) and scroll to **Frequently asked questions**.
2. Tab to any question, then click near the far right of its row.
3. Confirm the question has not gained extra horizontal inset and the full row remains interactive.

### Design-system Accordion

1. Open the [design-system Accordion preview](https://design-system-git-dnywh-fixaccordion-trigger-width-supabase.vercel.app/docs/components/accordion).
2. Tab through the three accordion triggers and toggle each one.
3. Confirm each focus outline fills its row, with no extra horizontal padding around the label.
