### PR TITLE
docs(storage): wrap transform options in the Python download example

### DIFF
--- a/apps/docs/content/guides/storage/serving/image-transformations.mdx
+++ b/apps/docs/content/guides/storage/serving/image-transformations.mdx
@@ -306,7 +306,7 @@ supabase.storage.from("bucket").downloadAuthenticatedTo("image.jpg", file) {
 response = supabase.storage.from_('bucket').download(
   'image.jpg',
   {
-       'transform': {
+    'transform': {
       'width': 800,
       'height': 300,
     },

--- a/apps/docs/content/guides/storage/serving/image-transformations.mdx
+++ b/apps/docs/content/guides/storage/serving/image-transformations.mdx
@@ -306,8 +306,10 @@ supabase.storage.from("bucket").downloadAuthenticatedTo("image.jpg", file) {
 response = supabase.storage.from_('bucket').download(
   'image.jpg',
   {
-    'width': 800,
-    'height': 300,
+       'transform': {
+      'width': 800,
+      'height': 300,
+    },
   },
 )
 ```


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs fix, a broken code sample.

What is the current behavior?

## What is the new behavior?
The options dict wraps the keys in transform, matching the SDK and the sentence directly above the tabs, "pass the transform option to the download function":

response = supabase.storage.from_('bucket').download(
  'image.jpg',
  {
    'transform': {
      'width': 800,
      'height': 300,
    },
  },
)
Additional context

Every other language tab on the same page already wraps: JavaScript uses transform:, Dart uses transform:, Swift uses options: TransformOptions(...), Kotlin uses transform { }, C# uses new TransformOptions. The get_public_url Python example earlier in the same file also wraps its options in transform, so the two Python samples on this page currently disagree with each other.

One code block changed. No prose changes.
Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Python image-download example to correctly nest image transformation options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->