### PR TITLE
fix(ui-patterns): stabilise multi-select trigger height

### DIFF
--- a/apps/design-system/content/docs/fragments/multi-select.mdx
+++ b/apps/design-system/content/docs/fragments/multi-select.mdx
@@ -41,6 +41,12 @@ import {
 
 <ComponentPreview name="multi-select-disabled" />
 
+### Without trigger icon
+
+Set `showIcon={false}` to hide the trigger icon.
+
+<ComponentPreview name="multi-select-without-icon" />
+
 ### Badge Combo Box
 
 Use `MultiSelectorInput`to add a search input.

--- a/apps/design-system/registry/default/example/multi-select-badge-limit-wrap.tsx
+++ b/apps/design-system/registry/default/example/multi-select-badge-limit-wrap.tsx
@@ -23,7 +23,6 @@ export default function MultiSelectDemo() {
         label="Select fruits"
         persistLabel
         badgeLimit="wrap"
-        showIcon={false}
         deletableBadge={false}
       />
       <MultiSelectorContent>

--- a/apps/design-system/registry/default/example/multi-select-deletable-badge.tsx
+++ b/apps/design-system/registry/default/example/multi-select-deletable-badge.tsx
@@ -17,7 +17,6 @@ export default function MultiSelectDemo() {
         label="Select fruits"
         deletableBadge
         badgeLimit="wrap"
-        showIcon={false}
       />
       <MultiSelectorContent>
         <MultiSelectorList>

--- a/apps/design-system/registry/default/example/multi-select-demo.tsx
+++ b/apps/design-system/registry/default/example/multi-select-demo.tsx
@@ -25,12 +25,7 @@ export default function MultiSelectDemo() {
 
   return (
     <MultiSelector values={selectedValues} onValuesChange={setSelectedValues}>
-      <MultiSelectorTrigger
-        className="w-72"
-        label="Select fruits"
-        badgeLimit="wrap"
-        showIcon={false}
-      />
+      <MultiSelectorTrigger className="w-72" label="Select fruits" badgeLimit="wrap" />
       <MultiSelectorContent>
         <MultiSelectorList>
           {fruits.map(({ value, isDisabled }) => (

--- a/apps/design-system/registry/default/example/multi-select-in-dialog.tsx
+++ b/apps/design-system/registry/default/example/multi-select-in-dialog.tsx
@@ -49,7 +49,7 @@ export default function MultiSelectDemo() {
           <div>
             <Label htmlFor="fruits">Fruits</Label>
             <MultiSelector id="fruits" values={selectedValues} onValuesChange={setSelectedValues}>
-              <MultiSelectorTrigger label="Select fruits" badgeLimit="wrap" showIcon={false} />
+              <MultiSelectorTrigger label="Select fruits" badgeLimit="wrap" />
               <MultiSelectorContent>
                 <MultiSelectorList>
                   {fruits.map(({ value, isDisabled }) => (

--- a/apps/design-system/registry/default/example/multi-select-inline-search-input.tsx
+++ b/apps/design-system/registry/default/example/multi-select-inline-search-input.tsx
@@ -18,7 +18,6 @@ export default function MultiSelectDemo() {
         label="Select fruits"
         deletableBadge
         badgeLimit="wrap"
-        showIcon={false}
       />
       <MultiSelectorContent>
         <MultiSelectorList>

--- a/apps/design-system/registry/default/example/multi-select-without-icon.tsx
+++ b/apps/design-system/registry/default/example/multi-select-without-icon.tsx
@@ -1,0 +1,25 @@
+import { useState } from 'react'
+import {
+  MultiSelector,
+  MultiSelectorContent,
+  MultiSelectorItem,
+  MultiSelectorList,
+  MultiSelectorTrigger,
+} from 'ui-patterns/multi-select'
+
+export default function MultiSelectWithoutIcon() {
+  const [selectedValues, setSelectedValues] = useState<string[]>([])
+
+  return (
+    <MultiSelector values={selectedValues} onValuesChange={setSelectedValues}>
+      <MultiSelectorTrigger className="w-72" label="Select fruits" showIcon={false} />
+      <MultiSelectorContent>
+        <MultiSelectorList>
+          <MultiSelectorItem value="Apple">Apple</MultiSelectorItem>
+          <MultiSelectorItem value="Banana">Banana</MultiSelectorItem>
+          <MultiSelectorItem value="Cherry">Cherry</MultiSelectorItem>
+        </MultiSelectorList>
+      </MultiSelectorContent>
+    </MultiSelector>
+  )
+}

--- a/apps/design-system/registry/examples.ts
+++ b/apps/design-system/registry/examples.ts
@@ -1514,6 +1514,11 @@ export const examples: Registry = [
     files: ['example/multi-select-disabled.tsx'],
   },
   {
+    name: 'multi-select-without-icon',
+    type: 'components:example',
+    files: ['example/multi-select-without-icon.tsx'],
+  },
+  {
     name: 'multi-select-badge-limit-wrap',
     type: 'components:example',
     files: ['example/multi-select-badge-limit-wrap.tsx'],

--- a/packages/ui-patterns/src/multi-select/multi-select.test.tsx
+++ b/packages/ui-patterns/src/multi-select/multi-select.test.tsx
@@ -60,6 +60,30 @@ describe('multi-select', () => {
     expect(trigger.firstElementChild).toHaveClass('gap-0.5')
   })
 
+  it('keeps the default trigger height stable when the first value is selected', () => {
+    const { rerender } = render(
+      <MultiSelector values={[]} onValuesChange={() => undefined}>
+        <MultiSelectorTrigger label="Select fruits" />
+      </MultiSelector>
+    )
+
+    const trigger = screen.getByRole('combobox')
+    expect(trigger).toHaveClass('min-h-[34px]', 'py-1.5')
+    expect(screen.getByText('Select fruits')).toHaveClass('leading-5')
+
+    rerender(
+      <MultiSelector values={['Apple']} onValuesChange={() => undefined}>
+        <MultiSelectorTrigger label="Select fruits" />
+      </MultiSelector>
+    )
+
+    expect(screen.getByText('Apple').closest('[class*=rounded]')).toHaveClass(
+      'text-xs/none',
+      'py-[3px]'
+    )
+    expect(trigger).toHaveClass('min-h-[34px]', 'py-1.5')
+  })
+
   it('renders selected values with a custom label', () => {
     render(
       <MultiSelector values={['101']} onValuesChange={() => undefined}>

--- a/packages/ui-patterns/src/multi-select/multi-select.test.tsx
+++ b/packages/ui-patterns/src/multi-select/multi-select.test.tsx
@@ -58,6 +58,7 @@ describe('multi-select', () => {
     const trigger = screen.getByRole('combobox')
     expect(trigger).toHaveClass('h-[26px]', 'p-0.5')
     expect(trigger.firstElementChild).toHaveClass('gap-0.5')
+    expect(trigger.lastElementChild).toHaveAttribute('aria-hidden', 'true')
   })
 
   it('keeps the default trigger height stable when the first value is selected', () => {

--- a/packages/ui-patterns/src/multi-select/multi-select.tsx
+++ b/packages/ui-patterns/src/multi-select/multi-select.tsx
@@ -262,11 +262,11 @@ const MultiSelectorBadgesVariants = cva('flex overflow-hidden flex-1 min-w-0', {
 })
 
 const MultiSelectorBadgeVariants = cva(
-  'rounded-sm shrink-0 px-1.5 bg-surface-75 dark:bg-white/5 normal-case tracking-normal text-xs',
+  'rounded-sm shrink-0 px-1.5 bg-surface-75 dark:bg-white/5 normal-case tracking-normal text-xs/none',
   {
     variants: {
       size: {
-        tiny: 'h-full py-0 leading-none',
+        tiny: 'h-full py-0',
         small: '',
         medium: '',
         large: '',
@@ -285,10 +285,10 @@ const MultiSelectorLabelVariants = cva(
     variants: {
       size: {
         tiny: 'leading-none',
-        small: 'ml-1 leading-5.5',
-        medium: 'ml-1 leading-5.5',
-        large: 'ml-1 leading-5.5',
-        xlarge: 'ml-1 leading-5.5',
+        small: 'ml-1 leading-5',
+        medium: 'ml-1 leading-5',
+        large: 'ml-1 leading-5',
+        xlarge: 'ml-1 leading-5',
       },
     },
     defaultVariants: {

--- a/packages/ui-patterns/src/multi-select/multi-select.tsx
+++ b/packages/ui-patterns/src/multi-select/multi-select.tsx
@@ -490,6 +490,7 @@ const MultiSelectorTrigger = React.forwardRef<HTMLButtonElement, MultiSelectorTr
 
           {showIcon && (
             <ChevronsUpDown
+              aria-hidden="true"
               size={16}
               strokeWidth={1.5}
               className="text-foreground-lighter shrink-0 ml-1.5 self-center"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix and design-system documentation update.

## What is the current behaviour?

Multi-select examples inconsistently hide the default trigger icon, which makes the component default difficult to understand from the design-system page.

The empty trigger label and selected badges also use different content heights. Selecting or removing the first item causes the default 34px trigger to grow or shrink slightly.

## What is the new behaviour?

- Shows the default trigger icon in every existing multi-select example
- Adds a dedicated **Without trigger icon** example for `showIcon={false}`
- Normalises the label and badge content rows to 20px so the default trigger remains 34px when the first item is selected or removed
- Adds regression coverage for the default trigger height classes

This follows the 34px trigger sizing introduced in [#48696](https://github.com/supabase/supabase/pull/48696).

## To test

1. Open [Design System > Fragment Components > Multi Select](https://design-system-git-dnywh-fixmulti-select-icon-ex-772e13-supabase.vercel.app/design-system/docs/fragments/multi-select).
2. Confirm every existing example shows the default trigger icon.
3. Confirm the new **Without trigger icon** example is the only example without it.
4. In the first example, select and remove the first fruit. The trigger should remain the same height throughout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a multi-select example and documentation for hiding the trigger icon.
  * Added a preview with selectable Apple, Banana, and Cherry options.

* **Bug Fixes**
  * Updated multi-select examples to display the trigger icon by default.
  * Improved badge and label alignment.
  * Preserved consistent trigger height when selecting the first item.
  * Updated the decorative trigger icon and kept it hidden from assistive technologies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->