### PR TITLE
fix: selfhost realtime settings

### DIFF
--- a/apps/studio/components/interfaces/Realtime/RealtimeSettings.test.tsx
+++ b/apps/studio/components/interfaces/Realtime/RealtimeSettings.test.tsx
@@ -20,12 +20,20 @@ const {
   mockUseSelectedOrganizationQuery,
   mockUseSelectedProjectQuery,
   mockUseDatabasePoliciesQuery,
+  mockIsPlatform,
+  mockUseDeploymentMode,
 } = vi.hoisted(() => ({
   mockUseAsyncCheckPermissions: vi.fn(),
   mockUseMaxConnectionsQuery: vi.fn(),
   mockUseSelectedOrganizationQuery: vi.fn(),
   mockUseSelectedProjectQuery: vi.fn(),
   mockUseDatabasePoliciesQuery: vi.fn(),
+  mockIsPlatform: { value: true },
+  mockUseDeploymentMode: vi.fn(),
+}))
+
+vi.mock('@/hooks/misc/useDeploymentMode', () => ({
+  useDeploymentMode: mockUseDeploymentMode,
 }))
 
 vi.mock('@/hooks/misc/useCheckPermissions', () => ({
@@ -50,7 +58,12 @@ vi.mock('@/data/database-policies/database-policies-query', () => ({
 
 vi.mock('@/lib/constants', async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>()
-  return { ...actual, IS_PLATFORM: true }
+  return {
+    ...actual,
+    get IS_PLATFORM() {
+      return mockIsPlatform.value
+    },
+  }
 })
 
 const REALTIME_CONFIG = {
@@ -85,6 +98,13 @@ const REALTIME_ENTITLEMENTS: Entitlement[] = (
 describe('RealtimeSettings', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+
+    mockIsPlatform.value = true
+    mockUseDeploymentMode.mockReturnValue({
+      isPlatform: true,
+      isCli: false,
+      isSelfHosted: false,
+    })
 
     mockUseAsyncCheckPermissions.mockReturnValue({ can: true, isSuccess: true })
     mockUseSelectedProjectQuery.mockReturnValue({
@@ -200,5 +220,33 @@ describe('RealtimeSettings', () => {
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
       expect(requests).toHaveLength(0)
     }
+  })
+
+  test('renders admonition for self-hosted projects when off-platform', async () => {
+    mockIsPlatform.value = false
+    mockUseDeploymentMode.mockReturnValue({ isPlatform: false, isCli: false, isSelfHosted: true })
+
+    customRender(<RealtimeSettings />)
+
+    expect(
+      screen.getByText('Realtime settings are not available for self-hosted projects')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/Realtime settings are configured via environment variables/)
+    ).toBeInTheDocument()
+    expect(screen.queryByLabelText('Postgres Changes connection pool size')).not.toBeInTheDocument()
+  })
+
+  test('renders admonition for CLI projects when off-platform', async () => {
+    mockIsPlatform.value = false
+    mockUseDeploymentMode.mockReturnValue({ isPlatform: false, isCli: true, isSelfHosted: false })
+
+    customRender(<RealtimeSettings />)
+
+    expect(
+      screen.getByText('Realtime settings are not available for self-hosted projects')
+    ).toBeInTheDocument()
+    expect(screen.getByText(/Realtime settings are configured in/)).toBeInTheDocument()
+    expect(screen.queryByLabelText('Postgres Changes connection pool size')).not.toBeInTheDocument()
   })
 })

--- a/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
+++ b/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
@@ -27,6 +27,7 @@ import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 import * as z from 'zod'
 
 import { AlertError } from '@/components/ui/AlertError'
+import { DocsButton } from '@/components/ui/DocsButton'
 import { ToggleSpendCapButton } from '@/components/ui/ToggleSpendCapButton'
 import { UpgradePlanButton } from '@/components/ui/UpgradePlanButton'
 import { useDatabasePoliciesQuery } from '@/data/database-policies/database-policies-query'
@@ -38,8 +39,10 @@ import {
 } from '@/data/realtime/realtime-config-query'
 import { useCheckEntitlements } from '@/hooks/misc/useCheckEntitlements'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
+import { useDeploymentMode } from '@/hooks/misc/useDeploymentMode'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { DOCS_URL, IS_PLATFORM } from '@/lib/constants'
 
 const formId = 'realtime-configuration-form'
 
@@ -53,6 +56,7 @@ const REALTIME_SOFT_LIMITS = {
 const MAX_POSTGRES_CHANGES_POOL = 20
 
 export const RealtimeSettings = () => {
+  const { isCli, isSelfHosted } = useDeploymentMode()
   const { ref: projectRef } = useParams()
   const { data: project } = useSelectedProjectQuery()
   const { data: organization, isSuccess: isSuccessOrganization } = useSelectedOrganizationQuery()
@@ -311,6 +315,36 @@ export const RealtimeSettings = () => {
       ),
       suspend: values.suspend,
     })
+  }
+
+  if (!IS_PLATFORM) {
+    return (
+      <Admonition
+        type="default"
+        title="Realtime settings are not available for self-hosted projects"
+        description={
+          isCli ? (
+            <p>
+              Realtime settings are configured in{' '}
+              <code className="text-code-inline">supabase/config.toml</code> under{' '}
+              <code className="text-code-inline">[realtime]</code>.
+            </p>
+          ) : (
+            <p>
+              Realtime settings are configured via environment variables in your deployment
+              configuration.
+            </p>
+          )
+        }
+        actions={
+          <DocsButton
+            href={
+              isCli ? `${DOCS_URL}/guides/local-development` : `${DOCS_URL}/guides/self-hosting`
+            }
+          />
+        }
+      />
+    )
   }
 
   if (isLoading) {


### PR DESCRIPTION
## TL;DR

Show an admonition on the Realtime settings page for self-hosted and CLI deployments instead of hanging on an infinite skeleton loader.

## Problem

In self-hosted and local Studio (`!IS_PLATFORM`), the Realtime config query is disabled, leaving React Query in a permanent pending state. As a result, `RealtimeSettings` gets stuck indefinitely on `<GenericSkeletonLoader />`.

## Solution

Follow the pattern used by `StorageSettings` and `General`: render an admonition explaining that Realtime settings are managed through environment variables for self-hosted deployments or `config.toml` for CLI, along with links to the self-hosting docs.

## Ref

* Closes #50142

## Proof

![Realtime Settings Self-hosted UI](https://github.com/mandar1045/supabase/releases/download/assets/realtime-settings-fix.png)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Realtime settings now display deployment-specific guidance for self-hosted and CLI projects.
  * Configuration fields are hidden when Realtime settings are unavailable on the current deployment.
  * Added links to documentation for configuring Realtime locally or in self-hosted environments.

* **Tests**
  * Added coverage for self-hosted and CLI deployment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->