### PR TITLE
docs(database): pg_net default timeout is 5000ms and http_delete acce…

### DIFF
--- a/apps/docs/content/guides/database/extensions/pg_net.mdx
+++ b/apps/docs/content/guides/database/extensions/pg_net.mdx
@@ -71,7 +71,7 @@ net.http_get(
     -- key/values to be included in request headers
     headers jsonb default '{}'::jsonb,
     -- the maximum number of milliseconds the request may take before being canceled
-    timeout_milliseconds int default 2000
+    timeout_milliseconds int default 5000
 )
     -- request_id reference
     returns bigint
@@ -119,7 +119,7 @@ net.http_post(
     -- key/values to be included in request headers
     headers jsonb default '{"Content-Type": "application/json"}'::jsonb,
     -- the maximum number of milliseconds the request may take before being canceled
-    timeout_milliseconds int default 2000
+    timeout_milliseconds int default 5000
 )
     -- request_id reference
     returns bigint
@@ -164,7 +164,9 @@ net.http_delete(
     -- key/values to be included in request headers
     headers jsonb default '{}'::jsonb,
     -- the maximum number of milliseconds the request may take before being canceled
-    timeout_milliseconds int default 2000
+    timeout_milliseconds int default 5000,
+    -- body of the DELETE request
+    body jsonb default null
 )
     -- request_id reference
     returns bigint


### PR DESCRIPTION
…pts a body

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

The pg_net guide publishes timeout_milliseconds int default 2000 for net.http_get, net.http_post and net.http_delete, and the net.http_delete signature has no body parameter.

## What is the current behavior?

The pg_net guide publishes timeout_milliseconds int default 2000 for net.http_get, net.http_post and net.http_delete, and the net.http_delete signature has no body parameter.

## What is the new behavior?

Both are corrected against sql/pg_net.sql on supabase/pg_net@master, where all three functions are defined with timeout_milliseconds int default 5000, and http_delete is:

create or replace function net.http_delete(
    url text,
    params jsonb default '{}'::jsonb,
    headers jsonb default '{}'::jsonb,
    timeout_milliseconds int default 5000,
    body jsonb default null
)

## Additional context
The 3000 ms difference matters when a job issues many requests: a caller sizing a batch against a documented 2 second ceiling will see requests cut at 5 seconds instead. Because net.http_post returns a request id immediately, the failure surfaces later in net._http_response rather than at the call site.

Note the pg_net README carries a third set of numbers (1000 / 1000 / 2000) and also omits body. I will open a separate PR there.
Add any other context or screenshots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated `pg_net` HTTP request documentation to reflect a 5-second default timeout for GET, POST, and DELETE requests.
  - Documented optional JSON request bodies for DELETE requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->