### PR TITLE
Adjust vertical space for explorer notebook query cells

### DIFF
--- a/apps/studio/components/interfaces/Explorer/QueryCell/index.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryCell/index.tsx
@@ -120,6 +120,7 @@ export const QueryCell = forwardRef<QueryEditorHandle, QueryCellProps>(function 
         ref={ref}
         id={cell._id}
         variant="embedded"
+        className="min-h-0"
         title={title}
         query={toQueryModel(cell, sql)}
         result={result}

--- a/apps/studio/components/interfaces/Explorer/QueryEditor/QueryResultChart.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryEditor/QueryResultChart.tsx
@@ -80,8 +80,7 @@ export const QueryResultChart = ({ chart, result }: QueryResultChartProps) => {
   if (!result || (result?.rows && result.rows.length === 0)) {
     return (
       <NoDataPlaceholder
-        isFullHeight
-        className="border-0"
+        className="border-0 min-h-0! py-8"
         size="normal"
         message="No results"
         description="Your query returned no rows"
@@ -92,8 +91,7 @@ export const QueryResultChart = ({ chart, result }: QueryResultChartProps) => {
   if (!hasConfig) {
     return (
       <NoDataPlaceholder
-        isFullHeight
-        className="border-0"
+        className="border-0 min-h-0! py-8"
         size="normal"
         message="Configure your chart"
         description="Select your X and Y axis in the display settings"

--- a/apps/studio/components/interfaces/Explorer/QueryEditor/QueryResultError.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryEditor/QueryResultError.tsx
@@ -85,7 +85,7 @@ export const QueryResultError = ({
 
   return (
     <div className="w-full overflow-y-auto">
-      <div className="flex flex-row justify-between items-start py-4 px-6 gap-x-4">
+      <div className="flex flex-row justify-between items-start p-3 gap-x-4">
         {isTimeout ? (
           <div className="flex flex-col gap-y-1">
             <p className="font-mono text-sm tracking-tight">

--- a/apps/studio/components/interfaces/Explorer/QueryEditor/QueryResultRenderer.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryEditor/QueryResultRenderer.tsx
@@ -1,3 +1,5 @@
+import { Play } from 'lucide-react'
+
 import { type SqlSnippetSource } from '../../SQLEditor/querySource'
 import { type QueryResult } from '../types'
 import { QueryResultChart } from './QueryResultChart'
@@ -26,7 +28,12 @@ export const QueryResultRenderer = ({
   const { rows, error, autoLimit } = result ?? {}
 
   if (!result) {
-    return <p className="text-xs text-foreground-lighter py-8">Run the query to see results</p>
+    return (
+      <div className="flex items-center gap-x-2 p-3 w-full">
+        <Play size={12} className="text-foreground-lighter" />
+        <p className="text-xs text-foreground-lighter">Run the query to see results</p>
+      </div>
+    )
   }
 
   if (error) {

--- a/apps/studio/components/interfaces/Explorer/QueryEditor/index.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryEditor/index.tsx
@@ -392,16 +392,8 @@ export const QueryEditor = forwardRef<QueryEditorHandle, QueryEditorProps>(funct
     return () => node.removeEventListener('keydown', handleEscapeKey)
   }, [promptState?.isOpen])
 
-  const shouldCenterResults =
-    !result?.error && ((result?.rows ?? []).length === 0 || (view === 'chart' && !hasConfig))
-
   const queryResults = (
-    <ExplorerQueryResults
-      className={cn(
-        variant === 'embedded' ? 'max-h-80' : 'h-full',
-        shouldCenterResults ? 'items-center justify-center' : 'overflow-x-auto'
-      )}
-    >
+    <ExplorerQueryResults className={cn(variant === 'embedded' ? 'max-h-80' : 'h-full')}>
       <QueryResultRenderer
         view={view}
         result={result}

--- a/apps/studio/components/interfaces/Explorer/QueryEditor/index.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryEditor/index.tsx
@@ -189,9 +189,6 @@ export const QueryEditor = forwardRef<QueryEditorHandle, QueryEditorProps>(funct
   const rowLimit = query._tag === 'database' ? query.rowLimit : undefined
   const databaseIdentifier = query._tag === 'database' ? query.database_identifier : undefined
 
-  const { x_column, y_series } = display?.chart ?? {}
-  const hasConfig = !!x_column && (y_series ?? []).length > 0
-
   const [promptInput, setPromptInput] = useState('')
   const [pendingRun, setPendingRun] = useState<{ sql: string; issues: PotentialIssues }>()
   const [pendingProposal, setPendingProposal] = useState<PendingProposal | null>(null)


### PR DESCRIPTION
## Context

As per PR title - just adjusts the vertical height for a couple of empty states in QueryCells for Notebooks

### Query not run yet

| Before | After |
| -------- | -------- |
| <img width="1072" height="350" alt="image" src="https://github.com/user-attachments/assets/cbf14619-ac01-4082-9732-41737a028c40" />    | <img width="1083" height="313" alt="image" src="https://github.com/user-attachments/assets/1144eebf-7293-4be4-adaf-af2dc21bc40f" />   |
| <img width="1083" height="292" alt="image" src="https://github.com/user-attachments/assets/511754f8-5128-41b7-a4c8-542fb93b77e5" />   | <img width="1100" height="163" alt="image" src="https://github.com/user-attachments/assets/53de5b4a-8284-406a-a8ae-4602f61f3ca3" />   |

### Chart empty state

| Before | After |
| -------- | -------- |
| <img width="1079" height="291" alt="image" src="https://github.com/user-attachments/assets/068fe573-1f65-4efc-831c-db2ddda2be1a" />    | <img width="1078" height="225" alt="image" src="https://github.com/user-attachments/assets/b9d58d8f-162d-463d-90e2-fbf3470c6db8" />   |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved query editor layout by reducing unnecessary spacing and ensuring result areas fit more consistently within available space.
  - Refined chart empty states with cleaner borders, compact spacing, and improved vertical sizing.
  - Updated query error presentation with more compact padding.
  - Simplified result panel sizing for a more consistent viewing experience.

- **User Experience**
  - Added a play icon alongside the “Run the query to see results” prompt when no results are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->