### PR TITLE
feat(ui): restyle link underlines

### DIFF
--- a/apps/docs/features/docs/MdxAnchor.tsx
+++ b/apps/docs/features/docs/MdxAnchor.tsx
@@ -25,7 +25,7 @@ const flattenChildrenToText = (node: unknown): string => {
 
 /** Same resting/hover contract as Studio InlineLink (no brand/green link color). */
 const mdxAnchorClassName =
-  'underline transition underline-offset-2 decoration-inherit hover:decoration-foreground text-inherit hover:text-foreground'
+  'text-foreground underline underline-offset-fluid decoration-fluid decoration-foreground-subtle hover:decoration-foreground transition-colors duration-200'
 
 const relForTarget = (target?: string, rel?: string) => {
   if (target !== '_blank') return rel

--- a/apps/studio/components/ui/InlineLink.tsx
+++ b/apps/studio/components/ui/InlineLink.tsx
@@ -12,7 +12,7 @@ interface InlineLinkProps {
 }
 
 export const InlineLinkClassName =
-  'underline transition underline-offset-2 decoration-inherit hover:decoration-foreground text-inherit hover:text-foreground'
+  'underline underline-offset-fluid decoration-fluid decoration-foreground-subtle hover:decoration-foreground text-inherit hover:text-foreground transition-colors duration-200'
 
 export const InlineLink = ({
   href,

--- a/packages/config/css/theme.css
+++ b/packages/config/css/theme.css
@@ -41,6 +41,7 @@
   --color-foreground-light: var(--muted-foreground);
   --color-foreground-lighter: var(--tertiary-foreground);
   --color-foreground-muted: var(--foreground-muted);
+  --color-foreground-subtle: var(--foreground-subtle);
   --color-foreground-contrast: var(--foreground-contrast);
   --color-background-200: var(--background-200);
   --color-background-alternative-200: var(--background-alternative-200);
@@ -374,4 +375,6 @@
   --spacing-card: var(--card-padding-x);
   --transform-origin-dropdown: var(--radix-dropdown-menu-content-transform-origin);
   --transform-origin-popover: var(--radix-popover-menu-content-transform-origin);
+  --text-underline-offset-fluid: clamp(2px, 0.17em, 4px);
+  --text-decoration-thickness-fluid: clamp(1px, 0.0684em, 3px);
 }

--- a/packages/config/typography.css
+++ b/packages/config/typography.css
@@ -38,7 +38,7 @@
 
 /* Link */
 @utility text-link {
-  @apply text-foreground-light underline underline-offset-4 decoration-inherit hover:decoration-foreground transition-colors hover:text-foreground;
+  @apply text-foreground underline underline-offset-fluid decoration-fluid decoration-foreground-subtle hover:decoration-foreground transition-colors duration-200;
 }
 
 @utility text-link-table-cell {

--- a/packages/ui/build/css/source/compat.css
+++ b/packages/ui/build/css/source/compat.css
@@ -16,6 +16,7 @@
   --foreground-light: var(--muted-foreground);
   --foreground-lighter: var(--tertiary-foreground);
   --foreground-muted: var(--tertiary-foreground);
+  --foreground-subtle: var(--subtle-foreground);
   /* --foreground-contrast lives in semantic.css — do not remap to --primary-foreground */
 
   /* Legacy background aliases */

--- a/packages/ui/build/css/source/semantic.css
+++ b/packages/ui/build/css/source/semantic.css
@@ -182,6 +182,16 @@
     calc(var(--surface) + var(--tone-span) * var(--tertiary-foreground-mix))
       var(--foreground-chroma) var(--surface-hue)
   );
+  --subtle-foreground-level: calc(var(--tertiary-foreground-level) * 0.6);
+  --subtle-foreground-mix: calc(
+    var(--subtle-foreground-level) + (1 - var(--subtle-foreground-level)) * var(--contrast-up) -
+      var(--subtle-foreground-level) * 0.5 * var(--contrast-down)
+  );
+  --subtle-foreground: oklch(
+    calc(var(--surface) + var(--tone-span) * var(--subtle-foreground-mix)) var(--foreground-chroma)
+      var(--surface-hue)
+  );
+
   --muted: oklch(from var(--foreground) l c h / var(--muted-alpha));
   --muted-foreground-mix: calc(
     var(--muted-foreground-level) + (1 - var(--muted-foreground-level)) * var(--contrast-up) -


### PR DESCRIPTION
## What kind of change does this PR introduce?

update design system + styling for link

## What is the current behavior?

link text is dimmed and brightens on hover, with the underline inheriting text color

## What is the new behavior?

- link text stays at full foreground _ the underline carries the hover instead, faint at rest, full on hover
- adds `--subtle-foreground`, a tone below tertiary
- applied to `text-link`, studio `InlineLink`, and the docs mdx anchor


| state | preview |
| -------|------|
| before | <img width="811" height="204" alt="image" src="https://github.com/user-attachments/assets/cb14bc17-b674-45ad-8b2a-45a5d9e45ace" /> |
| after | <img width="811" height="204" alt="image" src="https://github.com/user-attachments/assets/246bf3fc-deaa-4dcf-bd98-b68e2207e6e6" /> | 

| state | preview |
| -------|------|
| before | <img width="811" height="204" alt="image" src="https://github.com/user-attachments/assets/bfa23c23-f452-4980-9659-a989b6f8c491" /> |
| after | <img width="811" height="204" alt="image" src="https://github.com/user-attachments/assets/c7218a21-513e-430d-981e-2719f147b7ab" /> | 

## Test
1. visit `/docs/guides/database/prisma`

## Additional

mdx anchor still uses its own classes, because apps/docs doesn't import `typography.css` _ might beworth fixing.updating

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated links across documentation, studio, and shared typography styles with smoother underline sizing, spacing, and 200ms transitions.
  - Added a subtler foreground color option for link decorations and other interface text.
  - Preserved hover underline behavior while refining link color and decoration presentation.
- **Compatibility**
  - Added support for the new subtle foreground color in legacy styling aliases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->