### PR TITLE
fix(studio): reject database passwords Postgres cannot authenticate with

### DIFF
--- a/apps/studio/lib/api/self-hosted/util.test.ts
+++ b/apps/studio/lib/api/self-hosted/util.test.ts
@@ -104,6 +104,20 @@ describe('api/self-hosted/util', () => {
       expect(result).toBe('postgresql://readonly_user:secret@db.example.com:5433/mydb')
     })
 
+    it('should percent-encode credentials that are unsafe in a URL', async () => {
+      vi.stubEnv('POSTGRES_HOST', 'localhost')
+      vi.stubEnv('POSTGRES_PORT', '5432')
+      vi.stubEnv('POSTGRES_DB', 'testdb')
+      vi.stubEnv('POSTGRES_PASSWORD', 'p@ss/w#rd:1%2')
+      vi.stubEnv('POSTGRES_USER_READ_WRITE', 'admin user')
+
+      const { getConnectionString } = await import('./util')
+
+      const result = getConnectionString({ readOnly: false })
+
+      expect(result).toBe('postgresql://admin%20user:p%40ss%2Fw%23rd%3A1%252@localhost:5432/testdb')
+    })
+
     it('should use default values when env vars not set', async () => {
       vi.stubEnv('POSTGRES_HOST', '')
       vi.stubEnv('POSTGRES_PORT', '')

--- a/apps/studio/lib/api/self-hosted/util.ts
+++ b/apps/studio/lib/api/self-hosted/util.ts
@@ -24,6 +24,10 @@ export function encryptString(stringToEncrypt: string): string {
   return crypto.AES.encrypt(stringToEncrypt, ENCRYPTION_KEY).toString()
 }
 
+/**
+ * Builds the pg-meta connection URI for the self-hosted Postgres instance. Credentials
+ * are percent-encoded so characters that are reserved in a URI do not truncate it.
+ */
 export function getConnectionString({ readOnly }: { readOnly: boolean }) {
   const postgresUser = readOnly ? POSTGRES_USER_READ_ONLY : POSTGRES_USER_READ_WRITE
 

--- a/apps/studio/lib/api/self-hosted/util.ts
+++ b/apps/studio/lib/api/self-hosted/util.ts
@@ -27,5 +27,5 @@ export function encryptString(stringToEncrypt: string): string {
 export function getConnectionString({ readOnly }: { readOnly: boolean }) {
   const postgresUser = readOnly ? POSTGRES_USER_READ_ONLY : POSTGRES_USER_READ_WRITE
 
-  return `postgresql://${postgresUser}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DATABASE}`
+  return `postgresql://${encodeURIComponent(postgresUser)}:${encodeURIComponent(POSTGRES_PASSWORD)}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DATABASE}`
 }

--- a/apps/studio/lib/password-strength.test.ts
+++ b/apps/studio/lib/password-strength.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { passwordNeedsPercentEncoding, passwordStrength } from './password-strength'
+import {
+  passwordHasUnsupportedCharacters,
+  passwordNeedsPercentEncoding,
+  passwordStrength,
+} from './password-strength'
 
 describe('passwordNeedsPercentEncoding', () => {
   it('returns false for passwords that are safe to use in a connection string', () => {
@@ -20,6 +24,43 @@ describe('passwordNeedsPercentEncoding', () => {
     expect(passwordNeedsPercentEncoding('test?string')).toBe(true)
     expect(passwordNeedsPercentEncoding('test&string')).toBe(true)
     expect(passwordNeedsPercentEncoding('test string')).toBe(true)
+  })
+})
+
+describe('passwordHasUnsupportedCharacters', () => {
+  it('returns false for passwords Postgres stores exactly as they were typed', () => {
+    expect(passwordHasUnsupportedCharacters('')).toBe(false)
+    expect(passwordHasUnsupportedCharacters('Str0ngPassword123')).toBe(false)
+    expect(passwordHasUnsupportedCharacters('with-safe_chars.~!@#$%^&*()')).toBe(false)
+    expect(passwordHasUnsupportedCharacters('with a plain space')).toBe(false)
+    expect(passwordHasUnsupportedCharacters('precomposed\u00e8F\u00d6\u00c6aB12345')).toBe(false)
+  })
+
+  it('returns true for characters SASLprep rewrites before hashing', () => {
+    const passwords = {
+      'no-break space': 'aB1\u00a0xYz9',
+      'soft hyphen': 'aB1\u00adxYz9',
+      'combining grapheme joiner': 'aB1\u034fxYz9',
+      'ogham space mark': 'aB1\u1680xYz9',
+      'en quad': 'aB1\u2000xYz9',
+      'zero width space': 'aB1\u200bxYz9',
+      'word joiner': 'aB1\u2060xYz9',
+      'narrow no-break space': 'aB1\u202fxYz9',
+      'ideographic space': 'aB1\u3000xYz9',
+      'variation selector': 'aB1\ufe00xYz9',
+      'byte order mark': 'aB1\ufeffxYz9',
+    }
+
+    for (const [label, password] of Object.entries(passwords)) {
+      expect(passwordHasUnsupportedCharacters(password), label).toBe(true)
+    }
+  })
+
+  it('returns true for decomposed accents that NFKC recomposes', () => {
+    const decomposed = 'e\u0300FO\u0308\u00c6aB12345'
+
+    expect(passwordHasUnsupportedCharacters(decomposed)).toBe(true)
+    expect(passwordHasUnsupportedCharacters(decomposed.normalize('NFC'))).toBe(false)
   })
 })
 
@@ -43,6 +84,13 @@ describe('passwordStrength', () => {
     expect(result.message).toContain('This password is strong')
     expect(result.warning).toBe('')
     expect(result.strength).toBe(4)
+  })
+
+  it('rejects a strong password that Postgres cannot authenticate with', async () => {
+    const result = await passwordStrength('Str0ngPassword123\u00a0')
+    expect(result.message).toMatch(/cannot authenticate with/i)
+    expect(result.warning).toMatch(/letters, numbers, and standard symbols/i)
+    expect(result.strength).toBe(0)
   })
 
   it('returns weak score, suggestion, and warning for weak password', async () => {

--- a/apps/studio/lib/password-strength.test.ts
+++ b/apps/studio/lib/password-strength.test.ts
@@ -56,6 +56,17 @@ describe('passwordHasUnsupportedCharacters', () => {
     }
   })
 
+  it('returns false for characters SASLprep prohibits rather than rewrites', () => {
+    const passwords = {
+      'line separator': 'aB1\u2028xYz9',
+      'paragraph separator': 'aB1\u2029xYz9',
+    }
+
+    for (const [label, password] of Object.entries(passwords)) {
+      expect(passwordHasUnsupportedCharacters(password), label).toBe(false)
+    }
+  })
+
   it('returns true for decomposed accents that NFKC recomposes', () => {
     const decomposed = 'e\u0300FO\u0308\u00c6aB12345'
 

--- a/apps/studio/lib/password-strength.ts
+++ b/apps/studio/lib/password-strength.ts
@@ -17,6 +17,23 @@ export function passwordNeedsPercentEncoding(password: string) {
   }
 }
 
+/**
+ * Characters that Postgres rewrites via SASLprep (RFC 4013) when it derives the SCRAM
+ * verifier: the "commonly mapped to nothing" set of RFC 3454 table B.1, plus the
+ * non-ASCII spaces of table C.1.2 that it folds into a plain space.
+ */
+const SASLPREP_REWRITTEN_CHARACTERS =
+  /[\u00A0\u00AD\u034F\u1680\u1806\u180B-\u180D\u2000-\u200D\u2028\u2029\u202F\u205F\u2060\u3000\uFE00-\uFE0F\uFEFF]/
+
+/**
+ * True when Postgres would store a SCRAM verifier for a different string than the one
+ * typed. libpq applies SASLprep before it authenticates, node-postgres sends the raw
+ * string, so such a password is accepted on save and then fails every dashboard query.
+ */
+export function passwordHasUnsupportedCharacters(password: string) {
+  return SASLPREP_REWRITTEN_CHARACTERS.test(password) || password.normalize('NFKC') !== password
+}
+
 export async function passwordStrength(value: string) {
   // [Alaister]: Lazy load zxcvbn to avoid bundling it with the main app (it's pretty chunky)
   const zxcvbn = await import('zxcvbn').then((module) => module.default)
@@ -29,6 +46,9 @@ export async function passwordStrength(value: string) {
     if (value.length > 99) {
       message = `${PASSWORD_STRENGTH[0]} Maximum length of password exceeded`
       warning = `Password should be less than 100 characters`
+    } else if (passwordHasUnsupportedCharacters(value)) {
+      message = `${PASSWORD_STRENGTH[0]} Contains characters Postgres cannot authenticate with`
+      warning = `Use only letters, numbers, and standard symbols, or generate a new password.`
     } else {
       const result = zxcvbn(value)
       const resultScore = result?.score ?? 0

--- a/apps/studio/lib/password-strength.ts
+++ b/apps/studio/lib/password-strength.ts
@@ -23,7 +23,7 @@ export function passwordNeedsPercentEncoding(password: string) {
  * non-ASCII spaces of table C.1.2 that it folds into a plain space.
  */
 const SASLPREP_REWRITTEN_CHARACTERS =
-  /[\u00A0\u00AD\u034F\u1680\u1806\u180B-\u180D\u2000-\u200D\u2028\u2029\u202F\u205F\u2060\u3000\uFE00-\uFE0F\uFEFF]/
+  /[\u00A0\u00AD\u034F\u1680\u1806\u180B-\u180D\u2000-\u200D\u202F\u205F\u2060\u3000\uFE00-\uFE0F\uFEFF]/
 
 /**
  * True when Postgres would store a SCRAM verifier for a different string than the one

--- a/apps/studio/lib/password-strength.ts
+++ b/apps/studio/lib/password-strength.ts
@@ -34,6 +34,11 @@ export function passwordHasUnsupportedCharacters(password: string) {
   return SASLPREP_REWRITTEN_CHARACTERS.test(password) || password.normalize('NFKC') !== password
 }
 
+/**
+ * Scores a database password and returns the copy shown under the input. Returns a
+ * strength of 0 with a warning for passwords that are too long, or that contain
+ * characters Postgres cannot authenticate with, before falling back to zxcvbn.
+ */
 export async function passwordStrength(value: string) {
   // [Alaister]: Lazy load zxcvbn to avoid bundling it with the main app (it's pretty chunky)
   const zxcvbn = await import('zxcvbn').then((module) => module.default)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for #50156.

## What is the current behavior?

Postgres applies SASLprep (RFC 4013) when it derives the SCRAM verifier, and libpq applies it again on connect. `node-postgres` sends the raw string, so a password whose SASLprep form differs from what was typed is accepted on save and then fails every dashboard query.

I confirmed this on Postgres 17 with `scram-sha-256`. Precomposed accents like `èFÖÆ` are fine. What breaks is the set SASLprep deletes or folds, such as a no-break space, a soft hyphen, or a decomposed accent. Those authenticate from psql and fail from `node-postgres` against the same role, which is why a generated password can look valid and still lock the dashboard out.

Separately, `getConnectionString` interpolated the password into the pg-meta URI unencoded, so a self-hosted password containing `@`, `/`, `#`, `?`, or `%` broke the connection outright.

## What is the new behavior?

- `passwordHasUnsupportedCharacters` flags the RFC 3454 table B.1 and C.1.2 characters plus anything NFKC rewrites.
- Wired into `passwordStrength` next to the existing max-length branch, so project creation and the reset dialog both reject these passwords and state the requirement.
- Percent-encoded the credentials in the self-hosted pg-meta connection string.
- Unit tests for both.

## Additional context

Making these passwords actually work needs SASLprep in the connecting client, which lives in `node-postgres` and `supabase/postgres-meta`, so the issue should stay open. Projects already locked out are unaffected, and I did not normalize the password.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - PostgreSQL connection strings now safely encode special characters in usernames and passwords.
  - Password strength validation now identifies characters that may be rewritten during database authentication.
  - Passwords containing unsupported characters are rejected with a clear authentication warning instead of receiving an inaccurate strength assessment.
  - Password guidance now helps users choose characters that authenticate reliably and accurately reflect password strength.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->