### PR TITLE
fix(docs): inline button style inconsistency

### DIFF
--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -23,6 +23,7 @@ const buttonVariants = cva(
   transition-colors
   focus-ring
   border
+  not-prose no-underline
   `,
   {
     variants: {


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs bug fix on button caught by @dnywh 

## What is the current behavior?

button used within docs are getting style mismatch as receiving prose link styling

## What is the new behavior?

this pr is a proposal to present that at the button component level using utilities to avoid underline and prose style

| state | preview |
| -------|------|
| before | <img width="811" height="204" alt="image" src="https://github.com/user-attachments/assets/eb1e44de-73b1-4c50-b552-f543c2e7debf" /> |
| after | <img width="811" height="204" alt="image" src="https://github.com/user-attachments/assets/69331817-ecd7-4f52-b533-0a29b88c3a4e" /> | 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved button appearance by preventing prose formatting and unwanted underlines across all button variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->