### PR TITLE
Add horizontal padding for notebook home tab

### DIFF
--- a/apps/studio/components/interfaces/Explorer/ExplorerHomeTab.tsx
+++ b/apps/studio/components/interfaces/Explorer/ExplorerHomeTab.tsx
@@ -14,7 +14,7 @@ export const ExplorerHomeTab = () => {
   const [value, setValue] = useState<string>('')
 
   return (
-    <div className="bg-surface-100 h-full flex flex-col items-center justify-center">
+    <div className="bg-surface-100 h-full flex flex-col items-center justify-center px-10">
       <div className="w-full max-w-2xl">
         <div className="flex items-center justify-center flex-col gap-y-1 mb-12">
           <h1 className="heading-section">Explore your project</h1>


### PR DESCRIPTION
## Context

Theres no padding on smaller viewports - so the main content looks squished

### Before
<img width="1674" height="1882" alt="image" src="https://github.com/user-attachments/assets/e0b1fb05-d853-40db-8e06-51dec9a9376a" />


### After
<img width="947" height="981" alt="image" src="https://github.com/user-attachments/assets/28c6dab4-0c12-4851-aa40-c65d60797463" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved horizontal spacing on the Explorer home screen for a more balanced layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->