### PR TITLE
docs(platform): add remediation guidance for stale PITR WAL archiving

### DIFF
--- a/apps/docs/content/guides/platform/backups.mdx
+++ b/apps/docs/content/guides/platform/backups.mdx
@@ -143,6 +143,14 @@ After selecting your desired recovery point, the Dashboard prompts you to review
 
 When you disable PITR, we still take all new backups as physical backups only. You can still use physical backups for restoration, but they are not available for direct download. If you need to download a backup after disabling PITR, you need to take a manual [legacy logical backup using the Supabase CLI or pg_dump](/docs/guides/platform/migrating-within-supabase/backup-restore#backup-database-using-the-cli).
 
+### Troubleshooting stale WAL archiving [#troubleshooting-stale-wal-archiving]
+
+PITR depends on continuous WAL archiving to advance its recovery window. If archiving stops, the latest available recovery point stops advancing, and changes made after that point aren't protected by PITR until archiving resumes. The Security Advisor's "PITR archiving may be broken" finding flags this condition.
+
+To check whether it affects your project, open the [Point in Time](/dashboard/project/_/database/backups/pitr) settings and compare the latest restore point against your project's recent write activity. A restore point that's behind because the database has had no recent writes is expected, as described in [Backup process](#backup-process). A restore point that stays behind despite ongoing writes points to broken archiving.
+
+WAL archiving is managed by the platform, so you can't restart or reconfigure it yourself. If the restore point stays stale despite recent activity, or the Advisor finding persists, [contact support](/dashboard/support/new) and mention the "PITR archiving may be broken" finding. Verification runs periodically, so the finding can remain for a while after archiving recovers, and clears after the next successful check.
+
 ## Restore to a new project
 
 See the [Duplicate Project docs](/docs/guides/platform/clone-project).

--- a/apps/studio/components/interfaces/Linter/Linter.utils.test.tsx
+++ b/apps/studio/components/interfaces/Linter/Linter.utils.test.tsx
@@ -81,7 +81,7 @@ describe('Linter.utils lintInfoMap pitr_archiving_stale entry', () => {
     expect(info!.linkText).toBe('View settings')
     // metadata is unused by this entry's link(), and every field on Lint['metadata'] is optional, so {} needs no cast
     expect(info!.link({ projectRef, metadata: {} })).toBe('/project/abc/database/backups/pitr')
-    expect(info!.docsLink).toContain('/guides/platform/backups#point-in-time-recovery')
+    expect(info!.docsLink).toContain('/guides/platform/backups#troubleshooting-stale-wal-archiving')
   })
 })
 

--- a/apps/studio/components/interfaces/Linter/Linter.utils.tsx
+++ b/apps/studio/components/interfaces/Linter/Linter.utils.tsx
@@ -268,8 +268,7 @@ export const lintInfoMap: LintInfo[] = [
     icon: <Ruler className="text-foreground-muted" size={15} strokeWidth={1} />,
     link: ({ projectRef }) => `/project/${projectRef}/database/backups/pitr`,
     linkText: 'View settings',
-    // anchor explains what PITR is, not how to fix a stale archive; PITR-archiving-specific docs tracked in TODO: INDATA-1149
-    docsLink: `${DOCS_URL}/guides/platform/backups#point-in-time-recovery`,
+    docsLink: `${DOCS_URL}/guides/platform/backups#troubleshooting-stale-wal-archiving`,
     category: 'security',
   },
   {


### PR DESCRIPTION
## Summary

Studio's `pitr_archiving_stale` advisor lint (supabase/supabase#48044) linked its "Learn more" button to the general PITR overview, since no remediation content existed yet. This adds that content and repoints the link.

(bot-generated information collapsed below)

---

<details><summary>Details</summary>

- Adds a `### Troubleshooting stale WAL archiving` section to `apps/docs/content/guides/platform/backups.mdx`: what the "PITR archiving may be broken" finding means, how to tell it apart from an idle-database restore point (cross-referencing the existing `### Backup process` caveat), and when to contact support.
- Pins the new heading with an explicit anchor (`[#troubleshooting-stale-wal-archiving]`) rather than relying on the generated slug, since nothing in CI ties the Studio `docsLink` string to the docs heading text.
- Repoints `pitr_archiving_stale`'s `docsLink` in `apps/studio/components/interfaces/Linter/Linter.utils.tsx` at the new anchor, and removes the inline `TODO: INDATA-1149` comment it resolves.
- Updates `Linter.utils.test.tsx`'s existing assertion on that `docsLink` value to match.

</details>

---

<details><summary>Testing</summary>

- `pnpm lint:mdx` (from `apps/docs`) — zero new findings; all pre-existing findings are in unrelated files
- `pnpm build:guides-markdown` (from `apps/docs`) — fails with a pre-existing, unrelated error (missing generated `ai-skills.json`), confirmed present on `master` with this PR's changes stashed out
- **updated `Linter.utils.test.tsx`'s `pitr_archiving_stale` assertion** — passes
- `pnpm --filter=studio typecheck` — clean
- `pnpm --filter=studio lint` and `pnpm --filter studio run lint:ratchet` — clean, no new findings in touched files
- `prettier --check` on all three touched files — clean

</details>

---

## Misc

Resolves INDATA-1149
