### PR TITLE
test(api): exercise production types check

### DIFF
--- a/.github/workflows/label_prs.yml
+++ b/.github/workflows/label_prs.yml
@@ -22,5 +22,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: 'The `api-deploy-required` label was auto-applied to this PR because it updates the API types. Ensure that the new or updated API, if any, is deployed on production before **removing the label** and merging this PR.',
+              body: 'The `api-deploy-required` label was auto-applied to this PR because it updates the API types. The required `Verify production API types` check confirms that these types match production before the PR can merge.',
             })

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -17,12 +17,6 @@ jobs:
           echo "PR blocked: [tag: do not merge]"
           exit 1
 
-      - name: Tagged with 'api-deploy-required'
-        if: contains( github.event.pull_request.labels.*.name, 'api-deploy-required')
-        run: |
-          echo "PR blocked: [tag: api-deploy-required] — confirm the API is deployed in production, then remove the label."
-          exit 1
-
       - name: All good
         if: ${{ success() }}
         run: |

--- a/.github/workflows/verify-production-api-types.yml
+++ b/.github/workflows/verify-production-api-types.yml
@@ -1,0 +1,64 @@
+name: Verify production API types
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  verify-production-api-types:
+    runs-on: ubuntu-latest
+    steps:
+      - id: changes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate --jq '.[].filename' | rg -q '^packages/api-types/types/'; then
+            echo "api_types_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "api_types_changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check out trusted verifier
+        if: steps.changes.outputs.api_types_changed == 'true'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - name: Download pull request API types
+        if: steps.changes.outputs.api_types_changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/api-types"
+          for name in api-v1 api-v2 platform; do
+            gh api -H 'Accept: application/vnd.github.raw+json' "repos/${{ github.repository }}/contents/packages/api-types/types/$name.d.ts?ref=${{ github.event.pull_request.head.sha }}" > "$RUNNER_TEMP/api-types/$name.d.ts"
+          done
+
+      - name: Install pnpm
+        if: steps.changes.outputs.api_types_changed == 'true'
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
+        with:
+          run_install: false
+
+      - name: Set up Node.js
+        if: steps.changes.outputs.api_types_changed == 'true'
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version-file: '.nvmrc'
+          cache: pnpm
+
+      - name: Install API types dependencies
+        if: steps.changes.outputs.api_types_changed == 'true'
+        run: pnpm install --frozen-lockfile --filter=api-types...
+
+      - name: Verify production API types
+        if: steps.changes.outputs.api_types_changed == 'true'
+        env:
+          API_TYPES_DIRECTORY: ${{ runner.temp }}/api-types
+          PLATFORM_API_OPENAPI_TOKEN: ${{ secrets.PLATFORM_API_OPENAPI_TOKEN }}
+        run: pnpm --filter=api-types run verify-production-types

--- a/.github/workflows/verify-production-api-types.yml
+++ b/.github/workflows/verify-production-api-types.yml
@@ -1,7 +1,7 @@
 name: Verify production API types
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, synchronize]
 
 permissions:
@@ -22,22 +22,11 @@ jobs:
             echo "api_types_changed=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Check out trusted verifier
+      - name: Check out pull request
         if: steps.changes.outputs.api_types_changed == 'true'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
-          ref: ${{ github.event.pull_request.base.sha }}
-
-      - name: Download pull request API types
-        if: steps.changes.outputs.api_types_changed == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          mkdir -p "$RUNNER_TEMP/api-types"
-          for name in api-v1 api-v2 platform; do
-            gh api -H 'Accept: application/vnd.github.raw+json' "repos/${{ github.repository }}/contents/packages/api-types/types/$name.d.ts?ref=${{ github.event.pull_request.head.sha }}" > "$RUNNER_TEMP/api-types/$name.d.ts"
-          done
 
       - name: Install pnpm
         if: steps.changes.outputs.api_types_changed == 'true'
@@ -58,7 +47,4 @@ jobs:
 
       - name: Verify production API types
         if: steps.changes.outputs.api_types_changed == 'true'
-        env:
-          API_TYPES_DIRECTORY: ${{ runner.temp }}/api-types
-          PLATFORM_API_OPENAPI_TOKEN: ${{ secrets.PLATFORM_API_OPENAPI_TOKEN }}
         run: pnpm --filter=api-types run verify-production-types

--- a/.github/workflows/verify-production-api-types.yml
+++ b/.github/workflows/verify-production-api-types.yml
@@ -16,7 +16,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate --jq '.[].filename' | rg -q '^packages/api-types/types/'; then
+          if gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate --jq '.[].filename' | grep -q '^packages/api-types/types/'; then
             echo "api_types_changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "api_types_changed=false" >> "$GITHUB_OUTPUT"

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "setup:cli": "supabase start -x studio && supabase status --output json > keys.json && node scripts/generateLocalEnv.js",
     "generate:types": "supabase gen types typescript --local > ./supabase/functions/common/database-types.ts",
     "api:codegen": "cd packages/api-types && pnpm run codegen",
+    "api:verify-types": "pnpm --filter=api-types run verify-production-types",
     "knip": "knip",
     "authorize-vercel-deploys": "tsx scripts/authorizeVercelDeploys.ts"
   },

--- a/packages/api-types/package.json
+++ b/packages/api-types/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "preinstall": "npx only-allow pnpm",
     "clean": "rimraf .turbo tsconfig.tsbuildinfo",
-    "codegen": "openapi-typescript --redocly ./redocly.yaml --alphabetize --default-non-nullable=false && prettier --cache --write types/*.d.ts"
+    "codegen": "openapi-typescript --redocly ./redocly.yaml --alphabetize --default-non-nullable=false && prettier --cache --write types/*.d.ts",
+    "verify-production-types": "node ./scripts/verify-production-types.mjs"
   },
   "author": "",
   "license": "MIT",

--- a/packages/api-types/scripts/verify-production-types.mjs
+++ b/packages/api-types/scripts/verify-production-types.mjs
@@ -1,0 +1,99 @@
+import { execFile } from 'node:child_process'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { promisify } from 'node:util'
+
+const run = promisify(execFile)
+const packageDirectory = dirname(dirname(fileURLToPath(import.meta.url)))
+const typesDirectory = process.env.API_TYPES_DIRECTORY ?? join(packageDirectory, 'types')
+const platformApiToken = process.env.PLATFORM_API_OPENAPI_TOKEN || undefined
+const platformApiUrl =
+  process.env.PLATFORM_API_OPENAPI_URL ?? 'https://api.supabase.com/platform/v1-json'
+const fetchTimeout = 30_000
+
+const specifications = [
+  { name: 'api-v1', url: 'https://api.supabase.com/api/v1-json' },
+  { name: 'api-v2', url: 'https://api.supabase.com/api/v2-json' },
+  { name: 'platform', url: platformApiUrl, token: platformApiToken },
+]
+
+const temporaryDirectory = await mkdtemp(join(tmpdir(), 'api-types-'))
+const generatedTypesDirectory = join(temporaryDirectory, 'types')
+
+try {
+  await mkdir(generatedTypesDirectory)
+
+  const config = await Promise.all(
+    specifications.map(async ({ name, url, token }) => {
+      let response
+
+      try {
+        response = await fetch(url, {
+          headers: token === undefined ? undefined : { authorization: `Bearer ${token}` },
+          signal: AbortSignal.timeout(fetchTimeout),
+        })
+      } catch {
+        throw new Error(`Could not fetch ${name} OpenAPI specification from ${url}.`)
+      }
+
+      if (!response.ok) {
+        const credentialHint =
+          name === 'platform' && token === undefined ? ' Set PLATFORM_API_OPENAPI_TOKEN.' : ''
+        throw new Error(
+          `Could not fetch ${name} OpenAPI specification from ${url}: ${response.status}.${credentialHint}`
+        )
+      }
+
+      await writeFile(join(temporaryDirectory, `${name}.json`), await response.text())
+
+      return `  ${name}:\n    root: ${join(temporaryDirectory, `${name}.json`)}\n    x-openapi-ts:\n      output: ${join(generatedTypesDirectory, `${name}.d.ts`)}`
+    })
+  )
+
+  await writeFile(join(temporaryDirectory, 'redocly.yaml'), `apis:\n${config.join('\n')}`)
+  await run(
+    'pnpm',
+    [
+      'exec',
+      'openapi-typescript',
+      '--redocly',
+      join(temporaryDirectory, 'redocly.yaml'),
+      '--alphabetize',
+      '--default-non-nullable=false',
+    ],
+    { cwd: packageDirectory }
+  )
+
+  await run(
+    'pnpm',
+    [
+      'exec',
+      'prettier',
+      '--write',
+      ...specifications.map(({ name }) => join(generatedTypesDirectory, `${name}.d.ts`)),
+    ],
+    { cwd: packageDirectory }
+  )
+
+  const mismatches = await Promise.all(
+    specifications.map(async ({ name }) => {
+      const filename = `${name}.d.ts`
+      const [generated, committed] = await Promise.all([
+        readFile(join(generatedTypesDirectory, filename), 'utf8'),
+        readFile(join(typesDirectory, filename), 'utf8'),
+      ])
+
+      return generated === committed ? undefined : filename
+    })
+  )
+
+  const changedTypes = mismatches.filter((filename) => filename !== undefined)
+
+  if (changedTypes.length > 0) {
+    throw new Error(`Committed API types do not match production: ${changedTypes.join(', ')}`)
+  }
+} finally {
+  await rm(temporaryDirectory, { force: true, recursive: true })
+}

--- a/packages/api-types/scripts/verify-production-types.mjs
+++ b/packages/api-types/scripts/verify-production-types.mjs
@@ -8,7 +8,6 @@ import { promisify } from 'node:util'
 const run = promisify(execFile)
 const packageDirectory = dirname(dirname(fileURLToPath(import.meta.url)))
 const typesDirectory = process.env.API_TYPES_DIRECTORY ?? join(packageDirectory, 'types')
-const platformApiToken = process.env.PLATFORM_API_OPENAPI_TOKEN || undefined
 const platformApiUrl =
   process.env.PLATFORM_API_OPENAPI_URL ?? 'https://api.supabase.com/platform/v1-json'
 const fetchTimeout = 30_000
@@ -16,7 +15,7 @@ const fetchTimeout = 30_000
 const specifications = [
   { name: 'api-v1', url: 'https://api.supabase.com/api/v1-json' },
   { name: 'api-v2', url: 'https://api.supabase.com/api/v2-json' },
-  { name: 'platform', url: platformApiUrl, token: platformApiToken },
+  { name: 'platform', url: platformApiUrl },
 ]
 
 const temporaryDirectory = await mkdtemp(join(tmpdir(), 'api-types-'))
@@ -26,12 +25,11 @@ try {
   await mkdir(generatedTypesDirectory)
 
   const config = await Promise.all(
-    specifications.map(async ({ name, url, token }) => {
+    specifications.map(async ({ name, url }) => {
       let response
 
       try {
         response = await fetch(url, {
-          headers: token === undefined ? undefined : { authorization: `Bearer ${token}` },
           signal: AbortSignal.timeout(fetchTimeout),
         })
       } catch {
@@ -39,10 +37,8 @@ try {
       }
 
       if (!response.ok) {
-        const credentialHint =
-          name === 'platform' && token === undefined ? ' Set PLATFORM_API_OPENAPI_TOKEN.' : ''
         throw new Error(
-          `Could not fetch ${name} OpenAPI specification from ${url}: ${response.status}.${credentialHint}`
+          `Could not fetch ${name} OpenAPI specification from ${url}: ${response.status}.`
         )
       }
 

--- a/packages/api-types/scripts/verify-production-types.mjs
+++ b/packages/api-types/scripts/verify-production-types.mjs
@@ -9,7 +9,7 @@ const run = promisify(execFile)
 const packageDirectory = dirname(dirname(fileURLToPath(import.meta.url)))
 const typesDirectory = process.env.API_TYPES_DIRECTORY ?? join(packageDirectory, 'types')
 const platformApiUrl =
-  process.env.PLATFORM_API_OPENAPI_URL ?? 'https://api.supabase.com/platform/v1-json'
+  process.env.PLATFORM_API_OPENAPI_URL ?? 'https://api.supabase.com/api/platform-json'
 const fetchTimeout = 30_000
 
 const specifications = [

--- a/packages/api-types/types/api-v1.d.ts
+++ b/packages/api-types/types/api-v1.d.ts
@@ -14061,3 +14061,5 @@ export interface operations {
     }
   }
 }
+
+export type __production_api_types_check_probe = never


### PR DESCRIPTION
## Problem

The new production API-types check needs a live validation before it is made required.

## Fix

Add an unused declaration to `api-v1.d.ts`, creating a controlled mismatch with production without changing any existing type behavior.

## How to test

- Confirm the `Verify production API types` check runs.
- Expected result: it fails because the committed API types do not match production.
- Close this draft PR after the check result is confirmed.