### PR TITLE
chore(www): add open position to careers btn

### DIFF
--- a/apps/www/pages/careers.tsx
+++ b/apps/www/pages/careers.tsx
@@ -1,3 +1,4 @@
+import staticContent from '.generated/staticContent/_index.json'
 import { GlobeAltIcon } from '@heroicons/react/outline'
 import Globe from '~/components/Globe'
 import DefaultLayout from '~/components/Layouts/Default'
@@ -97,6 +98,7 @@ interface CareersPageProps {
 
 const CareerPage = ({ jobs, placeholderJob, contributors }: CareersPageProps) => {
   const { basePath } = useRouter()
+  const { jobsCount } = staticContent
 
   const meta_title = 'Careers | Supabase'
   const meta_description = 'Help build software developers love'
@@ -137,8 +139,8 @@ const CareerPage = ({ jobs, placeholderJob, contributors }: CareersPageProps) =>
             <p className="text-sm md:text-base text-foreground-lighter max-w-sm sm:max-w-md md:max-w-lg mx-auto">
               Explore remote opportunities and join our team to help us achieve it.
             </p>
-            <Button asChild variant="primary" className="mt-4">
-              <Link href="#positions">Open positions</Link>
+            <Button asChild variant="primary" size="medium" className="mt-4">
+              <Link href="#positions">Open positions ({jobsCount})</Link>
             </Button>
           </SectionContainer>
         </header>


### PR DESCRIPTION
Add number of open position on the main cta button in the careers page.

## Before

<img width="1328" height="614" alt="Screenshot 2026-09-08 at 16 57 24" src="https://github.com/user-attachments/assets/7c640e52-afdf-4e77-9705-fe539ed045a7" />

## After

<img width="1352" height="639" alt="Screenshot 2026-09-08 at 16 57 05" src="https://github.com/user-attachments/assets/40c265dd-b28e-44e7-9170-f45a330edfbb" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The careers page now displays the current number of open positions.
  * The “Open positions” call-to-action includes the position count and uses a medium-sized button style.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->