### PR TITLE
Scoped PAT: add `api_gateway_keys_secret_read` and `data_api_config_secret_read` permissions

### DIFF
--- a/apps/docs/content/_partials/access-control/scoped_pat_permissions.mdx
+++ b/apps/docs/content/_partials/access-control/scoped_pat_permissions.mdx
@@ -33,6 +33,7 @@
 |                                  | Read-write      | [Update action run status](/docs/reference/api/v1-update-action-run-status)                                         |
 | Advisors                         | Read            | [Get performance advisors](/docs/reference/api/v1-get-performance-advisors)                                         |
 |                                  |                 | [Get security advisors](/docs/reference/api/v1-get-security-advisors)                                               |
+|                                  |                 | [Run project advisors](/docs/reference/api/v2-run-project-advisors)                                                 |
 | Analytics Config                 | Read            | [List log drains](/docs/reference/api/v2-list-log-drains)                                                           |
 |                                  | Read-write      | [Create log drain](/docs/reference/api/v2-create-log-drain)                                                         |
 |                                  |                 | [Delete log drain](/docs/reference/api/v2-delete-log-drain)                                                         |
@@ -111,6 +112,8 @@
 |                                  |                 | [Delete project API key](/docs/reference/api/v1-delete-project-api-key)                                             |
 |                                  |                 | [Update project API key](/docs/reference/api/v1-update-project-api-key)                                             |
 |                                  |                 | [Update project legacy API keys](/docs/reference/api/v1-update-project-legacy-api-keys)                             |
+| API Key Secrets                  | Read            | [Get project API key](/docs/reference/api/v1-get-project-api-key)[^6]                                               |
+|                                  |                 | [Get project API keys](/docs/reference/api/v1-get-project-api-keys)[^6]                                             |
 | Auth Config                      | Read            | [Get a SSO provider](/docs/reference/api/v1-get-a-sso-provider)                                                     |
 |                                  |                 | [Get auth service config](/docs/reference/api/v1-get-auth-service-config)                                           |
 |                                  |                 | [Get project config](/docs/reference/api/v2-get-project-config)[^5]                                                 |
@@ -133,6 +136,7 @@
 | Data API Config                  | Read            | [Get PostgREST service config](/docs/reference/api/v1-get-postgrest-service-config)                                 |
 |                                  |                 | [Get project config](/docs/reference/api/v2-get-project-config)[^5]                                                 |
 |                                  | Read-write      | [Update PostgREST service config](/docs/reference/api/v1-update-postgrest-service-config)                           |
+| Data API JWT Secret              | Read            | [Get PostgREST service config](/docs/reference/api/v1-get-postgrest-service-config)[^7]                             |
 | Edge Functions                   | Read            | [Get a function](/docs/reference/api/v1-get-a-function)                                                             |
 |                                  |                 | [Get a function body](/docs/reference/api/v1-get-a-function-body)                                                   |
 |                                  |                 | [List all functions](/docs/reference/api/v1-list-all-functions)                                                     |
@@ -162,6 +166,7 @@
 |                                  |                 | [Get a branch config](/docs/reference/api/v1-get-a-branch-config)                                                   |
 |                                  |                 | [List all branches](/docs/reference/api/v1-list-all-branches)                                                       |
 |                                  | Read-write      | [Create a branch](/docs/reference/api/v1-create-a-branch)                                                           |
+|                                  |                 | [Create a branch](/docs/reference/api/v2-create-a-branch)                                                           |
 |                                  |                 | [Delete a branch](/docs/reference/api/v1-delete-a-branch)                                                           |
 |                                  |                 | [Diff a branch](/docs/reference/api/v1-diff-a-branch)                                                               |
 |                                  |                 | [Merge a branch](/docs/reference/api/v1-merge-a-branch)                                                             |
@@ -173,6 +178,7 @@
 |                                  |                 | [Get a branch config](/docs/reference/api/v1-get-a-branch-config)                                                   |
 |                                  |                 | [List all branches](/docs/reference/api/v1-list-all-branches)                                                       |
 |                                  | Read-write      | [Create a branch](/docs/reference/api/v1-create-a-branch)                                                           |
+|                                  |                 | [Create a branch](/docs/reference/api/v2-create-a-branch)                                                           |
 |                                  |                 | [Delete a branch](/docs/reference/api/v1-delete-a-branch)                                                           |
 |                                  |                 | [Diff a branch](/docs/reference/api/v1-diff-a-branch)                                                               |
 |                                  |                 | [Disable preview branching](/docs/reference/api/v1-disable-preview-branching)                                       |
@@ -239,3 +245,7 @@
 [^4]: Requires **Project Settings** (Read-write) and **Database** (Read-write).
 
 [^5]: Requires **Database Config** (Read), **Database** (Read), **SSL Enforcement** (Read), **Network Restrictions** (Read), **Auth Config** (Read), **Data API Config** (Read), **Realtime Config** (Read), and **Storage Config** (Read).
+
+[^6]: Requires **API Keys** (Read) and **API Key Secrets** (Read).
+
+[^7]: Requires **Data API Config** (Read) and **Data API JWT Secret** (Read).

--- a/apps/docs/content/_partials/access-control/scoped_pat_permissions.mdx
+++ b/apps/docs/content/_partials/access-control/scoped_pat_permissions.mdx
@@ -152,6 +152,11 @@
 | Storage Config                   | Read            | [Get project config](/docs/reference/api/v2-get-project-config)[^5]                                                 |
 |                                  |                 | [Get storage config](/docs/reference/api/v1-get-storage-config)                                                     |
 |                                  | Read-write      | [Update storage config](/docs/reference/api/v1-update-storage-config)                                               |
+| Compute                          | Read            | [Get a worker](/docs/reference/api/v2-get-a-worker)                                                                 |
+|                                  |                 | [List all workers](/docs/reference/api/v2-list-all-workers)                                                         |
+|                                  | Read-write      | [Create worker upload](/docs/reference/api/v2-create-worker-upload)                                                 |
+|                                  |                 | [Delete a worker](/docs/reference/api/v2-delete-a-worker)                                                           |
+|                                  |                 | [Deploy a worker](/docs/reference/api/v2-deploy-a-worker)                                                           |
 | **Infrastructure and delivery**  |                 |                                                                                                                     |
 | Development Branches             | Read            | [Get a branch](/docs/reference/api/v1-get-a-branch)                                                                 |
 |                                  |                 | [Get a branch config](/docs/reference/api/v1-get-a-branch-config)                                                   |

--- a/apps/docs/spec/api_v1_openapi.json
+++ b/apps/docs/spec/api_v1_openapi.json
@@ -37,10 +37,13 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/BranchDetailResponse" }
+                "schema": { "$ref": "#/components/schemas/BranchDetailResponse_Output" }
               }
             }
           },
+          "401": { "description": "Unauthorized" },
+          "403": { "description": "Forbidden action" },
+          "429": { "description": "Rate limit exceeded" },
           "500": { "description": "Failed to retrieve database branch" }
         },
         "security": [{ "bearer": [] }],
@@ -91,9 +94,14 @@
           "200": {
             "description": "",
             "content": {
-              "application/json": { "schema": { "$ref": "#/components/schemas/BranchResponse" } }
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/BranchResponse_Output" }
+              }
             }
           },
+          "401": { "description": "Unauthorized" },
+          "403": { "description": "Forbidden action" },
+          "429": { "description": "Rate limit exceeded" },
           "500": { "description": "Failed to update database branch" }
         },
         "security": [{ "bearer": [] }],
@@ -146,10 +154,13 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/BranchDeleteResponse" }
+                "schema": { "$ref": "#/components/schemas/BranchDeleteResponse_Output" }
               }
             }
           },
+          "401": { "description": "Unauthorized" },
+          "403": { "description": "Forbidden action" },
+          "429": { "description": "Rate limit exceeded" },
           "500": { "description": "Failed to delete database branch" }
         },
         "security": [{ "bearer": [] }],
@@ -203,10 +214,13 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/BranchUpdateResponse" }
+                "schema": { "$ref": "#/components/schemas/BranchUpdateResponse_Output" }
               }
             }
           },
+          "401": { "description": "Unauthorized" },
+          "403": { "description": "Forbidden action" },
+          "429": { "description": "Rate limit exceeded" },
           "500": { "description": "Failed to push database branch" }
         },
         "security": [{ "bearer": [] }],
@@ -260,10 +274,13 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/BranchUpdateResponse" }
+                "schema": { "$ref": "#/components/schemas/BranchUpdateResponse_Output" }
               }
             }
           },
+          "401": { "description": "Unauthorized" },
+          "403": { "description": "Forbidden action" },
+          "429": { "description": "Rate limit exceeded" },
           "500": { "description": "Failed to merge database branch" }
         },
         "security": [{ "bearer": [] }],
@@ -317,10 +334,13 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/BranchUpdateResponse" }
+                "schema": { "$ref": "#/components/schemas/BranchUpdateResponse_Output" }
               }
             }
           },
+          "401": { "description": "Unauthorized" },
+          "403": { "description": "Forbidden action" },
+          "429": { "description": "Rate limit exceeded" },
           "500": { "description": "Failed to reset database branch" }
         },
         "security": [{ "bearer": [] }],
@@ -364,14 +384,17 @@
           }
         ],
         "responses": {
-          "200": {
+          "201": {
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/BranchRestoreResponse" }
+                "schema": { "$ref": "#/components/schemas/BranchRestoreResponse_Output" }
               }
             }
           },
+          "401": { "description": "Unauthorized" },
+          "403": { "description": "Forbidden action" },
+          "429": { "description": "Rate limit exceeded" },
           "500": { "description": "Failed to restore database branch" }
         },
         "security": [{ "bearer": [] }],
@@ -432,6 +455,9 @@
             "content": { "text/plain": { "schema": { "type": "string" } } },
             "description": ""
           },
+          "401": { "description": "Unauthorized" },
+          "403": { "description": "Forbidden action" },
+          "429": { "description": "Rate limit exceeded" },
           "500": { "description": "Failed to diff database branch" }
         },
         "security": [{ "bearer": [] }],
@@ -455,7 +481,7 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/V1ProjectWithDatabaseResponse" }
+                  "items": { "$ref": "#/components/schemas/V1ProjectWithDatabaseResponse_Output" }
                 }
               }
             }
@@ -485,7 +511,9 @@
           "201": {
             "description": "",
             "content": {
-              "application/json": { "schema": { "$ref": "#/components/schemas/V1ProjectResponse" } }
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/V1ProjectResponse_Output" }
+              }
             }
           },
           "401": { "description": "Unauthorized" },
@@ -558,7 +586,9 @@
           "200": {
             "description": "",
             "content": {
-              "application/json": { "schema": { "$ref": "#/components/schemas/RegionsInfo" } }
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/RegionsInfo_Output" }
+              }
             }
           }
         },
@@ -582,7 +612,7 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/OrganizationResponseV1" }
+                  "items": { "$ref": "#/components/schemas/OrganizationResponseV1_Output" }
                 }
               }
             }
@@ -616,7 +646,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/OrganizationResponseV1" }
+                "schema": { "$ref": "#/components/schemas/OrganizationResponseV1_Output" }
               }
             }
           },
@@ -722,7 +752,12 @@
             }
           }
         ],
-        "responses": { "204": { "description": "" } },
+        "responses": {
+          "204": { "description": "" },
+          "401": { "description": "Unauthorized" },
+          "403": { "description": "Forbidden action" },
+          "429": { "description": "Rate limit exceeded" }
+        },
         "summary": "[Beta] Authorize user through oauth",
         "tags": ["OAuth"],
         "x-endpoint-owners": ["auth", "control-plane"]
@@ -746,10 +781,13 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/OAuthTokenResponse" }
+                "schema": { "$ref": "#/components/schemas/OAuthTokenResponse_Output" }
               }
             }
-          }
+          },
+          "401": { "description": "Unauthorized" },
+          "403": { "description": "Forbidden action" },
+          "429": { "description": "Rate limit exceeded" }
         },
         "summary": "[Beta] Exchange auth code for user's access and refresh token",
         "tags": ["OAuth"],
@@ -768,7 +806,12 @@
             }
           }
         },
-        "responses": { "204": { "description": "" } },
+        "responses": {
+          "204": { "description": "" },
+          "401": { "description": "Unauthorized" },
+          "403": { "description": "Forbidden action" },
+          "429": { "description": "Rate limit exceeded" }
+        },
         "summary": "[Beta] Revoke oauth app authorization and it's corresponding tokens",
         "tags": ["OAuth"],
         "x-endpoint-owners": ["auth", "control-plane"]
@@ -898,7 +941,9 @@
           "200": {
             "description": "",
             "content": {
-              "application/json": { "schema": { "$ref": "#/components/schemas/SnippetList" } }
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/SnippetList_Output" }
+              }
             }
           },
           "401": { "description": "Unauthorized" },
@@ -935,7 +980,9 @@
           "200": {
             "description": "",
             "content": {
-              "application/json": { "schema": { "$ref": "#/components/schemas/SnippetResponse" } }
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/SnippetResponse_Output" }
+              }
             }
           },
           "401": { "description": "Unauthorized" },
@@ -960,7 +1007,9 @@
           "200": {
             "description": "",
             "content": {
-              "application/json": { "schema": { "$ref": "#/components/schemas/V1ProfileResponse" } }
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/V1ProfileResponse_Output" }
+              }
             }
           }
         },
@@ -1046,7 +1095,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ListActionRunResponse" }
+                "schema": { "$ref": "#/components/schemas/ListActionRunResponse_Output" }
               }
             }
           },
@@ -1094,7 +1143,9 @@
           "200": {
             "description": "",
             "content": {
-              "application/json": { "schema": { "$ref": "#/components/schemas/ActionRunResponse" } }
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ActionRunResponse_Output" }
+              }
             }
           },
           "401": { "description": "Unauthorized" },
@@ -1148,7 +1199,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/UpdateRunStatusResponse" }
+                "schema": { "$ref": "#/components/schemas/UpdateRunStatusResponse_Output" }
               }
             }
           },
@@ -1243,7 +1294,7 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/ApiKeyResponse" }
+                  "items": { "$ref": "#/components/schemas/ApiKeyResponse_Output" }
                 }
               }
             }
@@ -1257,7 +1308,10 @@
         "tags": ["Secrets"],
         "x-badges": [{ "name": "OAuth scope: secrets:read", "position": "after" }],
         "x-endpoint-owners": ["auth", "control-plane"],
-        "x-fga-permissions": [["api_gateway_keys_read"]],
+        "x-fga-permissions": [
+          ["api_gateway_keys_read"],
+          ["api_gateway_keys_read", "api_gateway_keys_secret_read"]
+        ],
         "x-oauth-scope": "secrets:read"
       },
       "post": {
@@ -1294,7 +1348,9 @@
           "201": {
             "description": "",
             "content": {
-              "application/json": { "schema": { "$ref": "#/components/schemas/ApiKeyResponse" } }
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiKeyResponse_Output" }
+              }
             }
           },
           "401": { "description": "Unauthorized" },
@@ -1333,7 +1389,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/LegacyApiKeysResponse" }
+                "schema": { "$ref": "#/components/schemas/LegacyApiKeysResponse_Output" }
               }
             }
           },
@@ -1378,7 +1434,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/LegacyApiKeysResponse" }
+                "schema": { "$ref": "#/components/schemas/LegacyApiKeysResponse_Output" }
               }
             }
           },
@@ -1441,7 +1497,9 @@
           "200": {
             "description": "",
             "content": {
-              "application/json": { "schema": { "$ref": "#/components/schemas/ApiKeyResponse" } }
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiKeyResponse_Output" }
+              }
             }
           },
           "401": { "description": "Unauthorized" },
@@ -1495,7 +1553,9 @@
           "200": {
             "description": "",
             "content": {
-              "application/json": { "schema": { "$ref": "#/components/schemas/ApiKeyResponse" } }
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiKeyResponse_Output" }
+              }
             }
           },
           "401": { "description": "Unauthorized" },
@@ -1507,7 +1567,10 @@
         "tags": ["Secrets"],
         "x-badges": [{ "name": "OAuth scope: secrets:read", "position": "after" }],
         "x-endpoint-owners": ["auth", "control-plane"],
-        "x-fga-permissions": [["api_gateway_keys_read"]],
+        "x-fga-permissions": [
+          ["api_gateway_keys_read"],
+          ["api_gateway_keys_read", "api_gateway_keys_secret_read"]
+        ],
         "x-oauth-scope": "secrets:read"
       },
       "delete": {
@@ -1562,7 +1625,9 @@
           "200": {
             "description": "",
             "content": {
-              "application/json": { "schema": { "$ref": "#/components/schemas/ApiKeyResponse" } }
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiKeyResponse_Output" }
+              }
             }
           },
           "401": { "description": "Unauthorized" },
@@ -1604,11 +1669,14 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/BranchResponse" }
+                  "items": { "$ref": "#/components/schemas/BranchResponse_Output" }
                 }
               }
             }
           },
+          "401": { "description": "Unauthorized" },
+          "403": { "description": "Forbidden action" },
+          "429": { "description": "Rate limit exceeded" },
           "500": { "description": "Failed to retrieve database branches" }
         },
         "security": [{ "bearer": [] }],
@@ -1647,9 +1715,14 @@
           "201": {
             "description": "",
             "content": {
-              "application/json": { "schema": { "$ref": "#/components/schemas/BranchResponse" } }
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/BranchResponse_Output" }
+              }
             }
           },
+          "401": { "description": "Unauthorized" },
+          "403": { "description": "Forbidden action" },
+          "429": { "description": "Rate limit exceeded" },
           "500": { "description": "Failed to create database branch" }
         },
         "security": [{ "bearer": [] }],
@@ -1723,9 +1796,14 @@
           "200": {
             "description": "",
             "content": {
-              "application/json": { "schema": { "$ref": "#/components/schemas/BranchResponse" } }
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/BranchResponse_Output" }
+              }
             }
           },
+          "401": { "description": "Unauthorized" },
+          "403": { "description": "Forbidden action" },
+          "429": { "description": "Rate limit exceeded" },
           "500": { "description": "Failed to fetch database branch" }
         },
         "security": [{ "bearer": [] }],
@@ -1760,7 +1838,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/UpdateCustomHostnameResponse" }
+                "schema": { "$ref": "#/components/schemas/UpdateCustomHostnameResponse_Output" }
               }
             }
           },
@@ -1848,7 +1926,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/UpdateCustomHostnameResponse" }
+                "schema": { "$ref": "#/components/schemas/UpdateCustomHostnameResponse_Output" }
               }
             }
           },
@@ -1889,7 +1967,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/UpdateCustomHostnameResponse" }
+                "schema": { "$ref": "#/components/schemas/UpdateCustomHostnameResponse_Output" }
               }
             }
           },
@@ -1930,7 +2008,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/UpdateCustomHostnameResponse" }
+                "schema": { "$ref": "#/components/schemas/UpdateCustomHostnameResponse_Output" }
               }
             }
           },
@@ -1980,8 +2058,7 @@
                         "state": { "type": "string", "enum": ["enabled", "disabled"] },
                         "appliedSuccessfully": { "type": "boolean" }
                       },
-                      "required": ["state"],
-                      "additionalProperties": false
+                      "required": ["state"]
                     },
                     {
                       "type": "object",
@@ -1990,14 +2067,14 @@
                         "unavailableReason": {
                           "type": "string",
                           "enum": [
+                            "platform_unsupported",
                             "postgres_upgrade_required",
                             "ssl_enforcement_required",
                             "temporarily_unavailable"
                           ]
                         }
                       },
-                      "required": ["state", "unavailableReason"],
-                      "additionalProperties": false
+                      "required": ["state", "unavailableReason"]
                     }
                   ]
                 }
@@ -2056,8 +2133,7 @@
                         "state": { "type": "string", "enum": ["enabled", "disabled"] },
                         "appliedSuccessfully": { "type": "boolean" }
                       },
-                      "required": ["state"],
-                      "additionalProperties": false
+                      "required": ["state"]
                     },
                     {
                       "type": "object",
@@ -2066,14 +2142,14 @@
                         "unavailableReason": {
                           "type": "string",
                           "enum": [
+                            "platform_unsupported",
                             "postgres_upgrade_required",
                             "ssl_enforcement_required",
                             "temporarily_unavailable"
                           ]
                         }
                       },
-                      "required": ["state", "unavailableReason"],
-                      "additionalProperties": false
+                      "required": ["state", "unavailableReason"]
                     }
                   ]
                 }
@@ -2117,7 +2193,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/NetworkBanResponse" }
+                "schema": { "$ref": "#/components/schemas/NetworkBanResponse_Output" }
               }
             }
           },
@@ -2158,7 +2234,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/NetworkBanResponseEnriched" }
+                "schema": { "$ref": "#/components/schemas/NetworkBanResponseEnriched_Output" }
               }
             }
           },
@@ -2241,7 +2317,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/NetworkRestrictionsResponse" }
+                "schema": { "$ref": "#/components/schemas/NetworkRestrictionsResponse_Output" }
               }
             }
           },
@@ -2288,7 +2364,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/NetworkRestrictionsV2Response" }
+                "schema": { "$ref": "#/components/schemas/NetworkRestrictionsV2Response_Output" }
               }
             }
           },
@@ -2337,7 +2413,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/NetworkRestrictionsResponse" }
+                "schema": { "$ref": "#/components/schemas/NetworkRestrictionsResponse_Output" }
               }
             }
           },
@@ -2378,7 +2454,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/PgsodiumConfigResponse" }
+                "schema": { "$ref": "#/components/schemas/PgsodiumConfigResponse_Output" }
               }
             }
           },
@@ -2425,7 +2501,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/PgsodiumConfigResponse" }
+                "schema": { "$ref": "#/components/schemas/PgsodiumConfigResponse_Output" }
               }
             }
           },
@@ -2466,7 +2542,9 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/PostgrestConfigWithJWTSecretResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/PostgrestConfigWithJWTSecretResponse_Output"
+                }
               }
             }
           },
@@ -2480,7 +2558,10 @@
         "tags": ["Rest"],
         "x-badges": [{ "name": "OAuth scope: rest:read", "position": "after" }],
         "x-endpoint-owners": ["control-plane", "infra"],
-        "x-fga-permissions": [["data_api_config_read"]],
+        "x-fga-permissions": [
+          ["data_api_config_read"],
+          ["data_api_config_read", "data_api_config_secret_read"]
+        ],
         "x-oauth-scope": "rest:read"
       },
       "patch": {
@@ -2513,7 +2594,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/V1PostgrestConfigResponse" }
+                "schema": { "$ref": "#/components/schemas/V1PostgrestConfigResponse_Output" }
               }
             }
           },
@@ -2554,7 +2635,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/V1ProjectWithDatabaseResponse" }
+                "schema": { "$ref": "#/components/schemas/V1ProjectWithDatabaseResponse_Output" }
               }
             }
           },
@@ -2593,7 +2674,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/V1ProjectRefResponse" }
+                "schema": { "$ref": "#/components/schemas/V1ProjectRefResponse_Output" }
               }
             }
           },
@@ -2637,7 +2718,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/V1ProjectRefResponse" }
+                "schema": { "$ref": "#/components/schemas/V1ProjectRefResponse_Output" }
               }
             }
           },
@@ -2681,7 +2762,7 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/SecretResponse" }
+                  "items": { "$ref": "#/components/schemas/SecretResponse_Output" }
                 }
               }
             }
@@ -2801,7 +2882,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/SslEnforcementResponse" }
+                "schema": { "$ref": "#/components/schemas/SslEnforcementResponse_Output" }
               }
             }
           },
@@ -2848,7 +2929,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/SslEnforcementResponse" }
+                "schema": { "$ref": "#/components/schemas/SslEnforcementResponse_Output" }
               }
             }
           },
@@ -2896,7 +2977,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/TypescriptResponse" }
+                "schema": { "$ref": "#/components/schemas/TypescriptResponse_Output" }
               }
             }
           },
@@ -2937,7 +3018,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/VanitySubdomainConfigResponse" }
+                "schema": { "$ref": "#/components/schemas/VanitySubdomainConfigResponse_Output" }
               }
             }
           },
@@ -3026,7 +3107,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/SubdomainAvailabilityResponse" }
+                "schema": { "$ref": "#/components/schemas/SubdomainAvailabilityResponse_Output" }
               }
             }
           },
@@ -3083,7 +3164,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ActivateVanitySubdomainResponse" }
+                "schema": { "$ref": "#/components/schemas/ActivateVanitySubdomainResponse_Output" }
               }
             }
           },
@@ -3140,7 +3221,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ProjectUpgradeInitiateResponse" }
+                "schema": { "$ref": "#/components/schemas/ProjectUpgradeInitiateResponse_Output" }
               }
             }
           },
@@ -3181,7 +3262,9 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ProjectUpgradeEligibilityResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectUpgradeEligibilityResponse_Output"
+                }
               }
             }
           },
@@ -3228,7 +3311,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/DatabaseUpgradeStatusResponse" }
+                "schema": { "$ref": "#/components/schemas/DatabaseUpgradeStatusResponse_Output" }
               }
             }
           },
@@ -3269,7 +3352,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ReadOnlyStatusResponse" }
+                "schema": { "$ref": "#/components/schemas/ReadOnlyStatusResponse_Output" }
               }
             }
           },
@@ -3474,7 +3557,7 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/V1ServiceHealthResponse" }
+                  "items": { "$ref": "#/components/schemas/V1ServiceHealthResponse_Output" }
                 }
               }
             }
@@ -3516,7 +3599,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/SigningKeyResponse" }
+                "schema": { "$ref": "#/components/schemas/SigningKeyResponse_Output" }
               }
             }
           },
@@ -3554,7 +3637,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/SigningKeyResponse" }
+                "schema": { "$ref": "#/components/schemas/SigningKeyResponse_Output" }
               }
             }
           },
@@ -3602,7 +3685,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/SigningKeyResponse" }
+                "schema": { "$ref": "#/components/schemas/SigningKeyResponse_Output" }
               }
             }
           },
@@ -3640,7 +3723,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/SigningKeysResponse" }
+                "schema": { "$ref": "#/components/schemas/SigningKeysResponse_Output" }
               }
             }
           },
@@ -3691,7 +3774,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/SigningKeyResponse" }
+                "schema": { "$ref": "#/components/schemas/SigningKeyResponse_Output" }
               }
             }
           },
@@ -3738,7 +3821,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/SigningKeyResponse" }
+                "schema": { "$ref": "#/components/schemas/SigningKeyResponse_Output" }
               }
             }
           },
@@ -3795,7 +3878,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/SigningKeyResponse" }
+                "schema": { "$ref": "#/components/schemas/SigningKeyResponse_Output" }
               }
             }
           },
@@ -3835,7 +3918,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/AuthConfigResponse" }
+                "schema": { "$ref": "#/components/schemas/AuthConfigResponse_Output" }
               }
             }
           },
@@ -3882,7 +3965,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/AuthConfigResponse" }
+                "schema": { "$ref": "#/components/schemas/AuthConfigResponse_Output" }
               }
             }
           },
@@ -3930,7 +4013,9 @@
           "201": {
             "description": "",
             "content": {
-              "application/json": { "schema": { "$ref": "#/components/schemas/ThirdPartyAuth" } }
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ThirdPartyAuth_Output" }
+              }
             }
           },
           "401": { "description": "Unauthorized" },
@@ -3969,7 +4054,7 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/ThirdPartyAuth" }
+                  "items": { "$ref": "#/components/schemas/ThirdPartyAuth_Output" }
                 }
               }
             }
@@ -4020,7 +4105,9 @@
           "200": {
             "description": "",
             "content": {
-              "application/json": { "schema": { "$ref": "#/components/schemas/ThirdPartyAuth" } }
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ThirdPartyAuth_Output" }
+              }
             }
           },
           "401": { "description": "Unauthorized" },
@@ -4067,7 +4154,9 @@
           "200": {
             "description": "",
             "content": {
-              "application/json": { "schema": { "$ref": "#/components/schemas/ThirdPartyAuth" } }
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ThirdPartyAuth_Output" }
+              }
             }
           },
           "401": { "description": "Unauthorized" },
@@ -4173,7 +4262,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GetProjectAvailableRestoreVersionsResponse"
+                  "$ref": "#/components/schemas/GetProjectAvailableRestoreVersionsResponse_Output"
                 }
               }
             }
@@ -4279,7 +4368,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ListProjectAddonsResponse" }
+                "schema": { "$ref": "#/components/schemas/ListProjectAddonsResponse_Output" }
               }
             }
           },
@@ -4426,7 +4515,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ProjectClaimTokenResponse" }
+                "schema": { "$ref": "#/components/schemas/ProjectClaimTokenResponse_Output" }
               }
             }
           },
@@ -4463,7 +4552,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/CreateProjectClaimTokenResponse" }
+                "schema": { "$ref": "#/components/schemas/CreateProjectClaimTokenResponse_Output" }
               }
             }
           },
@@ -4534,7 +4623,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/V1ProjectAdvisorsResponse" }
+                "schema": { "$ref": "#/components/schemas/V1ProjectAdvisorsResponse_Output" }
               }
             }
           },
@@ -4582,7 +4671,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/V1ProjectAdvisorsResponse" }
+                "schema": { "$ref": "#/components/schemas/V1ProjectAdvisorsResponse_Output" }
               }
             }
           },
@@ -4655,7 +4744,9 @@
           "200": {
             "description": "",
             "content": {
-              "application/json": { "schema": { "$ref": "#/components/schemas/AnalyticsResponse" } }
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/AnalyticsResponse_Output" }
+              }
             }
           },
           "401": { "description": "Unauthorized" },
@@ -4667,7 +4758,7 @@
         "summary": "Gets project's logs",
         "tags": ["Analytics"],
         "x-badges": [{ "name": "OAuth scope: analytics:read", "position": "after" }],
-        "x-endpoint-owners": ["analytics"],
+        "x-endpoint-owners": ["observability"],
         "x-fga-permissions": [["analytics_logs_read"]],
         "x-oauth-scope": "analytics:read"
       }
@@ -4728,7 +4819,9 @@
           "200": {
             "description": "",
             "content": {
-              "application/json": { "schema": { "$ref": "#/components/schemas/AnalyticsResponse" } }
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/AnalyticsResponse_Output" }
+              }
             }
           },
           "401": { "description": "Unauthorized" },
@@ -4740,7 +4833,7 @@
         "summary": "Gets all project's logs in a single log stream",
         "tags": ["Analytics"],
         "x-badges": [{ "name": "OAuth scope: analytics:read", "position": "after" }],
-        "x-endpoint-owners": ["analytics"],
+        "x-endpoint-owners": ["observability"],
         "x-fga-permissions": [["analytics_logs_read"]],
         "x-oauth-scope": "analytics:read"
       }
@@ -4778,7 +4871,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/V1GetUsageApiCountResponse" }
+                "schema": { "$ref": "#/components/schemas/V1GetUsageApiCountResponse_Output" }
               }
             }
           },
@@ -4790,7 +4883,7 @@
         "security": [{ "bearer": [] }],
         "summary": "Gets project's usage api counts",
         "tags": ["Analytics"],
-        "x-endpoint-owners": ["analytics"],
+        "x-endpoint-owners": ["observability"],
         "x-fga-permissions": [["analytics_usage_read"]]
       }
     },
@@ -4817,7 +4910,9 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/V1GetUsageApiRequestsCountResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/V1GetUsageApiRequestsCountResponse_Output"
+                }
               }
             }
           },
@@ -4829,7 +4924,7 @@
         "security": [{ "bearer": [] }],
         "summary": "Gets project's usage api requests count",
         "tags": ["Analytics"],
-        "x-endpoint-owners": ["analytics"],
+        "x-endpoint-owners": ["observability"],
         "x-fga-permissions": [["analytics_usage_read"]]
       }
     },
@@ -4871,7 +4966,9 @@
           "200": {
             "description": "",
             "content": {
-              "application/json": { "schema": { "$ref": "#/components/schemas/AnalyticsResponse" } }
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/AnalyticsResponse_Output" }
+              }
             }
           },
           "401": { "description": "Unauthorized" },
@@ -4882,7 +4979,7 @@
         "security": [{ "bearer": [] }],
         "summary": "Gets a project's function combined statistics",
         "tags": ["Analytics"],
-        "x-endpoint-owners": ["analytics"],
+        "x-endpoint-owners": ["observability"],
         "x-fga-permissions": [["analytics_usage_read"]]
       }
     },
@@ -4925,7 +5022,7 @@
         "summary": "Scrape a project's metrics",
         "tags": ["Analytics"],
         "x-badges": [{ "name": "OAuth scope: analytics:read", "position": "after" }],
-        "x-endpoint-owners": ["analytics"],
+        "x-endpoint-owners": ["observability"],
         "x-fga-permissions": [["analytics_logs_read"]],
         "x-oauth-scope": "analytics:read"
       }
@@ -4959,7 +5056,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/CreateRoleResponse" }
+                "schema": { "$ref": "#/components/schemas/CreateRoleResponse_Output" }
               }
             }
           },
@@ -4998,7 +5095,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/DeleteRolesResponse" }
+                "schema": { "$ref": "#/components/schemas/DeleteRolesResponse_Output" }
               }
             }
           },
@@ -5039,7 +5136,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/V1ListMigrationsResponse" }
+                "schema": { "$ref": "#/components/schemas/V1ListMigrationsResponse_Output" }
               }
             }
           },
@@ -5219,7 +5316,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/V1GetMigrationResponse" }
+                "schema": { "$ref": "#/components/schemas/V1GetMigrationResponse_Output" }
               }
             }
           },
@@ -5423,7 +5520,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/GetProjectDbMetadataResponse" }
+                "schema": { "$ref": "#/components/schemas/GetProjectDbMetadataResponse_Output" }
               }
             }
           },
@@ -5471,7 +5568,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/V1UpdatePasswordResponse" }
+                "schema": { "$ref": "#/components/schemas/V1UpdatePasswordResponse_Output" }
               }
             }
           },
@@ -5512,7 +5609,9 @@
           "200": {
             "description": "",
             "content": {
-              "application/json": { "schema": { "$ref": "#/components/schemas/JitAccessResponse" } }
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/JitAccessResponse_Output" }
+              }
             }
           },
           "401": { "description": "Unauthorized" },
@@ -5559,7 +5658,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/JitAuthorizeAccessResponse" }
+                "schema": { "$ref": "#/components/schemas/JitAuthorizeAccessResponse_Output" }
               }
             }
           },
@@ -5604,7 +5703,9 @@
           "200": {
             "description": "",
             "content": {
-              "application/json": { "schema": { "$ref": "#/components/schemas/JitAccessResponse" } }
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/JitAccessResponse_Output" }
+              }
             }
           },
           "401": { "description": "Unauthorized" },
@@ -5643,7 +5744,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/JitListAccessResponse" }
+                "schema": { "$ref": "#/components/schemas/JitListAccessResponse_Output" }
               }
             }
           },
@@ -5691,7 +5792,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/InviteExternalUserJitResponse" }
+                "schema": { "$ref": "#/components/schemas/InviteExternalUserJitResponse_Output" }
               }
             }
           },
@@ -5738,7 +5839,9 @@
           "200": {
             "description": "",
             "content": {
-              "application/json": { "schema": { "$ref": "#/components/schemas/JitAccessResponse" } }
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/JitAccessResponse_Output" }
+              }
             }
           },
           "500": { "description": "Failed to accept invitation" }
@@ -5908,7 +6011,7 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/FunctionResponse" }
+                  "items": { "$ref": "#/components/schemas/FunctionResponse_Output" }
                 }
               }
             }
@@ -6005,7 +6108,9 @@
           "201": {
             "description": "",
             "content": {
-              "application/json": { "schema": { "$ref": "#/components/schemas/FunctionResponse" } }
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/FunctionResponse_Output" }
+              }
             }
           },
           "401": { "description": "Unauthorized" },
@@ -6053,7 +6158,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/BulkUpdateFunctionResponse" }
+                "schema": { "$ref": "#/components/schemas/BulkUpdateFunctionResponse_Output" }
               }
             }
           },
@@ -6120,7 +6225,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/DeployFunctionResponse" }
+                "schema": { "$ref": "#/components/schemas/DeployFunctionResponse_Output" }
               }
             }
           },
@@ -6170,7 +6275,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/FunctionSlugResponse" }
+                "schema": { "$ref": "#/components/schemas/FunctionSlugResponse_Output" }
               }
             }
           },
@@ -6272,7 +6377,9 @@
           "200": {
             "description": "",
             "content": {
-              "application/json": { "schema": { "$ref": "#/components/schemas/FunctionResponse" } }
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/FunctionSlugResponse_Output" }
+              }
             }
           },
           "401": { "description": "Unauthorized" },
@@ -6401,7 +6508,7 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/V1StorageBucketResponse" }
+                  "items": { "$ref": "#/components/schemas/V1StorageBucketResponse_Output" }
                 }
               }
             }
@@ -6442,7 +6549,9 @@
           "200": {
             "description": "",
             "content": {
-              "application/json": { "schema": { "$ref": "#/components/schemas/DiskResponse" } }
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/DiskResponse_Output" }
+              }
             }
           },
           "401": { "description": "Unauthorized" },
@@ -6516,7 +6625,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/DiskUtilMetricsResponse" }
+                "schema": { "$ref": "#/components/schemas/DiskUtilMetricsResponse_Output" }
               }
             }
           },
@@ -6555,7 +6664,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/DiskAutoscaleConfig" }
+                "schema": { "$ref": "#/components/schemas/DiskAutoscaleConfig_Output" }
               }
             }
           },
@@ -6594,7 +6703,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/StorageConfigResponse" }
+                "schema": { "$ref": "#/components/schemas/StorageConfigResponse_Output" }
               }
             }
           },
@@ -6671,7 +6780,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/V1PgbouncerConfigResponse" }
+                "schema": { "$ref": "#/components/schemas/V1PgbouncerConfigResponse_Output" }
               }
             }
           },
@@ -6713,7 +6822,7 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/SupavisorConfigResponse" }
+                  "items": { "$ref": "#/components/schemas/SupavisorConfigResponse_Output" }
                 }
               }
             }
@@ -6761,7 +6870,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/UpdateSupavisorConfigResponse" }
+                "schema": { "$ref": "#/components/schemas/UpdateSupavisorConfigResponse_Output" }
               }
             }
           },
@@ -6802,7 +6911,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/PostgresConfigResponse" }
+                "schema": { "$ref": "#/components/schemas/PostgresConfigResponse_Output" }
               }
             }
           },
@@ -6849,7 +6958,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/PostgresConfigResponse" }
+                "schema": { "$ref": "#/components/schemas/PostgresConfigResponse_Output" }
               }
             }
           },
@@ -6890,7 +6999,7 @@
             "description": "Gets project's realtime configuration",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/RealtimeConfigResponse" }
+                "schema": { "$ref": "#/components/schemas/RealtimeConfigResponse_Output" }
               }
             }
           },
@@ -7003,7 +7112,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/CreateProviderResponse" }
+                "schema": { "$ref": "#/components/schemas/CreateProviderResponse_Output" }
               }
             }
           },
@@ -7042,7 +7151,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ListProvidersResponse" }
+                "schema": { "$ref": "#/components/schemas/ListProvidersResponse_Output" }
               }
             }
           },
@@ -7094,7 +7203,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/GetProviderResponse" }
+                "schema": { "$ref": "#/components/schemas/GetProviderResponse_Output" }
               }
             }
           },
@@ -7152,7 +7261,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/UpdateProviderResponse" }
+                "schema": { "$ref": "#/components/schemas/UpdateProviderResponse_Output" }
               }
             }
           },
@@ -7204,7 +7313,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/DeleteProviderResponse" }
+                "schema": { "$ref": "#/components/schemas/DeleteProviderResponse_Output" }
               }
             }
           },
@@ -7246,7 +7355,9 @@
           "200": {
             "description": "",
             "content": {
-              "application/json": { "schema": { "$ref": "#/components/schemas/V1BackupsResponse" } }
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/V1BackupsResponse_Output" }
+              }
             }
           },
           "401": { "description": "Unauthorized" },
@@ -7460,7 +7571,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/V1BackupScheduleResponse" }
+                "schema": { "$ref": "#/components/schemas/V1BackupScheduleResponse_Output" }
               }
             }
           },
@@ -7519,7 +7630,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/V1BackupScheduleResponse" }
+                "schema": { "$ref": "#/components/schemas/V1BackupScheduleResponse_Output" }
               }
             }
           },
@@ -7611,7 +7722,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/V1ListEntitlementsResponse" }
+                "schema": { "$ref": "#/components/schemas/V1ListEntitlementsResponse_Output" }
               }
             }
           },
@@ -7651,11 +7762,14 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/V1OrganizationMemberResponse" }
+                  "items": { "$ref": "#/components/schemas/V1OrganizationMemberResponse_Output" }
                 }
               }
             }
-          }
+          },
+          "401": { "description": "Unauthorized" },
+          "403": { "description": "Forbidden action" },
+          "429": { "description": "Rate limit exceeded" }
         },
         "security": [{ "bearer": [] }],
         "summary": "List members of an organization",
@@ -7687,7 +7801,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/V1OrganizationSlugResponse" }
+                "schema": { "$ref": "#/components/schemas/V1OrganizationSlugResponse_Output" }
               }
             }
           },
@@ -7731,7 +7845,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/OrganizationProjectClaimResponse" }
+                "schema": { "$ref": "#/components/schemas/OrganizationProjectClaimResponse_Output" }
               }
             }
           },
@@ -7855,7 +7969,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/OrganizationProjectsResponse" }
+                "schema": { "$ref": "#/components/schemas/OrganizationProjectsResponse_Output" }
               }
             }
           },
@@ -7899,11 +8013,49 @@
       "description": "Visit [https://supabase.github.io/storage/](https://supabase.github.io/storage/) for complete documentation."
     }
   ],
-  "servers": [],
+  "servers": [{ "url": "https://api.supabase.com" }],
   "components": {
-    "securitySchemes": { "bearer": { "scheme": "bearer", "bearerFormat": "JWT", "type": "http" } },
+    "securitySchemes": {
+      "bearer": { "scheme": "bearer", "bearerFormat": "JWT", "type": "http" },
+      "oauth2": {
+        "type": "oauth2",
+        "flows": {
+          "authorizationCode": {
+            "authorizationUrl": "https://api.supabase.com/v1/oauth/authorize",
+            "tokenUrl": "https://api.supabase.com/v1/oauth/token",
+            "scopes": {
+              "analytics:read": "Read access to analytics",
+              "analytics:write": "Write access to analytics",
+              "analytics_config:read": "Read access to analytics config",
+              "analytics_config:write": "Write access to analytics config",
+              "auth:read": "Read access to auth",
+              "auth:write": "Write access to auth",
+              "database:read": "Read access to database",
+              "database:write": "Write access to database",
+              "domains:read": "Read access to domains",
+              "domains:write": "Write access to domains",
+              "edge_functions:read": "Read access to edge functions",
+              "edge_functions:write": "Write access to edge functions",
+              "environment:read": "Read access to environment",
+              "environment:write": "Write access to environment",
+              "organizations:read": "Read access to organizations",
+              "organizations:write": "Write access to organizations",
+              "projects:read": "Read access to projects",
+              "projects:write": "Write access to projects",
+              "rest:read": "Read access to rest",
+              "rest:write": "Write access to rest",
+              "secrets:read": "Read access to secrets",
+              "secrets:write": "Write access to secrets",
+              "storage:read": "Read access to storage",
+              "storage:write": "Write access to storage"
+            }
+          }
+        },
+        "description": "OAuth 2.0 authorization code flow for Supabase OAuth apps. Tokens carry the scopes approved for the app by the organization."
+      }
+    },
     "schemas": {
-      "BranchDetailResponse": {
+      "BranchDetailResponse_Output": {
         "type": "object",
         "properties": {
           "ref": { "type": "string" },
@@ -7988,7 +8140,7 @@
           "notify_url": "https://example.com/webhooks/branches"
         }
       },
-      "BranchResponse": {
+      "BranchResponse_Output": {
         "type": "object",
         "properties": {
           "id": {
@@ -8029,24 +8181,24 @@
           "created_at": {
             "type": "string",
             "format": "date-time",
-            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
           },
           "updated_at": {
             "type": "string",
             "format": "date-time",
-            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
           },
           "review_requested_at": {
             "type": "string",
             "format": "date-time",
-            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
           },
           "with_data": { "type": "boolean" },
           "notify_url": { "type": "string", "format": "uri" },
           "deletion_scheduled_at": {
             "type": "string",
             "format": "date-time",
-            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
           },
           "preview_project_status": {
             "type": "string",
@@ -8082,7 +8234,7 @@
           "with_data"
         ]
       },
-      "BranchDeleteResponse": {
+      "BranchDeleteResponse_Output": {
         "type": "object",
         "properties": { "message": { "type": "string", "enum": ["ok"] } },
         "required": ["message"]
@@ -8092,7 +8244,7 @@
         "properties": { "migration_version": { "type": "string" } },
         "example": { "migration_version": "20250312000000" }
       },
-      "BranchUpdateResponse": {
+      "BranchUpdateResponse_Output": {
         "type": "object",
         "properties": {
           "workflow_run_id": { "type": "string" },
@@ -8100,12 +8252,12 @@
         },
         "required": ["workflow_run_id", "message"]
       },
-      "BranchRestoreResponse": {
+      "BranchRestoreResponse_Output": {
         "type": "object",
         "properties": { "message": { "type": "string", "enum": ["Branch restoration initiated"] } },
         "required": ["message"]
       },
-      "V1ProjectWithDatabaseResponse": {
+      "V1ProjectWithDatabaseResponse_Output": {
         "type": "object",
         "properties": {
           "id": {
@@ -8324,7 +8476,7 @@
         },
         "additionalProperties": false
       },
-      "V1ProjectResponse": {
+      "V1ProjectResponse_Output": {
         "type": "object",
         "properties": {
           "id": {
@@ -8386,7 +8538,7 @@
           "status"
         ]
       },
-      "RegionsInfo": {
+      "RegionsInfo_Output": {
         "type": "object",
         "properties": {
           "recommendations": {
@@ -8497,7 +8649,7 @@
         },
         "required": ["recommendations", "all"]
       },
-      "OrganizationResponseV1": {
+      "OrganizationResponseV1_Output": {
         "type": "object",
         "properties": {
           "id": {
@@ -8565,7 +8717,7 @@
         },
         "additionalProperties": false
       },
-      "OAuthTokenResponse": {
+      "OAuthTokenResponse_Output": {
         "type": "object",
         "properties": {
           "access_token": { "type": "string" },
@@ -8580,8 +8732,7 @@
           },
           "token_type": { "type": "string", "enum": ["Bearer"] }
         },
-        "required": ["access_token", "expires_in", "token_type"],
-        "additionalProperties": false
+        "required": ["access_token", "expires_in", "token_type"]
       },
       "OAuthRevokeTokenBody": {
         "type": "object",
@@ -8602,7 +8753,7 @@
         },
         "additionalProperties": false
       },
-      "SnippetList": {
+      "SnippetList_Output": {
         "type": "object",
         "properties": {
           "data": {
@@ -8653,7 +8804,7 @@
         },
         "required": ["data"]
       },
-      "SnippetResponse": {
+      "SnippetResponse_Output": {
         "type": "object",
         "properties": {
           "id": { "type": "string" },
@@ -8708,7 +8859,7 @@
           "content"
         ]
       },
-      "V1ProfileResponse": {
+      "V1ProfileResponse_Output": {
         "type": "object",
         "properties": {
           "gotrue_id": { "type": "string" },
@@ -8717,7 +8868,7 @@
         },
         "required": ["gotrue_id", "primary_email", "username"]
       },
-      "ListActionRunResponse": {
+      "ListActionRunResponse_Output": {
         "type": "array",
         "items": {
           "type": "object",
@@ -8768,7 +8919,7 @@
           ]
         }
       },
-      "ActionRunResponse": {
+      "ActionRunResponse_Output": {
         "type": "object",
         "properties": {
           "id": { "type": "string" },
@@ -8855,12 +9006,12 @@
           "deploy": "CREATED"
         }
       },
-      "UpdateRunStatusResponse": {
+      "UpdateRunStatusResponse_Output": {
         "type": "object",
         "properties": { "message": { "type": "string", "enum": ["ok"] } },
         "required": ["message"]
       },
-      "ApiKeyResponse": {
+      "ApiKeyResponse_Output": {
         "type": "object",
         "properties": {
           "api_key": { "type": "string", "nullable": true },
@@ -8883,19 +9034,19 @@
           "inserted_at": {
             "type": "string",
             "format": "date-time",
-            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$",
             "nullable": true
           },
           "updated_at": {
             "type": "string",
             "format": "date-time",
-            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$",
             "nullable": true
           }
         },
         "required": ["name"]
       },
-      "LegacyApiKeysResponse": {
+      "LegacyApiKeysResponse_Output": {
         "type": "object",
         "properties": { "enabled": { "type": "boolean" } },
         "required": ["enabled"]
@@ -9000,26 +9151,21 @@
           "notify_url": "https://example.com/webhooks/branches"
         }
       },
-      "UpdateCustomHostnameResponseJsonValue": {
+      "JsonValue_Output": {
         "description": "Any JSON-serializable value",
         "anyOf": [
           {
             "anyOf": [{ "type": "string" }, { "type": "number" }, { "type": "boolean" }],
             "nullable": true
           },
-          {
-            "type": "array",
-            "items": { "$ref": "#/components/schemas/UpdateCustomHostnameResponseJsonValue" }
-          },
+          { "type": "array", "items": { "$ref": "#/components/schemas/JsonValue_Output" } },
           {
             "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/UpdateCustomHostnameResponseJsonValue"
-            }
+            "additionalProperties": { "$ref": "#/components/schemas/JsonValue_Output" }
           }
         ]
       },
-      "UpdateCustomHostnameResponse": {
+      "UpdateCustomHostnameResponse_Output": {
         "type": "object",
         "properties": {
           "status": {
@@ -9039,11 +9185,11 @@
               "success": { "type": "boolean" },
               "errors": {
                 "type": "array",
-                "items": { "$ref": "#/components/schemas/UpdateCustomHostnameResponseJsonValue" }
+                "items": { "$ref": "#/components/schemas/JsonValue_Output" }
               },
               "messages": {
                 "type": "array",
-                "items": { "$ref": "#/components/schemas/UpdateCustomHostnameResponseJsonValue" }
+                "items": { "$ref": "#/components/schemas/JsonValue_Output" }
               },
               "result": {
                 "type": "object",
@@ -9061,8 +9207,7 @@
                           "properties": {
                             "txt_name": { "type": "string" },
                             "txt_value": { "type": "string" }
-                          },
-                          "required": ["txt_name", "txt_value"]
+                          }
                         }
                       },
                       "validation_errors": {
@@ -9073,8 +9218,7 @@
                           "required": ["message"]
                         }
                       }
-                    },
-                    "required": ["status", "validation_records"]
+                    }
                   },
                   "ownership_verification": {
                     "type": "object",
@@ -9082,27 +9226,19 @@
                       "type": { "type": "string" },
                       "name": { "type": "string" },
                       "value": { "type": "string" }
-                    },
-                    "required": ["type", "name", "value"]
+                    }
                   },
                   "custom_origin_server": { "type": "string" },
                   "verification_errors": { "type": "array", "items": { "type": "string" } },
                   "status": { "type": "string" }
                 },
-                "required": [
-                  "id",
-                  "hostname",
-                  "ssl",
-                  "ownership_verification",
-                  "custom_origin_server",
-                  "status"
-                ]
+                "required": ["id", "hostname"]
               }
             },
             "required": ["success", "errors", "messages", "result"]
           }
         },
-        "required": ["status", "custom_hostname", "data"]
+        "required": ["status", "data"]
       },
       "UpdateCustomHostnameBody": {
         "type": "object",
@@ -9116,14 +9252,14 @@
         "required": ["state"],
         "example": { "state": "enabled" }
       },
-      "NetworkBanResponse": {
+      "NetworkBanResponse_Output": {
         "type": "object",
         "properties": {
           "banned_ipv4_addresses": { "type": "array", "items": { "type": "string" } }
         },
         "required": ["banned_ipv4_addresses"]
       },
-      "NetworkBanResponseEnriched": {
+      "NetworkBanResponseEnriched_Output": {
         "type": "object",
         "properties": {
           "banned_ipv4_addresses": {
@@ -9159,7 +9295,7 @@
         "required": ["ipv4_addresses"],
         "example": { "ipv4_addresses": ["203.0.113.10"], "requester_ip": false }
       },
-      "NetworkRestrictionsResponse": {
+      "NetworkRestrictionsResponse_Output": {
         "type": "object",
         "properties": {
           "entitlement": { "type": "string", "enum": ["disallowed", "allowed"] },
@@ -9191,12 +9327,12 @@
           "updated_at": {
             "type": "string",
             "format": "date-time",
-            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
           },
           "applied_at": {
             "type": "string",
             "format": "date-time",
-            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
           }
         },
         "required": ["entitlement", "config", "status"]
@@ -9232,7 +9368,7 @@
           "remove": { "dbAllowedCidrs": ["198.51.100.0/24"] }
         }
       },
-      "NetworkRestrictionsV2Response": {
+      "NetworkRestrictionsV2Response_Output": {
         "type": "object",
         "properties": {
           "entitlement": { "type": "string", "enum": ["disallowed", "allowed"] },
@@ -9273,18 +9409,18 @@
           "updated_at": {
             "type": "string",
             "format": "date-time",
-            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
           },
           "applied_at": {
             "type": "string",
             "format": "date-time",
-            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
           },
           "status": { "type": "string", "enum": ["stored", "applied"] }
         },
         "required": ["entitlement", "config", "status"]
       },
-      "PgsodiumConfigResponse": {
+      "PgsodiumConfigResponse_Output": {
         "type": "object",
         "properties": {
           "root_key": {
@@ -9310,7 +9446,7 @@
           "root_key": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
         }
       },
-      "PostgrestConfigWithJWTSecretResponse": {
+      "PostgrestConfigWithJWTSecretResponse_Output": {
         "type": "object",
         "properties": {
           "db_schema": { "type": "string" },
@@ -9355,7 +9491,7 @@
         },
         "example": { "db_schema": "public,storage", "db_pool": 20, "max_rows": 1000 }
       },
-      "V1PostgrestConfigResponse": {
+      "V1PostgrestConfigResponse_Output": {
         "type": "object",
         "properties": {
           "db_schema": { "type": "string" },
@@ -9388,7 +9524,7 @@
           "db_pool_acquisition_timeout"
         ]
       },
-      "V1ProjectRefResponse": {
+      "V1ProjectRefResponse_Output": {
         "type": "object",
         "properties": {
           "id": { "type": "integer", "minimum": -9007199254740991, "maximum": 9007199254740991 },
@@ -9403,7 +9539,7 @@
         "required": ["name"],
         "example": { "name": "Acme Platform" }
       },
-      "SecretResponse": {
+      "SecretResponse_Output": {
         "type": "object",
         "properties": {
           "name": { "type": "string" },
@@ -9438,7 +9574,7 @@
         "items": { "type": "string" },
         "example": ["OPENAI_API_KEY"]
       },
-      "SslEnforcementResponse": {
+      "SslEnforcementResponse_Output": {
         "type": "object",
         "properties": {
           "currentConfig": {
@@ -9462,12 +9598,12 @@
         "required": ["requestedConfig"],
         "example": { "requestedConfig": { "database": true } }
       },
-      "TypescriptResponse": {
+      "TypescriptResponse_Output": {
         "type": "object",
         "properties": { "types": { "type": "string" } },
         "required": ["types"]
       },
-      "VanitySubdomainConfigResponse": {
+      "VanitySubdomainConfigResponse_Output": {
         "type": "object",
         "properties": {
           "status": { "type": "string", "enum": ["not-used", "custom-domain-used", "active"] },
@@ -9511,12 +9647,12 @@
         "required": ["vanity_subdomain"],
         "example": { "vanity_subdomain": "acme-prod" }
       },
-      "SubdomainAvailabilityResponse": {
+      "SubdomainAvailabilityResponse_Output": {
         "type": "object",
         "properties": { "available": { "type": "boolean" } },
         "required": ["available"]
       },
-      "ActivateVanitySubdomainResponse": {
+      "ActivateVanitySubdomainResponse_Output": {
         "type": "object",
         "properties": { "custom_domain": { "type": "string" } },
         "required": ["custom_domain"]
@@ -9533,12 +9669,12 @@
         "required": ["target_version"],
         "example": { "target_version": "17", "release_channel": "ga" }
       },
-      "ProjectUpgradeInitiateResponse": {
+      "ProjectUpgradeInitiateResponse_Output": {
         "type": "object",
         "properties": { "tracking_id": { "type": "string" } },
         "required": ["tracking_id"]
       },
-      "ProjectUpgradeEligibilityResponse": {
+      "ProjectUpgradeEligibilityResponse_Output": {
         "type": "object",
         "properties": {
           "eligible": { "type": "boolean" },
@@ -9711,6 +9847,13 @@
                     "type": { "type": "string", "enum": ["operator_estimator_gate"] }
                   },
                   "required": ["type"]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": { "type": "string", "enum": ["btree_gist_nan_reindex"] }
+                  },
+                  "required": ["type"]
                 }
               ]
             }
@@ -9731,7 +9874,7 @@
           "warnings"
         ]
       },
-      "DatabaseUpgradeStatusResponse": {
+      "DatabaseUpgradeStatusResponse_Output": {
         "type": "object",
         "properties": {
           "databaseUpgradeStatus": {
@@ -9739,7 +9882,7 @@
             "properties": {
               "initiated_at": { "type": "string" },
               "latest_status_at": { "type": "string" },
-              "target_version": { "type": "number" },
+              "target_version": { "type": "string" },
               "error": {
                 "type": "string",
                 "enum": [
@@ -9778,7 +9921,7 @@
         },
         "required": ["databaseUpgradeStatus"]
       },
-      "ReadOnlyStatusResponse": {
+      "ReadOnlyStatusResponse_Output": {
         "type": "object",
         "properties": {
           "enabled": { "type": "boolean" },
@@ -9824,7 +9967,7 @@
         "required": ["database_identifier"],
         "example": { "database_identifier": "abcdefghijklmnopqrst-rr-us-west-1-abcde" }
       },
-      "V1ServiceHealthResponse": {
+      "V1ServiceHealthResponse_Output": {
         "type": "object",
         "properties": {
           "name": {
@@ -9891,7 +10034,7 @@
         },
         "required": ["name", "healthy", "status"]
       },
-      "SigningKeyResponse": {
+      "SigningKeyResponse_Output": {
         "type": "object",
         "properties": {
           "id": {
@@ -9908,16 +10051,15 @@
           "created_at": {
             "type": "string",
             "format": "date-time",
-            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
           },
           "updated_at": {
             "type": "string",
             "format": "date-time",
-            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
           }
         },
-        "required": ["id", "algorithm", "status", "public_jwk", "created_at", "updated_at"],
-        "additionalProperties": false
+        "required": ["id", "algorithm", "status", "public_jwk", "created_at", "updated_at"]
       },
       "CreateSigningKeyBody": {
         "type": "object",
@@ -10037,7 +10179,7 @@
         "example": { "algorithm": "RS256", "status": "standby" },
         "additionalProperties": false
       },
-      "SigningKeysResponse": {
+      "SigningKeysResponse_Output": {
         "type": "object",
         "properties": {
           "keys": {
@@ -10059,21 +10201,19 @@
                 "created_at": {
                   "type": "string",
                   "format": "date-time",
-                  "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+                  "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
                 },
                 "updated_at": {
                   "type": "string",
                   "format": "date-time",
-                  "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+                  "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
                 }
               },
-              "required": ["id", "algorithm", "status", "public_jwk", "created_at", "updated_at"],
-              "additionalProperties": false
+              "required": ["id", "algorithm", "status", "public_jwk", "created_at", "updated_at"]
             }
           }
         },
-        "required": ["keys"],
-        "additionalProperties": false
+        "required": ["keys"]
       },
       "UpdateSigningKeyBody": {
         "type": "object",
@@ -10087,7 +10227,7 @@
         "example": { "status": "standby" },
         "additionalProperties": false
       },
-      "AuthConfigResponse": {
+      "AuthConfigResponse_Output": {
         "type": "object",
         "properties": {
           "api_max_request_duration": {
@@ -10420,6 +10560,10 @@
             "maximum": 9007199254740991,
             "nullable": true
           },
+          "security_update_password_require_current_password": {
+            "type": "boolean",
+            "nullable": true
+          },
           "security_update_password_require_reauthentication": {
             "type": "boolean",
             "nullable": true
@@ -10699,6 +10843,7 @@
           "security_captcha_secret",
           "security_manual_linking_enabled",
           "security_refresh_token_reuse_interval",
+          "security_update_password_require_current_password",
           "security_update_password_require_reauthentication",
           "sessions_inactivity_timeout",
           "sessions_single_per_user",
@@ -10853,8 +10998,18 @@
             "nullable": true
           },
           "security_captcha_secret": { "type": "string", "nullable": true },
-          "sessions_timebox": { "type": "number", "minimum": 0, "nullable": true },
-          "sessions_inactivity_timeout": { "type": "number", "minimum": 0, "nullable": true },
+          "sessions_timebox": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Session timebox in hours. Maximum 8760 hours (1 year).",
+            "nullable": true
+          },
+          "sessions_inactivity_timeout": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Session inactivity timeout in hours. Maximum 8760 hours (1 year).",
+            "nullable": true
+          },
           "sessions_single_per_user": { "type": "boolean", "nullable": true },
           "sessions_tags": {
             "type": "string",
@@ -10928,10 +11083,16 @@
             "type": "boolean",
             "nullable": true
           },
+          "security_update_password_require_current_password": {
+            "type": "boolean",
+            "description": "Require the user's current password when updating their password.",
+            "nullable": true
+          },
           "security_refresh_token_reuse_interval": {
             "type": "integer",
             "minimum": 0,
             "maximum": 2147483647,
+            "description": "Refresh token reuse interval in seconds. Maximum 300 seconds (5 minutes).",
             "nullable": true
           },
           "mailer_otp_exp": { "type": "integer", "minimum": 0, "maximum": 2147483647 },
@@ -11159,7 +11320,7 @@
           "jwks_url": "https://login.acme.com/.well-known/jwks.json"
         }
       },
-      "ThirdPartyAuth": {
+      "ThirdPartyAuth_Output": {
         "type": "object",
         "properties": {
           "id": {
@@ -11178,7 +11339,7 @@
         },
         "required": ["id", "type", "inserted_at", "updated_at"]
       },
-      "GetProjectAvailableRestoreVersionsResponse": {
+      "GetProjectAvailableRestoreVersionsResponse_Output": {
         "type": "object",
         "properties": {
           "available_versions": {
@@ -11202,26 +11363,7 @@
         },
         "required": ["available_versions"]
       },
-      "ListProjectAddonsResponseJsonValue": {
-        "description": "Any JSON-serializable value",
-        "anyOf": [
-          {
-            "anyOf": [{ "type": "string" }, { "type": "number" }, { "type": "boolean" }],
-            "nullable": true
-          },
-          {
-            "type": "array",
-            "items": { "$ref": "#/components/schemas/ListProjectAddonsResponseJsonValue" }
-          },
-          {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/ListProjectAddonsResponseJsonValue"
-            }
-          }
-        ]
-      },
-      "ListProjectAddonsResponse": {
+      "ListProjectAddonsResponse_Output": {
         "type": "object",
         "properties": {
           "selected_addons": {
@@ -11290,7 +11432,7 @@
                       },
                       "required": ["description", "type", "interval", "amount"]
                     },
-                    "meta": { "$ref": "#/components/schemas/ListProjectAddonsResponseJsonValue" }
+                    "meta": { "$ref": "#/components/schemas/JsonValue_Output" }
                   },
                   "required": ["id", "name", "price"]
                 }
@@ -11367,7 +11509,7 @@
                         },
                         "required": ["description", "type", "interval", "amount"]
                       },
-                      "meta": { "$ref": "#/components/schemas/ListProjectAddonsResponseJsonValue" }
+                      "meta": { "$ref": "#/components/schemas/JsonValue_Output" }
                     },
                     "required": ["id", "name", "price"]
                   }
@@ -11429,7 +11571,7 @@
         "required": ["addon_variant", "addon_type"],
         "example": { "addon_variant": "pitr_7", "addon_type": "pitr" }
       },
-      "ProjectClaimTokenResponse": {
+      "ProjectClaimTokenResponse_Output": {
         "type": "object",
         "properties": {
           "token_alias": { "type": "string" },
@@ -11443,7 +11585,7 @@
         },
         "required": ["token_alias", "expires_at", "created_at", "created_by"]
       },
-      "CreateProjectClaimTokenResponse": {
+      "CreateProjectClaimTokenResponse_Output": {
         "type": "object",
         "properties": {
           "token": { "type": "string" },
@@ -11458,7 +11600,7 @@
         },
         "required": ["token", "token_alias", "expires_at", "created_at", "created_by"]
       },
-      "V1ProjectAdvisorsResponse": {
+      "V1ProjectAdvisorsResponse_Output": {
         "type": "object",
         "properties": {
           "lints": {
@@ -11467,6 +11609,7 @@
               "type": "object",
               "properties": {
                 "name": {
+                  "type": "string",
                   "enum": [
                     "unindexed_foreign_keys",
                     "auth_users_exposed",
@@ -11488,6 +11631,7 @@
                     "auth_otp_long_expiry",
                     "auth_otp_short_length",
                     "ssl_not_enforced",
+                    "log_connections_not_enabled",
                     "network_restrictions_not_set",
                     "password_requirements_min_length",
                     "pitr_not_enabled",
@@ -11496,16 +11640,28 @@
                     "auth_password_policy_missing",
                     "leaked_service_key",
                     "no_backup_admin",
-                    "vulnerable_postgres_version"
-                  ],
-                  "type": "string"
+                    "vulnerable_postgres_version",
+                    "db_not_reachable",
+                    "db_connection_failing",
+                    "db_connection_limit_reached",
+                    "instance_telemetry_lost",
+                    "instance_db_down",
+                    "instance_alert_firing",
+                    "log_data_api_error_rate_high",
+                    "log_auth_error_rate_high",
+                    "log_storage_error_rate_high",
+                    "log_edge_function_error_rate_high",
+                    "project_not_active",
+                    "advisor_check_unavailable"
+                  ]
                 },
                 "title": { "type": "string" },
                 "level": { "type": "string", "enum": ["ERROR", "WARN", "INFO"] },
                 "facing": { "type": "string", "enum": ["EXTERNAL"] },
                 "categories": {
                   "type": "array",
-                  "items": { "type": "string", "enum": ["PERFORMANCE", "SECURITY"] }
+                  "items": { "type": "string", "enum": ["PERFORMANCE", "SECURITY", "HEALTH"] },
+                  "x-ignore-array-items-must-be-objects": true
                 },
                 "description": { "type": "string" },
                 "detail": { "type": "string" },
@@ -11518,13 +11674,32 @@
                     "entity": { "type": "string" },
                     "type": {
                       "type": "string",
-                      "enum": ["table", "view", "auth", "function", "extension", "compliance"]
+                      "enum": [
+                        "table",
+                        "view",
+                        "materialized view",
+                        "foreign table",
+                        "auth",
+                        "function",
+                        "extension",
+                        "compliance",
+                        "health"
+                      ]
                     },
                     "fkey_name": { "type": "string" },
-                    "fkey_columns": { "type": "array", "items": { "type": "number" } }
+                    "fkey_columns": {
+                      "x-ignore-array-items-must-be-objects": true,
+                      "type": "array",
+                      "items": { "type": "number" }
+                    }
                   }
                 },
-                "cache_key": { "type": "string" }
+                "cache_key": { "type": "string" },
+                "observed_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+                }
               },
               "required": [
                 "name",
@@ -11542,7 +11717,7 @@
         },
         "required": ["lints"]
       },
-      "AnalyticsResponse": {
+      "AnalyticsResponse_Output": {
         "type": "object",
         "properties": {
           "result": { "type": "array", "items": {} },
@@ -11576,7 +11751,7 @@
           }
         }
       },
-      "V1GetUsageApiCountResponse": {
+      "V1GetUsageApiCountResponse_Output": {
         "type": "object",
         "properties": {
           "result": {
@@ -11633,7 +11808,7 @@
           }
         }
       },
-      "V1GetUsageApiRequestsCountResponse": {
+      "V1GetUsageApiRequestsCountResponse_Output": {
         "type": "object",
         "properties": {
           "result": {
@@ -11680,7 +11855,7 @@
         "required": ["read_only"],
         "example": { "read_only": true }
       },
-      "CreateRoleResponse": {
+      "CreateRoleResponse_Output": {
         "type": "object",
         "properties": {
           "role": { "type": "string", "minLength": 1 },
@@ -11694,19 +11869,16 @@
         },
         "required": ["role", "password", "ttl_seconds"]
       },
-      "DeleteRolesResponse": {
+      "DeleteRolesResponse_Output": {
         "type": "object",
         "properties": { "message": { "type": "string", "enum": ["ok"] } },
         "required": ["message"]
       },
-      "V1ListMigrationsResponse": {
+      "V1ListMigrationsResponse_Output": {
         "type": "array",
         "items": {
           "type": "object",
-          "properties": {
-            "version": { "type": "string", "minLength": 1 },
-            "name": { "type": "string" }
-          },
+          "properties": { "version": { "type": "string" }, "name": { "type": "string" } },
           "required": ["version"]
         }
       },
@@ -11738,10 +11910,10 @@
           "rollback": "drop table if exists public.widgets;"
         }
       },
-      "V1GetMigrationResponse": {
+      "V1GetMigrationResponse_Output": {
         "type": "object",
         "properties": {
-          "version": { "type": "string", "minLength": 1 },
+          "version": { "type": "string" },
           "name": { "type": "string" },
           "statements": { "type": "array", "items": { "type": "string" } },
           "rollback": { "type": "array", "items": { "type": "string" } },
@@ -11777,7 +11949,7 @@
         "required": ["query"],
         "example": { "query": "select * from pg_stat_activity limit 1;" }
       },
-      "GetProjectDbMetadataResponse": {
+      "GetProjectDbMetadataResponse_Output": {
         "type": "object",
         "properties": {
           "databases": {
@@ -11791,13 +11963,11 @@
                   "items": {
                     "type": "object",
                     "properties": { "name": { "type": "string" } },
-                    "required": ["name"],
-                    "additionalProperties": {}
+                    "required": ["name"]
                   }
                 }
               },
-              "required": ["name", "schemas"],
-              "additionalProperties": {}
+              "required": ["name", "schemas"]
             }
           }
         },
@@ -11809,12 +11979,12 @@
         "required": ["password"],
         "example": { "password": "correct-horse-battery-staple" }
       },
-      "V1UpdatePasswordResponse": {
+      "V1UpdatePasswordResponse_Output": {
         "type": "object",
         "properties": { "message": { "type": "string" } },
         "required": ["message"]
       },
-      "JitAccessResponse": {
+      "JitAccessResponse_Output": {
         "type": "object",
         "properties": {
           "user_id": {
@@ -11827,7 +11997,7 @@
             "items": {
               "type": "object",
               "properties": {
-                "role": { "type": "string", "minLength": 1 },
+                "role": { "type": "string" },
                 "expires_at": { "type": "number" },
                 "allowed_networks": {
                   "type": "object",
@@ -11892,7 +12062,7 @@
         "required": ["role", "rhost"],
         "example": { "role": "postgres", "rhost": "203.0.113.10" }
       },
-      "JitAuthorizeAccessResponse": {
+      "JitAuthorizeAccessResponse_Output": {
         "type": "object",
         "properties": {
           "user_id": {
@@ -11903,7 +12073,7 @@
           "user_role": {
             "type": "object",
             "properties": {
-              "role": { "type": "string", "minLength": 1 },
+              "role": { "type": "string" },
               "expires_at": { "type": "number" },
               "allowed_networks": {
                 "type": "object",
@@ -11945,7 +12115,7 @@
         },
         "required": ["user_id", "user_role"]
       },
-      "JitListAccessResponse": {
+      "JitListAccessResponse_Output": {
         "type": "object",
         "properties": {
           "items": {
@@ -11968,7 +12138,7 @@
                       "items": {
                         "type": "object",
                         "properties": {
-                          "role": { "type": "string", "minLength": 1 },
+                          "role": { "type": "string" },
                           "expires_at": { "type": "number" },
                           "allowed_networks": {
                             "type": "object",
@@ -12027,7 +12197,7 @@
                       "items": {
                         "type": "object",
                         "properties": {
-                          "role": { "type": "string", "minLength": 1 },
+                          "role": { "type": "string" },
                           "expires_at": { "type": "number" },
                           "allowed_networks": {
                             "type": "object",
@@ -12212,7 +12382,7 @@
           ]
         }
       },
-      "InviteExternalUserJitResponse": {
+      "InviteExternalUserJitResponse_Output": {
         "type": "object",
         "properties": {
           "email": {
@@ -12230,7 +12400,7 @@
             "items": {
               "type": "object",
               "properties": {
-                "role": { "type": "string", "minLength": 1 },
+                "role": { "type": "string" },
                 "expires_at": { "type": "number" },
                 "allowed_networks": {
                   "type": "object",
@@ -12287,7 +12457,7 @@
         "required": ["email", "token"],
         "example": { "email": "external-user@somedomain.xyz", "token": "" }
       },
-      "FunctionResponse": {
+      "FunctionResponse_Output": {
         "type": "object",
         "properties": {
           "id": { "type": "string" },
@@ -12375,7 +12545,7 @@
           }
         ]
       },
-      "BulkUpdateFunctionResponse": {
+      "BulkUpdateFunctionResponse_Output": {
         "type": "object",
         "properties": {
           "functions": {
@@ -12438,7 +12608,7 @@
           "metadata": { "entrypoint_path": "index.ts", "verify_jwt": true, "name": "Hello World" }
         }
       },
-      "DeployFunctionResponse": {
+      "DeployFunctionResponse_Output": {
         "type": "object",
         "properties": {
           "id": { "type": "string" },
@@ -12470,7 +12640,7 @@
         },
         "required": ["id", "slug", "name", "status", "version"]
       },
-      "FunctionSlugResponse": {
+      "FunctionSlugResponse_Output": {
         "type": "object",
         "properties": {
           "id": { "type": "string" },
@@ -12516,7 +12686,7 @@
           "verify_jwt": true
         }
       },
-      "V1StorageBucketResponse": {
+      "V1StorageBucketResponse_Output": {
         "type": "object",
         "properties": {
           "id": { "type": "string" },
@@ -12528,7 +12698,7 @@
         },
         "required": ["id", "name", "owner", "created_at", "updated_at", "public"]
       },
-      "DiskResponse": {
+      "DiskResponse_Output": {
         "type": "object",
         "properties": {
           "attributes": {
@@ -12640,7 +12810,7 @@
           "attributes": { "type": "gp3", "size_gb": 100, "iops": 3000, "throughput_mibps": 125 }
         }
       },
-      "DiskUtilMetricsResponse": {
+      "DiskUtilMetricsResponse_Output": {
         "type": "object",
         "properties": {
           "timestamp": { "type": "string" },
@@ -12656,7 +12826,7 @@
         },
         "required": ["timestamp", "metrics"]
       },
-      "DiskAutoscaleConfig": {
+      "DiskAutoscaleConfig_Output": {
         "type": "object",
         "properties": {
           "growth_percent": {
@@ -12683,7 +12853,7 @@
         },
         "required": ["growth_percent", "min_increment_gb", "max_size_gb"]
       },
-      "StorageConfigResponse": {
+      "StorageConfigResponse_Output": {
         "type": "object",
         "properties": {
           "fileSizeLimit": {
@@ -12742,26 +12912,19 @@
             "type": "object",
             "properties": {
               "list_v2": { "type": "boolean" },
-              "iceberg_catalog": { "type": "boolean" }
+              "iceberg_catalog": { "type": "boolean" },
+              "object_versioning": { "type": "boolean" }
             },
-            "required": ["list_v2", "iceberg_catalog"]
+            "required": ["list_v2", "iceberg_catalog", "object_versioning"]
           },
           "external": {
             "type": "object",
             "properties": { "upstreamTarget": { "type": "string", "enum": ["main", "canary"] } },
             "required": ["upstreamTarget"]
           },
-          "migrationVersion": { "type": "string" },
-          "databasePoolMode": { "type": "string" }
+          "migrationVersion": { "type": "string", "nullable": true }
         },
-        "required": [
-          "fileSizeLimit",
-          "features",
-          "capabilities",
-          "external",
-          "migrationVersion",
-          "databasePoolMode"
-        ]
+        "required": ["fileSizeLimit", "features", "capabilities", "external", "migrationVersion"]
       },
       "UpdateStorageConfigBody": {
         "type": "object",
@@ -12823,7 +12986,7 @@
         },
         "additionalProperties": false
       },
-      "V1PgbouncerConfigResponse": {
+      "V1PgbouncerConfigResponse_Output": {
         "type": "object",
         "properties": {
           "default_pool_size": {
@@ -12861,7 +13024,7 @@
           }
         }
       },
-      "SupavisorConfigResponse": {
+      "SupavisorConfigResponse_Output": {
         "type": "object",
         "properties": {
           "identifier": { "type": "string" },
@@ -12923,7 +13086,7 @@
         },
         "example": { "default_pool_size": 25, "pool_mode": "transaction" }
       },
-      "UpdateSupavisorConfigResponse": {
+      "UpdateSupavisorConfigResponse_Output": {
         "type": "object",
         "properties": {
           "default_pool_size": {
@@ -12936,7 +13099,7 @@
         },
         "required": ["default_pool_size", "pool_mode"]
       },
-      "PostgresConfigResponse": {
+      "PostgresConfigResponse_Output": {
         "type": "object",
         "properties": {
           "effective_cache_size": { "type": "string" },
@@ -13094,7 +13257,7 @@
         },
         "additionalProperties": false
       },
-      "RealtimeConfigResponse": {
+      "RealtimeConfigResponse_Output": {
         "type": "object",
         "properties": {
           "private_only": {
@@ -13282,6 +13445,7 @@
                   "properties": {
                     "name": { "type": "string" },
                     "names": { "type": "array", "items": { "type": "string" } },
+                    "array": { "type": "boolean" },
                     "default": {
                       "anyOf": [
                         { "type": "object", "properties": {} },
@@ -13289,8 +13453,7 @@
                         { "type": "string" },
                         { "type": "boolean" }
                       ]
-                    },
-                    "array": { "type": "boolean" }
+                    }
                   }
                 }
               }
@@ -13321,7 +13484,7 @@
           }
         }
       },
-      "CreateProviderResponse": {
+      "CreateProviderResponse_Output": {
         "type": "object",
         "properties": {
           "id": { "type": "string" },
@@ -13341,6 +13504,7 @@
                       "properties": {
                         "name": { "type": "string" },
                         "names": { "type": "array", "items": { "type": "string" } },
+                        "array": { "type": "boolean" },
                         "default": {
                           "anyOf": [
                             { "type": "object", "properties": {} },
@@ -13348,8 +13512,7 @@
                             { "type": "string" },
                             { "type": "boolean" }
                           ]
-                        },
-                        "array": { "type": "boolean" }
+                        }
                       }
                     }
                   }
@@ -13384,7 +13547,7 @@
         },
         "required": ["id"]
       },
-      "ListProvidersResponse": {
+      "ListProvidersResponse_Output": {
         "type": "object",
         "properties": {
           "items": {
@@ -13409,6 +13572,7 @@
                             "properties": {
                               "name": { "type": "string" },
                               "names": { "type": "array", "items": { "type": "string" } },
+                              "array": { "type": "boolean" },
                               "default": {
                                 "anyOf": [
                                   { "type": "object", "properties": {} },
@@ -13416,8 +13580,7 @@
                                   { "type": "string" },
                                   { "type": "boolean" }
                                 ]
-                              },
-                              "array": { "type": "boolean" }
+                              }
                             }
                           }
                         }
@@ -13456,7 +13619,7 @@
         },
         "required": ["items"]
       },
-      "GetProviderResponse": {
+      "GetProviderResponse_Output": {
         "type": "object",
         "properties": {
           "id": { "type": "string" },
@@ -13476,6 +13639,7 @@
                       "properties": {
                         "name": { "type": "string" },
                         "names": { "type": "array", "items": { "type": "string" } },
+                        "array": { "type": "boolean" },
                         "default": {
                           "anyOf": [
                             { "type": "object", "properties": {} },
@@ -13483,8 +13647,7 @@
                             { "type": "string" },
                             { "type": "boolean" }
                           ]
-                        },
-                        "array": { "type": "boolean" }
+                        }
                       }
                     }
                   }
@@ -13535,6 +13698,7 @@
                   "properties": {
                     "name": { "type": "string" },
                     "names": { "type": "array", "items": { "type": "string" } },
+                    "array": { "type": "boolean" },
                     "default": {
                       "anyOf": [
                         { "type": "object", "properties": {} },
@@ -13542,8 +13706,7 @@
                         { "type": "string" },
                         { "type": "boolean" }
                       ]
-                    },
-                    "array": { "type": "boolean" }
+                    }
                   }
                 }
               }
@@ -13565,7 +13728,7 @@
           "domains": ["acme.com", "contractors.acme.com"]
         }
       },
-      "UpdateProviderResponse": {
+      "UpdateProviderResponse_Output": {
         "type": "object",
         "properties": {
           "id": { "type": "string" },
@@ -13585,6 +13748,7 @@
                       "properties": {
                         "name": { "type": "string" },
                         "names": { "type": "array", "items": { "type": "string" } },
+                        "array": { "type": "boolean" },
                         "default": {
                           "anyOf": [
                             { "type": "object", "properties": {} },
@@ -13592,8 +13756,7 @@
                             { "type": "string" },
                             { "type": "boolean" }
                           ]
-                        },
-                        "array": { "type": "boolean" }
+                        }
                       }
                     }
                   }
@@ -13628,7 +13791,7 @@
         },
         "required": ["id"]
       },
-      "DeleteProviderResponse": {
+      "DeleteProviderResponse_Output": {
         "type": "object",
         "properties": {
           "id": { "type": "string" },
@@ -13648,6 +13811,7 @@
                       "properties": {
                         "name": { "type": "string" },
                         "names": { "type": "array", "items": { "type": "string" } },
+                        "array": { "type": "boolean" },
                         "default": {
                           "anyOf": [
                             { "type": "object", "properties": {} },
@@ -13655,8 +13819,7 @@
                             { "type": "string" },
                             { "type": "boolean" }
                           ]
-                        },
-                        "array": { "type": "boolean" }
+                        }
                       }
                     }
                   }
@@ -13691,7 +13854,7 @@
         },
         "required": ["id"]
       },
-      "V1BackupsResponse": {
+      "V1BackupsResponse_Output": {
         "type": "object",
         "properties": {
           "region": { "type": "string" },
@@ -13762,7 +13925,7 @@
           "completed_on": {
             "type": "string",
             "format": "date-time",
-            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$",
             "nullable": true
           }
         },
@@ -13776,7 +13939,7 @@
         "required": ["id"],
         "example": { "id": 12345 }
       },
-      "V1BackupScheduleResponse": {
+      "V1BackupScheduleResponse_Output": {
         "type": "object",
         "properties": {
           "schedule_for": {
@@ -13814,7 +13977,7 @@
         "required": ["name"],
         "example": { "name": "before-upgrade" }
       },
-      "V1ListEntitlementsResponse": {
+      "V1ListEntitlementsResponse_Output": {
         "type": "object",
         "properties": {
           "entitlements": {
@@ -13934,7 +14097,7 @@
         },
         "required": ["entitlements"]
       },
-      "V1OrganizationMemberResponse": {
+      "V1OrganizationMemberResponse_Output": {
         "type": "object",
         "properties": {
           "user_id": { "type": "string" },
@@ -13944,9 +14107,9 @@
           "mfa_enabled": { "type": "boolean" },
           "avatar_url": { "type": "string", "nullable": true }
         },
-        "required": ["user_id", "user_name", "role_name", "mfa_enabled", "avatar_url"]
+        "required": ["user_id", "user_name", "mfa_enabled", "avatar_url"]
       },
-      "V1OrganizationSlugResponse": {
+      "V1OrganizationSlugResponse_Output": {
         "type": "object",
         "properties": {
           "id": { "type": "string" },
@@ -13972,7 +14135,7 @@
         },
         "required": ["id", "name", "opt_in_tags", "allowed_release_channels"]
       },
-      "OrganizationProjectClaimResponse": {
+      "OrganizationProjectClaimResponse_Output": {
         "type": "object",
         "properties": {
           "project": {
@@ -14046,7 +14209,7 @@
         },
         "required": ["project", "preview", "expires_at", "created_at", "created_by"]
       },
-      "OrganizationProjectsResponse": {
+      "OrganizationProjectsResponse_Output": {
         "type": "object",
         "properties": {
           "projects": {

--- a/apps/docs/spec/api_v2_openapi.json
+++ b/apps/docs/spec/api_v2_openapi.json
@@ -24,7 +24,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ListLogDrainsResponse" }
+                "schema": { "$ref": "#/components/schemas/ListLogDrainsResponse_Output" }
               }
             }
           },
@@ -57,7 +57,7 @@
         "summary": "List project log drains",
         "tags": ["Analytics"],
         "x-badges": [{ "name": "OAuth scope: analytics_config:read", "position": "after" }],
-        "x-endpoint-owners": ["analytics"],
+        "x-endpoint-owners": ["observability"],
         "x-fga-permissions": [["analytics_config_read"]],
         "x-oauth-scope": "analytics_config:read"
       },
@@ -90,7 +90,9 @@
           "201": {
             "description": "",
             "content": {
-              "application/json": { "schema": { "$ref": "#/components/schemas/LogDrainResponse" } }
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/LogDrainResponse_Output" }
+              }
             }
           },
           "401": {
@@ -132,7 +134,7 @@
           { "name": "Only available on Pro, Team, Enterprise", "position": "before" },
           { "name": "OAuth scope: analytics_config:write", "position": "after" }
         ],
-        "x-endpoint-owners": ["analytics"],
+        "x-endpoint-owners": ["observability"],
         "x-fga-permissions": [["analytics_config_write"]],
         "x-oauth-scope": "analytics_config:write"
       }
@@ -178,7 +180,9 @@
           "200": {
             "description": "",
             "content": {
-              "application/json": { "schema": { "$ref": "#/components/schemas/LogDrainResponse" } }
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/LogDrainResponse_Output" }
+              }
             }
           },
           "401": {
@@ -210,7 +214,7 @@
         "summary": "Update a project log drain",
         "tags": ["Analytics"],
         "x-badges": [{ "name": "OAuth scope: analytics_config:write", "position": "after" }],
-        "x-endpoint-owners": ["analytics"],
+        "x-endpoint-owners": ["observability"],
         "x-fga-permissions": [["analytics_config_write"]],
         "x-oauth-scope": "analytics_config:write"
       },
@@ -273,9 +277,152 @@
         "summary": "Delete a project log drain",
         "tags": ["Analytics"],
         "x-badges": [{ "name": "OAuth scope: analytics_config:write", "position": "after" }],
-        "x-endpoint-owners": ["analytics"],
+        "x-endpoint-owners": ["observability"],
         "x-fga-permissions": [["analytics_config_write"]],
         "x-oauth-scope": "analytics_config:write"
+      }
+    },
+    "/v2/projects/{ref}/advisors/run": {
+      "post": {
+        "operationId": "v2-run-project-advisors",
+        "parameters": [
+          {
+            "name": "ref",
+            "required": true,
+            "in": "path",
+            "description": "Project ref",
+            "schema": {
+              "minLength": 20,
+              "maxLength": 20,
+              "pattern": "^[a-z]+$",
+              "example": "abcdefghijklmnopqrst",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/V2RunProjectAdvisorsBody" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/V2ProjectAdvisorsResponse_Output" }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponseBody" } }
+            }
+          },
+          "403": {
+            "description": "Forbidden action",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponseBody" } }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponseBody" } }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "Runs the project advisors with the given names",
+        "tags": ["Advisors"],
+        "x-endpoint-owners": ["control-plane"],
+        "x-fga-permissions": [["advisors_read"]]
+      }
+    },
+    "/v2/projects/{ref}/branches": {
+      "post": {
+        "description": "Creates a database branch from the specified project. Compute and disk size can be set here so the branch is provisioned at the requested size, instead of being resized after creation.",
+        "operationId": "v2-create-a-branch",
+        "parameters": [
+          {
+            "name": "ref",
+            "required": true,
+            "in": "path",
+            "description": "Project ref",
+            "schema": {
+              "minLength": 20,
+              "maxLength": 20,
+              "pattern": "^[a-z]+$",
+              "example": "abcdefghijklmnopqrst",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/V2CreateBranchRequest" }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/V2BranchResponse_Output" }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid branch configuration for this project",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponseBody" } }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponseBody" } }
+            }
+          },
+          "402": {
+            "description": "Organization plan does not cover the requested branch",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponseBody" } }
+            }
+          },
+          "403": {
+            "description": "Forbidden action",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponseBody" } }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponseBody" } }
+            }
+          },
+          "500": {
+            "description": "Failed to create database branch",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponseBody" } }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "Create a database branch",
+        "tags": ["Environments"],
+        "x-badges": [{ "name": "OAuth scope: environment:write", "position": "after" }],
+        "x-endpoint-owners": ["dev-workflows"],
+        "x-fga-permissions": [["branching_development_create"], ["branching_production_create"]],
+        "x-oauth-scope": "environment:write"
       }
     },
     "/v2/projects/{ref}/config": {
@@ -302,7 +449,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/V2ProjectConfigResponse" }
+                "schema": { "$ref": "#/components/schemas/V2ProjectConfigResponse_Output" }
               }
             }
           },
@@ -374,7 +521,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/V2PreviewProjectTransferResponse" }
+                "schema": { "$ref": "#/components/schemas/V2PreviewProjectTransferResponse_Output" }
               }
             }
           },
@@ -481,7 +628,9 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/V2ListPrivateLinkAssociationsResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/V2ListPrivateLinkAssociationsResponse_Output"
+                }
               }
             }
           },
@@ -547,7 +696,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/V2PrivateLinkAssociationResponse" }
+                "schema": { "$ref": "#/components/schemas/V2PrivateLinkAssociationResponse_Output" }
               }
             }
           },
@@ -742,7 +891,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/V2ListWorkersResponse" }
+                "schema": { "$ref": "#/components/schemas/V2ListWorkersResponse_Output" }
               }
             }
           },
@@ -807,7 +956,9 @@
           "200": {
             "description": "",
             "content": {
-              "application/json": { "schema": { "$ref": "#/components/schemas/V2WorkerResponse" } }
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/V2WorkerResponse_Output" }
+              }
             }
           },
           "401": {
@@ -929,7 +1080,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/V2WorkerUploadResponse" }
+                "schema": { "$ref": "#/components/schemas/V2WorkerUploadResponse_Output" }
               }
             }
           },
@@ -1002,7 +1153,9 @@
           "202": {
             "description": "",
             "content": {
-              "application/json": { "schema": { "$ref": "#/components/schemas/V2WorkerResponse" } }
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/V2WorkerResponse_Output" }
+              }
             }
           },
           "401": {
@@ -1094,7 +1247,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/V2ListMembersResponse" }
+                "schema": { "$ref": "#/components/schemas/V2ListMembersResponse_Output" }
               }
             }
           },
@@ -1166,7 +1319,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/OrganizationMemberRoleResponse" }
+                "schema": { "$ref": "#/components/schemas/OrganizationMemberRoleResponse_Output" }
               }
             }
           },
@@ -1232,7 +1385,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/V2ListRolesResponse" }
+                "schema": { "$ref": "#/components/schemas/V2ListRolesResponse_Output" }
               }
             }
           },
@@ -1294,7 +1447,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/V2CreateInvitationsResponse" }
+                "schema": { "$ref": "#/components/schemas/V2CreateInvitationsResponse_Output" }
               }
             }
           },
@@ -1364,7 +1517,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/V2DeleteInvitationsResponse" }
+                "schema": { "$ref": "#/components/schemas/V2DeleteInvitationsResponse_Output" }
               }
             }
           },
@@ -1460,7 +1613,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/V2ListProjectsResponse" }
+                "schema": { "$ref": "#/components/schemas/V2ListProjectsResponse_Output" }
               }
             }
           },
@@ -1561,7 +1714,7 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/V2ListGitHubConnectionsResponse" }
+                "schema": { "$ref": "#/components/schemas/V2ListGitHubConnectionsResponse_Output" }
               }
             }
           },
@@ -7600,7 +7753,6 @@
                                     }
                                   },
                                   "required": ["organization_slug", "project_ref"],
-                                  "additionalProperties": {},
                                   "description": "Final data sent to the consumer."
                                 },
                                 "timestamp": {
@@ -14778,7 +14930,6 @@
                                     }
                                   },
                                   "required": ["organization_slug", "project_ref"],
-                                  "additionalProperties": {},
                                   "description": "Final data sent to the consumer."
                                 },
                                 "timestamp": {
@@ -15977,7 +16128,7 @@
   "components": {
     "securitySchemes": { "bearer": { "scheme": "bearer", "bearerFormat": "JWT", "type": "http" } },
     "schemas": {
-      "ListLogDrainsResponse": {
+      "ListLogDrainsResponse_Output": {
         "type": "object",
         "properties": {
           "data": {
@@ -16001,19 +16152,6 @@
                         {
                           "type": "object",
                           "properties": {
-                            "url": { "type": "string", "nullable": true },
-                            "schema": { "type": "string" },
-                            "username": { "type": "string", "nullable": true },
-                            "password": { "type": "string", "nullable": true },
-                            "port": { "type": "number", "nullable": true },
-                            "hostname": { "type": "string" }
-                          },
-                          "additionalProperties": false,
-                          "title": "postgres"
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
                             "url": { "type": "string" },
                             "http": { "type": "string", "enum": ["http1", "http2"] },
                             "gzip": { "type": "boolean" },
@@ -16022,17 +16160,7 @@
                               "additionalProperties": { "type": "string" }
                             }
                           },
-                          "additionalProperties": false,
                           "title": "webhook"
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "project_id": { "type": "string" },
-                            "dataset_id": { "type": "string" }
-                          },
-                          "additionalProperties": false,
-                          "title": "bigquery"
                         },
                         {
                           "type": "object",
@@ -16040,7 +16168,6 @@
                             "api_key": { "type": "string" },
                             "region": { "type": "string" }
                           },
-                          "additionalProperties": false,
                           "title": "datadog"
                         },
                         {
@@ -16054,13 +16181,11 @@
                               "additionalProperties": { "type": "string" }
                             }
                           },
-                          "additionalProperties": false,
                           "title": "loki"
                         },
                         {
                           "type": "object",
                           "properties": { "dsn": { "type": "string" } },
-                          "additionalProperties": false,
                           "title": "sentry"
                         },
                         {
@@ -16070,7 +16195,6 @@
                             "api_token": { "type": "string" },
                             "dataset_name": { "type": "string" }
                           },
-                          "additionalProperties": false,
                           "title": "axiom"
                         },
                         {
@@ -16085,8 +16209,45 @@
                             "client_cert": { "type": "string" },
                             "client_key": { "type": "string" }
                           },
-                          "additionalProperties": false,
                           "title": "syslog"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "s3_bucket": { "type": "string" },
+                            "storage_region": { "type": "string" },
+                            "access_key_id": { "type": "string" },
+                            "secret_access_key": { "type": "string" },
+                            "batch_timeout": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            }
+                          },
+                          "title": "s3"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "region": { "type": "string" },
+                            "username": { "type": "string" },
+                            "password": { "type": "string" }
+                          },
+                          "title": "last9"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "endpoint": { "type": "string" },
+                            "protocol": { "default": "http/protobuf", "type": "string" },
+                            "gzip": { "default": true, "type": "boolean" },
+                            "headers": {
+                              "default": {},
+                              "type": "object",
+                              "additionalProperties": { "type": "string" }
+                            }
+                          },
+                          "title": "otlp"
                         }
                       ]
                     },
@@ -16172,19 +16333,6 @@
                       {
                         "type": "object",
                         "properties": {
-                          "url": { "type": "string", "nullable": true },
-                          "schema": { "type": "string" },
-                          "username": { "type": "string", "nullable": true },
-                          "password": { "type": "string", "nullable": true },
-                          "port": { "type": "number", "nullable": true },
-                          "hostname": { "type": "string" }
-                        },
-                        "additionalProperties": false,
-                        "title": "postgres"
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
                           "url": { "type": "string" },
                           "http": { "type": "string", "enum": ["http1", "http2"] },
                           "gzip": { "type": "boolean" },
@@ -16195,15 +16343,6 @@
                         },
                         "additionalProperties": false,
                         "title": "webhook"
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "project_id": { "type": "string" },
-                          "dataset_id": { "type": "string" }
-                        },
-                        "additionalProperties": false,
-                        "title": "bigquery"
                       },
                       {
                         "type": "object",
@@ -16258,6 +16397,47 @@
                         },
                         "additionalProperties": false,
                         "title": "syslog"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "s3_bucket": { "type": "string" },
+                          "storage_region": { "type": "string" },
+                          "access_key_id": { "type": "string" },
+                          "secret_access_key": { "type": "string" },
+                          "batch_timeout": {
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          }
+                        },
+                        "additionalProperties": false,
+                        "title": "s3"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "region": { "type": "string" },
+                          "username": { "type": "string" },
+                          "password": { "type": "string" }
+                        },
+                        "additionalProperties": false,
+                        "title": "last9"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "endpoint": { "type": "string" },
+                          "protocol": { "default": "http/protobuf", "type": "string" },
+                          "gzip": { "default": true, "type": "boolean" },
+                          "headers": {
+                            "default": {},
+                            "type": "object",
+                            "additionalProperties": { "type": "string" }
+                          }
+                        },
+                        "additionalProperties": false,
+                        "title": "otlp"
                       }
                     ]
                   },
@@ -16279,7 +16459,8 @@
                     ]
                   }
                 },
-                "required": ["name", "config", "backend_type"]
+                "required": ["name", "config", "backend_type"],
+                "additionalProperties": {}
               }
             },
             "required": ["type", "attributes"]
@@ -16287,7 +16468,7 @@
         },
         "required": ["data"]
       },
-      "LogDrainResponse": {
+      "LogDrainResponse_Output": {
         "type": "object",
         "properties": {
           "data": {
@@ -16305,19 +16486,6 @@
                       {
                         "type": "object",
                         "properties": {
-                          "url": { "type": "string", "nullable": true },
-                          "schema": { "type": "string" },
-                          "username": { "type": "string", "nullable": true },
-                          "password": { "type": "string", "nullable": true },
-                          "port": { "type": "number", "nullable": true },
-                          "hostname": { "type": "string" }
-                        },
-                        "additionalProperties": false,
-                        "title": "postgres"
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
                           "url": { "type": "string" },
                           "http": { "type": "string", "enum": ["http1", "http2"] },
                           "gzip": { "type": "boolean" },
@@ -16326,17 +16494,7 @@
                             "additionalProperties": { "type": "string" }
                           }
                         },
-                        "additionalProperties": false,
                         "title": "webhook"
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "project_id": { "type": "string" },
-                          "dataset_id": { "type": "string" }
-                        },
-                        "additionalProperties": false,
-                        "title": "bigquery"
                       },
                       {
                         "type": "object",
@@ -16344,7 +16502,6 @@
                           "api_key": { "type": "string" },
                           "region": { "type": "string" }
                         },
-                        "additionalProperties": false,
                         "title": "datadog"
                       },
                       {
@@ -16358,13 +16515,11 @@
                             "additionalProperties": { "type": "string" }
                           }
                         },
-                        "additionalProperties": false,
                         "title": "loki"
                       },
                       {
                         "type": "object",
                         "properties": { "dsn": { "type": "string" } },
-                        "additionalProperties": false,
                         "title": "sentry"
                       },
                       {
@@ -16374,7 +16529,6 @@
                           "api_token": { "type": "string" },
                           "dataset_name": { "type": "string" }
                         },
-                        "additionalProperties": false,
                         "title": "axiom"
                       },
                       {
@@ -16389,8 +16543,45 @@
                           "client_cert": { "type": "string" },
                           "client_key": { "type": "string" }
                         },
-                        "additionalProperties": false,
                         "title": "syslog"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "s3_bucket": { "type": "string" },
+                          "storage_region": { "type": "string" },
+                          "access_key_id": { "type": "string" },
+                          "secret_access_key": { "type": "string" },
+                          "batch_timeout": {
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          }
+                        },
+                        "title": "s3"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "region": { "type": "string" },
+                          "username": { "type": "string" },
+                          "password": { "type": "string" }
+                        },
+                        "title": "last9"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "endpoint": { "type": "string" },
+                          "protocol": { "default": "http/protobuf", "type": "string" },
+                          "gzip": { "default": true, "type": "boolean" },
+                          "headers": {
+                            "default": {},
+                            "type": "object",
+                            "additionalProperties": { "type": "string" }
+                          }
+                        },
+                        "title": "otlp"
                       }
                     ]
                   },
@@ -16437,19 +16628,6 @@
                       {
                         "type": "object",
                         "properties": {
-                          "url": { "type": "string", "nullable": true },
-                          "schema": { "type": "string" },
-                          "username": { "type": "string", "nullable": true },
-                          "password": { "type": "string", "nullable": true },
-                          "port": { "type": "number", "nullable": true },
-                          "hostname": { "type": "string" }
-                        },
-                        "additionalProperties": false,
-                        "title": "postgres"
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
                           "url": { "type": "string" },
                           "http": { "type": "string", "enum": ["http1", "http2"] },
                           "gzip": { "type": "boolean" },
@@ -16460,15 +16638,6 @@
                         },
                         "additionalProperties": false,
                         "title": "webhook"
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "project_id": { "type": "string" },
-                          "dataset_id": { "type": "string" }
-                        },
-                        "additionalProperties": false,
-                        "title": "bigquery"
                       },
                       {
                         "type": "object",
@@ -16523,6 +16692,47 @@
                         },
                         "additionalProperties": false,
                         "title": "syslog"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "s3_bucket": { "type": "string" },
+                          "storage_region": { "type": "string" },
+                          "access_key_id": { "type": "string" },
+                          "secret_access_key": { "type": "string" },
+                          "batch_timeout": {
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          }
+                        },
+                        "additionalProperties": false,
+                        "title": "s3"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "region": { "type": "string" },
+                          "username": { "type": "string" },
+                          "password": { "type": "string" }
+                        },
+                        "additionalProperties": false,
+                        "title": "last9"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "endpoint": { "type": "string" },
+                          "protocol": { "default": "http/protobuf", "type": "string" },
+                          "gzip": { "default": true, "type": "boolean" },
+                          "headers": {
+                            "default": {},
+                            "type": "object",
+                            "additionalProperties": { "type": "string" }
+                          }
+                        },
+                        "additionalProperties": false,
+                        "title": "otlp"
                       }
                     ]
                   },
@@ -16544,7 +16754,8 @@
                     ]
                   }
                 },
-                "required": ["backend_type"]
+                "required": ["backend_type"],
+                "additionalProperties": {}
               }
             },
             "required": ["type", "attributes"]
@@ -16552,7 +16763,377 @@
         },
         "required": ["data"]
       },
-      "V2ProjectConfigResponse": {
+      "V2RunProjectAdvisorsBody": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "Resource type.",
+                "enum": ["project_advisors"]
+              },
+              "attributes": {
+                "type": "object",
+                "properties": {
+                  "lints": {
+                    "minItems": 1,
+                    "maxItems": 10,
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "enum": [
+                            "unindexed_foreign_keys",
+                            "auth_users_exposed",
+                            "auth_rls_initplan",
+                            "no_primary_key",
+                            "unused_index",
+                            "multiple_permissive_policies",
+                            "policy_exists_rls_disabled",
+                            "rls_enabled_no_policy",
+                            "duplicate_index",
+                            "security_definer_view",
+                            "function_search_path_mutable",
+                            "rls_disabled_in_public",
+                            "extension_in_public",
+                            "rls_references_user_metadata",
+                            "materialized_view_in_api",
+                            "foreign_table_in_api",
+                            "unsupported_reg_types",
+                            "auth_otp_long_expiry",
+                            "auth_otp_short_length",
+                            "ssl_not_enforced",
+                            "log_connections_not_enabled",
+                            "network_restrictions_not_set",
+                            "password_requirements_min_length",
+                            "pitr_not_enabled",
+                            "auth_leaked_password_protection",
+                            "auth_insufficient_mfa_options",
+                            "auth_password_policy_missing",
+                            "leaked_service_key",
+                            "no_backup_admin",
+                            "vulnerable_postgres_version",
+                            "db_not_reachable",
+                            "db_connection_failing",
+                            "db_connection_limit_reached",
+                            "instance_telemetry_lost",
+                            "instance_db_down",
+                            "instance_alert_firing",
+                            "log_data_api_error_rate_high",
+                            "log_auth_error_rate_high",
+                            "log_storage_error_rate_high",
+                            "log_edge_function_error_rate_high"
+                          ]
+                        }
+                      },
+                      "required": ["name"],
+                      "additionalProperties": false
+                    }
+                  }
+                },
+                "required": ["lints"],
+                "additionalProperties": false
+              }
+            },
+            "required": ["type", "attributes"],
+            "additionalProperties": {}
+          }
+        },
+        "required": ["data"]
+      },
+      "V2ProjectAdvisorsResponse_Output": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "Resource type.",
+                "enum": ["project_advisors"]
+              },
+              "attributes": {
+                "type": "object",
+                "properties": {
+                  "lints": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "enum": [
+                            "unindexed_foreign_keys",
+                            "auth_users_exposed",
+                            "auth_rls_initplan",
+                            "no_primary_key",
+                            "unused_index",
+                            "multiple_permissive_policies",
+                            "policy_exists_rls_disabled",
+                            "rls_enabled_no_policy",
+                            "duplicate_index",
+                            "security_definer_view",
+                            "function_search_path_mutable",
+                            "rls_disabled_in_public",
+                            "extension_in_public",
+                            "rls_references_user_metadata",
+                            "materialized_view_in_api",
+                            "foreign_table_in_api",
+                            "unsupported_reg_types",
+                            "auth_otp_long_expiry",
+                            "auth_otp_short_length",
+                            "ssl_not_enforced",
+                            "log_connections_not_enabled",
+                            "network_restrictions_not_set",
+                            "password_requirements_min_length",
+                            "pitr_not_enabled",
+                            "auth_leaked_password_protection",
+                            "auth_insufficient_mfa_options",
+                            "auth_password_policy_missing",
+                            "leaked_service_key",
+                            "no_backup_admin",
+                            "vulnerable_postgres_version",
+                            "db_not_reachable",
+                            "db_connection_failing",
+                            "db_connection_limit_reached",
+                            "instance_telemetry_lost",
+                            "instance_db_down",
+                            "instance_alert_firing",
+                            "log_data_api_error_rate_high",
+                            "log_auth_error_rate_high",
+                            "log_storage_error_rate_high",
+                            "log_edge_function_error_rate_high",
+                            "project_not_active",
+                            "advisor_check_unavailable"
+                          ]
+                        },
+                        "title": { "type": "string" },
+                        "level": { "type": "string", "enum": ["ERROR", "WARN", "INFO"] },
+                        "facing": { "type": "string", "enum": ["EXTERNAL"] },
+                        "categories": {
+                          "type": "array",
+                          "items": {
+                            "type": "string",
+                            "enum": ["PERFORMANCE", "SECURITY", "HEALTH"]
+                          },
+                          "x-ignore-array-items-must-be-objects": true
+                        },
+                        "description": { "type": "string" },
+                        "detail": { "type": "string" },
+                        "remediation": { "type": "string" },
+                        "metadata": {
+                          "type": "object",
+                          "properties": {
+                            "schema": { "type": "string" },
+                            "name": { "type": "string" },
+                            "entity": { "type": "string" },
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "table",
+                                "view",
+                                "materialized view",
+                                "foreign table",
+                                "auth",
+                                "function",
+                                "extension",
+                                "compliance",
+                                "health"
+                              ]
+                            },
+                            "fkey_name": { "type": "string" },
+                            "fkey_columns": {
+                              "x-ignore-array-items-must-be-objects": true,
+                              "type": "array",
+                              "items": { "type": "number" }
+                            }
+                          }
+                        },
+                        "cache_key": { "type": "string" },
+                        "observed_at": {
+                          "type": "string",
+                          "format": "date-time",
+                          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "title",
+                        "level",
+                        "facing",
+                        "categories",
+                        "description",
+                        "detail",
+                        "remediation",
+                        "cache_key"
+                      ]
+                    }
+                  }
+                },
+                "required": ["lints"]
+              }
+            },
+            "required": ["type", "attributes"]
+          }
+        },
+        "required": ["data"]
+      },
+      "V2CreateBranchRequest": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "type": { "type": "string", "description": "Resource type.", "enum": ["branch"] },
+              "attributes": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Name of the branch.",
+                    "example": "preview-login-page"
+                  },
+                  "git_branch": {
+                    "description": "Git branch to track. Must exist on the connected GitHub repository when the project has one.",
+                    "example": "feature/login-page",
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "region": {
+                    "description": "Region to create the branch in. Omit to inherit the region of the project it branches from.",
+                    "type": "string"
+                  },
+                  "persistent": {
+                    "description": "Whether the branch is kept when its git branch is deleted or its PR is merged.",
+                    "type": "boolean"
+                  },
+                  "with_data": {
+                    "description": "Whether to seed the branch from the project's latest physical backup.",
+                    "type": "boolean"
+                  },
+                  "desired_instance_size": {
+                    "description": "Desired instance size. Omit this field to always default to the smallest possible size.",
+                    "type": "string",
+                    "enum": [
+                      "nano",
+                      "micro",
+                      "small",
+                      "medium",
+                      "large",
+                      "xlarge",
+                      "2xlarge",
+                      "4xlarge",
+                      "8xlarge",
+                      "12xlarge",
+                      "16xlarge",
+                      "24xlarge",
+                      "24xlarge_optimized_memory",
+                      "24xlarge_optimized_cpu",
+                      "24xlarge_high_memory",
+                      "48xlarge",
+                      "48xlarge_optimized_memory",
+                      "48xlarge_optimized_cpu",
+                      "48xlarge_high_memory"
+                    ]
+                  },
+                  "desired_disk_size_gb": {
+                    "description": "Desired disk size in GB. Omit this field to default to the smallest disk size available on the plan.",
+                    "type": "integer",
+                    "minimum": 8,
+                    "maximum": 61440
+                  },
+                  "notify_url": {
+                    "description": "HTTP endpoint to receive branch status updates.",
+                    "example": "https://example.com/webhooks/branches",
+                    "type": "string",
+                    "format": "uri"
+                  }
+                },
+                "required": ["name"]
+              }
+            },
+            "required": ["type", "attributes"]
+          }
+        },
+        "required": ["data"]
+      },
+      "V2BranchResponse_Output": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "type": { "type": "string", "description": "Resource type.", "enum": ["branch"] },
+              "id": {
+                "type": "string",
+                "format": "uuid",
+                "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
+                "description": "ID of the branch."
+              },
+              "attributes": {
+                "type": "object",
+                "properties": {
+                  "name": { "type": "string", "description": "Name of the branch." },
+                  "project_ref": {
+                    "type": "string",
+                    "description": "Ref of the project backing this branch."
+                  },
+                  "parent_project_ref": {
+                    "type": "string",
+                    "description": "Ref of the project it branches from."
+                  },
+                  "is_default": {
+                    "type": "boolean",
+                    "description": "Whether this is the default branch of the project."
+                  },
+                  "persistent": {
+                    "type": "boolean",
+                    "description": "Whether the branch is kept when its git branch is deleted or its PR is merged."
+                  },
+                  "with_data": {
+                    "type": "boolean",
+                    "description": "Whether the branch is seeded from the project's data."
+                  },
+                  "git_branch": { "description": "Git branch being tracked.", "type": "string" },
+                  "notify_url": {
+                    "description": "HTTP endpoint receiving branch status updates.",
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "created_at": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Creation timestamp."
+                  },
+                  "updated_at": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Last update timestamp."
+                  }
+                },
+                "required": [
+                  "name",
+                  "project_ref",
+                  "parent_project_ref",
+                  "is_default",
+                  "persistent",
+                  "with_data",
+                  "created_at",
+                  "updated_at"
+                ]
+              }
+            },
+            "required": ["type", "id", "attributes"]
+          }
+        },
+        "required": ["data"]
+      },
+      "V2ProjectConfigResponse_Output": {
         "type": "object",
         "properties": {
           "data": {
@@ -16956,21 +17537,20 @@
                         "type": "object",
                         "properties": {
                           "list_v2": { "type": "boolean" },
-                          "iceberg_catalog": { "type": "boolean" }
+                          "iceberg_catalog": { "type": "boolean" },
+                          "object_versioning": { "type": "boolean" }
                         },
-                        "required": ["list_v2", "iceberg_catalog"]
+                        "required": ["list_v2", "iceberg_catalog", "object_versioning"]
                       },
                       "upstream_target": { "type": "string", "enum": ["main", "canary"] },
-                      "migration_version": { "type": "string" },
-                      "database_pool_mode": { "type": "string" }
+                      "migration_version": { "type": "string", "nullable": true }
                     },
                     "required": [
                       "file_size_limit",
                       "features",
                       "capabilities",
                       "upstream_target",
-                      "migration_version",
-                      "database_pool_mode"
+                      "migration_version"
                     ],
                     "description": "Read from the storage service's admin API rather than the middleware DB, so unlike the rest of this resource it reflects the tenant's live config."
                   }
@@ -17005,7 +17585,7 @@
         },
         "required": ["data"]
       },
-      "V2PreviewProjectTransferResponse": {
+      "V2PreviewProjectTransferResponse_Output": {
         "type": "object",
         "properties": {
           "data": {
@@ -17062,7 +17642,7 @@
         },
         "required": ["data"]
       },
-      "V2ListPrivateLinkAssociationsResponse": {
+      "V2ListPrivateLinkAssociationsResponse_Output": {
         "type": "object",
         "properties": {
           "data": {
@@ -17185,7 +17765,7 @@
         },
         "required": ["data"]
       },
-      "V2PrivateLinkAssociationResponse": {
+      "V2PrivateLinkAssociationResponse_Output": {
         "type": "object",
         "properties": {
           "data": {
@@ -17266,7 +17846,7 @@
         },
         "required": ["data"]
       },
-      "V2ListWorkersResponse": {
+      "V2ListWorkersResponse_Output": {
         "type": "object",
         "properties": {
           "data": {
@@ -17340,7 +17920,7 @@
         },
         "required": ["data"]
       },
-      "V2WorkerResponse": {
+      "V2WorkerResponse_Output": {
         "type": "object",
         "properties": {
           "data": {
@@ -17411,7 +17991,7 @@
         },
         "required": ["data"]
       },
-      "V2WorkerUploadResponse": {
+      "V2WorkerUploadResponse_Output": {
         "type": "object",
         "properties": {
           "data": {
@@ -17490,7 +18070,7 @@
         },
         "required": ["data"]
       },
-      "V2ListMembersResponse": {
+      "V2ListMembersResponse_Output": {
         "type": "object",
         "properties": {
           "data": {
@@ -17658,7 +18238,7 @@
         },
         "required": ["data"]
       },
-      "OrganizationMemberRoleResponse": {
+      "OrganizationMemberRoleResponse_Output": {
         "type": "object",
         "properties": {
           "data": {
@@ -17700,7 +18280,7 @@
         },
         "required": ["data"]
       },
-      "V2ListRolesResponse": {
+      "V2ListRolesResponse_Output": {
         "type": "object",
         "properties": {
           "data": {
@@ -17790,7 +18370,7 @@
         },
         "required": ["data"]
       },
-      "V2CreateInvitationsResponse": {
+      "V2CreateInvitationsResponse_Output": {
         "type": "object",
         "properties": {
           "error": {
@@ -17925,7 +18505,7 @@
         },
         "required": ["data"]
       },
-      "V2DeleteInvitationsResponse": {
+      "V2DeleteInvitationsResponse_Output": {
         "type": "object",
         "properties": {
           "data": {
@@ -17958,7 +18538,7 @@
         },
         "required": ["data"]
       },
-      "V2ListProjectsResponse": {
+      "V2ListProjectsResponse_Output": {
         "type": "object",
         "properties": {
           "data": {
@@ -18119,7 +18699,7 @@
         },
         "required": ["data", "links"]
       },
-      "V2ListGitHubConnectionsResponse": {
+      "V2ListGitHubConnectionsResponse_Output": {
         "type": "object",
         "properties": {
           "data": {

--- a/apps/docs/spec/common-api-sections.json
+++ b/apps/docs/spec/common-api-sections.json
@@ -21,6 +21,12 @@
         "title": "Get security advisors",
         "slug": "v1-get-security-advisors",
         "type": "operation"
+      },
+      {
+        "id": "v2-run-project-advisors",
+        "title": "Run project advisors",
+        "slug": "v2-run-project-advisors",
+        "type": "operation"
       }
     ]
   },
@@ -608,6 +614,12 @@
         "id": "v1-create-a-branch",
         "title": "Create a branch",
         "slug": "v1-create-a-branch",
+        "type": "operation"
+      },
+      {
+        "id": "v2-create-a-branch",
+        "title": "Create a branch",
+        "slug": "v2-create-a-branch",
         "type": "operation"
       },
       {

--- a/apps/docs/spec/sections/generateAccessControlPartials.mts
+++ b/apps/docs/spec/sections/generateAccessControlPartials.mts
@@ -89,9 +89,6 @@ const permissionRows: PermissionRow[] = PERMISSION_CATALOG_BY_CATEGORY.flatMap((
 
 const rowByScope = new Map(permissionRows.flatMap((row) => row.scopes.map((scope) => [scope, row])))
 
-// Workers permissions are present in the API spec but are not live for scoped PATs yet.
-const EXCLUDED_SCOPES = new Set(['workers_read', 'workers_write'])
-
 // The public v2 webhook operations currently omit x-fga-permissions from the OpenAPI projection.
 // Keep this fallback narrow so the generated table can still link those endpoints, and fail below
 // if any other public operation has not been classified for the scoped-PAT table.
@@ -136,7 +133,6 @@ function webhookPermissionGroups(
 
 function knownGroups(groups: ScopeGroupAlternatives, missing: Set<string>) {
   return groups.filter((group) => {
-    if (group.some((scope) => EXCLUDED_SCOPES.has(scope))) return false
     const unknown = group.filter((scope) => !rowByScope.has(scope))
     unknown.forEach((scope) => missing.add(scope))
     return unknown.length === 0
@@ -265,12 +261,19 @@ function generatePermissionsPartial(specPaths: string[], tools: McpMap, outputPa
       const link = /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(endpoint.operationId)
         ? `[${label}](/docs/reference/api/${endpoint.operationId})`
         : label
-      const unlocksAlone = endpoint.groups.some((group) =>
+      // An endpoint can list alternative permission sets (e.g. reading API keys needs
+      // `api_gateway_keys_read`, and revealing their secret values needs that plus
+      // `api_gateway_keys_secret_read`). Only the alternatives that include this row's own scope
+      // say anything about this row, so the footnote ignores the rest.
+      const relevantGroups = endpoint.groups.filter((group) =>
+        group.some((scope) => rowScopes.has(scope))
+      )
+      const unlocksAlone = relevantGroups.some((group) =>
         group.every((scope) => rowScopes.has(scope))
       )
       let requirement = ''
       if (!unlocksAlone) {
-        const text = `Requires ${formatRequirement(endpoint.groups)}.`
+        const text = `Requires ${formatRequirement(relevantGroups)}.`
         const id = footnotes.get(text) ?? String(footnotes.size + 1)
         footnotes.set(text, id)
         requirement = `[^${id}]`

--- a/apps/docs/spec/transforms/api_v1_openapi_deparsed.json
+++ b/apps/docs/spec/transforms/api_v1_openapi_deparsed.json
@@ -6,7 +6,11 @@
     "version": "1.0.0",
     "contact": {}
   },
-  "servers": [],
+  "servers": [
+    {
+      "url": "https://api.supabase.com"
+    }
+  ],
   "tags": [
     {
       "name": "Advisors",
@@ -103,10 +107,19 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/BranchDetailResponse"
+                  "$ref": "#/components/schemas/BranchDetailResponse_Output"
                 }
               }
             }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden action"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
           },
           "500": {
             "description": "Failed to retrieve database branch"
@@ -175,10 +188,19 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/BranchResponse"
+                  "$ref": "#/components/schemas/BranchResponse_Output"
                 }
               }
             }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden action"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
           },
           "500": {
             "description": "Failed to update database branch"
@@ -247,10 +269,19 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/BranchDeleteResponse"
+                  "$ref": "#/components/schemas/BranchDeleteResponse_Output"
                 }
               }
             }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden action"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
           },
           "500": {
             "description": "Failed to delete database branch"
@@ -321,10 +352,19 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/BranchUpdateResponse"
+                  "$ref": "#/components/schemas/BranchUpdateResponse_Output"
                 }
               }
             }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden action"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
           },
           "500": {
             "description": "Failed to push database branch"
@@ -395,10 +435,19 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/BranchUpdateResponse"
+                  "$ref": "#/components/schemas/BranchUpdateResponse_Output"
                 }
               }
             }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden action"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
           },
           "500": {
             "description": "Failed to merge database branch"
@@ -469,10 +518,19 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/BranchUpdateResponse"
+                  "$ref": "#/components/schemas/BranchUpdateResponse_Output"
                 }
               }
             }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden action"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
           },
           "500": {
             "description": "Failed to reset database branch"
@@ -528,15 +586,24 @@
           }
         ],
         "responses": {
-          "200": {
+          "201": {
             "description": "",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/BranchRestoreResponse"
+                  "$ref": "#/components/schemas/BranchRestoreResponse_Output"
                 }
               }
             }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden action"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
           },
           "500": {
             "description": "Failed to restore database branch"
@@ -621,6 +688,15 @@
             },
             "description": ""
           },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden action"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
+          },
           "500": {
             "description": "Failed to diff database branch"
           }
@@ -656,7 +732,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/V1ProjectWithDatabaseResponse"
+                    "$ref": "#/components/schemas/V1ProjectWithDatabaseResponse_Output"
                   }
                 }
               }
@@ -708,7 +784,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/V1ProjectResponse"
+                  "$ref": "#/components/schemas/V1ProjectResponse_Output"
                 }
               }
             }
@@ -803,7 +879,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/RegionsInfo"
+                  "$ref": "#/components/schemas/RegionsInfo_Output"
                 }
               }
             }
@@ -839,7 +915,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/OrganizationResponseV1"
+                    "$ref": "#/components/schemas/OrganizationResponseV1_Output"
                   }
                 }
               }
@@ -894,7 +970,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/OrganizationResponseV1"
+                  "$ref": "#/components/schemas/OrganizationResponseV1_Output"
                 }
               }
             }
@@ -1037,6 +1113,15 @@
         "responses": {
           "204": {
             "description": ""
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden action"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
           }
         },
         "summary": "[Beta] Authorize user through oauth",
@@ -1065,10 +1150,19 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/OAuthTokenResponse"
+                  "$ref": "#/components/schemas/OAuthTokenResponse_Output"
                 }
               }
             }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden action"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
           }
         },
         "summary": "[Beta] Exchange auth code for user's access and refresh token",
@@ -1093,6 +1187,15 @@
         "responses": {
           "204": {
             "description": ""
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden action"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
           }
         },
         "summary": "[Beta] Revoke oauth app authorization and it's corresponding tokens",
@@ -1271,7 +1374,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SnippetList"
+                  "$ref": "#/components/schemas/SnippetList_Output"
                 }
               }
             }
@@ -1329,7 +1432,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SnippetResponse"
+                  "$ref": "#/components/schemas/SnippetResponse_Output"
                 }
               }
             }
@@ -1375,7 +1478,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/V1ProfileResponse"
+                  "$ref": "#/components/schemas/V1ProfileResponse_Output"
                 }
               }
             }
@@ -1497,7 +1600,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ListActionRunResponse"
+                  "$ref": "#/components/schemas/ListActionRunResponse_Output"
                 }
               }
             }
@@ -1568,7 +1671,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ActionRunResponse"
+                  "$ref": "#/components/schemas/ActionRunResponse_Output"
                 }
               }
             }
@@ -1649,7 +1752,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/UpdateRunStatusResponse"
+                  "$ref": "#/components/schemas/UpdateRunStatusResponse_Output"
                 }
               }
             }
@@ -1792,7 +1895,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/ApiKeyResponse"
+                    "$ref": "#/components/schemas/ApiKeyResponse_Output"
                   }
                 }
               }
@@ -1822,7 +1925,10 @@
           }
         ],
         "x-endpoint-owners": ["auth", "control-plane"],
-        "x-fga-permissions": [["api_gateway_keys_read"]],
+        "x-fga-permissions": [
+          ["api_gateway_keys_read"],
+          ["api_gateway_keys_read", "api_gateway_keys_secret_read"]
+        ],
         "x-oauth-scope": "secrets:read"
       },
       "post": {
@@ -1868,7 +1974,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiKeyResponse"
+                  "$ref": "#/components/schemas/ApiKeyResponse_Output"
                 }
               }
             }
@@ -1925,7 +2031,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/LegacyApiKeysResponse"
+                  "$ref": "#/components/schemas/LegacyApiKeysResponse_Output"
                 }
               }
             }
@@ -1990,7 +2096,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/LegacyApiKeysResponse"
+                  "$ref": "#/components/schemas/LegacyApiKeysResponse_Output"
                 }
               }
             }
@@ -2078,7 +2184,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiKeyResponse"
+                  "$ref": "#/components/schemas/ApiKeyResponse_Output"
                 }
               }
             }
@@ -2154,7 +2260,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiKeyResponse"
+                  "$ref": "#/components/schemas/ApiKeyResponse_Output"
                 }
               }
             }
@@ -2183,7 +2289,10 @@
           }
         ],
         "x-endpoint-owners": ["auth", "control-plane"],
-        "x-fga-permissions": [["api_gateway_keys_read"]],
+        "x-fga-permissions": [
+          ["api_gateway_keys_read"],
+          ["api_gateway_keys_read", "api_gateway_keys_secret_read"]
+        ],
         "x-oauth-scope": "secrets:read"
       },
       "delete": {
@@ -2249,7 +2358,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiKeyResponse"
+                  "$ref": "#/components/schemas/ApiKeyResponse_Output"
                 }
               }
             }
@@ -2309,11 +2418,20 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/BranchResponse"
+                    "$ref": "#/components/schemas/BranchResponse_Output"
                   }
                 }
               }
             }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden action"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
           },
           "500": {
             "description": "Failed to retrieve database branches"
@@ -2370,10 +2488,19 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/BranchResponse"
+                  "$ref": "#/components/schemas/BranchResponse_Output"
                 }
               }
             }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden action"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
           },
           "500": {
             "description": "Failed to create database branch"
@@ -2483,10 +2610,19 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/BranchResponse"
+                  "$ref": "#/components/schemas/BranchResponse_Output"
                 }
               }
             }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden action"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
           },
           "500": {
             "description": "Failed to fetch database branch"
@@ -2534,7 +2670,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/UpdateCustomHostnameResponse"
+                  "$ref": "#/components/schemas/UpdateCustomHostnameResponse_Output"
                 }
               }
             }
@@ -2664,7 +2800,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/UpdateCustomHostnameResponse"
+                  "$ref": "#/components/schemas/UpdateCustomHostnameResponse_Output"
                 }
               }
             }
@@ -2724,7 +2860,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/UpdateCustomHostnameResponse"
+                  "$ref": "#/components/schemas/UpdateCustomHostnameResponse_Output"
                 }
               }
             }
@@ -2784,7 +2920,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/UpdateCustomHostnameResponse"
+                  "$ref": "#/components/schemas/UpdateCustomHostnameResponse_Output"
                 }
               }
             }
@@ -2857,8 +2993,7 @@
                           "type": "boolean"
                         }
                       },
-                      "required": ["state"],
-                      "additionalProperties": false
+                      "required": ["state"]
                     },
                     {
                       "type": "object",
@@ -2870,14 +3005,14 @@
                         "unavailableReason": {
                           "type": "string",
                           "enum": [
+                            "platform_unsupported",
                             "postgres_upgrade_required",
                             "ssl_enforcement_required",
                             "temporarily_unavailable"
                           ]
                         }
                       },
-                      "required": ["state", "unavailableReason"],
-                      "additionalProperties": false
+                      "required": ["state", "unavailableReason"]
                     }
                   ]
                 }
@@ -2960,8 +3095,7 @@
                           "type": "boolean"
                         }
                       },
-                      "required": ["state"],
-                      "additionalProperties": false
+                      "required": ["state"]
                     },
                     {
                       "type": "object",
@@ -2973,14 +3107,14 @@
                         "unavailableReason": {
                           "type": "string",
                           "enum": [
+                            "platform_unsupported",
                             "postgres_upgrade_required",
                             "ssl_enforcement_required",
                             "temporarily_unavailable"
                           ]
                         }
                       },
-                      "required": ["state", "unavailableReason"],
-                      "additionalProperties": false
+                      "required": ["state", "unavailableReason"]
                     }
                   ]
                 }
@@ -3042,7 +3176,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/NetworkBanResponse"
+                  "$ref": "#/components/schemas/NetworkBanResponse_Output"
                 }
               }
             }
@@ -3102,7 +3236,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/NetworkBanResponseEnriched"
+                  "$ref": "#/components/schemas/NetworkBanResponseEnriched_Output"
                 }
               }
             }
@@ -3225,7 +3359,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/NetworkRestrictionsResponse"
+                  "$ref": "#/components/schemas/NetworkRestrictionsResponse_Output"
                 }
               }
             }
@@ -3293,7 +3427,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/NetworkRestrictionsV2Response"
+                  "$ref": "#/components/schemas/NetworkRestrictionsV2Response_Output"
                 }
               }
             }
@@ -3363,7 +3497,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/NetworkRestrictionsResponse"
+                  "$ref": "#/components/schemas/NetworkRestrictionsResponse_Output"
                 }
               }
             }
@@ -3423,7 +3557,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PgsodiumConfigResponse"
+                  "$ref": "#/components/schemas/PgsodiumConfigResponse_Output"
                 }
               }
             }
@@ -3491,7 +3625,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PgsodiumConfigResponse"
+                  "$ref": "#/components/schemas/PgsodiumConfigResponse_Output"
                 }
               }
             }
@@ -3551,7 +3685,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PostgrestConfigWithJWTSecretResponse"
+                  "$ref": "#/components/schemas/PostgrestConfigWithJWTSecretResponse_Output"
                 }
               }
             }
@@ -3583,7 +3717,10 @@
           }
         ],
         "x-endpoint-owners": ["control-plane", "infra"],
-        "x-fga-permissions": [["data_api_config_read"]],
+        "x-fga-permissions": [
+          ["data_api_config_read"],
+          ["data_api_config_read", "data_api_config_secret_read"]
+        ],
         "x-oauth-scope": "rest:read"
       },
       "patch": {
@@ -3619,7 +3756,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/V1PostgrestConfigResponse"
+                  "$ref": "#/components/schemas/V1PostgrestConfigResponse_Output"
                 }
               }
             }
@@ -3679,7 +3816,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/V1ProjectWithDatabaseResponse"
+                  "$ref": "#/components/schemas/V1ProjectWithDatabaseResponse_Output"
                 }
               }
             }
@@ -3737,7 +3874,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/V1ProjectRefResponse"
+                  "$ref": "#/components/schemas/V1ProjectRefResponse_Output"
                 }
               }
             }
@@ -3802,7 +3939,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/V1ProjectRefResponse"
+                  "$ref": "#/components/schemas/V1ProjectRefResponse_Output"
                 }
               }
             }
@@ -3865,7 +4002,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/SecretResponse"
+                    "$ref": "#/components/schemas/SecretResponse_Output"
                   }
                 }
               }
@@ -4050,7 +4187,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SslEnforcementResponse"
+                  "$ref": "#/components/schemas/SslEnforcementResponse_Output"
                 }
               }
             }
@@ -4118,7 +4255,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SslEnforcementResponse"
+                  "$ref": "#/components/schemas/SslEnforcementResponse_Output"
                 }
               }
             }
@@ -4189,7 +4326,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TypescriptResponse"
+                  "$ref": "#/components/schemas/TypescriptResponse_Output"
                 }
               }
             }
@@ -4249,7 +4386,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/VanitySubdomainConfigResponse"
+                  "$ref": "#/components/schemas/VanitySubdomainConfigResponse_Output"
                 }
               }
             }
@@ -4385,7 +4522,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SubdomainAvailabilityResponse"
+                  "$ref": "#/components/schemas/SubdomainAvailabilityResponse_Output"
                 }
               }
             }
@@ -4470,7 +4607,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ActivateVanitySubdomainResponse"
+                  "$ref": "#/components/schemas/ActivateVanitySubdomainResponse_Output"
                 }
               }
             }
@@ -4555,7 +4692,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProjectUpgradeInitiateResponse"
+                  "$ref": "#/components/schemas/ProjectUpgradeInitiateResponse_Output"
                 }
               }
             }
@@ -4615,7 +4752,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProjectUpgradeEligibilityResponse"
+                  "$ref": "#/components/schemas/ProjectUpgradeEligibilityResponse_Output"
                 }
               }
             }
@@ -4684,7 +4821,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DatabaseUpgradeStatusResponse"
+                  "$ref": "#/components/schemas/DatabaseUpgradeStatusResponse_Output"
                 }
               }
             }
@@ -4744,7 +4881,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ReadOnlyStatusResponse"
+                  "$ref": "#/components/schemas/ReadOnlyStatusResponse_Output"
                 }
               }
             }
@@ -5033,7 +5170,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/V1ServiceHealthResponse"
+                    "$ref": "#/components/schemas/V1ServiceHealthResponse_Output"
                   }
                 }
               }
@@ -5094,7 +5231,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SigningKeyResponse"
+                  "$ref": "#/components/schemas/SigningKeyResponse_Output"
                 }
               }
             }
@@ -5149,7 +5286,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SigningKeyResponse"
+                  "$ref": "#/components/schemas/SigningKeyResponse_Output"
                 }
               }
             }
@@ -5216,7 +5353,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SigningKeyResponse"
+                  "$ref": "#/components/schemas/SigningKeyResponse_Output"
                 }
               }
             }
@@ -5271,7 +5408,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SigningKeysResponse"
+                  "$ref": "#/components/schemas/SigningKeysResponse_Output"
                 }
               }
             }
@@ -5339,7 +5476,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SigningKeyResponse"
+                  "$ref": "#/components/schemas/SigningKeyResponse_Output"
                 }
               }
             }
@@ -5398,7 +5535,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SigningKeyResponse"
+                  "$ref": "#/components/schemas/SigningKeyResponse_Output"
                 }
               }
             }
@@ -5474,7 +5611,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SigningKeyResponse"
+                  "$ref": "#/components/schemas/SigningKeyResponse_Output"
                 }
               }
             }
@@ -5531,7 +5668,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AuthConfigResponse"
+                  "$ref": "#/components/schemas/AuthConfigResponse_Output"
                 }
               }
             }
@@ -5599,7 +5736,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AuthConfigResponse"
+                  "$ref": "#/components/schemas/AuthConfigResponse_Output"
                 }
               }
             }
@@ -5669,7 +5806,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ThirdPartyAuth"
+                  "$ref": "#/components/schemas/ThirdPartyAuth_Output"
                 }
               }
             }
@@ -5726,7 +5863,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/ThirdPartyAuth"
+                    "$ref": "#/components/schemas/ThirdPartyAuth_Output"
                   }
                 }
               }
@@ -5795,7 +5932,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ThirdPartyAuth"
+                  "$ref": "#/components/schemas/ThirdPartyAuth_Output"
                 }
               }
             }
@@ -5861,7 +5998,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ThirdPartyAuth"
+                  "$ref": "#/components/schemas/ThirdPartyAuth_Output"
                 }
               }
             }
@@ -6018,7 +6155,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GetProjectAvailableRestoreVersionsResponse"
+                  "$ref": "#/components/schemas/GetProjectAvailableRestoreVersionsResponse_Output"
                 }
               }
             }
@@ -6174,7 +6311,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ListProjectAddonsResponse"
+                  "$ref": "#/components/schemas/ListProjectAddonsResponse_Output"
                 }
               }
             }
@@ -6374,7 +6511,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProjectClaimTokenResponse"
+                  "$ref": "#/components/schemas/ProjectClaimTokenResponse_Output"
                 }
               }
             }
@@ -6423,7 +6560,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CreateProjectClaimTokenResponse"
+                  "$ref": "#/components/schemas/CreateProjectClaimTokenResponse_Output"
                 }
               }
             }
@@ -6518,7 +6655,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/V1ProjectAdvisorsResponse"
+                  "$ref": "#/components/schemas/V1ProjectAdvisorsResponse_Output"
                 }
               }
             }
@@ -6587,7 +6724,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/V1ProjectAdvisorsResponse"
+                  "$ref": "#/components/schemas/V1ProjectAdvisorsResponse_Output"
                 }
               }
             }
@@ -6678,7 +6815,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnalyticsResponse"
+                  "$ref": "#/components/schemas/AnalyticsResponse_Output"
                 }
               }
             }
@@ -6709,7 +6846,7 @@
             "position": "after"
           }
         ],
-        "x-endpoint-owners": ["analytics"],
+        "x-endpoint-owners": ["observability"],
         "x-fga-permissions": [["analytics_logs_read"]],
         "x-oauth-scope": "analytics:read"
       }
@@ -6772,7 +6909,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnalyticsResponse"
+                  "$ref": "#/components/schemas/AnalyticsResponse_Output"
                 }
               }
             }
@@ -6803,7 +6940,7 @@
             "position": "after"
           }
         ],
-        "x-endpoint-owners": ["analytics"],
+        "x-endpoint-owners": ["observability"],
         "x-fga-permissions": [["analytics_logs_read"]],
         "x-oauth-scope": "analytics:read"
       }
@@ -6842,7 +6979,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/V1GetUsageApiCountResponse"
+                  "$ref": "#/components/schemas/V1GetUsageApiCountResponse_Output"
                 }
               }
             }
@@ -6867,7 +7004,7 @@
         ],
         "summary": "Gets project's usage api counts",
         "tags": ["Analytics"],
-        "x-endpoint-owners": ["analytics"],
+        "x-endpoint-owners": ["observability"],
         "x-fga-permissions": [["analytics_usage_read"]]
       }
     },
@@ -6895,7 +7032,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/V1GetUsageApiRequestsCountResponse"
+                  "$ref": "#/components/schemas/V1GetUsageApiRequestsCountResponse_Output"
                 }
               }
             }
@@ -6920,7 +7057,7 @@
         ],
         "summary": "Gets project's usage api requests count",
         "tags": ["Analytics"],
-        "x-endpoint-owners": ["analytics"],
+        "x-endpoint-owners": ["observability"],
         "x-fga-permissions": [["analytics_usage_read"]]
       }
     },
@@ -6967,7 +7104,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnalyticsResponse"
+                  "$ref": "#/components/schemas/AnalyticsResponse_Output"
                 }
               }
             }
@@ -6992,7 +7129,7 @@
         ],
         "summary": "Gets a project's function combined statistics",
         "tags": ["Analytics"],
-        "x-endpoint-owners": ["analytics"],
+        "x-endpoint-owners": ["observability"],
         "x-fga-permissions": [["analytics_usage_read"]]
       }
     },
@@ -7060,7 +7197,7 @@
             "position": "after"
           }
         ],
-        "x-endpoint-owners": ["analytics"],
+        "x-endpoint-owners": ["observability"],
         "x-fga-permissions": [["analytics_logs_read"]],
         "x-oauth-scope": "analytics:read"
       }
@@ -7099,7 +7236,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CreateRoleResponse"
+                  "$ref": "#/components/schemas/CreateRoleResponse_Output"
                 }
               }
             }
@@ -7157,7 +7294,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DeleteRolesResponse"
+                  "$ref": "#/components/schemas/DeleteRolesResponse_Output"
                 }
               }
             }
@@ -7217,7 +7354,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/V1ListMigrationsResponse"
+                  "$ref": "#/components/schemas/V1ListMigrationsResponse_Output"
                 }
               }
             }
@@ -7489,7 +7626,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/V1GetMigrationResponse"
+                  "$ref": "#/components/schemas/V1GetMigrationResponse_Output"
                 }
               }
             }
@@ -7802,7 +7939,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GetProjectDbMetadataResponse"
+                  "$ref": "#/components/schemas/GetProjectDbMetadataResponse_Output"
                 }
               }
             }
@@ -7869,7 +8006,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/V1UpdatePasswordResponse"
+                  "$ref": "#/components/schemas/V1UpdatePasswordResponse_Output"
                 }
               }
             }
@@ -7930,7 +8067,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/JitAccessResponse"
+                  "$ref": "#/components/schemas/JitAccessResponse_Output"
                 }
               }
             }
@@ -7999,7 +8136,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/JitAuthorizeAccessResponse"
+                  "$ref": "#/components/schemas/JitAuthorizeAccessResponse_Output"
                 }
               }
             }
@@ -8068,7 +8205,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/JitAccessResponse"
+                  "$ref": "#/components/schemas/JitAccessResponse_Output"
                 }
               }
             }
@@ -8122,7 +8259,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/JitListAccessResponse"
+                  "$ref": "#/components/schemas/JitListAccessResponse_Output"
                 }
               }
             }
@@ -8186,7 +8323,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/InviteExternalUserJitResponse"
+                  "$ref": "#/components/schemas/InviteExternalUserJitResponse_Output"
                 }
               }
             }
@@ -8250,7 +8387,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/JitAccessResponse"
+                  "$ref": "#/components/schemas/JitAccessResponse_Output"
                 }
               }
             }
@@ -8483,7 +8620,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/FunctionResponse"
+                    "$ref": "#/components/schemas/FunctionResponse_Output"
                   }
                 }
               }
@@ -8624,7 +8761,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/FunctionResponse"
+                  "$ref": "#/components/schemas/FunctionResponse_Output"
                 }
               }
             }
@@ -8696,7 +8833,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/BulkUpdateFunctionResponse"
+                  "$ref": "#/components/schemas/BulkUpdateFunctionResponse_Output"
                 }
               }
             }
@@ -8789,7 +8926,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DeployFunctionResponse"
+                  "$ref": "#/components/schemas/DeployFunctionResponse_Output"
                 }
               }
             }
@@ -8864,7 +9001,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/FunctionSlugResponse"
+                  "$ref": "#/components/schemas/FunctionSlugResponse_Output"
                 }
               }
             }
@@ -9014,7 +9151,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/FunctionResponse"
+                  "$ref": "#/components/schemas/FunctionSlugResponse_Output"
                 }
               }
             }
@@ -9211,7 +9348,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/V1StorageBucketResponse"
+                    "$ref": "#/components/schemas/V1StorageBucketResponse_Output"
                   }
                 }
               }
@@ -9272,7 +9409,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DiskResponse"
+                  "$ref": "#/components/schemas/DiskResponse_Output"
                 }
               }
             }
@@ -9379,7 +9516,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DiskUtilMetricsResponse"
+                  "$ref": "#/components/schemas/DiskUtilMetricsResponse_Output"
                 }
               }
             }
@@ -9432,7 +9569,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DiskAutoscaleConfig"
+                  "$ref": "#/components/schemas/DiskAutoscaleConfig_Output"
                 }
               }
             }
@@ -9485,7 +9622,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/StorageConfigResponse"
+                  "$ref": "#/components/schemas/StorageConfigResponse_Output"
                 }
               }
             }
@@ -9592,7 +9729,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/V1PgbouncerConfigResponse"
+                  "$ref": "#/components/schemas/V1PgbouncerConfigResponse_Output"
                 }
               }
             }
@@ -9649,7 +9786,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/SupavisorConfigResponse"
+                    "$ref": "#/components/schemas/SupavisorConfigResponse_Output"
                   }
                 }
               }
@@ -9718,7 +9855,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/UpdateSupavisorConfigResponse"
+                  "$ref": "#/components/schemas/UpdateSupavisorConfigResponse_Output"
                 }
               }
             }
@@ -9778,7 +9915,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PostgresConfigResponse"
+                  "$ref": "#/components/schemas/PostgresConfigResponse_Output"
                 }
               }
             }
@@ -9846,7 +9983,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PostgresConfigResponse"
+                  "$ref": "#/components/schemas/PostgresConfigResponse_Output"
                 }
               }
             }
@@ -9906,7 +10043,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/RealtimeConfigResponse"
+                  "$ref": "#/components/schemas/RealtimeConfigResponse_Output"
                 }
               }
             }
@@ -10063,7 +10200,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CreateProviderResponse"
+                  "$ref": "#/components/schemas/CreateProviderResponse_Output"
                 }
               }
             }
@@ -10121,7 +10258,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ListProvidersResponse"
+                  "$ref": "#/components/schemas/ListProvidersResponse_Output"
                 }
               }
             }
@@ -10192,7 +10329,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GetProviderResponse"
+                  "$ref": "#/components/schemas/GetProviderResponse_Output"
                 }
               }
             }
@@ -10271,7 +10408,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/UpdateProviderResponse"
+                  "$ref": "#/components/schemas/UpdateProviderResponse_Output"
                 }
               }
             }
@@ -10340,7 +10477,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DeleteProviderResponse"
+                  "$ref": "#/components/schemas/DeleteProviderResponse_Output"
                 }
               }
             }
@@ -10400,7 +10537,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/V1BackupsResponse"
+                  "$ref": "#/components/schemas/V1BackupsResponse_Output"
                 }
               }
             }
@@ -10717,7 +10854,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/V1BackupScheduleResponse"
+                  "$ref": "#/components/schemas/V1BackupScheduleResponse_Output"
                 }
               }
             }
@@ -10804,7 +10941,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/V1BackupScheduleResponse"
+                  "$ref": "#/components/schemas/V1BackupScheduleResponse_Output"
                 }
               }
             }
@@ -10945,7 +11082,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/V1ListEntitlementsResponse"
+                  "$ref": "#/components/schemas/V1ListEntitlementsResponse_Output"
                 }
               }
             }
@@ -11002,11 +11139,20 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/V1OrganizationMemberResponse"
+                    "$ref": "#/components/schemas/V1OrganizationMemberResponse_Output"
                   }
                 }
               }
             }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden action"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
           }
         },
         "security": [
@@ -11049,7 +11195,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/V1OrganizationSlugResponse"
+                  "$ref": "#/components/schemas/V1OrganizationSlugResponse_Output"
                 }
               }
             }
@@ -11113,7 +11259,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/OrganizationProjectClaimResponse"
+                  "$ref": "#/components/schemas/OrganizationProjectClaimResponse_Output"
                 }
               }
             }
@@ -11270,7 +11416,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/OrganizationProjectsResponse"
+                  "$ref": "#/components/schemas/OrganizationProjectsResponse_Output"
                 }
               }
             }
@@ -11313,10 +11459,46 @@
         "scheme": "bearer",
         "bearerFormat": "JWT",
         "type": "http"
+      },
+      "oauth2": {
+        "type": "oauth2",
+        "flows": {
+          "authorizationCode": {
+            "authorizationUrl": "https://api.supabase.com/v1/oauth/authorize",
+            "tokenUrl": "https://api.supabase.com/v1/oauth/token",
+            "scopes": {
+              "analytics:read": "Read access to analytics",
+              "analytics:write": "Write access to analytics",
+              "analytics_config:read": "Read access to analytics config",
+              "analytics_config:write": "Write access to analytics config",
+              "auth:read": "Read access to auth",
+              "auth:write": "Write access to auth",
+              "database:read": "Read access to database",
+              "database:write": "Write access to database",
+              "domains:read": "Read access to domains",
+              "domains:write": "Write access to domains",
+              "edge_functions:read": "Read access to edge functions",
+              "edge_functions:write": "Write access to edge functions",
+              "environment:read": "Read access to environment",
+              "environment:write": "Write access to environment",
+              "organizations:read": "Read access to organizations",
+              "organizations:write": "Write access to organizations",
+              "projects:read": "Read access to projects",
+              "projects:write": "Write access to projects",
+              "rest:read": "Read access to rest",
+              "rest:write": "Write access to rest",
+              "secrets:read": "Read access to secrets",
+              "secrets:write": "Write access to secrets",
+              "storage:read": "Read access to storage",
+              "storage:write": "Write access to storage"
+            }
+          }
+        },
+        "description": "OAuth 2.0 authorization code flow for Supabase OAuth apps. Tokens carry the scopes approved for the app by the organization."
       }
     },
     "schemas": {
-      "BranchDetailResponse": {
+      "BranchDetailResponse_Output": {
         "type": "object",
         "properties": {
           "ref": {
@@ -11425,7 +11607,7 @@
           "notify_url": "https://example.com/webhooks/branches"
         }
       },
-      "BranchResponse": {
+      "BranchResponse_Output": {
         "type": "object",
         "properties": {
           "id": {
@@ -11478,17 +11660,17 @@
           "created_at": {
             "type": "string",
             "format": "date-time",
-            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
           },
           "updated_at": {
             "type": "string",
             "format": "date-time",
-            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
           },
           "review_requested_at": {
             "type": "string",
             "format": "date-time",
-            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
           },
           "with_data": {
             "type": "boolean"
@@ -11500,7 +11682,7 @@
           "deletion_scheduled_at": {
             "type": "string",
             "format": "date-time",
-            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
           },
           "preview_project_status": {
             "type": "string",
@@ -11536,7 +11718,7 @@
           "with_data"
         ]
       },
-      "BranchDeleteResponse": {
+      "BranchDeleteResponse_Output": {
         "type": "object",
         "properties": {
           "message": {
@@ -11557,7 +11739,7 @@
           "migration_version": "20250312000000"
         }
       },
-      "BranchUpdateResponse": {
+      "BranchUpdateResponse_Output": {
         "type": "object",
         "properties": {
           "workflow_run_id": {
@@ -11570,7 +11752,7 @@
         },
         "required": ["workflow_run_id", "message"]
       },
-      "BranchRestoreResponse": {
+      "BranchRestoreResponse_Output": {
         "type": "object",
         "properties": {
           "message": {
@@ -11580,7 +11762,7 @@
         },
         "required": ["message"]
       },
-      "V1ProjectWithDatabaseResponse": {
+      "V1ProjectWithDatabaseResponse_Output": {
         "type": "object",
         "properties": {
           "id": {
@@ -11839,7 +12021,7 @@
         },
         "additionalProperties": false
       },
-      "V1ProjectResponse": {
+      "V1ProjectResponse_Output": {
         "type": "object",
         "properties": {
           "id": {
@@ -11910,7 +12092,7 @@
           "status"
         ]
       },
-      "RegionsInfo": {
+      "RegionsInfo_Output": {
         "type": "object",
         "properties": {
           "recommendations": {
@@ -12059,7 +12241,7 @@
         },
         "required": ["recommendations", "all"]
       },
-      "OrganizationResponseV1": {
+      "OrganizationResponseV1_Output": {
         "type": "object",
         "properties": {
           "id": {
@@ -12148,7 +12330,7 @@
         },
         "additionalProperties": false
       },
-      "OAuthTokenResponse": {
+      "OAuthTokenResponse_Output": {
         "type": "object",
         "properties": {
           "access_token": {
@@ -12168,8 +12350,7 @@
             "enum": ["Bearer"]
           }
         },
-        "required": ["access_token", "expires_in", "token_type"],
-        "additionalProperties": false
+        "required": ["access_token", "expires_in", "token_type"]
       },
       "OAuthRevokeTokenBody": {
         "type": "object",
@@ -12194,7 +12375,7 @@
         },
         "additionalProperties": false
       },
-      "SnippetList": {
+      "SnippetList_Output": {
         "type": "object",
         "properties": {
           "data": {
@@ -12287,7 +12468,7 @@
         },
         "required": ["data"]
       },
-      "SnippetResponse": {
+      "SnippetResponse_Output": {
         "type": "object",
         "properties": {
           "id": {
@@ -12386,7 +12567,7 @@
           "content"
         ]
       },
-      "V1ProfileResponse": {
+      "V1ProfileResponse_Output": {
         "type": "object",
         "properties": {
           "gotrue_id": {
@@ -12401,7 +12582,7 @@
         },
         "required": ["gotrue_id", "primary_email", "username"]
       },
-      "ListActionRunResponse": {
+      "ListActionRunResponse_Output": {
         "type": "array",
         "items": {
           "type": "object",
@@ -12472,7 +12653,7 @@
           ]
         }
       },
-      "ActionRunResponse": {
+      "ActionRunResponse_Output": {
         "type": "object",
         "properties": {
           "id": {
@@ -12579,7 +12760,7 @@
           "deploy": "CREATED"
         }
       },
-      "UpdateRunStatusResponse": {
+      "UpdateRunStatusResponse_Output": {
         "type": "object",
         "properties": {
           "message": {
@@ -12589,7 +12770,7 @@
         },
         "required": ["message"]
       },
-      "ApiKeyResponse": {
+      "ApiKeyResponse_Output": {
         "type": "object",
         "properties": {
           "api_key": {
@@ -12631,19 +12812,19 @@
           "inserted_at": {
             "type": "string",
             "format": "date-time",
-            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$",
             "nullable": true
           },
           "updated_at": {
             "type": "string",
             "format": "date-time",
-            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$",
             "nullable": true
           }
         },
         "required": ["name"]
       },
-      "LegacyApiKeysResponse": {
+      "LegacyApiKeysResponse_Output": {
         "type": "object",
         "properties": {
           "enabled": {
@@ -12790,7 +12971,7 @@
           "notify_url": "https://example.com/webhooks/branches"
         }
       },
-      "UpdateCustomHostnameResponseJsonValue": {
+      "JsonValue_Output": {
         "description": "Any JSON-serializable value",
         "anyOf": [
           {
@@ -12810,18 +12991,18 @@
           {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/UpdateCustomHostnameResponseJsonValue"
+              "$ref": "#/components/schemas/JsonValue_Output"
             }
           },
           {
             "type": "object",
             "additionalProperties": {
-              "$ref": "#/components/schemas/UpdateCustomHostnameResponseJsonValue"
+              "$ref": "#/components/schemas/JsonValue_Output"
             }
           }
         ]
       },
-      "UpdateCustomHostnameResponse": {
+      "UpdateCustomHostnameResponse_Output": {
         "type": "object",
         "properties": {
           "status": {
@@ -12846,13 +13027,13 @@
               "errors": {
                 "type": "array",
                 "items": {
-                  "$ref": "#/components/schemas/UpdateCustomHostnameResponseJsonValue"
+                  "$ref": "#/components/schemas/JsonValue_Output"
                 }
               },
               "messages": {
                 "type": "array",
                 "items": {
-                  "$ref": "#/components/schemas/UpdateCustomHostnameResponseJsonValue"
+                  "$ref": "#/components/schemas/JsonValue_Output"
                 }
               },
               "result": {
@@ -12881,8 +13062,7 @@
                             "txt_value": {
                               "type": "string"
                             }
-                          },
-                          "required": ["txt_name", "txt_value"]
+                          }
                         }
                       },
                       "validation_errors": {
@@ -12897,8 +13077,7 @@
                           "required": ["message"]
                         }
                       }
-                    },
-                    "required": ["status", "validation_records"]
+                    }
                   },
                   "ownership_verification": {
                     "type": "object",
@@ -12912,8 +13091,7 @@
                       "value": {
                         "type": "string"
                       }
-                    },
-                    "required": ["type", "name", "value"]
+                    }
                   },
                   "custom_origin_server": {
                     "type": "string"
@@ -12928,20 +13106,13 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "id",
-                  "hostname",
-                  "ssl",
-                  "ownership_verification",
-                  "custom_origin_server",
-                  "status"
-                ]
+                "required": ["id", "hostname"]
               }
             },
             "required": ["success", "errors", "messages", "result"]
           }
         },
-        "required": ["status", "custom_hostname", "data"]
+        "required": ["status", "data"]
       },
       "UpdateCustomHostnameBody": {
         "type": "object",
@@ -12970,7 +13141,7 @@
           "state": "enabled"
         }
       },
-      "NetworkBanResponse": {
+      "NetworkBanResponse_Output": {
         "type": "object",
         "properties": {
           "banned_ipv4_addresses": {
@@ -12982,7 +13153,7 @@
         },
         "required": ["banned_ipv4_addresses"]
       },
-      "NetworkBanResponseEnriched": {
+      "NetworkBanResponseEnriched_Output": {
         "type": "object",
         "properties": {
           "banned_ipv4_addresses": {
@@ -13031,7 +13202,7 @@
           "requester_ip": false
         }
       },
-      "NetworkRestrictionsResponse": {
+      "NetworkRestrictionsResponse_Output": {
         "type": "object",
         "properties": {
           "entitlement": {
@@ -13089,12 +13260,12 @@
           "updated_at": {
             "type": "string",
             "format": "date-time",
-            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
           },
           "applied_at": {
             "type": "string",
             "format": "date-time",
-            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
           }
         },
         "required": ["entitlement", "config", "status"]
@@ -13167,7 +13338,7 @@
           }
         }
       },
-      "NetworkRestrictionsV2Response": {
+      "NetworkRestrictionsV2Response_Output": {
         "type": "object",
         "properties": {
           "entitlement": {
@@ -13221,12 +13392,12 @@
           "updated_at": {
             "type": "string",
             "format": "date-time",
-            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
           },
           "applied_at": {
             "type": "string",
             "format": "date-time",
-            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
           },
           "status": {
             "type": "string",
@@ -13235,7 +13406,7 @@
         },
         "required": ["entitlement", "config", "status"]
       },
-      "PgsodiumConfigResponse": {
+      "PgsodiumConfigResponse_Output": {
         "type": "object",
         "properties": {
           "root_key": {
@@ -13261,7 +13432,7 @@
           "root_key": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
         }
       },
-      "PostgrestConfigWithJWTSecretResponse": {
+      "PostgrestConfigWithJWTSecretResponse_Output": {
         "type": "object",
         "properties": {
           "db_schema": {
@@ -13332,7 +13503,7 @@
           "max_rows": 1000
         }
       },
-      "V1PostgrestConfigResponse": {
+      "V1PostgrestConfigResponse_Output": {
         "type": "object",
         "properties": {
           "db_schema": {
@@ -13369,7 +13540,7 @@
           "db_pool_acquisition_timeout"
         ]
       },
-      "V1ProjectRefResponse": {
+      "V1ProjectRefResponse_Output": {
         "type": "object",
         "properties": {
           "id": {
@@ -13400,7 +13571,7 @@
           "name": "Acme Platform"
         }
       },
-      "SecretResponse": {
+      "SecretResponse_Output": {
         "type": "object",
         "properties": {
           "name": {
@@ -13452,7 +13623,7 @@
         },
         "example": ["OPENAI_API_KEY"]
       },
-      "SslEnforcementResponse": {
+      "SslEnforcementResponse_Output": {
         "type": "object",
         "properties": {
           "currentConfig": {
@@ -13490,7 +13661,7 @@
           }
         }
       },
-      "TypescriptResponse": {
+      "TypescriptResponse_Output": {
         "type": "object",
         "properties": {
           "types": {
@@ -13499,7 +13670,7 @@
         },
         "required": ["types"]
       },
-      "VanitySubdomainConfigResponse": {
+      "VanitySubdomainConfigResponse_Output": {
         "type": "object",
         "properties": {
           "status": {
@@ -13556,7 +13727,7 @@
           "vanity_subdomain": "acme-prod"
         }
       },
-      "SubdomainAvailabilityResponse": {
+      "SubdomainAvailabilityResponse_Output": {
         "type": "object",
         "properties": {
           "available": {
@@ -13565,7 +13736,7 @@
         },
         "required": ["available"]
       },
-      "ActivateVanitySubdomainResponse": {
+      "ActivateVanitySubdomainResponse_Output": {
         "type": "object",
         "properties": {
           "custom_domain": {
@@ -13591,7 +13762,7 @@
           "release_channel": "ga"
         }
       },
-      "ProjectUpgradeInitiateResponse": {
+      "ProjectUpgradeInitiateResponse_Output": {
         "type": "object",
         "properties": {
           "tracking_id": {
@@ -13600,7 +13771,7 @@
         },
         "required": ["tracking_id"]
       },
-      "ProjectUpgradeEligibilityResponse": {
+      "ProjectUpgradeEligibilityResponse_Output": {
         "type": "object",
         "properties": {
           "eligible": {
@@ -13872,6 +14043,16 @@
                     }
                   },
                   "required": ["type"]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": ["btree_gist_nan_reindex"]
+                    }
+                  },
+                  "required": ["type"]
                 }
               ]
             }
@@ -13892,7 +14073,7 @@
           "warnings"
         ]
       },
-      "DatabaseUpgradeStatusResponse": {
+      "DatabaseUpgradeStatusResponse_Output": {
         "type": "object",
         "properties": {
           "databaseUpgradeStatus": {
@@ -13905,7 +14086,7 @@
                 "type": "string"
               },
               "target_version": {
-                "type": "number"
+                "type": "string"
               },
               "error": {
                 "type": "string",
@@ -13947,7 +14128,7 @@
         },
         "required": ["databaseUpgradeStatus"]
       },
-      "ReadOnlyStatusResponse": {
+      "ReadOnlyStatusResponse_Output": {
         "type": "object",
         "properties": {
           "enabled": {
@@ -14007,7 +14188,7 @@
           "database_identifier": "abcdefghijklmnopqrst-rr-us-west-1-abcde"
         }
       },
-      "V1ServiceHealthResponse": {
+      "V1ServiceHealthResponse_Output": {
         "type": "object",
         "properties": {
           "name": {
@@ -14094,7 +14275,7 @@
         },
         "required": ["name", "healthy", "status"]
       },
-      "SigningKeyResponse": {
+      "SigningKeyResponse_Output": {
         "type": "object",
         "properties": {
           "id": {
@@ -14116,16 +14297,15 @@
           "created_at": {
             "type": "string",
             "format": "date-time",
-            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
           },
           "updated_at": {
             "type": "string",
             "format": "date-time",
-            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
           }
         },
-        "required": ["id", "algorithm", "status", "public_jwk", "created_at", "updated_at"],
-        "additionalProperties": false
+        "required": ["id", "algorithm", "status", "public_jwk", "created_at", "updated_at"]
       },
       "CreateSigningKeyBody": {
         "type": "object",
@@ -14350,7 +14530,7 @@
         },
         "additionalProperties": false
       },
-      "SigningKeysResponse": {
+      "SigningKeysResponse_Output": {
         "type": "object",
         "properties": {
           "keys": {
@@ -14377,21 +14557,19 @@
                 "created_at": {
                   "type": "string",
                   "format": "date-time",
-                  "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+                  "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
                 },
                 "updated_at": {
                   "type": "string",
                   "format": "date-time",
-                  "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+                  "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
                 }
               },
-              "required": ["id", "algorithm", "status", "public_jwk", "created_at", "updated_at"],
-              "additionalProperties": false
+              "required": ["id", "algorithm", "status", "public_jwk", "created_at", "updated_at"]
             }
           }
         },
-        "required": ["keys"],
-        "additionalProperties": false
+        "required": ["keys"]
       },
       "UpdateSigningKeyBody": {
         "type": "object",
@@ -14407,7 +14585,7 @@
         },
         "additionalProperties": false
       },
-      "AuthConfigResponse": {
+      "AuthConfigResponse_Output": {
         "type": "object",
         "properties": {
           "api_max_request_duration": {
@@ -15234,6 +15412,10 @@
             "maximum": 9007199254740991,
             "nullable": true
           },
+          "security_update_password_require_current_password": {
+            "type": "boolean",
+            "nullable": true
+          },
           "security_update_password_require_reauthentication": {
             "type": "boolean",
             "nullable": true
@@ -15606,6 +15788,7 @@
           "security_captcha_secret",
           "security_manual_linking_enabled",
           "security_refresh_token_reuse_interval",
+          "security_update_password_require_current_password",
           "security_update_password_require_reauthentication",
           "sessions_inactivity_timeout",
           "sessions_single_per_user",
@@ -15890,11 +16073,13 @@
           "sessions_timebox": {
             "type": "number",
             "minimum": 0,
+            "description": "Session timebox in hours. Maximum 8760 hours (1 year).",
             "nullable": true
           },
           "sessions_inactivity_timeout": {
             "type": "number",
             "minimum": 0,
+            "description": "Session inactivity timeout in hours. Maximum 8760 hours (1 year).",
             "nullable": true
           },
           "sessions_single_per_user": {
@@ -15985,10 +16170,16 @@
             "type": "boolean",
             "nullable": true
           },
+          "security_update_password_require_current_password": {
+            "type": "boolean",
+            "description": "Require the user's current password when updating their password.",
+            "nullable": true
+          },
           "security_refresh_token_reuse_interval": {
             "type": "integer",
             "minimum": 0,
             "maximum": 2147483647,
+            "description": "Refresh token reuse interval in seconds. Maximum 300 seconds (5 minutes).",
             "nullable": true
           },
           "mailer_otp_exp": {
@@ -16669,7 +16860,7 @@
           "jwks_url": "https://login.acme.com/.well-known/jwks.json"
         }
       },
-      "ThirdPartyAuth": {
+      "ThirdPartyAuth_Output": {
         "type": "object",
         "properties": {
           "id": {
@@ -16707,7 +16898,7 @@
         },
         "required": ["id", "type", "inserted_at", "updated_at"]
       },
-      "GetProjectAvailableRestoreVersionsResponse": {
+      "GetProjectAvailableRestoreVersionsResponse_Output": {
         "type": "object",
         "properties": {
           "available_versions": {
@@ -16733,38 +16924,7 @@
         },
         "required": ["available_versions"]
       },
-      "ListProjectAddonsResponseJsonValue": {
-        "description": "Any JSON-serializable value",
-        "anyOf": [
-          {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "number"
-              },
-              {
-                "type": "boolean"
-              }
-            ],
-            "nullable": true
-          },
-          {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ListProjectAddonsResponseJsonValue"
-            }
-          },
-          {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/ListProjectAddonsResponseJsonValue"
-            }
-          }
-        ]
-      },
-      "ListProjectAddonsResponse": {
+      "ListProjectAddonsResponse_Output": {
         "type": "object",
         "properties": {
           "selected_addons": {
@@ -16867,7 +17027,7 @@
                       "required": ["description", "type", "interval", "amount"]
                     },
                     "meta": {
-                      "$ref": "#/components/schemas/ListProjectAddonsResponseJsonValue"
+                      "$ref": "#/components/schemas/JsonValue_Output"
                     }
                   },
                   "required": ["id", "name", "price"]
@@ -16981,7 +17141,7 @@
                         "required": ["description", "type", "interval", "amount"]
                       },
                       "meta": {
-                        "$ref": "#/components/schemas/ListProjectAddonsResponseJsonValue"
+                        "$ref": "#/components/schemas/JsonValue_Output"
                       }
                     },
                     "required": ["id", "name", "price"]
@@ -17056,7 +17216,7 @@
           "addon_type": "pitr"
         }
       },
-      "ProjectClaimTokenResponse": {
+      "ProjectClaimTokenResponse_Output": {
         "type": "object",
         "properties": {
           "token_alias": {
@@ -17076,7 +17236,7 @@
         },
         "required": ["token_alias", "expires_at", "created_at", "created_by"]
       },
-      "CreateProjectClaimTokenResponse": {
+      "CreateProjectClaimTokenResponse_Output": {
         "type": "object",
         "properties": {
           "token": {
@@ -17099,7 +17259,7 @@
         },
         "required": ["token", "token_alias", "expires_at", "created_at", "created_by"]
       },
-      "V1ProjectAdvisorsResponse": {
+      "V1ProjectAdvisorsResponse_Output": {
         "type": "object",
         "properties": {
           "lints": {
@@ -17108,6 +17268,7 @@
               "type": "object",
               "properties": {
                 "name": {
+                  "type": "string",
                   "enum": [
                     "unindexed_foreign_keys",
                     "auth_users_exposed",
@@ -17129,6 +17290,7 @@
                     "auth_otp_long_expiry",
                     "auth_otp_short_length",
                     "ssl_not_enforced",
+                    "log_connections_not_enabled",
                     "network_restrictions_not_set",
                     "password_requirements_min_length",
                     "pitr_not_enabled",
@@ -17137,9 +17299,20 @@
                     "auth_password_policy_missing",
                     "leaked_service_key",
                     "no_backup_admin",
-                    "vulnerable_postgres_version"
-                  ],
-                  "type": "string"
+                    "vulnerable_postgres_version",
+                    "db_not_reachable",
+                    "db_connection_failing",
+                    "db_connection_limit_reached",
+                    "instance_telemetry_lost",
+                    "instance_db_down",
+                    "instance_alert_firing",
+                    "log_data_api_error_rate_high",
+                    "log_auth_error_rate_high",
+                    "log_storage_error_rate_high",
+                    "log_edge_function_error_rate_high",
+                    "project_not_active",
+                    "advisor_check_unavailable"
+                  ]
                 },
                 "title": {
                   "type": "string"
@@ -17156,8 +17329,9 @@
                   "type": "array",
                   "items": {
                     "type": "string",
-                    "enum": ["PERFORMANCE", "SECURITY"]
-                  }
+                    "enum": ["PERFORMANCE", "SECURITY", "HEALTH"]
+                  },
+                  "x-ignore-array-items-must-be-objects": true
                 },
                 "description": {
                   "type": "string"
@@ -17182,12 +17356,23 @@
                     },
                     "type": {
                       "type": "string",
-                      "enum": ["table", "view", "auth", "function", "extension", "compliance"]
+                      "enum": [
+                        "table",
+                        "view",
+                        "materialized view",
+                        "foreign table",
+                        "auth",
+                        "function",
+                        "extension",
+                        "compliance",
+                        "health"
+                      ]
                     },
                     "fkey_name": {
                       "type": "string"
                     },
                     "fkey_columns": {
+                      "x-ignore-array-items-must-be-objects": true,
                       "type": "array",
                       "items": {
                         "type": "number"
@@ -17197,6 +17382,11 @@
                 },
                 "cache_key": {
                   "type": "string"
+                },
+                "observed_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
                 }
               },
               "required": [
@@ -17215,7 +17405,7 @@
         },
         "required": ["lints"]
       },
-      "AnalyticsResponse": {
+      "AnalyticsResponse_Output": {
         "type": "object",
         "properties": {
           "result": {
@@ -17270,7 +17460,7 @@
           }
         }
       },
-      "V1GetUsageApiCountResponse": {
+      "V1GetUsageApiCountResponse_Output": {
         "type": "object",
         "properties": {
           "result": {
@@ -17353,7 +17543,7 @@
           }
         }
       },
-      "V1GetUsageApiRequestsCountResponse": {
+      "V1GetUsageApiRequestsCountResponse_Output": {
         "type": "object",
         "properties": {
           "result": {
@@ -17428,7 +17618,7 @@
           "read_only": true
         }
       },
-      "CreateRoleResponse": {
+      "CreateRoleResponse_Output": {
         "type": "object",
         "properties": {
           "role": {
@@ -17448,7 +17638,7 @@
         },
         "required": ["role", "password", "ttl_seconds"]
       },
-      "DeleteRolesResponse": {
+      "DeleteRolesResponse_Output": {
         "type": "object",
         "properties": {
           "message": {
@@ -17458,14 +17648,13 @@
         },
         "required": ["message"]
       },
-      "V1ListMigrationsResponse": {
+      "V1ListMigrationsResponse_Output": {
         "type": "array",
         "items": {
           "type": "object",
           "properties": {
             "version": {
-              "type": "string",
-              "minLength": 1
+              "type": "string"
             },
             "name": {
               "type": "string"
@@ -17516,12 +17705,11 @@
           "rollback": "drop table if exists public.widgets;"
         }
       },
-      "V1GetMigrationResponse": {
+      "V1GetMigrationResponse_Output": {
         "type": "object",
         "properties": {
           "version": {
-            "type": "string",
-            "minLength": 1
+            "type": "string"
           },
           "name": {
             "type": "string"
@@ -17600,7 +17788,7 @@
           "query": "select * from pg_stat_activity limit 1;"
         }
       },
-      "GetProjectDbMetadataResponse": {
+      "GetProjectDbMetadataResponse_Output": {
         "type": "object",
         "properties": {
           "databases": {
@@ -17620,13 +17808,11 @@
                         "type": "string"
                       }
                     },
-                    "required": ["name"],
-                    "additionalProperties": {}
+                    "required": ["name"]
                   }
                 }
               },
-              "required": ["name", "schemas"],
-              "additionalProperties": {}
+              "required": ["name", "schemas"]
             }
           }
         },
@@ -17645,7 +17831,7 @@
           "password": "correct-horse-battery-staple"
         }
       },
-      "V1UpdatePasswordResponse": {
+      "V1UpdatePasswordResponse_Output": {
         "type": "object",
         "properties": {
           "message": {
@@ -17654,7 +17840,7 @@
         },
         "required": ["message"]
       },
-      "JitAccessResponse": {
+      "JitAccessResponse_Output": {
         "type": "object",
         "properties": {
           "user_id": {
@@ -17668,8 +17854,7 @@
               "type": "object",
               "properties": {
                 "role": {
-                  "type": "string",
-                  "minLength": 1
+                  "type": "string"
                 },
                 "expires_at": {
                   "type": "number"
@@ -17745,7 +17930,7 @@
           "rhost": "203.0.113.10"
         }
       },
-      "JitAuthorizeAccessResponse": {
+      "JitAuthorizeAccessResponse_Output": {
         "type": "object",
         "properties": {
           "user_id": {
@@ -17757,8 +17942,7 @@
             "type": "object",
             "properties": {
               "role": {
-                "type": "string",
-                "minLength": 1
+                "type": "string"
               },
               "expires_at": {
                 "type": "number"
@@ -17805,7 +17989,7 @@
         },
         "required": ["user_id", "user_role"]
       },
-      "JitListAccessResponse": {
+      "JitListAccessResponse_Output": {
         "type": "object",
         "properties": {
           "items": {
@@ -17836,8 +18020,7 @@
                         "type": "object",
                         "properties": {
                           "role": {
-                            "type": "string",
-                            "minLength": 1
+                            "type": "string"
                           },
                           "expires_at": {
                             "type": "number"
@@ -17908,8 +18091,7 @@
                         "type": "object",
                         "properties": {
                           "role": {
-                            "type": "string",
-                            "minLength": 1
+                            "type": "string"
                           },
                           "expires_at": {
                             "type": "number"
@@ -18125,7 +18307,7 @@
           ]
         }
       },
-      "InviteExternalUserJitResponse": {
+      "InviteExternalUserJitResponse_Output": {
         "type": "object",
         "properties": {
           "email": {
@@ -18144,8 +18326,7 @@
               "type": "object",
               "properties": {
                 "role": {
-                  "type": "string",
-                  "minLength": 1
+                  "type": "string"
                 },
                 "expires_at": {
                   "type": "number"
@@ -18213,7 +18394,7 @@
           "token": ""
         }
       },
-      "FunctionResponse": {
+      "FunctionResponse_Output": {
         "type": "object",
         "properties": {
           "id": {
@@ -18349,7 +18530,7 @@
           }
         ]
       },
-      "BulkUpdateFunctionResponse": {
+      "BulkUpdateFunctionResponse_Output": {
         "type": "object",
         "properties": {
           "functions": {
@@ -18454,7 +18635,7 @@
           }
         }
       },
-      "DeployFunctionResponse": {
+      "DeployFunctionResponse_Output": {
         "type": "object",
         "properties": {
           "id": {
@@ -18505,7 +18686,7 @@
         },
         "required": ["id", "slug", "name", "status", "version"]
       },
-      "FunctionSlugResponse": {
+      "FunctionSlugResponse_Output": {
         "type": "object",
         "properties": {
           "id": {
@@ -18579,7 +18760,7 @@
           "verify_jwt": true
         }
       },
-      "V1StorageBucketResponse": {
+      "V1StorageBucketResponse_Output": {
         "type": "object",
         "properties": {
           "id": {
@@ -18603,7 +18784,7 @@
         },
         "required": ["id", "name", "owner", "created_at", "updated_at", "public"]
       },
-      "DiskResponse": {
+      "DiskResponse_Output": {
         "type": "object",
         "properties": {
           "attributes": {
@@ -18734,7 +18915,7 @@
           }
         }
       },
-      "DiskUtilMetricsResponse": {
+      "DiskUtilMetricsResponse_Output": {
         "type": "object",
         "properties": {
           "timestamp": {
@@ -18758,7 +18939,7 @@
         },
         "required": ["timestamp", "metrics"]
       },
-      "DiskAutoscaleConfig": {
+      "DiskAutoscaleConfig_Output": {
         "type": "object",
         "properties": {
           "growth_percent": {
@@ -18785,7 +18966,7 @@
         },
         "required": ["growth_percent", "min_increment_gb", "max_size_gb"]
       },
-      "StorageConfigResponse": {
+      "StorageConfigResponse_Output": {
         "type": "object",
         "properties": {
           "fileSizeLimit": {
@@ -18884,9 +19065,12 @@
               },
               "iceberg_catalog": {
                 "type": "boolean"
+              },
+              "object_versioning": {
+                "type": "boolean"
               }
             },
-            "required": ["list_v2", "iceberg_catalog"]
+            "required": ["list_v2", "iceberg_catalog", "object_versioning"]
           },
           "external": {
             "type": "object",
@@ -18899,20 +19083,11 @@
             "required": ["upstreamTarget"]
           },
           "migrationVersion": {
-            "type": "string"
-          },
-          "databasePoolMode": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
           }
         },
-        "required": [
-          "fileSizeLimit",
-          "features",
-          "capabilities",
-          "external",
-          "migrationVersion",
-          "databasePoolMode"
-        ]
+        "required": ["fileSizeLimit", "features", "capabilities", "external", "migrationVersion"]
       },
       "UpdateStorageConfigBody": {
         "type": "object",
@@ -19019,7 +19194,7 @@
         },
         "additionalProperties": false
       },
-      "V1PgbouncerConfigResponse": {
+      "V1PgbouncerConfigResponse_Output": {
         "type": "object",
         "properties": {
           "default_pool_size": {
@@ -19064,7 +19239,7 @@
           }
         }
       },
-      "SupavisorConfigResponse": {
+      "SupavisorConfigResponse_Output": {
         "type": "object",
         "properties": {
           "identifier": {
@@ -19150,7 +19325,7 @@
           "pool_mode": "transaction"
         }
       },
-      "UpdateSupavisorConfigResponse": {
+      "UpdateSupavisorConfigResponse_Output": {
         "type": "object",
         "properties": {
           "default_pool_size": {
@@ -19165,7 +19340,7 @@
         },
         "required": ["default_pool_size", "pool_mode"]
       },
-      "PostgresConfigResponse": {
+      "PostgresConfigResponse_Output": {
         "type": "object",
         "properties": {
           "effective_cache_size": {
@@ -19475,7 +19650,7 @@
         },
         "additionalProperties": false
       },
-      "RealtimeConfigResponse": {
+      "RealtimeConfigResponse_Output": {
         "type": "object",
         "properties": {
           "private_only": {
@@ -19685,6 +19860,9 @@
                         "type": "string"
                       }
                     },
+                    "array": {
+                      "type": "boolean"
+                    },
                     "default": {
                       "anyOf": [
                         {
@@ -19701,9 +19879,6 @@
                           "type": "boolean"
                         }
                       ]
-                    },
-                    "array": {
-                      "type": "boolean"
                     }
                   }
                 }
@@ -19741,7 +19916,7 @@
           }
         }
       },
-      "CreateProviderResponse": {
+      "CreateProviderResponse_Output": {
         "type": "object",
         "properties": {
           "id": {
@@ -19776,6 +19951,9 @@
                             "type": "string"
                           }
                         },
+                        "array": {
+                          "type": "boolean"
+                        },
                         "default": {
                           "anyOf": [
                             {
@@ -19792,9 +19970,6 @@
                               "type": "boolean"
                             }
                           ]
-                        },
-                        "array": {
-                          "type": "boolean"
                         }
                       }
                     }
@@ -19840,7 +20015,7 @@
         },
         "required": ["id"]
       },
-      "ListProvidersResponse": {
+      "ListProvidersResponse_Output": {
         "type": "object",
         "properties": {
           "items": {
@@ -19880,6 +20055,9 @@
                                   "type": "string"
                                 }
                               },
+                              "array": {
+                                "type": "boolean"
+                              },
                               "default": {
                                 "anyOf": [
                                   {
@@ -19896,9 +20074,6 @@
                                     "type": "boolean"
                                   }
                                 ]
-                              },
-                              "array": {
-                                "type": "boolean"
                               }
                             }
                           }
@@ -19948,7 +20123,7 @@
         },
         "required": ["items"]
       },
-      "GetProviderResponse": {
+      "GetProviderResponse_Output": {
         "type": "object",
         "properties": {
           "id": {
@@ -19983,6 +20158,9 @@
                             "type": "string"
                           }
                         },
+                        "array": {
+                          "type": "boolean"
+                        },
                         "default": {
                           "anyOf": [
                             {
@@ -19999,9 +20177,6 @@
                               "type": "boolean"
                             }
                           ]
-                        },
-                        "array": {
-                          "type": "boolean"
                         }
                       }
                     }
@@ -20079,6 +20254,9 @@
                         "type": "string"
                       }
                     },
+                    "array": {
+                      "type": "boolean"
+                    },
                     "default": {
                       "anyOf": [
                         {
@@ -20095,9 +20273,6 @@
                           "type": "boolean"
                         }
                       ]
-                    },
-                    "array": {
-                      "type": "boolean"
                     }
                   }
                 }
@@ -20120,7 +20295,7 @@
           "domains": ["acme.com", "contractors.acme.com"]
         }
       },
-      "UpdateProviderResponse": {
+      "UpdateProviderResponse_Output": {
         "type": "object",
         "properties": {
           "id": {
@@ -20155,6 +20330,9 @@
                             "type": "string"
                           }
                         },
+                        "array": {
+                          "type": "boolean"
+                        },
                         "default": {
                           "anyOf": [
                             {
@@ -20171,9 +20349,6 @@
                               "type": "boolean"
                             }
                           ]
-                        },
-                        "array": {
-                          "type": "boolean"
                         }
                       }
                     }
@@ -20219,7 +20394,7 @@
         },
         "required": ["id"]
       },
-      "DeleteProviderResponse": {
+      "DeleteProviderResponse_Output": {
         "type": "object",
         "properties": {
           "id": {
@@ -20254,6 +20429,9 @@
                             "type": "string"
                           }
                         },
+                        "array": {
+                          "type": "boolean"
+                        },
                         "default": {
                           "anyOf": [
                             {
@@ -20270,9 +20448,6 @@
                               "type": "boolean"
                             }
                           ]
-                        },
-                        "array": {
-                          "type": "boolean"
                         }
                       }
                     }
@@ -20318,7 +20493,7 @@
         },
         "required": ["id"]
       },
-      "V1BackupsResponse": {
+      "V1BackupsResponse_Output": {
         "type": "object",
         "properties": {
           "region": {
@@ -20413,7 +20588,7 @@
           "completed_on": {
             "type": "string",
             "format": "date-time",
-            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$",
             "nullable": true
           }
         },
@@ -20433,7 +20608,7 @@
           "id": 12345
         }
       },
-      "V1BackupScheduleResponse": {
+      "V1BackupScheduleResponse_Output": {
         "type": "object",
         "properties": {
           "schedule_for": {
@@ -20480,7 +20655,7 @@
           "name": "before-upgrade"
         }
       },
-      "V1ListEntitlementsResponse": {
+      "V1ListEntitlementsResponse_Output": {
         "type": "object",
         "properties": {
           "entitlements": {
@@ -20627,7 +20802,7 @@
         },
         "required": ["entitlements"]
       },
-      "V1OrganizationMemberResponse": {
+      "V1OrganizationMemberResponse_Output": {
         "type": "object",
         "properties": {
           "user_id": {
@@ -20650,9 +20825,9 @@
             "nullable": true
           }
         },
-        "required": ["user_id", "user_name", "role_name", "mfa_enabled", "avatar_url"]
+        "required": ["user_id", "user_name", "mfa_enabled", "avatar_url"]
       },
-      "V1OrganizationSlugResponse": {
+      "V1OrganizationSlugResponse_Output": {
         "type": "object",
         "properties": {
           "id": {
@@ -20685,7 +20860,7 @@
         },
         "required": ["id", "name", "opt_in_tags", "allowed_release_channels"]
       },
-      "OrganizationProjectClaimResponse": {
+      "OrganizationProjectClaimResponse_Output": {
         "type": "object",
         "properties": {
           "project": {
@@ -20800,7 +20975,7 @@
         },
         "required": ["project", "preview", "expires_at", "created_at", "created_by"]
       },
-      "OrganizationProjectsResponse": {
+      "OrganizationProjectsResponse_Output": {
         "type": "object",
         "properties": {
           "projects": {

--- a/apps/docs/spec/transforms/api_v2_openapi_deparsed.json
+++ b/apps/docs/spec/transforms/api_v2_openapi_deparsed.json
@@ -33,7 +33,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ListLogDrainsResponse"
+                  "$ref": "#/components/schemas/ListLogDrainsResponse_Output"
                 }
               }
             }
@@ -92,7 +92,7 @@
             "position": "after"
           }
         ],
-        "x-endpoint-owners": ["analytics"],
+        "x-endpoint-owners": ["observability"],
         "x-fga-permissions": [["analytics_config_read"]],
         "x-oauth-scope": "analytics_config:read"
       },
@@ -129,7 +129,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/LogDrainResponse"
+                  "$ref": "#/components/schemas/LogDrainResponse_Output"
                 }
               }
             }
@@ -203,7 +203,7 @@
             "position": "after"
           }
         ],
-        "x-endpoint-owners": ["analytics"],
+        "x-endpoint-owners": ["observability"],
         "x-fga-permissions": [["analytics_config_write"]],
         "x-oauth-scope": "analytics_config:write"
       }
@@ -253,7 +253,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/LogDrainResponse"
+                  "$ref": "#/components/schemas/LogDrainResponse_Output"
                 }
               }
             }
@@ -312,7 +312,7 @@
             "position": "after"
           }
         ],
-        "x-endpoint-owners": ["analytics"],
+        "x-endpoint-owners": ["observability"],
         "x-fga-permissions": [["analytics_config_write"]],
         "x-oauth-scope": "analytics_config:write"
       },
@@ -402,9 +402,209 @@
             "position": "after"
           }
         ],
-        "x-endpoint-owners": ["analytics"],
+        "x-endpoint-owners": ["observability"],
         "x-fga-permissions": [["analytics_config_write"]],
         "x-oauth-scope": "analytics_config:write"
+      }
+    },
+    "/v2/projects/{ref}/advisors/run": {
+      "post": {
+        "operationId": "v2-run-project-advisors",
+        "parameters": [
+          {
+            "name": "ref",
+            "required": true,
+            "in": "path",
+            "description": "Project ref",
+            "schema": {
+              "minLength": 20,
+              "maxLength": 20,
+              "pattern": "^[a-z]+$",
+              "example": "abcdefghijklmnopqrst",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/V2RunProjectAdvisorsBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/V2ProjectAdvisorsResponse_Output"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponseBody"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden action",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponseBody"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponseBody"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Runs the project advisors with the given names",
+        "tags": ["Advisors"],
+        "x-endpoint-owners": ["control-plane"],
+        "x-fga-permissions": [["advisors_read"]]
+      }
+    },
+    "/v2/projects/{ref}/branches": {
+      "post": {
+        "description": "Creates a database branch from the specified project. Compute and disk size can be set here so the branch is provisioned at the requested size, instead of being resized after creation.",
+        "operationId": "v2-create-a-branch",
+        "parameters": [
+          {
+            "name": "ref",
+            "required": true,
+            "in": "path",
+            "description": "Project ref",
+            "schema": {
+              "minLength": 20,
+              "maxLength": 20,
+              "pattern": "^[a-z]+$",
+              "example": "abcdefghijklmnopqrst",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/V2CreateBranchRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/V2BranchResponse_Output"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid branch configuration for this project",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponseBody"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponseBody"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Organization plan does not cover the requested branch",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponseBody"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden action",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponseBody"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponseBody"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Failed to create database branch",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponseBody"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Create a database branch",
+        "tags": ["Environments"],
+        "x-badges": [
+          {
+            "name": "OAuth scope: environment:write",
+            "position": "after"
+          }
+        ],
+        "x-endpoint-owners": ["dev-workflows"],
+        "x-fga-permissions": [["branching_development_create"], ["branching_production_create"]],
+        "x-oauth-scope": "environment:write"
       }
     },
     "/v2/projects/{ref}/config": {
@@ -432,7 +632,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/V2ProjectConfigResponse"
+                  "$ref": "#/components/schemas/V2ProjectConfigResponse_Output"
                 }
               }
             }
@@ -524,7 +724,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/V2PreviewProjectTransferResponse"
+                  "$ref": "#/components/schemas/V2PreviewProjectTransferResponse_Output"
                 }
               }
             }
@@ -669,7 +869,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/V2ListPrivateLinkAssociationsResponse"
+                  "$ref": "#/components/schemas/V2ListPrivateLinkAssociationsResponse_Output"
                 }
               }
             }
@@ -759,7 +959,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/V2PrivateLinkAssociationResponse"
+                  "$ref": "#/components/schemas/V2PrivateLinkAssociationResponse_Output"
                 }
               }
             }
@@ -1035,7 +1235,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/V2ListWorkersResponse"
+                  "$ref": "#/components/schemas/V2ListWorkersResponse_Output"
                 }
               }
             }
@@ -1124,7 +1324,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/V2WorkerResponse"
+                  "$ref": "#/components/schemas/V2WorkerResponse_Output"
                 }
               }
             }
@@ -1293,7 +1493,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/V2WorkerUploadResponse"
+                  "$ref": "#/components/schemas/V2WorkerUploadResponse_Output"
                 }
               }
             }
@@ -1392,7 +1592,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/V2WorkerResponse"
+                  "$ref": "#/components/schemas/V2WorkerResponse_Output"
                 }
               }
             }
@@ -1514,7 +1714,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/V2ListMembersResponse"
+                  "$ref": "#/components/schemas/V2ListMembersResponse_Output"
                 }
               }
             }
@@ -1611,7 +1811,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/OrganizationMemberRoleResponse"
+                  "$ref": "#/components/schemas/OrganizationMemberRoleResponse_Output"
                 }
               }
             }
@@ -1708,7 +1908,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/V2ListRolesResponse"
+                  "$ref": "#/components/schemas/V2ListRolesResponse_Output"
                 }
               }
             }
@@ -1795,7 +1995,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/V2CreateInvitationsResponse"
+                  "$ref": "#/components/schemas/V2CreateInvitationsResponse_Output"
                 }
               }
             }
@@ -1895,7 +2095,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/V2DeleteInvitationsResponse"
+                  "$ref": "#/components/schemas/V2DeleteInvitationsResponse_Output"
                 }
               }
             }
@@ -2032,7 +2232,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/V2ListProjectsResponse"
+                  "$ref": "#/components/schemas/V2ListProjectsResponse_Output"
                 }
               }
             }
@@ -2160,7 +2360,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/V2ListGitHubConnectionsResponse"
+                  "$ref": "#/components/schemas/V2ListGitHubConnectionsResponse_Output"
                 }
               }
             }
@@ -10665,7 +10865,6 @@
                                     }
                                   },
                                   "required": ["organization_slug", "project_ref"],
-                                  "additionalProperties": {},
                                   "description": "Final data sent to the consumer."
                                 },
                                 "timestamp": {
@@ -20853,7 +21052,6 @@
                                     }
                                   },
                                   "required": ["organization_slug", "project_ref"],
-                                  "additionalProperties": {},
                                   "description": "Final data sent to the consumer."
                                 },
                                 "timestamp": {
@@ -22616,7 +22814,7 @@
       }
     },
     "schemas": {
-      "ListLogDrainsResponse": {
+      "ListLogDrainsResponse_Output": {
         "type": "object",
         "properties": {
           "data": {
@@ -22647,35 +22845,6 @@
                           "type": "object",
                           "properties": {
                             "url": {
-                              "type": "string",
-                              "nullable": true
-                            },
-                            "schema": {
-                              "type": "string"
-                            },
-                            "username": {
-                              "type": "string",
-                              "nullable": true
-                            },
-                            "password": {
-                              "type": "string",
-                              "nullable": true
-                            },
-                            "port": {
-                              "type": "number",
-                              "nullable": true
-                            },
-                            "hostname": {
-                              "type": "string"
-                            }
-                          },
-                          "additionalProperties": false,
-                          "title": "postgres"
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "url": {
                               "type": "string"
                             },
                             "http": {
@@ -22692,21 +22861,7 @@
                               }
                             }
                           },
-                          "additionalProperties": false,
                           "title": "webhook"
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "project_id": {
-                              "type": "string"
-                            },
-                            "dataset_id": {
-                              "type": "string"
-                            }
-                          },
-                          "additionalProperties": false,
-                          "title": "bigquery"
                         },
                         {
                           "type": "object",
@@ -22718,7 +22873,6 @@
                               "type": "string"
                             }
                           },
-                          "additionalProperties": false,
                           "title": "datadog"
                         },
                         {
@@ -22742,7 +22896,6 @@
                               }
                             }
                           },
-                          "additionalProperties": false,
                           "title": "loki"
                         },
                         {
@@ -22752,7 +22905,6 @@
                               "type": "string"
                             }
                           },
-                          "additionalProperties": false,
                           "title": "sentry"
                         },
                         {
@@ -22768,7 +22920,6 @@
                               "type": "string"
                             }
                           },
-                          "additionalProperties": false,
                           "title": "axiom"
                         },
                         {
@@ -22802,8 +22953,69 @@
                               "type": "string"
                             }
                           },
-                          "additionalProperties": false,
                           "title": "syslog"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "s3_bucket": {
+                              "type": "string"
+                            },
+                            "storage_region": {
+                              "type": "string"
+                            },
+                            "access_key_id": {
+                              "type": "string"
+                            },
+                            "secret_access_key": {
+                              "type": "string"
+                            },
+                            "batch_timeout": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            }
+                          },
+                          "title": "s3"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "region": {
+                              "type": "string"
+                            },
+                            "username": {
+                              "type": "string"
+                            },
+                            "password": {
+                              "type": "string"
+                            }
+                          },
+                          "title": "last9"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "protocol": {
+                              "default": "http/protobuf",
+                              "type": "string"
+                            },
+                            "gzip": {
+                              "default": true,
+                              "type": "boolean"
+                            },
+                            "headers": {
+                              "default": {},
+                              "type": "object",
+                              "additionalProperties": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "title": "otlp"
                         }
                       ]
                     },
@@ -22926,35 +23138,6 @@
                         "type": "object",
                         "properties": {
                           "url": {
-                            "type": "string",
-                            "nullable": true
-                          },
-                          "schema": {
-                            "type": "string"
-                          },
-                          "username": {
-                            "type": "string",
-                            "nullable": true
-                          },
-                          "password": {
-                            "type": "string",
-                            "nullable": true
-                          },
-                          "port": {
-                            "type": "number",
-                            "nullable": true
-                          },
-                          "hostname": {
-                            "type": "string"
-                          }
-                        },
-                        "additionalProperties": false,
-                        "title": "postgres"
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "url": {
                             "type": "string"
                           },
                           "http": {
@@ -22973,19 +23156,6 @@
                         },
                         "additionalProperties": false,
                         "title": "webhook"
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "project_id": {
-                            "type": "string"
-                          },
-                          "dataset_id": {
-                            "type": "string"
-                          }
-                        },
-                        "additionalProperties": false,
-                        "title": "bigquery"
                       },
                       {
                         "type": "object",
@@ -23083,6 +23253,71 @@
                         },
                         "additionalProperties": false,
                         "title": "syslog"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "s3_bucket": {
+                            "type": "string"
+                          },
+                          "storage_region": {
+                            "type": "string"
+                          },
+                          "access_key_id": {
+                            "type": "string"
+                          },
+                          "secret_access_key": {
+                            "type": "string"
+                          },
+                          "batch_timeout": {
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          }
+                        },
+                        "additionalProperties": false,
+                        "title": "s3"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "region": {
+                            "type": "string"
+                          },
+                          "username": {
+                            "type": "string"
+                          },
+                          "password": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "title": "last9"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "endpoint": {
+                            "type": "string"
+                          },
+                          "protocol": {
+                            "default": "http/protobuf",
+                            "type": "string"
+                          },
+                          "gzip": {
+                            "default": true,
+                            "type": "boolean"
+                          },
+                          "headers": {
+                            "default": {},
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": false,
+                        "title": "otlp"
                       }
                     ]
                   },
@@ -23104,7 +23339,8 @@
                     ]
                   }
                 },
-                "required": ["name", "config", "backend_type"]
+                "required": ["name", "config", "backend_type"],
+                "additionalProperties": {}
               }
             },
             "required": ["type", "attributes"]
@@ -23112,7 +23348,7 @@
         },
         "required": ["data"]
       },
-      "LogDrainResponse": {
+      "LogDrainResponse_Output": {
         "type": "object",
         "properties": {
           "data": {
@@ -23141,35 +23377,6 @@
                         "type": "object",
                         "properties": {
                           "url": {
-                            "type": "string",
-                            "nullable": true
-                          },
-                          "schema": {
-                            "type": "string"
-                          },
-                          "username": {
-                            "type": "string",
-                            "nullable": true
-                          },
-                          "password": {
-                            "type": "string",
-                            "nullable": true
-                          },
-                          "port": {
-                            "type": "number",
-                            "nullable": true
-                          },
-                          "hostname": {
-                            "type": "string"
-                          }
-                        },
-                        "additionalProperties": false,
-                        "title": "postgres"
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "url": {
                             "type": "string"
                           },
                           "http": {
@@ -23186,21 +23393,7 @@
                             }
                           }
                         },
-                        "additionalProperties": false,
                         "title": "webhook"
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "project_id": {
-                            "type": "string"
-                          },
-                          "dataset_id": {
-                            "type": "string"
-                          }
-                        },
-                        "additionalProperties": false,
-                        "title": "bigquery"
                       },
                       {
                         "type": "object",
@@ -23212,7 +23405,6 @@
                             "type": "string"
                           }
                         },
-                        "additionalProperties": false,
                         "title": "datadog"
                       },
                       {
@@ -23236,7 +23428,6 @@
                             }
                           }
                         },
-                        "additionalProperties": false,
                         "title": "loki"
                       },
                       {
@@ -23246,7 +23437,6 @@
                             "type": "string"
                           }
                         },
-                        "additionalProperties": false,
                         "title": "sentry"
                       },
                       {
@@ -23262,7 +23452,6 @@
                             "type": "string"
                           }
                         },
-                        "additionalProperties": false,
                         "title": "axiom"
                       },
                       {
@@ -23296,8 +23485,69 @@
                             "type": "string"
                           }
                         },
-                        "additionalProperties": false,
                         "title": "syslog"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "s3_bucket": {
+                            "type": "string"
+                          },
+                          "storage_region": {
+                            "type": "string"
+                          },
+                          "access_key_id": {
+                            "type": "string"
+                          },
+                          "secret_access_key": {
+                            "type": "string"
+                          },
+                          "batch_timeout": {
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          }
+                        },
+                        "title": "s3"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "region": {
+                            "type": "string"
+                          },
+                          "username": {
+                            "type": "string"
+                          },
+                          "password": {
+                            "type": "string"
+                          }
+                        },
+                        "title": "last9"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "endpoint": {
+                            "type": "string"
+                          },
+                          "protocol": {
+                            "default": "http/protobuf",
+                            "type": "string"
+                          },
+                          "gzip": {
+                            "default": true,
+                            "type": "boolean"
+                          },
+                          "headers": {
+                            "default": {},
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "title": "otlp"
                       }
                     ]
                   },
@@ -23353,35 +23603,6 @@
                         "type": "object",
                         "properties": {
                           "url": {
-                            "type": "string",
-                            "nullable": true
-                          },
-                          "schema": {
-                            "type": "string"
-                          },
-                          "username": {
-                            "type": "string",
-                            "nullable": true
-                          },
-                          "password": {
-                            "type": "string",
-                            "nullable": true
-                          },
-                          "port": {
-                            "type": "number",
-                            "nullable": true
-                          },
-                          "hostname": {
-                            "type": "string"
-                          }
-                        },
-                        "additionalProperties": false,
-                        "title": "postgres"
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "url": {
                             "type": "string"
                           },
                           "http": {
@@ -23400,19 +23621,6 @@
                         },
                         "additionalProperties": false,
                         "title": "webhook"
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "project_id": {
-                            "type": "string"
-                          },
-                          "dataset_id": {
-                            "type": "string"
-                          }
-                        },
-                        "additionalProperties": false,
-                        "title": "bigquery"
                       },
                       {
                         "type": "object",
@@ -23510,6 +23718,71 @@
                         },
                         "additionalProperties": false,
                         "title": "syslog"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "s3_bucket": {
+                            "type": "string"
+                          },
+                          "storage_region": {
+                            "type": "string"
+                          },
+                          "access_key_id": {
+                            "type": "string"
+                          },
+                          "secret_access_key": {
+                            "type": "string"
+                          },
+                          "batch_timeout": {
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          }
+                        },
+                        "additionalProperties": false,
+                        "title": "s3"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "region": {
+                            "type": "string"
+                          },
+                          "username": {
+                            "type": "string"
+                          },
+                          "password": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "title": "last9"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "endpoint": {
+                            "type": "string"
+                          },
+                          "protocol": {
+                            "default": "http/protobuf",
+                            "type": "string"
+                          },
+                          "gzip": {
+                            "default": true,
+                            "type": "boolean"
+                          },
+                          "headers": {
+                            "default": {},
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": false,
+                        "title": "otlp"
                       }
                     ]
                   },
@@ -23531,7 +23804,8 @@
                     ]
                   }
                 },
-                "required": ["backend_type"]
+                "required": ["backend_type"],
+                "additionalProperties": {}
               }
             },
             "required": ["type", "attributes"]
@@ -23539,7 +23813,417 @@
         },
         "required": ["data"]
       },
-      "V2ProjectConfigResponse": {
+      "V2RunProjectAdvisorsBody": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "Resource type.",
+                "enum": ["project_advisors"]
+              },
+              "attributes": {
+                "type": "object",
+                "properties": {
+                  "lints": {
+                    "minItems": 1,
+                    "maxItems": 10,
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "enum": [
+                            "unindexed_foreign_keys",
+                            "auth_users_exposed",
+                            "auth_rls_initplan",
+                            "no_primary_key",
+                            "unused_index",
+                            "multiple_permissive_policies",
+                            "policy_exists_rls_disabled",
+                            "rls_enabled_no_policy",
+                            "duplicate_index",
+                            "security_definer_view",
+                            "function_search_path_mutable",
+                            "rls_disabled_in_public",
+                            "extension_in_public",
+                            "rls_references_user_metadata",
+                            "materialized_view_in_api",
+                            "foreign_table_in_api",
+                            "unsupported_reg_types",
+                            "auth_otp_long_expiry",
+                            "auth_otp_short_length",
+                            "ssl_not_enforced",
+                            "log_connections_not_enabled",
+                            "network_restrictions_not_set",
+                            "password_requirements_min_length",
+                            "pitr_not_enabled",
+                            "auth_leaked_password_protection",
+                            "auth_insufficient_mfa_options",
+                            "auth_password_policy_missing",
+                            "leaked_service_key",
+                            "no_backup_admin",
+                            "vulnerable_postgres_version",
+                            "db_not_reachable",
+                            "db_connection_failing",
+                            "db_connection_limit_reached",
+                            "instance_telemetry_lost",
+                            "instance_db_down",
+                            "instance_alert_firing",
+                            "log_data_api_error_rate_high",
+                            "log_auth_error_rate_high",
+                            "log_storage_error_rate_high",
+                            "log_edge_function_error_rate_high"
+                          ]
+                        }
+                      },
+                      "required": ["name"],
+                      "additionalProperties": false
+                    }
+                  }
+                },
+                "required": ["lints"],
+                "additionalProperties": false
+              }
+            },
+            "required": ["type", "attributes"],
+            "additionalProperties": {}
+          }
+        },
+        "required": ["data"]
+      },
+      "V2ProjectAdvisorsResponse_Output": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "Resource type.",
+                "enum": ["project_advisors"]
+              },
+              "attributes": {
+                "type": "object",
+                "properties": {
+                  "lints": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "enum": [
+                            "unindexed_foreign_keys",
+                            "auth_users_exposed",
+                            "auth_rls_initplan",
+                            "no_primary_key",
+                            "unused_index",
+                            "multiple_permissive_policies",
+                            "policy_exists_rls_disabled",
+                            "rls_enabled_no_policy",
+                            "duplicate_index",
+                            "security_definer_view",
+                            "function_search_path_mutable",
+                            "rls_disabled_in_public",
+                            "extension_in_public",
+                            "rls_references_user_metadata",
+                            "materialized_view_in_api",
+                            "foreign_table_in_api",
+                            "unsupported_reg_types",
+                            "auth_otp_long_expiry",
+                            "auth_otp_short_length",
+                            "ssl_not_enforced",
+                            "log_connections_not_enabled",
+                            "network_restrictions_not_set",
+                            "password_requirements_min_length",
+                            "pitr_not_enabled",
+                            "auth_leaked_password_protection",
+                            "auth_insufficient_mfa_options",
+                            "auth_password_policy_missing",
+                            "leaked_service_key",
+                            "no_backup_admin",
+                            "vulnerable_postgres_version",
+                            "db_not_reachable",
+                            "db_connection_failing",
+                            "db_connection_limit_reached",
+                            "instance_telemetry_lost",
+                            "instance_db_down",
+                            "instance_alert_firing",
+                            "log_data_api_error_rate_high",
+                            "log_auth_error_rate_high",
+                            "log_storage_error_rate_high",
+                            "log_edge_function_error_rate_high",
+                            "project_not_active",
+                            "advisor_check_unavailable"
+                          ]
+                        },
+                        "title": {
+                          "type": "string"
+                        },
+                        "level": {
+                          "type": "string",
+                          "enum": ["ERROR", "WARN", "INFO"]
+                        },
+                        "facing": {
+                          "type": "string",
+                          "enum": ["EXTERNAL"]
+                        },
+                        "categories": {
+                          "type": "array",
+                          "items": {
+                            "type": "string",
+                            "enum": ["PERFORMANCE", "SECURITY", "HEALTH"]
+                          },
+                          "x-ignore-array-items-must-be-objects": true
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "detail": {
+                          "type": "string"
+                        },
+                        "remediation": {
+                          "type": "string"
+                        },
+                        "metadata": {
+                          "type": "object",
+                          "properties": {
+                            "schema": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "entity": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "table",
+                                "view",
+                                "materialized view",
+                                "foreign table",
+                                "auth",
+                                "function",
+                                "extension",
+                                "compliance",
+                                "health"
+                              ]
+                            },
+                            "fkey_name": {
+                              "type": "string"
+                            },
+                            "fkey_columns": {
+                              "x-ignore-array-items-must-be-objects": true,
+                              "type": "array",
+                              "items": {
+                                "type": "number"
+                              }
+                            }
+                          }
+                        },
+                        "cache_key": {
+                          "type": "string"
+                        },
+                        "observed_at": {
+                          "type": "string",
+                          "format": "date-time",
+                          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "title",
+                        "level",
+                        "facing",
+                        "categories",
+                        "description",
+                        "detail",
+                        "remediation",
+                        "cache_key"
+                      ]
+                    }
+                  }
+                },
+                "required": ["lints"]
+              }
+            },
+            "required": ["type", "attributes"]
+          }
+        },
+        "required": ["data"]
+      },
+      "V2CreateBranchRequest": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "Resource type.",
+                "enum": ["branch"]
+              },
+              "attributes": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Name of the branch.",
+                    "example": "preview-login-page"
+                  },
+                  "git_branch": {
+                    "description": "Git branch to track. Must exist on the connected GitHub repository when the project has one.",
+                    "example": "feature/login-page",
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "region": {
+                    "description": "Region to create the branch in. Omit to inherit the region of the project it branches from.",
+                    "type": "string"
+                  },
+                  "persistent": {
+                    "description": "Whether the branch is kept when its git branch is deleted or its PR is merged.",
+                    "type": "boolean"
+                  },
+                  "with_data": {
+                    "description": "Whether to seed the branch from the project's latest physical backup.",
+                    "type": "boolean"
+                  },
+                  "desired_instance_size": {
+                    "description": "Desired instance size. Omit this field to always default to the smallest possible size.",
+                    "type": "string",
+                    "enum": [
+                      "nano",
+                      "micro",
+                      "small",
+                      "medium",
+                      "large",
+                      "xlarge",
+                      "2xlarge",
+                      "4xlarge",
+                      "8xlarge",
+                      "12xlarge",
+                      "16xlarge",
+                      "24xlarge",
+                      "24xlarge_optimized_memory",
+                      "24xlarge_optimized_cpu",
+                      "24xlarge_high_memory",
+                      "48xlarge",
+                      "48xlarge_optimized_memory",
+                      "48xlarge_optimized_cpu",
+                      "48xlarge_high_memory"
+                    ]
+                  },
+                  "desired_disk_size_gb": {
+                    "description": "Desired disk size in GB. Omit this field to default to the smallest disk size available on the plan.",
+                    "type": "integer",
+                    "minimum": 8,
+                    "maximum": 61440
+                  },
+                  "notify_url": {
+                    "description": "HTTP endpoint to receive branch status updates.",
+                    "example": "https://example.com/webhooks/branches",
+                    "type": "string",
+                    "format": "uri"
+                  }
+                },
+                "required": ["name"]
+              }
+            },
+            "required": ["type", "attributes"]
+          }
+        },
+        "required": ["data"]
+      },
+      "V2BranchResponse_Output": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "Resource type.",
+                "enum": ["branch"]
+              },
+              "id": {
+                "type": "string",
+                "format": "uuid",
+                "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
+                "description": "ID of the branch."
+              },
+              "attributes": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Name of the branch."
+                  },
+                  "project_ref": {
+                    "type": "string",
+                    "description": "Ref of the project backing this branch."
+                  },
+                  "parent_project_ref": {
+                    "type": "string",
+                    "description": "Ref of the project it branches from."
+                  },
+                  "is_default": {
+                    "type": "boolean",
+                    "description": "Whether this is the default branch of the project."
+                  },
+                  "persistent": {
+                    "type": "boolean",
+                    "description": "Whether the branch is kept when its git branch is deleted or its PR is merged."
+                  },
+                  "with_data": {
+                    "type": "boolean",
+                    "description": "Whether the branch is seeded from the project's data."
+                  },
+                  "git_branch": {
+                    "description": "Git branch being tracked.",
+                    "type": "string"
+                  },
+                  "notify_url": {
+                    "description": "HTTP endpoint receiving branch status updates.",
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "created_at": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Creation timestamp."
+                  },
+                  "updated_at": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Last update timestamp."
+                  }
+                },
+                "required": [
+                  "name",
+                  "project_ref",
+                  "parent_project_ref",
+                  "is_default",
+                  "persistent",
+                  "with_data",
+                  "created_at",
+                  "updated_at"
+                ]
+              }
+            },
+            "required": ["type", "id", "attributes"]
+          }
+        },
+        "required": ["data"]
+      },
+      "V2ProjectConfigResponse_Output": {
         "type": "object",
         "properties": {
           "data": {
@@ -24036,19 +24720,20 @@
                           },
                           "iceberg_catalog": {
                             "type": "boolean"
+                          },
+                          "object_versioning": {
+                            "type": "boolean"
                           }
                         },
-                        "required": ["list_v2", "iceberg_catalog"]
+                        "required": ["list_v2", "iceberg_catalog", "object_versioning"]
                       },
                       "upstream_target": {
                         "type": "string",
                         "enum": ["main", "canary"]
                       },
                       "migration_version": {
-                        "type": "string"
-                      },
-                      "database_pool_mode": {
-                        "type": "string"
+                        "type": "string",
+                        "nullable": true
                       }
                     },
                     "required": [
@@ -24056,8 +24741,7 @@
                       "features",
                       "capabilities",
                       "upstream_target",
-                      "migration_version",
-                      "database_pool_mode"
+                      "migration_version"
                     ],
                     "description": "Read from the storage service's admin API rather than the middleware DB, so unlike the rest of this resource it reflects the tenant's live config."
                   }
@@ -24096,7 +24780,7 @@
         },
         "required": ["data"]
       },
-      "V2PreviewProjectTransferResponse": {
+      "V2PreviewProjectTransferResponse_Output": {
         "type": "object",
         "properties": {
           "data": {
@@ -24167,7 +24851,7 @@
         },
         "required": ["data"]
       },
-      "V2ListPrivateLinkAssociationsResponse": {
+      "V2ListPrivateLinkAssociationsResponse_Output": {
         "type": "object",
         "properties": {
           "data": {
@@ -24292,7 +24976,7 @@
         },
         "required": ["data"]
       },
-      "V2PrivateLinkAssociationResponse": {
+      "V2PrivateLinkAssociationResponse_Output": {
         "type": "object",
         "properties": {
           "data": {
@@ -24375,7 +25059,7 @@
         },
         "required": ["data"]
       },
-      "V2ListWorkersResponse": {
+      "V2ListWorkersResponse_Output": {
         "type": "object",
         "properties": {
           "data": {
@@ -24475,7 +25159,7 @@
         },
         "required": ["data"]
       },
-      "V2WorkerResponse": {
+      "V2WorkerResponse_Output": {
         "type": "object",
         "properties": {
           "data": {
@@ -24572,7 +25256,7 @@
         },
         "required": ["data"]
       },
-      "V2WorkerUploadResponse": {
+      "V2WorkerUploadResponse_Output": {
         "type": "object",
         "properties": {
           "data": {
@@ -24663,7 +25347,7 @@
         },
         "required": ["data"]
       },
-      "V2ListMembersResponse": {
+      "V2ListMembersResponse_Output": {
         "type": "object",
         "properties": {
           "data": {
@@ -24835,7 +25519,7 @@
         },
         "required": ["data"]
       },
-      "OrganizationMemberRoleResponse": {
+      "OrganizationMemberRoleResponse_Output": {
         "type": "object",
         "properties": {
           "data": {
@@ -24884,7 +25568,7 @@
         },
         "required": ["data"]
       },
-      "V2ListRolesResponse": {
+      "V2ListRolesResponse_Output": {
         "type": "object",
         "properties": {
           "data": {
@@ -24980,7 +25664,7 @@
         },
         "required": ["data"]
       },
-      "V2CreateInvitationsResponse": {
+      "V2CreateInvitationsResponse_Output": {
         "type": "object",
         "properties": {
           "error": {
@@ -25160,7 +25844,7 @@
         },
         "required": ["data"]
       },
-      "V2DeleteInvitationsResponse": {
+      "V2DeleteInvitationsResponse_Output": {
         "type": "object",
         "properties": {
           "data": {
@@ -25193,7 +25877,7 @@
         },
         "required": ["data"]
       },
-      "V2ListProjectsResponse": {
+      "V2ListProjectsResponse_Output": {
         "type": "object",
         "properties": {
           "data": {
@@ -25380,7 +26064,7 @@
         },
         "required": ["data", "links"]
       },
-      "V2ListGitHubConnectionsResponse": {
+      "V2ListGitHubConnectionsResponse_Output": {
         "type": "object",
         "properties": {
           "data": {

--- a/apps/studio/components/interfaces/Account/AccessTokens/AccessToken.roles.ts
+++ b/apps/studio/components/interfaces/Account/AccessTokens/AccessToken.roles.ts
@@ -95,6 +95,7 @@ export const FGA_SCOPE_MINIMUM_ROLE: Record<string, TokenRoleLevel> = {
   analytics_logs_read: 'readonly',
   analytics_usage_read: 'readonly',
   api_gateway_keys_read: 'developer',
+  api_gateway_keys_secret_read: 'developer',
   api_gateway_keys_write: 'administrator',
   auth_config_read: 'readonly',
   auth_config_write: 'developer',
@@ -113,6 +114,7 @@ export const FGA_SCOPE_MINIMUM_ROLE: Record<string, TokenRoleLevel> = {
   custom_domain_read: 'readonly',
   custom_domain_write: 'administrator',
   data_api_config_read: 'readonly',
+  data_api_config_secret_read: 'developer',
   data_api_config_write: 'administrator',
   database_read: 'readonly',
   database_write: 'developer',
@@ -156,6 +158,8 @@ export const FGA_SCOPE_MINIMUM_ROLE: Record<string, TokenRoleLevel> = {
   vanity_subdomain_write: 'administrator',
   platform_webhooks_projects_read: 'member',
   platform_webhooks_projects_write: 'administrator',
+  workers_read: 'readonly',
+  workers_write: 'developer',
 }
 
 /**

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -73,7 +73,7 @@
     "@supabase/mcp-server-supabase": "^0.12.0",
     "@supabase/pg-meta": "workspace:*",
     "@supabase/realtime-js": "catalog:",
-    "@supabase/shared-types": "0.1.91",
+    "@supabase/shared-types": "0.1.95",
     "@supabase/supabase-js": "catalog:",
     "@tanstack/react-devtools": "^0.10.3",
     "@tanstack/react-hotkeys": "^0.10.0",

--- a/packages/shared-data/package.json
+++ b/packages/shared-data/package.json
@@ -15,7 +15,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@supabase/shared-types": "0.1.91",
+    "@supabase/shared-types": "0.1.95",
     "zod": "catalog:"
   }
 }

--- a/packages/shared-data/scoped-access-token-permissions.ts
+++ b/packages/shared-data/scoped-access-token-permissions.ts
@@ -619,7 +619,6 @@ const buildCatalog = (): PermissionCatalogEntry[] => {
       writeScopes: writeScopes as FgaScopeId[],
     })
   }
-  console.log({ catalog })
   return catalog
 }
 

--- a/packages/shared-data/scoped-access-token-permissions.ts
+++ b/packages/shared-data/scoped-access-token-permissions.ts
@@ -364,6 +364,14 @@ const RESOURCE_METADATA: Record<string, ResourceMeta> = {
     allowsRead: ['Read project API keys'],
     allowsWrite: ['Create and revoke API keys'],
   },
+  'project:api_gateway_keys_secret': {
+    category: 'appsvc',
+    name: 'JWT secret',
+    description: 'Project JWT secret.',
+    risk: 'high',
+    riskReason: 'Read exposes project JWT secret.',
+    allowsRead: ['Read project JWT secret'],
+  },
   'project:edge_functions': {
     category: 'appsvc',
     name: 'Edge Functions',
@@ -417,6 +425,14 @@ const RESOURCE_METADATA: Record<string, ResourceMeta> = {
     riskReason: 'Read-write can change how the auto-generated Data API behaves.',
     allowsRead: ['Read Data API configuration'],
     allowsWrite: ['Update Data API configuration'],
+  },
+  'project:data_api_config_secret': {
+    category: 'appsvc',
+    name: 'Data API Config Secret',
+    description: 'PostgREST behavior and settings.',
+    risk: 'high',
+    riskReason: 'Read exposes Data API secrets.',
+    allowsRead: ['Read Data API Secret'],
   },
 
   // --- Infrastructure and delivery ---
@@ -603,6 +619,7 @@ const buildCatalog = (): PermissionCatalogEntry[] => {
       writeScopes: writeScopes as FgaScopeId[],
     })
   }
+  console.log({ catalog })
   return catalog
 }
 

--- a/packages/shared-data/scoped-access-token-permissions.ts
+++ b/packages/shared-data/scoped-access-token-permissions.ts
@@ -367,7 +367,7 @@ const RESOURCE_METADATA: Record<string, ResourceMeta> = {
   'project:api_gateway_keys_secret': {
     category: 'appsvc',
     name: 'JWT secret',
-    description: 'Project JWT secret.',
+    description: 'Project JWT secret exposure.',
     risk: 'high',
     riskReason: 'Read exposes project JWT secret.',
     allowsRead: ['Read project JWT secret'],
@@ -429,7 +429,7 @@ const RESOURCE_METADATA: Record<string, ResourceMeta> = {
   'project:data_api_config_secret': {
     category: 'appsvc',
     name: 'Data API Config - JWT Secret',
-    description: 'Data API Config JWT secret.',
+    description: 'Data API Config JWT secret exposure.',
     risk: 'high',
     riskReason: 'Read exposes Data API JWT secret.',
     allowsRead: ['Read Data API JWT secret'],

--- a/packages/shared-data/scoped-access-token-permissions.ts
+++ b/packages/shared-data/scoped-access-token-permissions.ts
@@ -420,7 +420,7 @@ const RESOURCE_METADATA: Record<string, ResourceMeta> = {
   'project:data_api_config': {
     category: 'appsvc',
     name: 'Data API Config',
-    description: 'PostgREST behavior and settings.',
+    description: 'Data API behavior and settings.',
     risk: 'medium',
     riskReason: 'Read-write can change how the auto-generated Data API behaves.',
     allowsRead: ['Read Data API configuration'],
@@ -428,11 +428,11 @@ const RESOURCE_METADATA: Record<string, ResourceMeta> = {
   },
   'project:data_api_config_secret': {
     category: 'appsvc',
-    name: 'Data API Config Secret',
-    description: 'PostgREST behavior and settings.',
+    name: 'Data API Config - JWT Secret',
+    description: 'Data API Config JWT secret.',
     risk: 'high',
-    riskReason: 'Read exposes Data API secrets.',
-    allowsRead: ['Read Data API Secret'],
+    riskReason: 'Read exposes Data API JWT secret.',
+    allowsRead: ['Read Data API JWT secret'],
   },
 
   // --- Infrastructure and delivery ---

--- a/packages/shared-data/scoped-access-token-permissions.ts
+++ b/packages/shared-data/scoped-access-token-permissions.ts
@@ -366,11 +366,11 @@ const RESOURCE_METADATA: Record<string, ResourceMeta> = {
   },
   'project:api_gateway_keys_secret': {
     category: 'appsvc',
-    name: 'JWT secret',
-    description: 'Project JWT secret exposure.',
+    name: 'API Key Secrets',
+    description: 'Secret values of project API keys.',
     risk: 'high',
-    riskReason: 'Read exposes project JWT secret.',
-    allowsRead: ['Read project JWT secret'],
+    riskReason: 'Read reveals the secret values of project API keys.',
+    allowsRead: ['Reveal project API key secrets'],
   },
   'project:edge_functions': {
     category: 'appsvc',
@@ -389,6 +389,15 @@ const RESOURCE_METADATA: Record<string, ResourceMeta> = {
     riskReason: 'Read exposes function secrets; read-write can set new secret values.',
     allowsRead: ['Read edge function secrets'],
     allowsWrite: ['Set edge function secrets'],
+  },
+  'project:workers': {
+    category: 'appsvc',
+    name: 'Compute',
+    description: 'Compute workers deployed to the project.',
+    risk: 'medium',
+    riskReason: 'Read-write can deploy or delete compute workers.',
+    allowsRead: ['List compute workers'],
+    allowsWrite: ['Deploy and delete compute workers'],
   },
   'project:realtime_config': {
     category: 'appsvc',
@@ -428,10 +437,10 @@ const RESOURCE_METADATA: Record<string, ResourceMeta> = {
   },
   'project:data_api_config_secret': {
     category: 'appsvc',
-    name: 'Data API Config - JWT Secret',
-    description: 'Data API Config JWT secret exposure.',
+    name: 'Data API JWT Secret',
+    description: 'JWT secret used by the Data API.',
     risk: 'high',
-    riskReason: 'Read exposes Data API JWT secret.',
+    riskReason: 'Read exposes the JWT secret, which can be used to mint tokens for any role.',
     allowsRead: ['Read Data API JWT secret'],
   },
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1051,8 +1051,8 @@ importers:
         specifier: 'catalog:'
         version: 2.112.4
       '@supabase/shared-types':
-        specifier: 0.1.91
-        version: 0.1.91
+        specifier: 0.1.95
+        version: 0.1.95
       '@supabase/supabase-js':
         specifier: 'catalog:'
         version: 2.112.4(@opentelemetry/api@1.9.1)
@@ -2614,8 +2614,8 @@ importers:
   packages/shared-data:
     dependencies:
       '@supabase/shared-types':
-        specifier: 0.1.91
-        version: 0.1.91
+        specifier: 0.1.95
+        version: 0.1.95
       zod:
         specifier: 'catalog:'
         version: 3.25.76
@@ -8022,8 +8022,8 @@ packages:
     resolution: {integrity: sha512-vZ+j079SKrM0Xiq7MJCvQKLDpaH2kfKfLY68xuQE1sqsCsMmx1CyrDBJHsxZ3cX01VOs5SI9igmoZAF3BmdZxw==}
     engines: {node: '>=22.0.0'}
 
-  '@supabase/shared-types@0.1.91':
-    resolution: {integrity: sha512-n4co7cT2MD0RGKkAdVPRz8O+f+LaWAqfujV/ug/4U434u5bmopLvCWrA8AzIgNSEr9xyJ+Yv3ksCQo9C0UJWTw==}
+  '@supabase/shared-types@0.1.95':
+    resolution: {integrity: sha512-Z/L/nHCiQVqj6nRIBerfQJLcEgYUUFTw+pIr/RMCbldibFrsAg8AkZQxVx/Oe9kSlwgKVxiWHj8m89CLtqo6lg==}
 
   '@supabase/sql-to-rest@0.1.6':
     resolution: {integrity: sha512-06KgjeINtc6405XQvfnchBE1azEsU8G2NElfadmvVHKmHa5l2bFzjbtFbpaYgpgTzccHlcDmBaCgedVf2Gyl8Q==}
@@ -24583,7 +24583,7 @@ snapshots:
       '@supabase/phoenix': 0.4.5
       tslib: 2.8.1
 
-  '@supabase/shared-types@0.1.91': {}
+  '@supabase/shared-types@0.1.95': {}
 
   '@supabase/sql-to-rest@0.1.6(encoding@0.1.13)(supports-color@8.1.1)':
     dependencies:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Surface the new scoped personal access token permissions published in `@supabase/shared-types` 0.1.95 (added by https://github.com/supabase/platform/pull/38060, now deployed).

**Stacked on #50234**, which regenerates the Management API types so Studio's scope type includes the new ids. This PR targets that branch and will retarget to `master` when it merges.

## What's in here

- Bump `@supabase/shared-types` to 0.1.95 (Studio and shared-data).
- Catalog entries in `packages/shared-data/scoped-access-token-permissions.ts`:
  - **API Key Secrets** (`api_gateway_keys_secret_read`): gates `?reveal=true` on the API keys endpoints. Renamed from "JWT secret", which described the wrong thing.
  - **Data API JWT Secret** (`data_api_config_secret_read`): gates the `jwt_secret` field on the PostgREST config endpoint.
  - **Compute** (`workers_read` / `workers_write`): shared-types 0.1.95 also publishes the workers scopes, so they surface in the catalog now. Named to match Studio's product naming (#50208).
- Minimum roles for the four new ids in `FGA_SCOPE_MINIMUM_ROLE`, transcribed from the OpenFGA model (secret reads: developer; workers read: readonly; workers write: developer).
- Docs generator (`generateAccessControlPartials.mts`):
  - Drop the workers exclusion now that the scopes are live.
  - When an endpoint lists alternative permission sets (for example API keys read alone, or read plus secret read for reveal), a row's footnote now only considers the alternatives that include that row's own scope. Previously the API Key Secrets row would have said "Requires API Keys (Read), or API Keys (Read) and API Key Secrets (Read)".
- Regenerated PAT guide tables. The committed Management API specs predate the secret scopes, so this also includes the same spec refresh the weekly docs bot performs (`chore(docs): refresh the Management API specs`, kept as its own commit). Besides the new rows it picks up two new upstream endpoints under Advisors and the branch rows.

## Verified

- `pnpm --filter studio typecheck` clean on top of #50234.
- Access token test suite passes, including the guard that the role table covers exactly the ids shared-types publishes.
- Partial regeneration is idempotent, so the Docs Tests stale-table gate passes.

## Follow-ups (not in this PR)

- `apps/docs/content/guides/getting-started/api-keys.mdx` says a fine-grained token needs `api_gateway_keys_read` for the `?reveal=true` example. It now also needs `api_gateway_keys_secret_read`.
- `project:api_gateway_keys` still says "Read exposes API keys" in its risk reason, which overstates it now that secret values sit behind a separate scope. Rewording may mean revisiting its risk level.
- The comment in `ComputeLayout.tsx` about shared-types not exposing `workers_read` is stale.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added permission support for API key secrets, Data API JWT secrets, and compute workers.
  * Added API endpoints to run project advisors and create branches.
  * Added support for additional log-drain destinations, including S3, Last9, and OTLP.
  * Added storage object versioning information to project configuration responses.
* **Documentation**
  * Updated access-control documentation for new permissions, worker operations, advisor runs, and branch creation.
  * Clarified Data API configuration and secret descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->