### PR TITLE
fix(ui): default Button variant to default instead of primary

### DIFF
--- a/apps/design-system/content/docs/components/button.mdx
+++ b/apps/design-system/content/docs/components/button.mdx
@@ -59,8 +59,7 @@ Used for data insertion actions, confirming purchases, strong positive actions.
 
 Used for opening dialogs, navigating to pages, and other non CRUD actions.
 
-This `variant` will probably be the most used button variant.
-It will probably be changed to be the default variant in future.
+This is the default `variant` when none is specified. It is the most used button variant.
 
 <ComponentPreview name="button-default" />
 

--- a/apps/design-system/content/docs/components/button.mdx
+++ b/apps/design-system/content/docs/components/button.mdx
@@ -5,7 +5,7 @@ featured: true
 component: true
 ---
 
-<ComponentPreview name="button-demo" peekCode wide />
+<ComponentPreview name="button-default" peekCode wide />
 
 ## Usage
 
@@ -47,21 +47,17 @@ Use the `size` prop to determine the size of the button.
 
 ### Variants
 
-These are all the different `variant` variations.
+#### Default
+
+Used when no `variant` is specified. Prefer this unless another variant fits better, as below.
+
+<ComponentPreview name="button-default" />
 
 #### Primary
 
-Used for data insertion actions, confirming purchases, strong positive actions.
+Use sparingly for data insertion, confirming purchases, and other strong positive actions. Because it is so prominent, aim for at most one primary button in a viewport.
 
 <ComponentPreview name="button-demo" />
-
-#### Default
-
-Used for opening dialogs, navigating to pages, and other non CRUD actions.
-
-This is the default `variant` when none is specified. It is the most used button variant.
-
-<ComponentPreview name="button-default" />
 
 #### Secondary
 

--- a/apps/design-system/registry/default/example/button-as-child.tsx
+++ b/apps/design-system/registry/default/example/button-as-child.tsx
@@ -3,7 +3,7 @@ import { Button } from 'ui'
 
 export default function ButtonAsChild() {
   return (
-    <Button asChild>
+    <Button variant="primary" asChild>
       <Link href="/login">Sign in</Link>
     </Button>
   )

--- a/apps/design-system/registry/default/example/button-loading.tsx
+++ b/apps/design-system/registry/default/example/button-loading.tsx
@@ -2,7 +2,7 @@ import { Button } from 'ui'
 
 export default function ButtonLoading() {
   return (
-    <Button disabled loading>
+    <Button variant="primary" disabled loading>
       Please wait
     </Button>
   )

--- a/apps/design-system/registry/default/example/button-with-icon.tsx
+++ b/apps/design-system/registry/default/example/button-with-icon.tsx
@@ -2,5 +2,9 @@ import { Mail } from 'lucide-react'
 import { Button } from 'ui'
 
 export default function ButtonWithIcon() {
-  return <Button icon={<Mail className="mr-2 h-4 w-4" />}>Sign in with email</Button>
+  return (
+    <Button variant="primary" icon={<Mail className="mr-2 h-4 w-4" />}>
+      Sign in with email
+    </Button>
+  )
 }

--- a/apps/design-system/registry/default/example/calendar-form.tsx
+++ b/apps/design-system/registry/default/example/calendar-form.tsx
@@ -84,7 +84,9 @@ export default function CalendarForm() {
             </FormItem>
           )}
         />
-        <Button type="submit">Submit</Button>
+        <Button variant="primary" type="submit">
+          Submit
+        </Button>
       </form>
     </Form>
   )

--- a/apps/design-system/registry/default/example/calendar-react-hook-form.tsx
+++ b/apps/design-system/registry/default/example/calendar-react-hook-form.tsx
@@ -83,7 +83,9 @@ export default function CalendarForm() {
             </FormItem>
           )}
         />
-        <Button type="submit">Submit</Button>
+        <Button variant="primary" type="submit">
+          Submit
+        </Button>
       </form>
     </Form>
   )

--- a/apps/design-system/registry/default/example/checkbox-form-multiple.tsx
+++ b/apps/design-system/registry/default/example/checkbox-form-multiple.tsx
@@ -112,7 +112,9 @@ export default function CheckboxReactHookFormMultiple() {
             </FormItem>
           )}
         />
-        <Button type="submit">Submit</Button>
+        <Button variant="primary" type="submit">
+          Submit
+        </Button>
       </form>
     </Form>
   )

--- a/apps/design-system/registry/default/example/checkbox-form-single.tsx
+++ b/apps/design-system/registry/default/example/checkbox-form-single.tsx
@@ -59,7 +59,9 @@ export default function CheckboxReactHookFormSingle() {
             </FormItem>
           )}
         />
-        <Button type="submit">Submit</Button>
+        <Button variant="primary" type="submit">
+          Submit
+        </Button>
       </form>
     </Form>
   )

--- a/apps/design-system/registry/default/example/date-picker-form.tsx
+++ b/apps/design-system/registry/default/example/date-picker-form.tsx
@@ -76,7 +76,9 @@ export default function DatePickerForm() {
             </FormItem>
           )}
         />
-        <Button type="submit">Submit</Button>
+        <Button variant="primary" type="submit">
+          Submit
+        </Button>
       </form>
     </Form>
   )

--- a/apps/design-system/registry/default/example/dialog-centered-off.tsx
+++ b/apps/design-system/registry/default/example/dialog-centered-off.tsx
@@ -40,7 +40,9 @@ export default function DialogDemo() {
           </div>
         </DialogSection>
         <DialogFooter>
-          <Button type="submit">Save changes</Button>
+          <Button variant="primary" type="submit">
+            Save changes
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/apps/design-system/registry/default/example/dialog-demo.tsx
+++ b/apps/design-system/registry/default/example/dialog-demo.tsx
@@ -36,7 +36,7 @@ export default function DialogDemo() {
           </div>
         </DialogSection>
         <DialogFooter>
-          <Button>Save changes</Button>
+          <Button variant="primary">Save changes</Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/apps/design-system/registry/default/example/drawer-demo.tsx
+++ b/apps/design-system/registry/default/example/drawer-demo.tsx
@@ -121,7 +121,7 @@ export default function DrawerDemo() {
             </div>
           </div>
           <DrawerFooter>
-            <Button>Submit</Button>
+            <Button variant="primary">Submit</Button>
             <DrawerClose asChild>
               <Button variant="outline">Cancel</Button>
             </DrawerClose>

--- a/apps/design-system/registry/default/example/drawer-dialog.tsx
+++ b/apps/design-system/registry/default/example/drawer-dialog.tsx
@@ -81,7 +81,9 @@ function ProfileForm({ className }: React.ComponentProps<'form'>) {
         <Label htmlFor="username">Username</Label>
         <Input id="username" defaultValue="@shadcn" />
       </div>
-      <Button type="submit">Save changes</Button>
+      <Button variant="primary" type="submit">
+        Save changes
+      </Button>
     </form>
   )
 }

--- a/apps/design-system/registry/default/example/field-demo.tsx
+++ b/apps/design-system/registry/default/example/field-demo.tsx
@@ -113,7 +113,9 @@ export default function FieldDemo() {
             </FieldGroup>
           </FieldSet>
           <Field orientation="horizontal">
-            <Button type="submit">Submit</Button>
+            <Button variant="primary" type="submit">
+              Submit
+            </Button>
             <Button type="button" variant="default">
               Cancel
             </Button>

--- a/apps/design-system/registry/default/example/field-responsive.tsx
+++ b/apps/design-system/registry/default/example/field-responsive.tsx
@@ -45,7 +45,9 @@ export default function FieldResponsive() {
             </Field>
             <FieldSeparator />
             <Field orientation="responsive">
-              <Button type="submit">Submit</Button>
+              <Button variant="primary" type="submit">
+                Submit
+              </Button>
               <Button type="button" variant="default">
                 Cancel
               </Button>

--- a/apps/design-system/registry/default/example/input-otp-form.tsx
+++ b/apps/design-system/registry/default/example/input-otp-form.tsx
@@ -71,7 +71,9 @@ export default function InputOTPForm() {
           )}
         />
 
-        <Button type="submit">Submit</Button>
+        <Button variant="primary" type="submit">
+          Submit
+        </Button>
       </form>
     </Form>
   )

--- a/apps/design-system/registry/default/example/multi-select-in-dialog.tsx
+++ b/apps/design-system/registry/default/example/multi-select-in-dialog.tsx
@@ -63,7 +63,7 @@ export default function MultiSelectDemo() {
           </div>
         </DialogSection>
         <DialogFooter>
-          <Button>Save changes</Button>
+          <Button variant="primary">Save changes</Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/apps/design-system/registry/default/example/radio-group-form.tsx
+++ b/apps/design-system/registry/default/example/radio-group-form.tsx
@@ -76,7 +76,9 @@ export default function RadioGroupForm() {
             </FormItem>
           )}
         />
-        <Button type="submit">Submit</Button>
+        <Button variant="primary" type="submit">
+          Submit
+        </Button>
       </form>
     </Form>
   )

--- a/apps/design-system/registry/default/example/sheet-confirm-on-close-demo.tsx
+++ b/apps/design-system/registry/default/example/sheet-confirm-on-close-demo.tsx
@@ -213,7 +213,7 @@ export default function SheetConfirmOnCloseDemo() {
             <Button variant="default" onClick={confirmOnClose}>
               Cancel
             </Button>
-            <Button onClick={saveChanges} disabled={!isDirty}>
+            <Button variant="primary" onClick={saveChanges} disabled={!isDirty}>
               Save changes
             </Button>
           </SheetFooter>

--- a/apps/design-system/registry/default/example/tabs-demo.tsx
+++ b/apps/design-system/registry/default/example/tabs-demo.tsx
@@ -40,7 +40,7 @@ export default function TabsDemo() {
             </div>
           </CardContent>
           <CardFooter>
-            <Button>Save changes</Button>
+            <Button variant="primary">Save changes</Button>
           </CardFooter>
         </Card>
       </TabsContent>
@@ -63,7 +63,7 @@ export default function TabsDemo() {
             </div>
           </CardContent>
           <CardFooter>
-            <Button>Save password</Button>
+            <Button variant="primary">Save password</Button>
           </CardFooter>
         </Card>
       </TabsContent>

--- a/apps/design-system/registry/default/example/textarea-with-button.tsx
+++ b/apps/design-system/registry/default/example/textarea-with-button.tsx
@@ -4,7 +4,7 @@ export default function TextareaWithButton() {
   return (
     <div className="grid w-full gap-2">
       <Textarea placeholder="Type your message here." />
-      <Button>Send message</Button>
+      <Button variant="primary">Send message</Button>
     </div>
   )
 }

--- a/apps/docs/components/AppleSecretGenerator/AppleSecretGenerator.tsx
+++ b/apps/docs/components/AppleSecretGenerator/AppleSecretGenerator.tsx
@@ -157,6 +157,7 @@ const AppleSecretGenerator = () => {
       <div style={{ height: '1rem' }} />
 
       <Button
+        variant="primary"
         size="medium"
         disabled={
           !(

--- a/apps/docs/components/Feedback/FeedbackModal.tsx
+++ b/apps/docs/components/Feedback/FeedbackModal.tsx
@@ -109,7 +109,13 @@ function FeedbackModal({ visible, page, onCancel, onSubmit }: FeedbackModalProps
             <Button type="reset" variant="default" onClick={handleCancel} disabled={isSubmitting}>
               Cancel
             </Button>
-            <Button type="submit" form={formId} loading={isSubmitting} disabled={isSubmitting}>
+            <Button
+              variant="primary"
+              type="submit"
+              form={formId}
+              loading={isSubmitting}
+              disabled={isSubmitting}
+            >
               Submit feedback
             </Button>
           </div>

--- a/apps/docs/components/Navigation/NavigationMenu/GlobalMobileMenu.tsx
+++ b/apps/docs/components/Navigation/NavigationMenu/GlobalMobileMenu.tsx
@@ -167,7 +167,7 @@ const GlobalMobileMenu = ({ open, setOpen }: Props) => {
                       <Button block size="medium" variant="default" asChild>
                         <Link href="https://supabase.com/dashboard/sign-in">Sign in</Link>
                       </Button>
-                      <Button block size="medium" asChild>
+                      <Button variant="primary" block size="medium" asChild>
                         <Link href="https://supabase.com/dashboard/sign-up">
                           Start your project
                         </Link>

--- a/apps/docs/components/Navigation/NavigationMenu/TopNavBar.tsx
+++ b/apps/docs/components/Navigation/NavigationMenu/TopNavBar.tsx
@@ -71,7 +71,7 @@ const TopNavBar: FC = () => {
           </div>
           <div className="hidden lg:flex items-center justify-end gap-3">
             {!isUserLoading && (
-              <Button asChild>
+              <Button variant="primary" asChild>
                 <a href="/dashboard" className="h-[30px]" target="_blank" rel="noreferrer noopener">
                   {isLoggedIn ? 'Dashboard' : 'Sign up'}
                 </a>

--- a/apps/studio/components/interfaces/APIKeys/CreateNewAPIKeysButton.tsx
+++ b/apps/studio/components/interfaces/APIKeys/CreateNewAPIKeysButton.tsx
@@ -59,7 +59,9 @@ export const CreateNewAPIKeysButton = () => {
 
   return (
     <AlertDialog open={createKeysDialogOpen} onOpenChange={setCreateKeysDialogOpen}>
-      <Button onClick={() => setCreateKeysDialogOpen(true)}>Create new API keys</Button>
+      <Button variant="primary" onClick={() => setCreateKeysDialogOpen(true)}>
+        Create new API keys
+      </Button>
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle>Create new API keys</AlertDialogTitle>

--- a/apps/studio/components/interfaces/APIKeys/CreatePublishableAPIKeyDialog.tsx
+++ b/apps/studio/components/interfaces/APIKeys/CreatePublishableAPIKeyDialog.tsx
@@ -148,7 +148,7 @@ export const CreatePublishableAPIKeyDialog = () => {
             options={{ enabled: visible === 'publishable' && !isCreatingAPIKey }}
             side="top"
           >
-            <Button form={FORM_ID} type="submit" loading={isCreatingAPIKey}>
+            <Button variant="primary" form={FORM_ID} type="submit" loading={isCreatingAPIKey}>
               Create Publishable API key
             </Button>
           </Shortcut>

--- a/apps/studio/components/interfaces/APIKeys/CreateSecretAPIKeyDialog.tsx
+++ b/apps/studio/components/interfaces/APIKeys/CreateSecretAPIKeyDialog.tsx
@@ -176,7 +176,7 @@ export const CreateSecretAPIKeyDialog = () => {
             options={{ enabled: visible === 'secret' && !isCreatingAPIKey }}
             side="top"
           >
-            <Button form={FORM_ID} type="submit" loading={isCreatingAPIKey}>
+            <Button variant="primary" form={FORM_ID} type="submit" loading={isCreatingAPIKey}>
               Create API key
             </Button>
           </Shortcut>

--- a/apps/studio/components/interfaces/Account/AccessTokens/Classic/NewTokenButton.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Classic/NewTokenButton.tsx
@@ -16,6 +16,7 @@ export const NewTokenButton = ({ onCreateToken }: NewAccessTokenButtonProps) => 
     <>
       <div className="flex items-center">
         <Button
+          variant="primary"
           className="rounded-r-none px-3 hover:z-10 focus-visible:z-10 focus-visible:rounded-r-sm"
           onClick={() => setVisible(true)}
         >

--- a/apps/studio/components/interfaces/Account/AccessTokens/Classic/NewTokenDialog.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Classic/NewTokenDialog.tsx
@@ -246,7 +246,7 @@ export const NewTokenDialog = ({
           >
             Cancel
           </Button>
-          <Button form={formId} type="submit" loading={isPending}>
+          <Button variant="primary" form={formId} type="submit" loading={isPending}>
             Generate token
           </Button>
         </DialogFooter>

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/NewScopedTokenForm.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/NewScopedTokenForm.tsx
@@ -240,19 +240,23 @@ export const NewScopedTokenForm = forwardRef<
             <Button variant="default">Cancel</Button>
           </SheetClose>
           {step === 'form' && isClassicMode && (
-            <Button type="submit" form={FORM_ID} loading={isPending}>
+            <Button variant="primary" type="submit" form={FORM_ID} loading={isPending}>
               Generate token
             </Button>
           )}
           {step === 'form' && !isClassicMode && (
-            <Button type="submit" form={FORM_ID} iconRight={<ChevronRight />}>
+            <Button variant="primary" type="submit" form={FORM_ID} iconRight={<ChevronRight />}>
               Review access
             </Button>
           )}
           {step === 'review' && (
             <Popover open={!isCreateHintDismissed}>
               <PopoverAnchor asChild>
-                <Button loading={isPending} onClick={() => onCreateToken(formValues)}>
+                <Button
+                  variant="primary"
+                  loading={isPending}
+                  onClick={() => onCreateToken(formValues)}
+                >
                   Create token
                 </Button>
               </PopoverAnchor>

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/NewScopedTokenSuccess.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/NewScopedTokenSuccess.tsx
@@ -82,7 +82,7 @@ export const NewScopedTokenSuccess = ({
         </div>
       </ScrollArea>
       <SheetFooter className="mt-auto flex w-full items-center justify-between! border-t py-4">
-        <Button className="ml-auto" disabled={!keyCopied} onClick={handleDone}>
+        <Button variant="primary" className="ml-auto" disabled={!keyCopied} onClick={handleDone}>
           Done
         </Button>
       </SheetFooter>

--- a/apps/studio/components/interfaces/Account/Preferences/AddPasswordRow.tsx
+++ b/apps/studio/components/interfaces/Account/Preferences/AddPasswordRow.tsx
@@ -140,7 +140,7 @@ const AddPasswordForm = ({ email, onClose }: { email: string; onClose: () => voi
           <Button variant="default" disabled={isPending} onClick={onClose}>
             Cancel
           </Button>
-          <Button type="submit" loading={isPending} disabled={isPending}>
+          <Button variant="primary" type="submit" loading={isPending} disabled={isPending}>
             Add password
           </Button>
         </DialogFooter>

--- a/apps/studio/components/interfaces/Account/Preferences/ChangeEmailAddress.tsx
+++ b/apps/studio/components/interfaces/Account/Preferences/ChangeEmailAddress.tsx
@@ -116,7 +116,7 @@ export const ChangeEmailAddressForm = ({ onClose }: { onClose: () => void }) => 
           <Button variant="default" disabled={isPending} onClick={onClose}>
             Cancel
           </Button>
-          <Button type="submit" loading={isPending} disabled={isPending}>
+          <Button variant="primary" type="submit" loading={isPending} disabled={isPending}>
             Confirm
           </Button>
         </DialogFooter>

--- a/apps/studio/components/interfaces/Advisors/CreateRuleSheet.tsx
+++ b/apps/studio/components/interfaces/Advisors/CreateRuleSheet.tsx
@@ -240,7 +240,7 @@ export const CreateRuleSheet = ({ lint, open, onOpenChange }: CreateRuleSheetPro
           <Button disabled={isCreating} variant="default" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>
-          <Button form={formId} type="submit" loading={isCreating}>
+          <Button variant="primary" form={formId} type="submit" loading={isCreating}>
             Create rule
           </Button>
         </SheetFooter>

--- a/apps/studio/components/interfaces/App/CommandMenu/ApiKeys.test.tsx
+++ b/apps/studio/components/interfaces/App/CommandMenu/ApiKeys.test.tsx
@@ -62,7 +62,9 @@ const CommandPageHarness = () => {
 
   return (
     <>
-      <Button onClick={() => setPage('API Keys')}>Open API keys page</Button>
+      <Button variant="primary" onClick={() => setPage('API Keys')}>
+        Open API keys page
+      </Button>
       <ul>
         {commands.map((command) => (
           <li key={command.id}>{command.name}</li>

--- a/apps/studio/components/interfaces/App/CommandMenu/ApiKeys.test.tsx
+++ b/apps/studio/components/interfaces/App/CommandMenu/ApiKeys.test.tsx
@@ -62,9 +62,7 @@ const CommandPageHarness = () => {
 
   return (
     <>
-      <Button variant="primary" onClick={() => setPage('API Keys')}>
-        Open API keys page
-      </Button>
+      <Button onClick={() => setPage('API Keys')}>Open API keys page</Button>
       <ul>
         {commands.map((command) => (
           <li key={command.id}>{command.name}</li>

--- a/apps/studio/components/interfaces/App/IndirectTaxDeclarationModal.tsx
+++ b/apps/studio/components/interfaces/App/IndirectTaxDeclarationModal.tsx
@@ -129,6 +129,7 @@ export const IndirectTaxDeclarationModal = () => {
 
           <DialogFooter>
             <ButtonTooltip
+              variant="primary"
               onClick={onSubmit}
               disabled={response === ''}
               loading={isPending}

--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
@@ -291,6 +291,7 @@ export const ProviderForm = ({ config, provider, isActive }: ProviderFormProps) 
                   Cancel
                 </Button>
                 <ButtonTooltip
+                  variant="primary"
                   form={formId}
                   type="submit"
                   loading={isUpdatingConfig}

--- a/apps/studio/components/interfaces/Auth/CustomAuthProviders/CreateOrUpdateCustomProviderSheet.tsx
+++ b/apps/studio/components/interfaces/Auth/CustomAuthProviders/CreateOrUpdateCustomProviderSheet.tsx
@@ -514,7 +514,7 @@ export const CreateOrUpdateCustomProviderSheet = ({
           <Button variant="default" onClick={confirmOnClose}>
             Cancel
           </Button>
-          <Button type="submit" form={FORM_ID} loading={isCreating || isUpdating}>
+          <Button variant="primary" type="submit" form={FORM_ID} loading={isCreating || isUpdating}>
             {isEditMode ? 'Update provider' : 'Create and enable provider'}
           </Button>
         </SheetFooter>

--- a/apps/studio/components/interfaces/Auth/Hooks/CreateHookSheet.tsx
+++ b/apps/studio/components/interfaces/Auth/Hooks/CreateHookSheet.tsx
@@ -559,6 +559,7 @@ revoke execute on function ${ident(schema)}.${ident(functionName)} from authenti
             Cancel
           </Button>
           <Button
+            variant="primary"
             form={FORM_ID}
             type="submit"
             disabled={isUpdatingAuthHooks}

--- a/apps/studio/components/interfaces/Auth/OAuthApps/CreateOrUpdateOAuthAppSheet.tsx
+++ b/apps/studio/components/interfaces/Auth/OAuthApps/CreateOrUpdateOAuthAppSheet.tsx
@@ -518,7 +518,12 @@ export const CreateOrUpdateOAuthAppSheet = ({
             <Button variant="default" disabled={isCreating || isUpdating} onClick={onClose}>
               Cancel
             </Button>
-            <Button type="submit" form={FORM_ID} loading={isCreating || isUpdating}>
+            <Button
+              variant="primary"
+              type="submit"
+              form={FORM_ID}
+              loading={isCreating || isUpdating}
+            >
               {isEditMode ? 'Update app' : 'Create app'}
             </Button>
           </SheetFooter>

--- a/apps/studio/components/interfaces/Auth/OAuthApps/OAuthAppsList.tsx
+++ b/apps/studio/components/interfaces/Auth/OAuthApps/OAuthAppsList.tsx
@@ -315,6 +315,7 @@ export const OAuthAppsList = () => {
               </Shortcut>
             ) : (
               <ButtonTooltip
+                variant="primary"
                 disabled
                 icon={<Plus />}
                 onClick={() => setShowCreateSheet(true)}

--- a/apps/studio/components/interfaces/Auth/RedirectUrls/AddNewURLModal.tsx
+++ b/apps/studio/components/interfaces/Auth/RedirectUrls/AddNewURLModal.tsx
@@ -171,6 +171,7 @@ export const AddNewURLModal = ({ visible, allowList, onClose }: AddNewURLModalPr
             </DialogSection>
             <DialogFooter>
               <Button
+                variant="primary"
                 block
                 type="submit"
                 size="small"

--- a/apps/studio/components/interfaces/Auth/RedirectUrls/RedirectUrlList.tsx
+++ b/apps/studio/components/interfaces/Auth/RedirectUrls/RedirectUrlList.tsx
@@ -97,6 +97,7 @@ export const RedirectUrlList = ({
             side="bottom"
           >
             <ButtonTooltip
+              variant="primary"
               disabled={!canUpdateConfig}
               onClick={() => onSelectAddURL()}
               tooltip={{

--- a/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/CreateAuth0Dialog.tsx
+++ b/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/CreateAuth0Dialog.tsx
@@ -169,7 +169,13 @@ export const CreateAuth0IntegrationDialog = ({
           <Button disabled={isPending} variant="default" onClick={() => onClose()}>
             Cancel
           </Button>
-          <Button form={FORM_ID} type="submit" disabled={isPending} loading={isPending}>
+          <Button
+            variant="primary"
+            form={FORM_ID}
+            type="submit"
+            disabled={isPending}
+            loading={isPending}
+          >
             {isCreating ? 'Create connection' : 'Update connection'}
           </Button>
         </DialogFooter>

--- a/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/CreateAwsCognitoAuthDialog.tsx
+++ b/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/CreateAwsCognitoAuthDialog.tsx
@@ -182,7 +182,13 @@ export const CreateAwsCognitoAuthIntegrationDialog = ({
           <Button disabled={isPending} variant="default" onClick={() => onClose()}>
             Cancel
           </Button>
-          <Button form={FORM_ID} type="submit" disabled={isPending} loading={isPending}>
+          <Button
+            variant="primary"
+            form={FORM_ID}
+            type="submit"
+            disabled={isPending}
+            loading={isPending}
+          >
             {isCreating ? 'Create connection' : 'Update connection'}
           </Button>
         </DialogFooter>

--- a/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/CreateClerkAuthDialog.tsx
+++ b/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/CreateClerkAuthDialog.tsx
@@ -139,7 +139,13 @@ export const CreateClerkAuthIntegrationDialog = ({
           <Button disabled={isPending} variant="default" onClick={() => onClose()}>
             Cancel
           </Button>
-          <Button form={FORM_ID} type="submit" disabled={isPending} loading={isPending}>
+          <Button
+            variant="primary"
+            form={FORM_ID}
+            type="submit"
+            disabled={isPending}
+            loading={isPending}
+          >
             Create connection
           </Button>
         </DialogFooter>

--- a/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/CreateFirebaseAuthDialog.tsx
+++ b/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/CreateFirebaseAuthDialog.tsx
@@ -154,7 +154,13 @@ export const CreateFirebaseAuthIntegrationDialog = ({
           <Button disabled={isPending} variant="default" onClick={() => onClose()}>
             Cancel
           </Button>
-          <Button form={FORM_ID} type="submit" disabled={isPending} loading={isPending}>
+          <Button
+            variant="primary"
+            form={FORM_ID}
+            type="submit"
+            disabled={isPending}
+            loading={isPending}
+          >
             {isCreating ? 'Create connection' : 'Update connection'}
           </Button>
         </DialogFooter>

--- a/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/CreateWorkOSDialog.tsx
+++ b/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/CreateWorkOSDialog.tsx
@@ -163,7 +163,13 @@ export const CreateWorkOSIntegrationDialog = ({
           <Button disabled={isPending} variant="default" onClick={() => onClose()}>
             Cancel
           </Button>
-          <Button form={FORM_ID} type="submit" disabled={isPending} loading={isPending}>
+          <Button
+            variant="primary"
+            form={FORM_ID}
+            type="submit"
+            disabled={isPending}
+            loading={isPending}
+          >
             {isCreating ? 'Create connection' : 'Update connection'}
           </Button>
         </DialogFooter>

--- a/apps/studio/components/interfaces/Auth/Users/CreateUserModal.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/CreateUserModal.tsx
@@ -156,6 +156,7 @@ const CreateUserModal = ({ visible, setVisible }: CreateUserModalProps) => {
             </FormLabel>
 
             <Button
+              variant="primary"
               block
               size="small"
               type="submit"

--- a/apps/studio/components/interfaces/Auth/Users/InviteUserModal.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/InviteUserModal.tsx
@@ -95,6 +95,7 @@ const InviteUserModal = ({ visible, setVisible }: InviteUserModalProps) => {
               Cancel
             </Button>
             <Button
+              variant="primary"
               form={formId}
               type="submit"
               loading={isInviting}

--- a/apps/studio/components/interfaces/Database/Backups/PITR/PITRStatus.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/PITR/PITRStatus.tsx
@@ -59,6 +59,7 @@ const PITRStatus = ({
               </span>
             </div>
             <ButtonTooltip
+              variant="primary"
               disabled={hasReadReplicas || !canTriggerPhysicalBackup}
               onClick={() => onSetConfiguration()}
               tooltip={{

--- a/apps/studio/components/interfaces/Database/Backups/RestoreToNewProject/ConfirmRestoreDialog.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/RestoreToNewProject/ConfirmRestoreDialog.tsx
@@ -72,7 +72,9 @@ export const ConfirmRestoreDialog = ({
           <Button variant="outline" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>
-          <Button onClick={() => onSelectContinue()}>Continue</Button>
+          <Button variant="primary" onClick={() => onSelectContinue()}>
+            Continue
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/apps/studio/components/interfaces/Database/Backups/RestoreToNewProject/CreateNewProjectDialog.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/RestoreToNewProject/CreateNewProjectDialog.tsx
@@ -187,7 +187,7 @@ export const CreateNewProjectDialog = ({
               <Button type="reset" variant="outline" onClick={() => onOpenChange(false)}>
                 Cancel
               </Button>
-              <Button type="submit" loading={cloneMutationLoading}>
+              <Button variant="primary" type="submit" loading={cloneMutationLoading}>
                 Restore to new project
               </Button>
             </DialogFooter>

--- a/apps/studio/components/interfaces/Database/Extensions/EnableExtensionModal.tsx
+++ b/apps/studio/components/interfaces/Database/Extensions/EnableExtensionModal.tsx
@@ -258,6 +258,7 @@ export const EnableExtensionModal = ({
             Cancel
           </Button>
           <Button
+            variant="primary"
             type="submit"
             form="enable-extensions-form"
             loading={isEnabling}

--- a/apps/studio/components/interfaces/Database/Functions/CreateFunction/index.tsx
+++ b/apps/studio/components/interfaces/Database/Functions/CreateFunction/index.tsx
@@ -455,6 +455,7 @@ export const CreateFunction = ({
               Cancel
             </Button>
             <Button
+              variant="primary"
               form={FORM_ID}
               type="submit"
               disabled={isCreating || isUpdating}

--- a/apps/studio/components/interfaces/Database/Hooks/HTTPRequestConfig.tsx
+++ b/apps/studio/components/interfaces/Database/Hooks/HTTPRequestConfig.tsx
@@ -93,7 +93,7 @@ export const HTTPRequestConfig = ({ form }: HTTPRequestConfigProps) => {
             <p className="text-sm text-foreground-light">Select which edge function to trigger</p>
             <div className="px-4 py-4 border rounded-sm bg-surface-300 border-strong flex items-center justify-between space-x-4">
               <p className="text-sm">No edge functions created yet</p>
-              <Button asChild>
+              <Button variant="primary" asChild>
                 <Link href={`/project/${ref}/functions`}>Create an edge function</Link>
               </Button>
             </div>

--- a/apps/studio/components/interfaces/Database/Hooks/HooksList/HooksList.tsx
+++ b/apps/studio/components/interfaces/Database/Hooks/HooksList/HooksList.tsx
@@ -82,6 +82,7 @@ export const HooksList = () => {
         <div className="flex items-center gap-x-2">
           <DocsButton href={`${DOCS_URL}/guides/database/webhooks`} />
           <ButtonTooltip
+            variant="primary"
             onClick={() => setShowCreateHookForm(true)}
             disabled={!isPermissionsLoaded || !canCreateWebhooks}
             tooltip={{

--- a/apps/studio/components/interfaces/Database/Policies/PolicyEditorPanel/index.tsx
+++ b/apps/studio/components/interfaces/Database/Policies/PolicyEditorPanel/index.tsx
@@ -545,6 +545,7 @@ export const PolicyEditorPanel = memo(function ({
                       </Button>
 
                       <ButtonTooltip
+                        variant="primary"
                         form={FORM_ID}
                         type="submit"
                         loading={isExecuting || isUpdating}

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DuckLake/Fields.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DuckLake/Fields.tsx
@@ -352,6 +352,7 @@ const DuckLakeSupabaseFields = ({ form }: { form: UseFormReturn<DestinationPanel
               Cancel
             </Button>
             <Button
+              variant="primary"
               type="button"
               loading={isCreatingBucket}
               disabled={!newBucketName.trim()}

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/index.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/index.tsx
@@ -528,7 +528,13 @@ export const DestinationForm = ({
           <Button disabled={isSaving} variant="default" onClick={onCancel}>
             Cancel
           </Button>
-          <Button disabled={isSubmitDisabled} loading={isSaving} form={formId} type="submit">
+          <Button
+            variant="primary"
+            disabled={isSubmitDisabled}
+            loading={isSaving}
+            form={formId}
+            type="submit"
+          >
             {getSubmitButtonText()}
           </Button>
         </div>

--- a/apps/studio/components/interfaces/Database/Tables/TableList.tsx
+++ b/apps/studio/components/interfaces/Database/Tables/TableList.tsx
@@ -342,12 +342,18 @@ export const TableList = ({
               onTrigger={() => onAddTable()}
               side="bottom"
             >
-              <Button className="w-auto ml-auto" icon={<Plus />} onClick={() => onAddTable()}>
+              <Button
+                variant="primary"
+                className="w-auto ml-auto"
+                icon={<Plus />}
+                onClick={() => onAddTable()}
+              >
                 New table
               </Button>
             </Shortcut>
           ) : (
             <ButtonTooltip
+              variant="primary"
               className="w-auto ml-auto"
               icon={<Plus />}
               disabled

--- a/apps/studio/components/interfaces/Database/Triggers/TriggerSheet.tsx
+++ b/apps/studio/components/interfaces/Database/Triggers/TriggerSheet.tsx
@@ -483,7 +483,12 @@ export const TriggerSheet = ({
             >
               Cancel
             </Button>
-            <Button form={formId} type="submit" loading={isCreating || isUpdating}>
+            <Button
+              variant="primary"
+              form={formId}
+              type="submit"
+              loading={isCreating || isUpdating}
+            >
               {isEditing ? 'Save' : 'Create'} trigger
             </Button>
           </SheetFooter>

--- a/apps/studio/components/interfaces/Docs/Description.tsx
+++ b/apps/studio/components/interfaces/Docs/Description.tsx
@@ -108,7 +108,7 @@ const Description = ({ content, metadata, onChange = noop }: DescrptionProps) =>
         >
           Cancel
         </Button>
-        <Button disabled={!hasChanged} onClick={updateDescription}>
+        <Button variant="primary" disabled={!hasChanged} onClick={updateDescription}>
           {isUpdating ? (
             <Loader className="mx-auto animate-spin" size={14} strokeWidth={2} />
           ) : (

--- a/apps/studio/components/interfaces/Explorer/ExplorerQueryTab.tsx
+++ b/apps/studio/components/interfaces/Explorer/ExplorerQueryTab.tsx
@@ -121,7 +121,9 @@ export const ExplorerQueryTab = () => {
             This local draft may have been closed or cleared from this browser.
           </p>
         </div>
-        <Button onClick={() => router.push(`/project/${ref}/explorer`)}>Back to Explorer</Button>
+        <Button variant="primary" onClick={() => router.push(`/project/${ref}/explorer`)}>
+          Back to Explorer
+        </Button>
       </div>
     )
   }

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/EditSecretSheet.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/EditSecretSheet.tsx
@@ -165,7 +165,13 @@ export function EditSecretSheet({ secret, visible, onClose }: EditSecretSheetPro
           <Button disabled={isUpdating} variant="default" onClick={confirmOnClose}>
             Cancel
           </Button>
-          <Button form={FORM_ID} type="submit" disabled={!isValid} loading={isUpdating}>
+          <Button
+            variant="primary"
+            form={FORM_ID}
+            type="submit"
+            disabled={!isValid}
+            loading={isUpdating}
+          >
             Save
           </Button>
         </SheetFooter>

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobsTab.EnableCleanupButton.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobsTab.EnableCleanupButton.tsx
@@ -134,7 +134,7 @@ export const EnableCleanupButton = ({ onScheduled }: EnableCleanupButtonProps) =
           <Button variant="default" disabled={isScheduling} onClick={() => setOpen(false)}>
             Cancel
           </Button>
-          <Button loading={isScheduling} onClick={onConfirm}>
+          <Button variant="primary" loading={isScheduling} onClick={onConfirm}>
             Enable cleanup
           </Button>
         </DialogFooter>

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobsTab.Header.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobsTab.Header.tsx
@@ -64,7 +64,9 @@ export const CronJobsTabHeader = ({
         <Button variant="default" icon={<RefreshCw />} loading={isRefreshing} onClick={onRefresh}>
           Refresh
         </Button>
-        <Button onClick={onCreateJob}>Create job</Button>
+        <Button variant="primary" onClick={onCreateJob}>
+          Create job
+        </Button>
       </div>
     </div>
   )

--- a/apps/studio/components/interfaces/Integrations/CronJobs/EdgeFunctionSection.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/EdgeFunctionSection.tsx
@@ -108,7 +108,7 @@ export const EdgeFunctionSection = ({ form }: HTTPRequestFieldsProps) => {
           ) : (
             <div className="px-4 py-4 border rounded-sm bg-surface-300 border-strong flex items-center justify-between space-x-4">
               <p className="text-sm">No edge functions created yet</p>
-              <Button asChild>
+              <Button variant="primary" asChild>
                 <Link href={`/project/${ref}/functions`}>Create an edge function</Link>
               </Button>
             </div>

--- a/apps/studio/components/interfaces/Integrations/Queues/QueuesTab.tsx
+++ b/apps/studio/components/interfaces/Integrations/Queues/QueuesTab.tsx
@@ -117,7 +117,9 @@ export const QueuesTab = () => {
               >
                 Refresh
               </Button>
-              <Button onClick={() => setCreateQueueSheetShown(true)}>Create queue</Button>
+              <Button variant="primary" onClick={() => setCreateQueueSheetShown(true)}>
+                Create queue
+              </Button>
             </div>
           </div>
 

--- a/apps/studio/components/interfaces/Integrations/Queues/SingleQueue/QueueDataGrid.tsx
+++ b/apps/studio/components/interfaces/Integrations/Queues/SingleQueue/QueueDataGrid.tsx
@@ -198,7 +198,7 @@ export const QueueMessagesDataGrid = ({
                 <p className="text-foreground-light">
                   The selected queue doesn't have any messages.
                 </p>
-                <Button className="mt-2" onClick={() => showMessageModal()}>
+                <Button variant="primary" className="mt-2" onClick={() => showMessageModal()}>
                   Add message
                 </Button>
               </div>

--- a/apps/studio/components/interfaces/Integrations/Queues/UpgradeDatabaseAlert.tsx
+++ b/apps/studio/components/interfaces/Integrations/Queues/UpgradeDatabaseAlert.tsx
@@ -24,7 +24,7 @@ export const UpgradeDatabaseAlert = ({ minimumVersion = '15.6' }: UpgradeDatabas
           version of Postgres. The extension is available on version {minimumVersion} and higher.
         </p>
       </div>
-      <Button color="primary" className="w-fit">
+      <Button variant="primary" color="primary" className="w-fit">
         <Link href={getServiceVersionsPath(project?.ref)}>Upgrade database</Link>
       </Button>
     </Admonition>

--- a/apps/studio/components/interfaces/Integrations/Vault/Secrets/AddNewSecretModal.tsx
+++ b/apps/studio/components/interfaces/Integrations/Vault/Secrets/AddNewSecretModal.tsx
@@ -177,6 +177,7 @@ export const AddNewSecretModal = () => {
             Cancel
           </Button>
           <Button
+            variant="primary"
             form={formId}
             type="submit"
             disabled={!isDirty || isSubmitting}

--- a/apps/studio/components/interfaces/Integrations/Vault/Secrets/EditSecretModal.tsx
+++ b/apps/studio/components/interfaces/Integrations/Vault/Secrets/EditSecretModal.tsx
@@ -222,7 +222,7 @@ export const EditSecretModal = () => {
               >
                 Cancel
               </Button>
-              <Button form={formId} type="submit" loading={isSubmitting}>
+              <Button variant="primary" form={formId} type="submit" loading={isSubmitting}>
                 Update secret
               </Button>
             </DialogFooter>

--- a/apps/studio/components/interfaces/Integrations/Webhooks/OverviewTab.tsx
+++ b/apps/studio/components/interfaces/Integrations/Webhooks/OverviewTab.tsx
@@ -70,6 +70,7 @@ const WebhooksContent = () => {
         endpoint
       </p>
       <ButtonTooltip
+        variant="primary"
         className="mt-2 w-fit"
         onClick={() => enableHooksForProject()}
         disabled={isEnablingHooks}

--- a/apps/studio/components/interfaces/JwtSecrets/jwt-secret-keys-table/create-key-dialog.tsx
+++ b/apps/studio/components/interfaces/JwtSecrets/jwt-secret-keys-table/create-key-dialog.tsx
@@ -240,6 +240,7 @@ export const CreateKeyDialog = ({
           side="top"
         >
           <Button
+            variant="primary"
             onClick={() => handleAddNewStandbyKey()}
             disabled={
               isPendingMutation || !!privateKeyMessage || (isBYOK && privateKey.trim().length === 0)

--- a/apps/studio/components/interfaces/JwtSecrets/jwt-secret-keys-table/index.tsx
+++ b/apps/studio/components/interfaces/JwtSecrets/jwt-secret-keys-table/index.tsx
@@ -412,6 +412,7 @@ export const JWTSecretKeysTable = () => {
           </DialogSection>
           <DialogFooter>
             <Button
+              variant="primary"
               loading={isMigrating}
               onClick={() => migrateJWTSecret({ projectRef: projectRef! })}
             >

--- a/apps/studio/components/interfaces/JwtSecrets/jwt-secret-keys-table/rotate-key-dialog.tsx
+++ b/apps/studio/components/interfaces/JwtSecrets/jwt-secret-keys-table/rotate-key-dialog.tsx
@@ -275,6 +275,7 @@ export function RotateKeyDialog({
       </DialogSection>
       <DialogFooter>
         <Button
+          variant="primary"
           onClick={() => mutate({ projectRef, keyId: standbyKey.id, status: 'in_use' })}
           disabled={
             isLoadingEdgeFunctions ||

--- a/apps/studio/components/interfaces/Organization/CloudMarketplace/NewAwsMarketplaceOrgModal.tsx
+++ b/apps/studio/components/interfaces/Organization/CloudMarketplace/NewAwsMarketplaceOrgModal.tsx
@@ -103,6 +103,7 @@ const AwsMarketplaceOrgCreationDialog = ({
         </DialogSection>
         <DialogFooter>
           <Button
+            variant="primary"
             form={CREATE_AWS_MANAGED_ORG_FORM_ID}
             type="submit"
             loading={isCreatingOrganization}

--- a/apps/studio/components/interfaces/Organization/InvoicesSettings/InvoicePayButton.tsx
+++ b/apps/studio/components/interfaces/Organization/InvoicesSettings/InvoicePayButton.tsx
@@ -22,7 +22,7 @@ const InvoicePayButton = ({ slug, invoiceId }: InvoicePayButtonProps) => {
   }
 
   return (
-    <Button onClick={onPayNow} loading={isPending} disabled={isPending}>
+    <Button variant="primary" onClick={onPayNow} loading={isPending} disabled={isPending}>
       Pay now
     </Button>
   )

--- a/apps/studio/components/interfaces/Organization/OAuthApps/PublishAppSidePanel/index.tsx
+++ b/apps/studio/components/interfaces/Organization/OAuthApps/PublishAppSidePanel/index.tsx
@@ -430,7 +430,12 @@ export const PublishAppSidePanel = ({
                     options={{ enabled: visible && !isSubmitting }}
                     side="top"
                   >
-                    <Button type="submit" loading={isSubmitting} disabled={isSubmitting}>
+                    <Button
+                      variant="primary"
+                      type="submit"
+                      loading={isSubmitting}
+                      disabled={isSubmitting}
+                    >
                       Confirm
                     </Button>
                   </Shortcut>

--- a/apps/studio/components/interfaces/Organization/ProjectClaim/benefits.tsx
+++ b/apps/studio/components/interfaces/Organization/ProjectClaim/benefits.tsx
@@ -81,7 +81,7 @@ export const ProjectClaimBenefits = ({
           </ul>
         </div>
         <div className="flex justify-center sticky bottom-0">
-          <Button size="medium" onClick={onContinue}>
+          <Button variant="primary" size="medium" onClick={onContinue}>
             Continue connection
           </Button>
         </div>

--- a/apps/studio/components/interfaces/Organization/ProjectClaim/confirm.tsx
+++ b/apps/studio/components/interfaces/Organization/ProjectClaim/confirm.tsx
@@ -255,7 +255,13 @@ export const ProjectClaimConfirm = ({
         </div>
       </div>
       <div className="flex justify-center sticky bottom-0">
-        <Button size="medium" loading={isLoading} disabled={isLoading} onClick={onClaimProject}>
+        <Button
+          variant="primary"
+          size="medium"
+          loading={isLoading}
+          disabled={isLoading}
+          onClick={onClaimProject}
+        >
           Claim project {projectClaim?.project?.name}
         </Button>
       </div>

--- a/apps/studio/components/interfaces/Organization/TeamSettings/UpdateRolesPanel/UpdateRolesPanel.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/UpdateRolesPanel/UpdateRolesPanel.tsx
@@ -373,6 +373,7 @@ export const UpdateRolesPanel = ({ visible, member, onClose }: UpdateRolesPanelP
                 Cancel
               </Button>
               <Button
+                variant="primary"
                 loading={false}
                 disabled={!canSaveRoles || hasNoChanges}
                 onClick={() => {

--- a/apps/studio/components/interfaces/Platform/Webhooks/PlatformWebhooksEndpointSheet.tsx
+++ b/apps/studio/components/interfaces/Platform/Webhooks/PlatformWebhooksEndpointSheet.tsx
@@ -590,7 +590,7 @@ export const PlatformWebhooksEndpointSheet = ({
             label={mode === 'create' ? 'Create endpoint' : 'Save changes'}
             onTrigger={() => form.handleSubmit(onSubmit)()}
           >
-            <Button form="platform-webhook-endpoint-form" type="submit">
+            <Button variant="primary" form="platform-webhook-endpoint-form" type="submit">
               {mode === 'create' ? 'Create endpoint' : 'Save changes'}
             </Button>
           </Shortcut>

--- a/apps/studio/components/interfaces/ProjectCreation/ProjectCreationFooter.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/ProjectCreationFooter.tsx
@@ -228,6 +228,7 @@ export const ProjectCreationFooter = ({
         )}
 
         <Button
+          variant="primary"
           type="submit"
           loading={isCreatingNewProject || isSuccessNewProject}
           disabled={!canCreateProject}

--- a/apps/studio/components/interfaces/QueryPerformance/IndexAdvisor/IndexSuggestionIcon.tsx
+++ b/apps/studio/components/interfaces/QueryPerformance/IndexAdvisor/IndexSuggestionIcon.tsx
@@ -136,7 +136,12 @@ export const IndexSuggestionIcon = ({
           >
             View details
           </Button>
-          <Button onClick={handleCreateIndex} loading={isCreatingIndex} disabled={isCreatingIndex}>
+          <Button
+            variant="primary"
+            onClick={handleCreateIndex}
+            loading={isCreatingIndex}
+            disabled={isCreatingIndex}
+          >
             Create index
           </Button>
         </div>

--- a/apps/studio/components/interfaces/QueryPerformance/QueryDetail.tsx
+++ b/apps/studio/components/interfaces/QueryPerformance/QueryDetail.tsx
@@ -112,7 +112,7 @@ export const QueryDetail = ({ selectedRow, onClickViewSuggestion, onClose }: Que
                 Adding an index will help this query execute faster
               </AlertDescription>
               <AlertDescription>
-                <Button className="mt-3" onClick={() => onClickViewSuggestion()}>
+                <Button variant="primary" className="mt-3" onClick={() => onClickViewSuggestion()}>
                   View suggestion
                 </Button>
               </AlertDescription>

--- a/apps/studio/components/interfaces/QuerySources/LogsCustomRangeDialog.tsx
+++ b/apps/studio/components/interfaces/QuerySources/LogsCustomRangeDialog.tsx
@@ -48,7 +48,7 @@ export const LogsCustomRangeDialog = ({
           <Button variant="default" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>
-          <Button disabled={!canApply} onClick={handleApply}>
+          <Button variant="primary" disabled={!canApply} onClick={handleApply}>
             Apply
           </Button>
         </DialogFooter>

--- a/apps/studio/components/interfaces/Realtime/Inspector/RealtimeFilterPopover/index.tsx
+++ b/apps/studio/components/interfaces/Realtime/Inspector/RealtimeFilterPopover/index.tsx
@@ -255,7 +255,9 @@ export const RealtimeFilterPopover = ({
             <Button variant="default" onClick={() => setOpen(false)}>
               Cancel
             </Button>
-            <Button onClick={() => setApplyConfigOpen(true)}>Apply</Button>
+            <Button variant="primary" onClick={() => setApplyConfigOpen(true)}>
+              Apply
+            </Button>
           </div>
         </PopoverContent>
       </Popover>

--- a/apps/studio/components/interfaces/Reports/CreateReportModal.tsx
+++ b/apps/studio/components/interfaces/Reports/CreateReportModal.tsx
@@ -156,7 +156,12 @@ export const CreateReportModal = ({ visible, onCancel, afterSubmit }: CreateRepo
               <Button type="reset" variant="default" onClick={handleCancel} disabled={isCreating}>
                 Cancel
               </Button>
-              <Button type="submit" loading={isCreating} disabled={isCreating || !isDirty}>
+              <Button
+                variant="primary"
+                type="submit"
+                loading={isCreating}
+                disabled={isCreating || !isDirty}
+              >
                 Create report
               </Button>
             </DialogFooter>

--- a/apps/studio/components/interfaces/Reports/UpdateModal.tsx
+++ b/apps/studio/components/interfaces/Reports/UpdateModal.tsx
@@ -133,7 +133,12 @@ export const UpdateCustomReportModal = ({
               <Button type="reset" variant="default" onClick={handleCancel} disabled={isUpdating}>
                 Cancel
               </Button>
-              <Button type="submit" loading={isUpdating} disabled={isUpdating || !isDirty}>
+              <Button
+                variant="primary"
+                type="submit"
+                loading={isUpdating}
+                disabled={isUpdating || !isDirty}
+              >
                 Save custom report
               </Button>
             </DialogFooter>

--- a/apps/studio/components/interfaces/SQLEditor/RenameQueryModal.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/RenameQueryModal.tsx
@@ -226,7 +226,12 @@ const RenameQueryForm = ({ snippet, onCancel, onComplete }: RenameQueryFormProps
           <Button type="reset" variant="default" onClick={onCancel} disabled={isSubmitting}>
             Cancel
           </Button>
-          <Button type="submit" loading={isSubmitting} disabled={isSubmitting || !isDirty}>
+          <Button
+            variant="primary"
+            type="submit"
+            loading={isSubmitting}
+            disabled={isSubmitting || !isDirty}
+          >
             Rename query
           </Button>
         </DialogFooter>

--- a/apps/studio/components/interfaces/SQLEditor/SqlEditorManualSaveNoticeDialog.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/SqlEditorManualSaveNoticeDialog.tsx
@@ -77,7 +77,9 @@ export const SqlEditorManualSaveNoticeDialog = () => {
         </DialogSection>
 
         <DialogFooter>
-          <Button onClick={() => setIsNoticeDismissed(true)}>Understood</Button>
+          <Button variant="primary" onClick={() => setIsNoticeDismissed(true)}>
+            Understood
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/apps/studio/components/interfaces/Settings/Database/NetworkRestrictions/AddRestrictionModal.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/NetworkRestrictions/AddRestrictionModal.tsx
@@ -267,7 +267,13 @@ const AddRestrictionModal = ({
             <Button variant="default" disabled={isApplying} onClick={() => onClose()}>
               Cancel
             </Button>
-            <Button form={formId} type="submit" loading={isApplying} disabled={isApplying}>
+            <Button
+              variant="primary"
+              form={formId}
+              type="submit"
+              loading={isApplying}
+              disabled={isApplying}
+            >
               Save restriction
             </Button>
           </DialogFooter>

--- a/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainActivate.tsx
+++ b/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainActivate.tsx
@@ -104,6 +104,7 @@ export const CustomDomainActivate = ({ projectRef, customDomain }: CustomDomainA
                 Cancel
               </Button>
               <Button
+                variant="primary"
                 disabled={isDeleting}
                 onClick={() => setIsActivateConfirmModalVisible(true)}
                 className="self-end"

--- a/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainVerify.tsx
+++ b/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainVerify.tsx
@@ -184,6 +184,7 @@ export const CustomDomainVerify = () => {
               Cancel
             </Button>
             <Button
+              variant="primary"
               icon={<RefreshCw />}
               onClick={onReverifyCustomDomain}
               loading={!isValidating && isReverifyLoading}

--- a/apps/studio/components/interfaces/Settings/General/Infrastructure/ProjectUpgradeAlert.tsx
+++ b/apps/studio/components/interfaces/Settings/General/Infrastructure/ProjectUpgradeAlert.tsx
@@ -283,7 +283,12 @@ export const ProjectUpgradeAlert = () => {
                   >
                     Cancel
                   </Button>
-                  <Button type="submit" disabled={isUpgrading} loading={isUpgrading}>
+                  <Button
+                    variant="primary"
+                    type="submit"
+                    disabled={isUpgrading}
+                    loading={isUpgrading}
+                  >
                     Confirm upgrade
                   </Button>
                 </DialogFooter>

--- a/apps/studio/components/interfaces/Settings/General/TransferProjectPanel/TransferProjectButton.tsx
+++ b/apps/studio/components/interfaces/Settings/General/TransferProjectPanel/TransferProjectButton.tsx
@@ -287,6 +287,7 @@ export const TransferProjectButton = () => {
             Cancel
           </Button>
           <Button
+            variant="primary"
             onClick={() => handleTransferProject()}
             disabled={
               !transferPreviewData || !transferPreviewData.valid || isTransferring || !selectedOrg

--- a/apps/studio/components/interfaces/Settings/Infrastructure/ReadReplicas/ReadReplicaForm/index.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/ReadReplicas/ReadReplicaForm/index.tsx
@@ -143,7 +143,12 @@ export const ReadReplicaForm = ({
         <Button disabled={isSettingUp} variant="default" onClick={onClose}>
           Cancel
         </Button>
-        <Button disabled={!canDeployReplica} loading={isSettingUp} onClick={onSubmit}>
+        <Button
+          variant="primary"
+          disabled={!canDeployReplica}
+          loading={isSettingUp}
+          onClick={onSubmit}
+        >
           Add replica
         </Button>
       </DialogFooter>

--- a/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLinkForm.tsx
+++ b/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLinkForm.tsx
@@ -269,7 +269,7 @@ export const AWSPrivateLinkForm = ({
                   >
                     Cancel
                   </Button>
-                  <Button form={FORM_ID} type="submit" loading={isPending}>
+                  <Button variant="primary" form={FORM_ID} type="submit" loading={isPending}>
                     Add connection
                   </Button>
                 </>

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.DatePickers.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.DatePickers.tsx
@@ -431,7 +431,9 @@ export const LogsDatePicker = ({
             >
               Today
             </Button>
-            <Button onClick={handleApply}>Apply</Button>
+            <Button variant="primary" onClick={handleApply}>
+              Apply
+            </Button>
           </div>
         </div>
       </PopoverContent>

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.UpdateSavedQueryModal.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.UpdateSavedQueryModal.tsx
@@ -97,7 +97,12 @@ export const UpdateSavedQueryModal = ({
               <Button type="reset" variant="default" onClick={handleCancel} disabled={isSubmitting}>
                 Cancel
               </Button>
-              <Button type="submit" loading={isSubmitting} disabled={isSubmitting || !isDirty}>
+              <Button
+                variant="primary"
+                type="submit"
+                loading={isSubmitting}
+                disabled={isSubmitting || !isDirty}
+              >
                 Save query
               </Button>
             </DialogFooter>

--- a/apps/studio/components/interfaces/Settings/Logs/UpgradePrompt.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/UpgradePrompt.tsx
@@ -88,7 +88,7 @@ const UpgradePrompt: React.FC<Props> = ({
           <Button variant="default" onClick={() => setShowUpgradePrompt(false)}>
             Close
           </Button>
-          <Button asChild size="tiny">
+          <Button variant="primary" asChild size="tiny">
             <Link
               href={`/org/${organization?.slug}/billing?panel=subscriptionPlan&source=${source}`}
             >

--- a/apps/studio/components/interfaces/SignIn/ForgotPasswordWizard.tsx
+++ b/apps/studio/components/interfaces/SignIn/ForgotPasswordWizard.tsx
@@ -99,7 +99,14 @@ const ConfirmResetCodeForm = ({ email }: { email: string }) => {
 
         <div className="border-t border-overlay-border" />
 
-        <Button block form="code-input-form" type="submit" size="medium" loading={isLoading}>
+        <Button
+          variant="primary"
+          block
+          form="code-input-form"
+          type="submit"
+          size="medium"
+          loading={isLoading}
+        >
           Confirm reset code
         </Button>
       </form>
@@ -188,6 +195,7 @@ const ForgotPasswordForm = ({ onSuccess }: { onSuccess: (email: string) => void 
         <div className="border-t border-overlay-border" />
 
         <Button
+          variant="primary"
           block
           form="forgot-password-form"
           type="submit"

--- a/apps/studio/components/interfaces/SignIn/ResetPasswordForm.tsx
+++ b/apps/studio/components/interfaces/SignIn/ResetPasswordForm.tsx
@@ -141,6 +141,7 @@ export const ResetPasswordForm = () => {
         <Separator className="bg-border" />
 
         <Button
+          variant="primary"
           block
           type="submit"
           size="medium"

--- a/apps/studio/components/interfaces/SignIn/SignInForm.tsx
+++ b/apps/studio/components/interfaces/SignIn/SignInForm.tsx
@@ -221,7 +221,14 @@ export const SignInForm = () => {
         </div>
 
         <LastSignInWrapper type="email">
-          <Button block form={formId} type="submit" size="large" loading={isSubmitting}>
+          <Button
+            variant="primary"
+            block
+            form={formId}
+            type="submit"
+            size="large"
+            loading={isSubmitting}
+          >
             Sign in
           </Button>
         </LastSignInWrapper>

--- a/apps/studio/components/interfaces/SignIn/SignInMfaForm.tsx
+++ b/apps/studio/components/interfaces/SignIn/SignInMfaForm.tsx
@@ -208,6 +208,7 @@ export const SignInMfaForm = ({ context = 'sign-in' }: SignInMfaFormProps) => {
                 Cancel
               </Button>
               <Button
+                variant="primary"
                 block
                 form={formId}
                 type="submit"

--- a/apps/studio/components/interfaces/SignIn/SignInSSOForm.tsx
+++ b/apps/studio/components/interfaces/SignIn/SignInSSOForm.tsx
@@ -127,7 +127,14 @@ export const SignInSSOForm = () => {
           />
         </div>
 
-        <Button block form={formId} type="submit" size="large" loading={isSubmitting}>
+        <Button
+          variant="primary"
+          block
+          form={formId}
+          type="submit"
+          size="large"
+          loading={isSubmitting}
+        >
           Sign in
         </Button>
       </form>

--- a/apps/studio/components/interfaces/SignIn/SignUpForm.tsx
+++ b/apps/studio/components/interfaces/SignIn/SignUpForm.tsx
@@ -225,6 +225,7 @@ export const SignUpForm = ({ onSuccess }: { onSuccess?: () => void }) => {
             </div>
 
             <Button
+              variant="primary"
               block
               form={formId}
               type="submit"

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/CreateTable/CreateTableSheet.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/CreateTable/CreateTableSheet.tsx
@@ -267,7 +267,7 @@ export const CreateTableSheet = ({ open, onOpenChange }: CreateTableSheetProps) 
               >
                 Cancel
               </Button>
-              <Button form={formId} type="submit" loading={isCreating}>
+              <Button variant="primary" form={formId} type="submit" loading={isCreating}>
                 Create table
               </Button>
             </SheetFooter>

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/CreateAnalyticsBucketForm.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/CreateAnalyticsBucketForm.tsx
@@ -260,6 +260,7 @@ export const CreateAnalyticsBucketForm = ({
           Cancel
         </Button>
         <Button
+          variant="primary"
           form={formId}
           type="submit"
           loading={isCreating}

--- a/apps/studio/components/interfaces/Storage/BucketFilePickerDialog/BucketFilePickerPreviewPane.tsx
+++ b/apps/studio/components/interfaces/Storage/BucketFilePickerDialog/BucketFilePickerPreviewPane.tsx
@@ -130,6 +130,7 @@ export const PreviewPane = ({ onSelect }: { onSelect: (url: string) => void }) =
       {/* Preview Header */}
       <div className="flex w-full justify-end items-center gap-2 sticky top-0 bg-surface-100 p-4 border-b">
         <Button
+          variant="primary"
           size="tiny"
           onClick={() => onSelect(previewUrl!)}
           disabled={!previewUrl}

--- a/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
@@ -376,6 +376,7 @@ export const CreateBucketModal = ({ open, onOpenChange }: CreateBucketModalProps
             Cancel
           </Button>
           <Button
+            variant="primary"
             form={formId}
             type="submit"
             loading={isCreatingBucket}

--- a/apps/studio/components/interfaces/Storage/EditBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/EditBucketModal.tsx
@@ -413,7 +413,7 @@ export const EditBucketModal = ({ visible, bucket, onClose }: EditBucketModalPro
           <Button variant="default" disabled={isUpdating} onClick={closeModal}>
             Cancel
           </Button>
-          <Button form={formId} type="submit" loading={isUpdating}>
+          <Button variant="primary" form={formId} type="submit" loading={isUpdating}>
             Save
           </Button>
         </DialogFooter>

--- a/apps/studio/components/interfaces/Storage/StorageSettings/CreateCredentialModal.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageSettings/CreateCredentialModal.tsx
@@ -172,7 +172,7 @@ export const CreateCredentialModal = ({ visible, onOpenChange }: CreateCredentia
                   />
                 </DialogSection>
                 <DialogFooter>
-                  <Button type="submit" loading={isCreating}>
+                  <Button variant="primary" type="submit" loading={isCreating}>
                     Create access key
                   </Button>
                 </DialogFooter>

--- a/apps/studio/components/interfaces/Storage/VectorBuckets/CreateVectorBucketDialog.tsx
+++ b/apps/studio/components/interfaces/Storage/VectorBuckets/CreateVectorBucketDialog.tsx
@@ -223,7 +223,7 @@ export const CreateVectorBucketDialog = ({
           <Button variant="default" disabled={isLoading} onClick={() => setVisible(false)}>
             Cancel
           </Button>
-          <Button form={formId} type="submit" loading={isLoading}>
+          <Button variant="primary" form={formId} type="submit" loading={isLoading}>
             Create
           </Button>
         </DialogFooter>

--- a/apps/studio/components/interfaces/Storage/VectorBuckets/CreateVectorTableSheet.tsx
+++ b/apps/studio/components/interfaces/Storage/VectorBuckets/CreateVectorTableSheet.tsx
@@ -396,6 +396,7 @@ export const CreateVectorTableSheet = ({ bucketName }: CreateVectorTableSheetPro
             Cancel
           </Button>
           <Button
+            variant="primary"
             form={formId}
             type="submit"
             loading={isCreating}

--- a/apps/studio/components/interfaces/Support/ProjectAndPlanInfo.tsx
+++ b/apps/studio/components/interfaces/Support/ProjectAndPlanInfo.tsx
@@ -199,7 +199,7 @@ export const PlanExpectationInfoContent = ({
 
       {shouldShowUpgradeActions && (
         <div className="flex flex-wrap gap-2 pt-1">
-          <Button asChild size="tiny">
+          <Button variant="primary" asChild size="tiny">
             <Link
               href={`/org/${orgSlug}/billing?panel=subscriptionPlan&source=planSupportExpectationInfoBox`}
             >

--- a/apps/studio/components/interfaces/Support/SubmitButton.tsx
+++ b/apps/studio/components/interfaces/Support/SubmitButton.tsx
@@ -21,6 +21,7 @@ export function SubmitButton({
   return (
     <div className={cn('flex flex-col gap-3', className)}>
       <Button
+        variant="primary"
         type="submit"
         size="small"
         block

--- a/apps/studio/components/layouts/Navigation/LayoutHeader/FeedbackDropdown/FeedbackWidget.tsx
+++ b/apps/studio/components/layouts/Navigation/LayoutHeader/FeedbackDropdown/FeedbackWidget.tsx
@@ -309,6 +309,7 @@ export const FeedbackWidget = ({ onClose, onSwitchToIssueOptions }: FeedbackWidg
             onChange={onFilesUpload}
           />
           <Button
+            variant="primary"
             disabled={feedback.length === 0 || isSending}
             loading={isSending}
             onClick={() => {

--- a/apps/studio/components/layouts/ProjectLayout/RestoringState.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/RestoringState.tsx
@@ -135,7 +135,12 @@ export const RestoringState = () => {
               </div>
             </div>
             <div className="border-t border-overlay flex items-center justify-end py-4 px-8">
-              <Button disabled={isConfirming} loading={isConfirming} onClick={onConfirm}>
+              <Button
+                variant="primary"
+                disabled={isConfirming}
+                loading={isConfirming}
+                onClick={onConfirm}
+              >
                 Return to project
               </Button>
             </div>

--- a/apps/studio/components/layouts/ProjectLayout/UpgradingState/index.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/UpgradingState/index.tsx
@@ -89,7 +89,12 @@ export const UpgradingState = () => {
                   </p>
                 </div>
                 <div className="mx-auto">
-                  <Button loading={loading} disabled={loading} onClick={refetchProjectDetails}>
+                  <Button
+                    variant="primary"
+                    loading={loading}
+                    disabled={loading}
+                    onClick={refetchProjectDetails}
+                  >
                     Return to project
                   </Button>
                 </div>
@@ -119,7 +124,12 @@ export const UpgradingState = () => {
                       Contact support
                     </SupportLink>
                   </Button>
-                  <Button loading={loading} disabled={loading} onClick={refetchProjectDetails}>
+                  <Button
+                    variant="primary"
+                    loading={loading}
+                    disabled={loading}
+                    onClick={refetchProjectDetails}
+                  >
                     Return to project
                   </Button>
                 </div>

--- a/apps/studio/components/ui/AutoEnableRLSNotice.tsx
+++ b/apps/studio/components/ui/AutoEnableRLSNotice.tsx
@@ -160,6 +160,7 @@ const CreateEnsureRLSTriggerDialog = ({ iconOnly }: { iconOnly?: boolean }) => {
             Cancel
           </Button>
           <ButtonTooltip
+            variant="primary"
             disabled={!canCreateTriggers}
             loading={isCreating}
             onClick={handleCreateTrigger}

--- a/apps/studio/components/ui/DatePicker/index.tsx
+++ b/apps/studio/components/ui/DatePicker/index.tsx
@@ -321,7 +321,9 @@ export function DatePicker({
                 Clear
               </Button>
             )}
-            <Button onClick={() => handleSubmit()}>Apply</Button>
+            <Button variant="primary" onClick={() => handleSubmit()}>
+              Apply
+            </Button>
           </div>
         </>
       </PopoverContent>

--- a/apps/studio/components/ui/EditorPanel/SaveSnippetDialog.tsx
+++ b/apps/studio/components/ui/EditorPanel/SaveSnippetDialog.tsx
@@ -108,7 +108,7 @@ export const SaveSnippetDialog = ({ open, sql, onOpenChange, onSave }: SaveSnipp
           <Button variant="default" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>
-          <Button disabled={!name.trim()} onClick={handleSave}>
+          <Button variant="primary" disabled={!name.trim()} onClick={handleSave}>
             Save snippet
           </Button>
         </DialogFooter>

--- a/apps/studio/components/ui/RequestUpgradeToBillingOwners.tsx
+++ b/apps/studio/components/ui/RequestUpgradeToBillingOwners.tsx
@@ -239,7 +239,7 @@ export const RequestUpgradeToBillingOwners = ({
               <Button variant="default" disabled={isSubmitting} onClick={() => setOpen(false)}>
                 Cancel
               </Button>
-              <Button type="submit" form={formId} loading={isSubmitting}>
+              <Button variant="primary" type="submit" form={formId} loading={isSubmitting}>
                 Submit request
               </Button>
             </DialogFooter>

--- a/apps/studio/hooks/use-check-latest-deploy.tsx
+++ b/apps/studio/hooks/use-check-latest-deploy.tsx
@@ -25,6 +25,7 @@ const DeployCheckToast = ({ id }: { id: string | number }) => {
           Not now
         </Button>
         <Button
+          variant="primary"
           onClick={() => {
             // Document requests carry no skew-protection pin (only built
             // asset URLs do — see skewProtectionDpl in vite.config.ts), so a

--- a/apps/studio/pages/404.tsx
+++ b/apps/studio/pages/404.tsx
@@ -58,7 +58,7 @@ const Error404: NextPage = ({}) => {
           </p>
         </div>
         <div className="flex items-center space-x-4">
-          <Button asChild size="small">
+          <Button variant="primary" asChild size="small">
             <Link href="/projects">Head back</Link>
           </Button>
         </div>

--- a/apps/studio/pages/404.tsx
+++ b/apps/studio/pages/404.tsx
@@ -58,7 +58,7 @@ const Error404: NextPage = ({}) => {
           </p>
         </div>
         <div className="flex items-center space-x-4">
-          <Button variant="primary" asChild size="small">
+          <Button asChild size="small">
             <Link href="/projects">Head back</Link>
           </Button>
         </div>

--- a/apps/studio/pages/500.tsx
+++ b/apps/studio/pages/500.tsx
@@ -53,7 +53,7 @@ const Error500: NextPage = () => {
       </div>
       <div className="flex items-center space-x-4">
         {router.pathname !== '/organizations' ? (
-          <Button asChild>
+          <Button variant="primary" asChild>
             <Link
               href={
                 !!lastVisitedOrganization ? `/org/${lastVisitedOrganization}` : '/organizations'
@@ -63,7 +63,9 @@ const Error500: NextPage = () => {
             </Link>
           </Button>
         ) : (
-          <Button onClick={onClickLogout}>Head back</Button>
+          <Button variant="primary" onClick={onClickLogout}>
+            Head back
+          </Button>
         )}
         <Button variant="secondary" asChild>
           <SupportLink>Submit a support request</SupportLink>

--- a/apps/studio/pages/integrations/vercel/[slug]/deploy-button/new-project.tsx
+++ b/apps/studio/pages/integrations/vercel/[slug]/deploy-button/new-project.tsx
@@ -218,7 +218,9 @@ export function VercelConnectionError({
         <Button asChild variant="default">
           <Link href={`/project/${projectRef}`}>Open project</Link>
         </Button>
-        <Button onClick={onRetry}>Retry connection</Button>
+        <Button variant="primary" onClick={onRetry}>
+          Retry connection
+        </Button>
       </div>
     </div>
   )

--- a/apps/studio/pages/project/[ref]/database/column-privileges.tsx
+++ b/apps/studio/pages/project/[ref]/database/column-privileges.tsx
@@ -335,7 +335,7 @@ const PrivilegesPage: NextPageWithLayout = () => {
                     privileges here
                   </p>
                   {selectedSchema === 'public' && (
-                    <Button asChild className="mt-4">
+                    <Button variant="primary" asChild className="mt-4">
                       <Link href={`/project/${ref}/editor`}>Create a new table</Link>
                     </Button>
                   )}

--- a/apps/studio/pages/project/[ref]/functions/[functionSlug]/code.tsx
+++ b/apps/studio/pages/project/[ref]/functions/[functionSlug]/code.tsx
@@ -214,6 +214,7 @@ const CodePage = () => {
           {IS_PLATFORM && (
             <div className="flex items-center bg-background-muted justify-end p-4 border-t bg-surface-100 shrink-0">
               <ButtonTooltip
+                variant="primary"
                 loading={isDeploying}
                 size="medium"
                 disabled={!canDeployFunction || files.length === 0 || isLoadingFiles}

--- a/apps/studio/pages/project/[ref]/functions/new.tsx
+++ b/apps/studio/pages/project/[ref]/functions/new.tsx
@@ -409,6 +409,7 @@ const NewFunctionPage = () => {
             />
           </div>
           <Button
+            variant="primary"
             loading={isDeploying}
             size="medium"
             disabled={files.length === 0 || isDeploying}

--- a/apps/studio/tests/pages/sign-up.test.tsx
+++ b/apps/studio/tests/pages/sign-up.test.tsx
@@ -18,7 +18,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('@/components/interfaces/SignIn/SignInWithExternalProvider', () => ({
   SignInWithExternalProvider: ({ provider }: { provider: ExternalIdentityProviderConfig }) => (
-    <Button>Continue with {provider.displayName}</Button>
+    <Button variant="primary">Continue with {provider.displayName}</Button>
   ),
 }))
 
@@ -29,6 +29,7 @@ vi.mock('@/components/interfaces/SignIn/SignUpForm', () => ({
     return (
       <>
         <Button
+          variant="primary"
           onClick={() => {
             setIsSubmitted(true)
             onSuccess?.()

--- a/apps/www/app/(home)/_components/CTASection.tsx
+++ b/apps/www/app/(home)/_components/CTASection.tsx
@@ -19,7 +19,7 @@ export function CTASection() {
           <span className="text-foreground block sm:inline"> scale to millions</span>
         </h2>
         <div className="flex items-center gap-2">
-          <Button asChild size="medium">
+          <Button variant="primary" asChild size="medium">
             <Link
               href={getDashboardCtaHref(isLoggedIn)}
               onClick={() =>

--- a/apps/www/app/(home)/_components/Hero.tsx
+++ b/apps/www/app/(home)/_components/Hero.tsx
@@ -26,7 +26,7 @@ export function Hero() {
           </p>
         </div>
         <div className="flex items-center gap-2">
-          <Button asChild size="medium">
+          <Button variant="primary" asChild size="medium">
             <Link
               href={getDashboardCtaHref(isLoggedIn)}
               onClick={() =>

--- a/apps/www/app/partners/catalog/IntegrationsContent.tsx
+++ b/apps/www/app/partners/catalog/IntegrationsContent.tsx
@@ -203,7 +203,7 @@ export default function IntegrationsContent({
                 {metaDescription}
               </p>
             </div>
-            <Button asChild size="tiny" className="shrink-0">
+            <Button variant="primary" asChild size="tiny" className="shrink-0">
               <Link href="https://forms.supabase.com/partner">Apply as a Partner</Link>
             </Button>
           </div>
@@ -461,7 +461,7 @@ export default function IntegrationsContent({
           className="mx-auto max-w-2xl flex flex-col items-center gap-6 py-32 px-6 text-center"
         >
           <h2 className="h2 text-balance">Interested in partnering with Supabase?</h2>
-          <Button asChild size="medium" iconRight={<ArrowRight />}>
+          <Button variant="primary" asChild size="medium" iconRight={<ArrowRight />}>
             <Link href="https://forms.supabase.com/partner">Apply as a Partner</Link>
           </Button>
         </div>

--- a/apps/www/app/partners/catalog/[slug]/PartnerCatalogDetail.tsx
+++ b/apps/www/app/partners/catalog/[slug]/PartnerCatalogDetail.tsx
@@ -142,7 +142,12 @@ export default function PartnerCatalogDetail({ partner, serializedListings }: Pr
                 <h1 className="h1 mb-0!">{partner.title}</h1>
               </div>
               {installHref && (
-                <Button asChild size="medium" iconRight={<ArrowUpRight strokeWidth={1.5} />}>
+                <Button
+                  variant="primary"
+                  asChild
+                  size="medium"
+                  iconRight={<ArrowUpRight strokeWidth={1.5} />}
+                >
                   <a href={installHref} target="_blank" rel="noreferrer">
                     {activeListing.publishedInMarketplace
                       ? 'Install integration'
@@ -295,7 +300,7 @@ export default function PartnerCatalogDetail({ partner, serializedListings }: Pr
                   </div>
                 </div>
                 {installHref && (
-                  <Button asChild>
+                  <Button variant="primary" asChild>
                     <a href={installHref} target="_blank" rel="noreferrer">
                       {activeListing.publishedInMarketplace
                         ? 'Install integration'
@@ -311,7 +316,7 @@ export default function PartnerCatalogDetail({ partner, serializedListings }: Pr
         <div className="border-t bg-background">
           <SectionContainerWithCn className="mx-auto max-w-2xl flex flex-col items-center gap-6 py-24 px-6 text-center">
             <h2 className="h2 text-balance">Interested in partnering with Supabase?</h2>
-            <Button asChild size="medium">
+            <Button variant="primary" asChild size="medium">
               <Link href="/partners#become-a-partner">Become a partner</Link>
             </Button>
           </SectionContainerWithCn>

--- a/apps/www/app/state-of-startups/StateOfStartups2026Content.tsx
+++ b/apps/www/app/state-of-startups/StateOfStartups2026Content.tsx
@@ -301,7 +301,7 @@ const CTABanner = forwardRef<HTMLElement>((props, ref) => {
         </p>
       </div>
       <div className="flex items-center justify-center gap-2 mt-4">
-        <Button asChild size="medium">
+        <Button variant="primary" asChild size="medium">
           <Link
             href="https://supabase.com/dashboard"
             onClick={() =>

--- a/apps/www/app/state-of-startups/register/RegisterContent.tsx
+++ b/apps/www/app/state-of-startups/register/RegisterContent.tsx
@@ -105,7 +105,12 @@ export function RegisterContent() {
                   We want to know what building at startups looks like from where you sit.
                 </p>
 
-                <Button asChild size="medium" iconRight={<ArrowRight size={12} />}>
+                <Button
+                  variant="primary"
+                  asChild
+                  size="medium"
+                  iconRight={<ArrowRight size={12} />}
+                >
                   <Link href="https://supabase.typeform.com/to/p2XiROl8" target="_blank">
                     Take the Survey
                   </Link>

--- a/apps/www/components/CTABanner/index.tsx
+++ b/apps/www/components/CTABanner/index.tsx
@@ -30,7 +30,7 @@ const CTABanner = ({ darkerBg, className }: Props) => {
         </h2>
       </div>
       <div className="flex items-center justify-center gap-2 col-span-12 mt-4">
-        <Button asChild size="medium">
+        <Button variant="primary" asChild size="medium">
           <Link
             href={getDashboardCtaHref(isLoggedIn)}
             onClick={() =>

--- a/apps/www/components/CTASection.tsx
+++ b/apps/www/components/CTASection.tsx
@@ -19,7 +19,7 @@ export function CTASection() {
           <span className="text-foreground block sm:inline"> scale to millions</span>
         </h2>
         <div className="flex items-center gap-2">
-          <Button asChild size="medium">
+          <Button variant="primary" asChild size="medium">
             <Link
               href={getDashboardCtaHref(isLoggedIn)}
               onClick={() =>

--- a/apps/www/components/Contribute/SimilarSolvedThreads.tsx
+++ b/apps/www/components/Contribute/SimilarSolvedThreads.tsx
@@ -301,7 +301,12 @@ export const SimilarSolvedThreads = ({ threads, parentThreadId }: SimilarSolvedT
             </div>
           </DialogSection>
           <DialogFooter>
-            <Button onClick={persistAndCloseDialog} disabled={isSubmitting} loading={isSubmitting}>
+            <Button
+              variant="primary"
+              onClick={persistAndCloseDialog}
+              disabled={isSubmitting}
+              loading={isSubmitting}
+            >
               {isSubmitting ? 'Submitting...' : 'Submit feedback'}
             </Button>
           </DialogFooter>

--- a/apps/www/components/Error404.tsx
+++ b/apps/www/components/Error404.tsx
@@ -51,7 +51,7 @@ const Error404 = () => {
             </p>
           </div>
           <div className="flex items-center space-x-4">
-            <Button asChild size="small">
+            <Button variant="primary" asChild size="small">
               <Link href="/">Head back</Link>
             </Button>
           </div>

--- a/apps/www/components/Error404.tsx
+++ b/apps/www/components/Error404.tsx
@@ -51,7 +51,7 @@ const Error404 = () => {
             </p>
           </div>
           <div className="flex items-center space-x-4">
-            <Button variant="primary" asChild size="small">
+            <Button asChild size="small">
               <Link href="/">Head back</Link>
             </Button>
           </div>

--- a/apps/www/components/Events/new/EventBanner.tsx
+++ b/apps/www/components/Events/new/EventBanner.tsx
@@ -61,7 +61,12 @@ export function EventBanner() {
               </Button>
             )}
             {featuredEvent.link && (
-              <Button size="medium" asChild iconRight={<ArrowRightIcon size={14} />}>
+              <Button
+                variant="primary"
+                size="medium"
+                asChild
+                iconRight={<ArrowRightIcon size={14} />}
+              >
                 <Link
                   href={featuredEvent.link.href}
                   target={featuredEvent.link.target}

--- a/apps/www/components/Forms/ApplyToSupaSquadForm.tsx
+++ b/apps/www/components/Forms/ApplyToSupaSquadForm.tsx
@@ -551,7 +551,13 @@ const FormContent = memo(function FormContent({
               >
                 Cancel
               </Button>
-              <Button size="small" type="submit" disabled={isSubmitting} className="flex-1">
+              <Button
+                variant="primary"
+                size="small"
+                type="submit"
+                disabled={isSubmitting}
+                className="flex-1"
+              >
                 {isSubmitting ? <>Submitting...</> : <>Submit Application</>}
               </Button>
             </div>

--- a/apps/www/components/Forms/RequestADemoForm.tsx
+++ b/apps/www/components/Forms/RequestADemoForm.tsx
@@ -254,6 +254,7 @@ const RequestADemoForm: FC<Props> = ({ className }) => {
 
             <Separator className="col-span-full" />
             <Button
+              variant="primary"
               block
               type="submit"
               size="small"

--- a/apps/www/components/Forms/TalkToPartnershipTeamForm.tsx
+++ b/apps/www/components/Forms/TalkToPartnershipTeamForm.tsx
@@ -244,6 +244,7 @@ const TalkToPartnershipTeamForm: FC<Props> = ({ className }) => {
 
             <Separator className="col-span-full" />
             <Button
+              variant="primary"
               block
               type="submit"
               size="small"

--- a/apps/www/components/Nav/MobileMenu.tsx
+++ b/apps/www/components/Nav/MobileMenu.tsx
@@ -292,7 +292,7 @@ export const MobileMenu = ({ open, setOpen, menu }: Props) => {
                           })
                         }
                       >
-                        <Button block asChild>
+                        <Button variant="primary" block asChild>
                           <a type={undefined} className="h-10 py-4">
                             Start your project
                           </a>

--- a/apps/www/components/Nav/index.tsx
+++ b/apps/www/components/Nav/index.tsx
@@ -180,7 +180,7 @@ const Nav = ({ hideNavbar, stickyNavbar = true }: Props) => {
                           Sign in
                         </Link>
                       </Button>
-                      <Button className="hidden lg:block" asChild>
+                      <Button variant="primary" className="hidden lg:block" asChild>
                         <Link
                           href="https://supabase.com/dashboard/sign-up"
                           onClick={() =>

--- a/apps/www/components/NewFeatureCard.tsx
+++ b/apps/www/components/NewFeatureCard.tsx
@@ -43,7 +43,7 @@ const NewFeatureCard = (props: CardProps) => (
 
       <div className="flex items-center flex-wrap gap-1">
         {props.ctas.map((cta: any) => (
-          <Button type={cta.type} asChild>
+          <Button variant={cta.type} asChild>
             <Link href={cta.href} target={cta.target}>
               {cta.label}
             </Link>

--- a/apps/www/components/Pricing/UpgradePlan.tsx
+++ b/apps/www/components/Pricing/UpgradePlan.tsx
@@ -141,7 +141,7 @@ const UpgradePlan = ({ organizations = [], onClick, size = 'large', planId }: Up
           <DialogClose asChild>
             <Button variant="outline">Cancel</Button>
           </DialogClose>
-          <Button disabled={!value} asChild>
+          <Button variant="primary" disabled={!value} asChild>
             <Link
               href={
                 value === 'new-organization'

--- a/apps/www/components/Sections/EnterpriseCta.tsx
+++ b/apps/www/components/Sections/EnterpriseCta.tsx
@@ -1,7 +1,7 @@
+import SectionContainer from '~/components/Layouts/SectionContainer'
 import Link from 'next/link'
 import React from 'react'
 import { Button } from 'ui'
-import SectionContainer from '~/components/Layouts/SectionContainer'
 
 const EnterpriseCta = () => {
   return (
@@ -16,7 +16,7 @@ const EnterpriseCta = () => {
           and managing embeddings at scale.
         </p>
         <div className="w-full mt-4 flex items-center justify-center text-center gap-4">
-          <Button asChild size="medium">
+          <Button variant="primary" asChild size="medium">
             <Link href="https://forms.supabase.com/enterprise">Fill out Enterprise Form</Link>
           </Button>
         </div>

--- a/apps/www/components/Sections/ProductHeader.tsx
+++ b/apps/www/components/Sections/ProductHeader.tsx
@@ -53,7 +53,7 @@ const ProductHeader = (props: Types) => {
               })}
           </div>
           <div className="flex flex-row md:flex-row md:items-center">
-            <Button asChild size="medium">
+            <Button variant="primary" asChild size="medium">
               <Link
                 href={getDashboardCtaHref(isLoggedIn)}
                 onClick={() =>

--- a/apps/www/components/Sections/ProductHeaderCentered.tsx
+++ b/apps/www/components/Sections/ProductHeaderCentered.tsx
@@ -81,7 +81,7 @@ const ProductHeaderCentered = (props: Types) => (
         </div>
         <div className="w-full sm:w-auto flex flex-col items-stretch sm:flex-row pt-2 sm:items-center gap-2">
           {props.cta && (
-            <Button size="medium" iconRight={props.cta.icon} asChild>
+            <Button variant="primary" size="medium" iconRight={props.cta.icon} asChild>
               <Link href={props.cta.link} as={props.cta.link}>
                 {props.cta.label ?? 'Start for free'}
               </Link>

--- a/apps/www/components/Sections/ProductModulesHeader.tsx
+++ b/apps/www/components/Sections/ProductModulesHeader.tsx
@@ -1,9 +1,10 @@
+import styles from '~/styles/animations.module.css'
+import { PlayCircle } from 'lucide-react'
 import Image from 'next/image'
 import Link from 'next/link'
 import { Button, cn } from 'ui'
-import styles from '~/styles/animations.module.css'
+
 import AnnouncementBadge from '../Announcement/Badge'
-import { PlayCircle } from 'lucide-react'
 
 interface Types {
   h1: string | React.ReactNode
@@ -102,7 +103,7 @@ const ProductModulesHeader = (props: Types) => (
         </div>
         <div className="w-full sm:w-auto flex flex-col items-stretch sm:flex-row pt-2 sm:items-center gap-2">
           {props.cta && (
-            <Button size="small" asChild>
+            <Button variant="primary" size="small" asChild>
               <Link href={props.cta.link} as={props.cta.link}>
                 {props.cta.label ?? 'Start for free'}
               </Link>

--- a/apps/www/components/Solutions/CtaSection.tsx
+++ b/apps/www/components/Solutions/CtaSection.tsx
@@ -43,7 +43,7 @@ const CtaSection = ({
           <h2 className="text-foreground-light text-2xl lg:text-3xl leading-tight">{title}</h2>
           {subtitle && <p className="text-foreground-light text-lg">{subtitle}</p>}
           <div className="flex flex-wrap gap-3 pt-4">
-            <Button asChild size="medium" icon={primaryCta.icon}>
+            <Button variant="primary" asChild size="medium" icon={primaryCta.icon}>
               <Link href={primaryCta.url} target={primaryCta.target}>
                 {primaryCta.label}
               </Link>

--- a/apps/www/components/Supasquad/CtaSection.tsx
+++ b/apps/www/components/Supasquad/CtaSection.tsx
@@ -36,7 +36,7 @@ const CtaSection = ({ id, title, subtitle, primaryCta, secondaryCta, className }
           <h2 className="text-foreground-light text-2xl lg:text-3xl leading-tight">{title}</h2>
           {subtitle && <p className="text-foreground-light text-lg">{subtitle}</p>}
           <div className="flex flex-wrap gap-3 pt-4">
-            <Button asChild size="medium" icon={primaryCta.icon}>
+            <Button variant="primary" asChild size="medium" icon={primaryCta.icon}>
               <Link href={primaryCta.url} target={primaryCta.target}>
                 {primaryCta.label}
               </Link>

--- a/apps/www/pages/company.tsx
+++ b/apps/www/pages/company.tsx
@@ -91,7 +91,9 @@ const Team = () => {
           </div>
           <div className=" col-span-4 pt-8 md:mt-0 md:text-right">
             <a href="https://supabase.com/careers">
-              <Button size="medium">Join the team</Button>
+              <Button variant="primary" size="medium">
+                Join the team
+              </Button>
             </a>
           </div>
         </div>

--- a/apps/www/pages/opt-out/[ref].tsx
+++ b/apps/www/pages/opt-out/[ref].tsx
@@ -227,7 +227,12 @@ export default function OptOutPage() {
               )}
             </div>
 
-            <Button type="submit" size="small" disabled={submissionType === 'success'}>
+            <Button
+              variant="primary"
+              type="submit"
+              size="small"
+              disabled={submissionType === 'success'}
+            >
               Report spam
             </Button>
             <FormMessage

--- a/apps/www/pages/partners/index.tsx
+++ b/apps/www/pages/partners/index.tsx
@@ -206,7 +206,7 @@ const Partners = () => {
               Reach out to partner with Supabase
             </h2>
             <div className="w-full mt-4 flex items-center justify-center text-center gap-4">
-              <Button asChild size="medium">
+              <Button variant="primary" asChild size="medium">
                 <Link href="https://forms.supabase.com/partner" tabIndex={-1}>
                   Become a Partner
                 </Link>

--- a/apps/www/pages/state-of-startups-2025.tsx
+++ b/apps/www/pages/state-of-startups-2025.tsx
@@ -311,7 +311,7 @@ const CTABanner = forwardRef<HTMLElement>((props, ref) => {
         </p>
       </div>
       <div className="flex items-center justify-center gap-2 mt-4">
-        <Button asChild size="medium">
+        <Button variant="primary" asChild size="medium">
           <Link
             href="https://supabase.com/dashboard"
             onClick={() =>

--- a/packages/ui-patterns/src/PrivacySettings/index.tsx
+++ b/packages/ui-patterns/src/PrivacySettings/index.tsx
@@ -94,7 +94,9 @@ export const PrivacySettings = ({
         </DialogSection>
         <DialogFooter>
           <Button onClick={() => setIsOpen(false)}>Cancel</Button>
-          <Button onClick={handleConfirmPreferences}>Confirm</Button>
+          <Button variant="primary" onClick={handleConfirmPreferences}>
+            Confirm
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/packages/ui-patterns/src/form/FormLayout2.tsx
+++ b/packages/ui-patterns/src/form/FormLayout2.tsx
@@ -420,7 +420,9 @@ export const Page = () => {
             </SheetSection>
             <SheetFooter>
               <Button variant="default">Cancel</Button>
-              <Button type="submit">Submit</Button>
+              <Button variant="primary" type="submit">
+                Submit
+              </Button>
             </SheetFooter>
           </form>
         </Form>

--- a/packages/ui-patterns/src/form/KeyValueFieldArray/KeyValueFieldArray.test.tsx
+++ b/packages/ui-patterns/src/form/KeyValueFieldArray/KeyValueFieldArray.test.tsx
@@ -78,7 +78,9 @@ const KeyValueForm = ({
           addActions={addActions}
           removeLabel="Remove header"
         />
-        <Button type="submit">Submit</Button>
+        <Button variant="primary" type="submit">
+          Submit
+        </Button>
       </form>
     </Form>
   )
@@ -110,7 +112,9 @@ const NameValueForm = ({
           addLabel="Add header"
           removeLabel="Remove header"
         />
-        <Button type="submit">Submit</Button>
+        <Button variant="primary" type="submit">
+          Submit
+        </Button>
       </form>
     </Form>
   )

--- a/packages/ui-patterns/src/form/SingleValueFieldArray/SingleValueFieldArray.test.tsx
+++ b/packages/ui-patterns/src/form/SingleValueFieldArray/SingleValueFieldArray.test.tsx
@@ -57,7 +57,9 @@ const ValueForm = ({
           removeLabel="Remove URL"
           minimumRows={1}
         />
-        <Button type="submit">Submit</Button>
+        <Button variant="primary" type="submit">
+          Submit
+        </Button>
       </form>
     </Form>
   )
@@ -84,7 +86,9 @@ const NameForm = ({ onSubmit = vi.fn() }: { onSubmit?: (values: NameFormValues) 
           removeLabel="Remove domain"
           minimumRows={1}
         />
-        <Button type="submit">Submit</Button>
+        <Button variant="primary" type="submit">
+          Submit
+        </Button>
       </form>
     </Form>
   )

--- a/packages/ui/src/components/Button/Button.test.tsx
+++ b/packages/ui/src/components/Button/Button.test.tsx
@@ -26,6 +26,22 @@ describe('#Button', () => {
     expect(() => wrapper.unmount()).not.toThrow()
   })
 
+  it('should default to the neutral default variant', () => {
+    render(<Button>Neutral</Button>)
+
+    const button = screen.getByRole('button', { name: 'Neutral' })
+    expect(button.className).toContain('bg-background')
+    expect(button.className).toContain('hover:bg-popover')
+    expect(button.className).not.toContain('bg-brand-400')
+  })
+
+  it('should allow an explicit primary variant override', () => {
+    render(<Button variant="primary">Primary</Button>)
+
+    const button = screen.getByRole('button', { name: 'Primary' })
+    expect(button.className).toContain('bg-brand-400')
+  })
+
   it('should render different text', () => {
     const wrapper = render(<Button>Button</Button>)
 

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -191,7 +191,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     {
       asChild = false,
       size = 'tiny',
-      variant = 'primary',
+      variant = 'default',
       children,
       loading,
       block,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix / design-system alignment for the legacy `Button` from `ui`.

## What is the current behavior?

Omitting `variant` on the legacy `Button` falls back to brand-green `primary`. That makes accidental greens easy, and it is hard to spot the real main action on busy pages.

## What is the new behavior?

- Legacy `Button` now defaults to neutral `default`
- Intentional primary CTAs (create, save, submit, marketing CTAs, and matching `ButtonTooltip` usages) now set `variant="primary"` so their appearance is unchanged
- Neutral actions that previously relied on the old fallback (cancel, close, back, dashboard nav, and similar) become grey/white
- Design-system docs updated; regression tests cover the new default

`Button_Shadcn_` is unchanged. It already uses its own CVA default.

This is PR 1 of 2 in a stack. PR 2 drops now-redundant `variant="default"` props.

## To test

Studio (http://localhost:8082):

- `/sign-in`: Sign in stays green
- Open a project → Database → Tables: New table stays green
- Auth → Users → Invite: Invite user stays green; Cancel / dismiss controls stay neutral
- Project Settings → General: edit a field so Cancel and Save appear. Cancel is neutral, Save is green

Design system (http://localhost:3003):

- Components → Button: default demo is neutral; primary demo is green; featured preview is the default variant

Marketing (optional):

- www header: Start your project stays green; logged-in Dashboard is neutral

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Buttons now default to a neutral style, while primary actions across Studio, documentation, marketing pages, forms, dialogs, and error states use prominent primary styling.
  - Updated button examples and previews clarify the distinction between default and primary variants.
  - Event registration now includes a directional arrow icon.

- **Tests**
  - Added coverage confirming default button styling and explicit primary styling behave as expected.
  - Updated related test fixtures to use primary styling where appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->