### PR TITLE
docs: fix dead relative links in i18n READMEs and CONFIG.md

### DIFF
--- a/docker/CONFIG.md
+++ b/docker/CONFIG.md
@@ -1236,7 +1236,7 @@ The fields below are repeated for each provider. Substitute `<PROVIDER>` with on
 
 ## Analytics
 
-> The `analytics` container runs [logflare/logflare](github.com/Logflare/logflare), an Elixir/Phoenix application. Almost all runtime env reads live in [config/runtime.exs](https://github.com/Logflare/logflare/blob/main/config/runtime.exs). Self-hosted Supabase runs it in single-tenant Supabase mode with the Postgres backend; BigQuery support is available but commented out in `docker-compose.yml`. The container is the consumer of `LOGFLARE_PUBLIC_ACCESS_TOKEN`/`LOGFLARE_PRIVATE_ACCESS_TOKEN`.
+> The `analytics` container runs [logflare/logflare](https://github.com/Logflare/logflare), an Elixir/Phoenix application. Almost all runtime env reads live in [config/runtime.exs](https://github.com/Logflare/logflare/blob/main/config/runtime.exs). Self-hosted Supabase runs it in single-tenant Supabase mode with the Postgres backend; BigQuery support is available but commented out in `docker-compose.yml`. The container is the consumer of `LOGFLARE_PUBLIC_ACCESS_TOKEN`/`LOGFLARE_PRIVATE_ACCESS_TOKEN`.
 
 > **Heads-up - always-on admin UI:** Logflare's admin pages under `/admin/*` (sources, accounts, cluster view) **are reachable by default**. `LOGFLARE_SUPABASE_MODE=true` provisions an auto-admin user, and the `/admin/*` routes are gated by an auth pipeline rather than an env var - there is no flag to disable them.
 >

--- a/i18n/README.ar.md
+++ b/i18n/README.ar.md
@@ -34,7 +34,7 @@
 
 للحصول على الشرح الكامل، قم بزيارة [supabase.com/docs](https://supabase.com/docs).
 
-لمعرفه كيفية دعم المشروع قم بزيارة [Getting Started](./DEVELOPERS.md).
+لمعرفه كيفية دعم المشروع قم بزيارة [Getting Started](../DEVELOPERS.md).
 
 ## المجتمع والدعم
 

--- a/i18n/README.hr.md
+++ b/i18n/README.hr.md
@@ -31,7 +31,7 @@ Pratite "izdanja" ovog repozitorija da bi bili obaviješteni o većim ažuriranj
 
 Za cjelovitu dokumentaciju, posjetite [supabase.com/docs](https://supabase.com/docs)
 
-Za informacije kako doprinijeti razvoju, posjetite [Početak rada](./DEVELOPERS.md)
+Za informacije kako doprinijeti razvoju, posjetite [Početak rada](../DEVELOPERS.md)
 
 ## Zajednica & Podrška
 
@@ -49,7 +49,7 @@ Supabase je kombinacija alata otvorenog koda. Izgrađujemo funkcionalnosti Fireb
 Supabase je [hostana platforma](https://supabase.com/dashboard). Možete se registrirati i odmah počet koristiti Supabase bez ikakvih instalacija.
 Također možete ju [samostalno hostati](https://supabase.com/docs/guides/hosting/overview) i [razvijati lokalno](https://supabase.com/docs/guides/local-development).
 
-![Arhitektura](apps/docs/public/img/supabase-architecture.svg)
+![Arhitektura](../apps/docs/public/img/supabase-architecture.svg)
 
 - [Postgres](https://www.postgresql.org/) je objektno-relacijska baza podataka koja je aktivno u razvoju preko 30 godina i na glasu je kao jako pouzdana, robusna i performantna.
 - [Realtime](https://github.com/supabase/realtime) je Elixir server koji vam dopušta da prisluškujete unose, ažuriranja i brisanja u PostgreSQL bazi koristeći websockete. Realtime prati Postgres-ovu funkcionalnost repliciranja i osluškuje promjene u bazi podataka, te iste upakira u JSON, na kraju emitira taj JSON preko websocketa do autoriziranih klijenata.

--- a/i18n/README.si.md
+++ b/i18n/README.si.md
@@ -32,7 +32,7 @@
 
 සම්පූර්ණ විස්තරය කියවන්න ,මෙතනින් [supabase.com/docs](https://supabase.com/docs)
 
-දායක වන ආකාරය බැලීමට, ආරම්භ කිරීම වෙත [පිවිසෙන්න](./DEVELOPERS.md)
+දායක වන ආකාරය බැලීමට, ආරම්භ කිරීම වෙත [පිවිසෙන්න](../DEVELOPERS.md)
 
 ## Community එක හා සහයෝගය ගැනීමට
 
@@ -50,7 +50,7 @@ Supabase යනු විවෘත පරිශීලක උපාංග කි�
 Supabase යනු [hosted platform](https://supabase.com/dashboard). ඔබට කිසිවක් ස්ථාපනය නොකර ලියාපදිංචි වී Supabase භාවිතා කිරීම ආරම්භ කළ හැකිය.
 ඔබට [self-host](https://supabase.com/docs/guides/hosting/overview) සහ [develop locally](https://supabase.com/docs/guides/local-development) කළ හැකිය.
 
-![Architecture](apps/docs/public/img/supabase-architecture.svg)
+![Architecture](../apps/docs/public/img/supabase-architecture.svg)
 
 - [PostgreSQL](https://www.postgresql.org/) යනු අවුරුදු 30 වඩා කාලයක් ක්‍රියාත්මක වෙමින් පවතින object-relational database system එකක් වන අතර එය විශ්වාසනීයත්වයට,ක්‍රියාකාරීත්වයට හා feature robustness බවට කීර්තියක් අත්පත්කරගෙන සිටියි
 - [Realtime](https://github.com/supabase/realtime) is an Elixir server that allows you to listen to PostgreSQL inserts, updates, and deletes using websockets. Realtime polls Postgres' built-in replication functionality for database changes, converts changes to JSON, then broadcasts the JSON over websockets to authorized clients.


### PR DESCRIPTION
- All localized `i18n/README.*.md` files linked `./DEVELOPERS.md` — resolved from `i18n/` it 404s (the file is at the repo root → `../DEVELOPERS.md`); `README.hr.md`'s architecture-image link had the same missing-parent-hop problem
- `docker/CONFIG.md`: `[logflare/logflare](github.com/Logflare/logflare)` has no URL scheme, so it renders as a relative link that 404s — added `https://`

Docs-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected the Analytics documentation URL to use a complete HTTPS link.
  - Fixed contributor and support links in translated README files so they correctly point to the developer documentation.
  - Corrected architecture image paths in translated README files, ensuring the images display properly from their current locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->