### PR TITLE
test(studio): scope realtime broadcast helper

### DIFF
--- a/e2e/studio/utils/realtime-helpers.ts
+++ b/e2e/studio/utils/realtime-helpers.ts
@@ -36,7 +36,9 @@ export async function stopListening(page: Page) {
 }
 
 export async function openBroadcastModal(page: Page) {
-  const broadcastButton = page.getByRole('button', { name: 'Broadcast a message' })
+  const broadcastButton = page
+    .getByRole('status')
+    .getByRole('button', { name: 'Broadcast a message' })
   await expect(broadcastButton).toBeVisible({ timeout: 5000 })
   await broadcastButton.click()
   await expect(page.getByText('Broadcast a message to all clients')).toBeVisible({ timeout: 5000 })


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The Realtime Inspector has two buttons named “Broadcast a message” after joining a channel: one in the listening status toolbar and one in the empty grid state. The shared E2E helper matches both and fails with a Playwright strict mode violation.

## What is the new behavior?

The helper scopes the action to the listening status region, where the persistent broadcast control lives.

## To test

Run the Realtime Inspector E2E tests:

```bash
pnpm --prefix e2e/studio run e2e -- features/realtime-inspector.spec.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability when opening the broadcast message modal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->