### PR TITLE
fix(warehouse): don't display ducklake metadata schema in replicated tables/schemas

### DIFF
--- a/apps/studio/components/interfaces/ConnectSheet/WarehouseModePanel/WarehouseModePanel.utils.ts
+++ b/apps/studio/components/interfaces/ConnectSheet/WarehouseModePanel/WarehouseModePanel.utils.ts
@@ -1,6 +1,7 @@
 import type { components } from 'api-types'
 
 import { INTERNAL_SCHEMAS } from '@/hooks/useProtectedSchemas'
+import { WAREHOUSE_METADATA_SCHEMA } from '@/lib/warehouse'
 
 export type WarehouseSetupBody = components['schemas']['WarehouseSetupBody']
 export type WarehouseSetupTarget = WarehouseSetupBody['targets'][number]
@@ -26,9 +27,20 @@ const NON_SELECTABLE_SCHEMAS = new Set(
   INTERNAL_SCHEMAS.filter((schema) => !REPLICABLE_INTERNAL_SCHEMAS.includes(schema))
 )
 
-/** Postgres schemas Warehouse setup shouldn't offer for replication. */
+/**
+ * Postgres schemas Warehouse setup shouldn't offer for replication.
+ *
+ * `WAREHOUSE_METADATA_SCHEMA` is excluded on top of the infrastructure schemas above: it holds the
+ * DuckLake catalog describing the Warehouse itself, so replicating it would feed every Warehouse
+ * write back in as more catalog rows to replicate. The platform rejects it server-side too — this
+ * just keeps it out of the picker so the user never picks a target that can only fail.
+ */
 export function isSelectableWarehouseSchema(schemaName: string): boolean {
-  return !schemaName.startsWith('pg_') && !NON_SELECTABLE_SCHEMAS.has(schemaName)
+  return (
+    !schemaName.startsWith('pg_') &&
+    !NON_SELECTABLE_SCHEMAS.has(schemaName) &&
+    schemaName !== WAREHOUSE_METADATA_SCHEMA
+  )
 }
 
 export function getSelectedTableCount(selection: SchemaTableSelection): number {

--- a/apps/studio/components/interfaces/ConnectSheet/__tests__/WarehouseModePanel.utils.test.ts
+++ b/apps/studio/components/interfaces/ConnectSheet/__tests__/WarehouseModePanel.utils.test.ts
@@ -10,6 +10,7 @@ import {
   type SchemaTableSelection,
   type SchemaWithTables,
 } from '../WarehouseModePanel/WarehouseModePanel.utils'
+import { WAREHOUSE_METADATA_SCHEMA } from '@/lib/warehouse'
 
 describe('WarehouseModePanel.utils:isSelectableWarehouseSchema', () => {
   test('excludes information_schema', () => {
@@ -40,6 +41,17 @@ describe('WarehouseModePanel.utils:isSelectableWarehouseSchema', () => {
   test('includes auth and storage, which hold product data users replicate', () => {
     expect(isSelectableWarehouseSchema('auth')).toBe(true)
     expect(isSelectableWarehouseSchema('storage')).toBe(true)
+  })
+
+  test("excludes the Warehouse's own DuckLake catalog schema", () => {
+    // Replicating the catalog that describes the Warehouse would feed it its own metadata
+    expect(isSelectableWarehouseSchema(WAREHOUSE_METADATA_SCHEMA)).toBe(false)
+    expect(isSelectableWarehouseSchema('ducklake')).toBe(false)
+  })
+
+  test('includes schemas whose names merely resemble the catalog schema', () => {
+    expect(isSelectableWarehouseSchema('ducklake_staging')).toBe(true)
+    expect(isSelectableWarehouseSchema('my_ducklake')).toBe(true)
   })
 })
 

--- a/apps/studio/lib/warehouse.ts
+++ b/apps/studio/lib/warehouse.ts
@@ -9,6 +9,15 @@ const WAREHOUSE_TLD = IS_STAGING_OR_LOCAL ? 'red' : 'io'
  */
 export const WAREHOUSE_PUBLICATION_NAME = 'supabase_warehouse'
 
+/**
+ * Postgres schema the managed Warehouse destination keeps its DuckLake catalog in —
+ * `WAREHOUSE_METADATA_SCHEMA` in the platform repo, where it's a hardcoded constant: the schema is
+ * always provisioned under this name, the destination config is always built with it, and no
+ * request body accepts an override. Mirrored here so the schema picker can exclude it; the platform
+ * also rejects it server-side.
+ */
+export const WAREHOUSE_METADATA_SCHEMA = 'ducklake'
+
 export function getWarehouseFlightSqlEndpoint(projectRef: string): string {
   return `${projectRef}.warehouse.supabase.${WAREHOUSE_TLD}`
 }


### PR DESCRIPTION
Don't show to users replicated schema or tables from the ducklake metadata schema to avoid infinite loop. (This is already forbidden at API level)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented the warehouse’s internal metadata schema from appearing as an available replication option.
  - Kept similarly named schemas available for selection when they are not the internal metadata schema.

- **Tests**
  - Added coverage confirming the metadata schema is excluded while similarly named schemas remain selectable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->