### PR TITLE
Api authorization to add returnTo param when linking to /new for no org empty state

### DIFF
--- a/apps/studio/components/interfaces/ApiAuthorization/ApiAuthorization.Form.tsx
+++ b/apps/studio/components/interfaces/ApiAuthorization/ApiAuthorization.Form.tsx
@@ -71,6 +71,7 @@ function isExternalRedirectUrl(url: string): boolean {
 }
 
 export interface ApiAuthorizationMainViewProps {
+  auth_id: string
   approvalState: ApprovalState
   form: UseFormReturn<IApprovalFormSchema>
   requester: ApiAuthorizationResponse
@@ -83,6 +84,7 @@ export interface ApiAuthorizationMainViewProps {
 }
 
 export function ApiAuthorizationMainView({
+  auth_id,
   approvalState,
   form,
   requester,
@@ -125,7 +127,7 @@ export function ApiAuthorizationMainView({
               {organizations._tag === 'error' && (
                 <OrganizationsErrorNotice error={organizations.error} />
               )}
-              {organizations._tag === 'empty' && <OrganizationsEmptyState />}
+              {organizations._tag === 'empty' && <OrganizationsEmptyState authId={auth_id} />}
               {organizations._tag === 'not_member' && <NotMemberOfOrganizationNotice />}
               {organizations._tag === 'success' && (
                 <OrganizationSelector
@@ -204,16 +206,21 @@ function OrganizationsErrorNotice({ error }: OrganizationsErrorNoticeProps): Rea
   )
 }
 
-function OrganizationsEmptyState(): ReactNode {
+interface OrganizationsEmptyStateProps {
+  authId: string
+}
+
+function OrganizationsEmptyState({ authId }: OrganizationsEmptyStateProps): ReactNode {
+  const returnTo = `/authorize?auth_id=${authId}`
+
   return (
     <Admonition
       type="warning"
       title="No organizations found"
       description="Create an organization before authorizing this request."
       actions={[
-        // [Joshen] JFYI this is a short term solution to guide users with creating an org from here
         <Button asChild key="new-org" variant="default">
-          <Link href="/new">Create an organization</Link>
+          <Link href={`/new?returnTo=${encodeURIComponent(returnTo)}`}>Create an organization</Link>
         </Button>,
       ]}
     />

--- a/apps/studio/components/interfaces/ApiAuthorization/ApiAuthorization.Valid.tsx
+++ b/apps/studio/components/interfaces/ApiAuthorization/ApiAuthorization.Valid.tsx
@@ -238,6 +238,7 @@ export function ApiAuthorizationValidScreen({
     <>
       <Head>{pageTitle && <title>{pageTitle}</title>}</Head>
       <ApiAuthorizationMainView
+        auth_id={auth_id}
         approvalState={effectiveApprovalState}
         form={form}
         requester={effectiveRequester}

--- a/apps/studio/tests/components/ApiAuthorization.test.tsx
+++ b/apps/studio/tests/components/ApiAuthorization.test.tsx
@@ -327,6 +327,16 @@ describe('ApiAuthorizationScreen', () => {
           ).not.toBeInTheDocument()
         })
 
+        test('empty state links back to this authorize request via returnTo', async () => {
+          mockBothEndpoints(createMockAuthResponse(), [])
+          renderScreen()
+          const link = await screen.findByRole('link', { name: 'Create an organization' })
+          expect(link).toHaveAttribute(
+            'href',
+            `/new?returnTo=${encodeURIComponent('/authorize?auth_id=test-auth-id')}`
+          )
+        })
+
         test('shows not_member notice when organization_slug does not match any user organization', async () => {
           mockBothEndpoints()
           renderScreen({ organization_slug: 'nonexistent-org' })


### PR DESCRIPTION
### Context

Resolves FE-4355

- Users who reach `/authorize` with zero organizations see a "Create an organization" CTA that links to a bare `/new`
- After creating the org, they land on `/new/<slug>?projectName=...` instead of back at `/authorize?auth_id=...`
- `returnTo` handling used to exist here ([#30211](https://github.com/supabase/supabase/pull/30211), refactored in [#44522](https://github.com/supabase/supabase/pull/44522)) but was dropped as a side effect of the interstitial redesign in [#46359](https://github.com/supabase/supabase/pull/46359)
  - [#47760](https://github.com/supabase/supabase/pull/47760) later patched the missing CTA back in but not the returnTo round-trip