### PR TITLE
chore(self-hosted): update 2026-09-09 - 0.8.1

### DIFF
--- a/apps/docs/content/guides/self-hosting/docker.mdx
+++ b/apps/docs/content/guides/self-hosting/docker.mdx
@@ -122,7 +122,7 @@ A shallow clone of the full Supabase repository. Works on any OS with `git` inst
 
 ```sh
 # Get the code
-git clone --depth 1 --branch self-hosted/v0.8.0 https://github.com/supabase/supabase
+git clone --depth 1 --branch self-hosted/v0.8.1 https://github.com/supabase/supabase
 
 # Make your new supabase project directory
 mkdir supabase-project
@@ -139,7 +139,7 @@ cp -rf supabase/docker/. supabase-project
 cd supabase-project && cp .env.example .env
 
 # Record the base version so update.sh can upgrade this install later
-printf 'ref=self-hosted/v0.8.0\n' > .supabase-version
+printf 'ref=self-hosted/v0.8.1\n' > .supabase-version
 
 # Pull the latest images
 docker compose pull
@@ -153,7 +153,7 @@ Only downloads the `docker/` directory from the repository, saving bandwidth and
 
 ```sh
 # Get the code using git sparse checkout
-git clone --filter=blob:none --no-checkout --depth=1 --quiet --branch self-hosted/v0.8.0 https://github.com/supabase/supabase
+git clone --filter=blob:none --no-checkout --depth=1 --quiet --branch self-hosted/v0.8.1 https://github.com/supabase/supabase
 cd supabase
 git sparse-checkout init --cone
 git sparse-checkout set docker
@@ -175,7 +175,7 @@ cp -rf supabase/docker/. supabase-project
 cd supabase-project && cp .env.example .env
 
 # Record the base version so update.sh can upgrade this install later
-printf 'ref=self-hosted/v0.8.0\n' > .supabase-version
+printf 'ref=self-hosted/v0.8.1\n' > .supabase-version
 
 # Pull the latest images
 docker compose pull

--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -13,7 +13,7 @@ See per-service updates below for details. Only the most important changes relev
 ## [0.8.1](https://github.com/supabase/supabase/releases/tag/self-hosted/v0.8.1) - 2026-09-09
 
 ### Configuration
-- Added an optional [PgBouncer](https://www.pgbouncer.org/) override (requires `docker-compose.pgbouncer.yml`) as an alternative to the default Supavisor pooler - PR [#49052](https://github.com/supabase/supabase/pull/49052) (via [@singh-inder](https://github.com/singh-inder/)
+- Added an optional [PgBouncer](https://www.pgbouncer.org/) override (requires `docker-compose.pgbouncer.yml`) as an alternative to the default Supavisor pooler - PR [#49052](https://github.com/supabase/supabase/pull/49052) (via [@singh-inder](https://github.com/singh-inder/))
 
 ### Documentation
 - Added a new guide [Accessing Postgres](https://supabase.com/docs/guides/self-hosting/accessing-postgres) - PR [#49303](https://github.com/supabase/supabase/pull/49303)
@@ -21,7 +21,7 @@ See per-service updates below for details. Only the most important changes relev
 
 ### API gateway
 - Updated Envoy to `v1.39.1` - [Release](https://github.com/envoyproxy/envoy/releases/tag/v1.39.1)
-- Changed CORS configuration for `/pg` route (requires `docker-compose.yml`, `volumes/api/envoy/docker-entrypoints.sh`, `volumes/api/envoy/lds.template.yml` update) - PR [#49136](https://github.com/supabase/supabase/pull/49136)
+- Changed CORS configuration for `/pg` route (requires `docker-compose.yml`, `volumes/api/envoy/docker-entrypoint.sh`, `volumes/api/envoy/lds.template.yaml` update) - PR [#49136](https://github.com/supabase/supabase/pull/49136)
 - Updated [nginx-certbot](https://github.com/JonasAlfredsson/docker-nginx-certbot) to `6.2.0-nginx1.31.5` (requires `docker-compose.nginx.yml` update)
 
 ### Studio

--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -10,6 +10,57 @@ See per-service updates below for details. Only the most important changes relev
 
 ---
 
+## [0.8.1](https://github.com/supabase/supabase/releases/tag/self-hosted/v0.8.1) - 2026-09-09
+
+### Configuration
+- Added an optional [PgBouncer](https://www.pgbouncer.org/) override (requires `docker-compose.pgbouncer.yml`) as an alternative to the default Supavisor pooler - PR [#49052](https://github.com/supabase/supabase/pull/49052)
+
+### Documentation
+- Added a new guide [Accessing Postgres](https://supabase.com/docs/guides/self-hosting/accessing-postgres) - PR [#49303](https://github.com/supabase/supabase/pull/49303)
+- Added new how-to guides (configuring auth hooks, passkeys) - PR [#43372](https://github.com/supabase/supabase/pull/43372), PR [#48954](https://github.com/supabase/supabase/pull/48954) (via [@singh-inder](https://github.com/singh-inder/))
+
+### API gateway
+- Updated Envoy to `v1.39.1` - [Release](https://github.com/envoyproxy/envoy/releases/tag/v1.39.1)
+- Changed CORS configuration for `/pg` postgres-meta route - PR [#49136](https://github.com/supabase/supabase/pull/49136)
+- Updated [nginx-certbot](https://github.com/JonasAlfredsson/docker-nginx-certbot) to `6.2.0-nginx1.31.5` (requires `docker-compose.nginx.yml` update)
+
+### Studio
+- Updated to `2026.09.07-sha-7996410`
+
+### MCP Server
+- Updated to `v0.11.0` - [Release](https://github.com/supabase/mcp/releases/tag/mcp-server-supabase-v0.11.0)
+
+### Auth
+- Updated to `v2.196.0` - [Changelog](https://github.com/supabase/auth/blob/master/CHANGELOG.md) | [Release](https://github.com/supabase/auth/releases/tag/v2.196.0)
+
+### PostgREST
+- Updated to `v14.17` - [Changelog](https://github.com/PostgREST/postgrest/blob/main/CHANGELOG.md) | [Release](https://github.com/PostgREST/postgrest/releases/tag/v14.17)
+
+### Realtime
+- Updated to `v2.134.10` - [Release](https://github.com/supabase/realtime/releases/tag/v2.134.10)
+
+### Storage
+- Updated to `v1.74.0` - [Release](https://github.com/supabase/storage/releases/tag/v1.74.0)
+- Updated RustFS to `v1.0.0-rc.5` (requires `docker-compose.rustfs.yml` update)
+
+### imgproxy
+- Updated to `v3.31.4` - [Changelog](https://github.com/imgproxy/imgproxy/blob/master/CHANGELOG.md) | [Release](https://github.com/imgproxy/imgproxy/releases/tag/v3.31.4)
+
+### Postgres Meta
+- Updated to `v0.99.0` - [Release](https://github.com/supabase/postgres-meta/releases/tag/v0.99.0)
+
+### Edge Runtime
+- Updated to `v1.76.2` - [Release](https://github.com/supabase/edge-runtime/releases/tag/v1.76.2)
+- Changed the main worker to use `@supabase/server` (requires `volumes/functions/deno.jsonc` and `volumes/functions/main/index.ts` update) - PR [#48996](https://github.com/supabase/supabase/pull/48996)
+
+### Supavisor
+- Updated to `2.9.12` - [Release](https://github.com/supabase/supavisor/releases/tag/v2.9.12)
+
+### Analytics (Logflare)
+- Updated to `1.50.10` - [Release](https://github.com/Logflare/logflare/releases/tag/v1.50.10)
+
+---
+
 ## [0.8.0](https://github.com/supabase/supabase/releases/tag/self-hosted/v0.8.0) - 2026-08-11
 
 ⚠️ **Note:** This update contains **breaking changes**. Make sure to read the **important** details below:
@@ -60,7 +111,7 @@ See per-service updates below for details. Only the most important changes relev
 ### API gateway
 - Updated Kong to `3.9.3`
 - Added `KONG_DNS_VALID_TTL` configuration environment variable (requires `docker-compose.yml` update) - PR [#47846](https://github.com/supabase/supabase/pull/47846)
-- Updated Envoy to `1.39.0` (requires `docker-compose.envoy.yml` update)
+- Updated Envoy to `v1.39.0` (requires `docker-compose.envoy.yml` update) - [Release](https://github.com/envoyproxy/envoy/releases/tag/v1.39.0)
 - Updated [nginx-certbot](https://github.com/JonasAlfredsson/docker-nginx-certbot) to `6.2.0-nginx1.31.3` (requires `docker-compose.nginx.yml` update)
 
 ### Studio
@@ -69,7 +120,7 @@ See per-service updates below for details. Only the most important changes relev
 - Fixed the Logs tab visibility in **Auth > Users** - PR [#48122](https://github.com/supabase/supabase/pull/48122) (via [@luizfelmach](https://github.com/luizfelmach/))
 
 ### Storage
-- Changed RustFS image to `1.0.0-beta.11` temporarily (requires `docker-compose.rustfs.yml` update) - PR [#48500](https://github.com/supabase/supabase/pull/48500)
+- Changed RustFS image to `v1.0.0-beta.11` temporarily (requires `docker-compose.rustfs.yml` update) - PR [#48500](https://github.com/supabase/supabase/pull/48500)
 
 ### Edge Runtime
 - Changed JWKS configuration mechanism for main worker (requires `docker-compose.yml` and `volumes/functions/main/index.ts` update) - PR [#45635](https://github.com/supabase/supabase/pull/45635)
@@ -176,8 +227,8 @@ See per-service updates below for details. Only the most important changes relev
 - Updated `tests/test-container-logs.sh` to skip checks for `kong`, `analytics` and `vector` when the services are not running - PR [#46099](https://github.com/supabase/supabase/pull/46099)
 
 ### API gateway
-- Updated Envoy version to `1.38.0` (see `docker-compose.envoy.yml`) - PR [#46023](https://github.com/supabase/supabase/pull/46023)
-- Updated Envoy configuration to address a discrepancy in API key checking (requires `volumes/api/envoy` update) - PR [#46023](https://github.com/supabase/supabase/pull/46023)
+- Updated Envoy to `v1.38.0` (requires `docker-compose.envoy.yml` update) - [Release](https://github.com/envoyproxy/envoy/releases/tag/v1.38.0)
+- Changed Envoy configuration to address a discrepancy in API key checking (requires `volumes/api/envoy` update) - PR [#46023](https://github.com/supabase/supabase/pull/46023)
 
 ### Studio
 - Updated to `2026.06.03-sha-0bca601`

--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -13,15 +13,15 @@ See per-service updates below for details. Only the most important changes relev
 ## [0.8.1](https://github.com/supabase/supabase/releases/tag/self-hosted/v0.8.1) - 2026-09-09
 
 ### Configuration
-- Added an optional [PgBouncer](https://www.pgbouncer.org/) override (requires `docker-compose.pgbouncer.yml`) as an alternative to the default Supavisor pooler - PR [#49052](https://github.com/supabase/supabase/pull/49052)
+- Added an optional [PgBouncer](https://www.pgbouncer.org/) override (requires `docker-compose.pgbouncer.yml`) as an alternative to the default Supavisor pooler - PR [#49052](https://github.com/supabase/supabase/pull/49052) (via [@singh-inder](https://github.com/singh-inder/)
 
 ### Documentation
 - Added a new guide [Accessing Postgres](https://supabase.com/docs/guides/self-hosting/accessing-postgres) - PR [#49303](https://github.com/supabase/supabase/pull/49303)
-- Added new how-to guides (configuring auth hooks, passkeys) - PR [#43372](https://github.com/supabase/supabase/pull/43372), PR [#48954](https://github.com/supabase/supabase/pull/48954) (via [@singh-inder](https://github.com/singh-inder/))
+- Added new how-to guides (configuring [auth hooks](https://supabase.com/docs/guides/self-hosting/self-hosted-auth-hooks), [passkeys](https://supabase.com/docs/guides/self-hosting/self-hosted-passkeys)) - PR [#43372](https://github.com/supabase/supabase/pull/43372), PR [#48954](https://github.com/supabase/supabase/pull/48954) (via [@singh-inder](https://github.com/singh-inder/))
 
 ### API gateway
 - Updated Envoy to `v1.39.1` - [Release](https://github.com/envoyproxy/envoy/releases/tag/v1.39.1)
-- Changed CORS configuration for `/pg` postgres-meta route - PR [#49136](https://github.com/supabase/supabase/pull/49136)
+- Changed CORS configuration for `/pg` route (requires `docker-compose.yml`, `volumes/api/envoy/docker-entrypoints.sh`, `volumes/api/envoy/lds.template.yml` update) - PR [#49136](https://github.com/supabase/supabase/pull/49136)
 - Updated [nginx-certbot](https://github.com/JonasAlfredsson/docker-nginx-certbot) to `6.2.0-nginx1.31.5` (requires `docker-compose.nginx.yml` update)
 
 ### Studio

--- a/docker/docker-compose.logs.yml
+++ b/docker/docker-compose.logs.yml
@@ -18,7 +18,7 @@ services:
 
   analytics:
     container_name: supabase-analytics
-    image: supabase/logflare:1.43.1
+    image: supabase/logflare:1.50.10
     restart: unless-stopped
     #ports:
     #  - 4000:4000

--- a/docker/docker-compose.nginx.yml
+++ b/docker/docker-compose.nginx.yml
@@ -11,7 +11,7 @@ services:
 
   nginx:
     container_name: supabase-nginx
-    image: jonasal/nginx-certbot:6.2.0-nginx1.31.3
+    image: jonasal/nginx-certbot:6.2.0-nginx1.31.5
     restart: unless-stopped
     ports:
       - "80:80"

--- a/docker/docker-compose.rustfs.yml
+++ b/docker/docker-compose.rustfs.yml
@@ -1,7 +1,7 @@
 services:
 
   rustfs:
-    image: rustfs/rustfs:1.0.0-beta.11
+    image: rustfs/rustfs:v1.0.0-rc.5
     environment:
       RUSTFS_ACCESS_KEY: ${MINIO_ROOT_USER}
       RUSTFS_SECRET_KEY: ${MINIO_ROOT_PASSWORD}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,7 +14,7 @@ services:
 
   studio:
     container_name: supabase-studio
-    image: supabase/studio:2026.08.03-sha-022b374
+    image: supabase/studio:2026.09.07-sha-7996410
     restart: unless-stopped
     healthcheck:
       test:
@@ -69,7 +69,7 @@ services:
   # See: https://github.com/orgs/supabase/discussions/48048
   api-gw:
     container_name: supabase-envoy
-    image: envoyproxy/envoy:v1.39.0
+    image: envoyproxy/envoy:v1.39.1
     restart: unless-stopped
     networks:
       default:
@@ -108,7 +108,7 @@ services:
 
   auth:
     container_name: supabase-auth
-    image: supabase/gotrue:v2.189.0
+    image: supabase/gotrue:v2.196.0
     restart: unless-stopped
     healthcheck:
       test:
@@ -248,7 +248,7 @@ services:
 
   rest:
     container_name: supabase-rest
-    image: postgrest/postgrest:v14.12
+    image: postgrest/postgrest:v14.17
     restart: unless-stopped
     depends_on:
       db:
@@ -285,7 +285,7 @@ services:
   realtime:
     # This container name looks inconsistent but is correct because realtime constructs tenant id by parsing the subdomain
     container_name: realtime-dev.supabase-realtime
-    image: supabase/realtime:v2.102.3
+    image: supabase/realtime:v2.134.10
     restart: unless-stopped
     depends_on:
       db:
@@ -331,7 +331,7 @@ services:
   # To use S3 backed storage: docker compose -f docker-compose.yml -f docker-compose.s3.yml up
   storage:
     container_name: supabase-storage
-    image: supabase/storage-api:v1.60.4
+    image: supabase/storage-api:v1.74.0
     restart: unless-stopped
     depends_on:
       db:
@@ -394,7 +394,7 @@ services:
 
   imgproxy:
     container_name: supabase-imgproxy
-    image: darthsim/imgproxy:v3.30.1
+    image: darthsim/imgproxy:v3.31.4
     restart: unless-stopped
     volumes:
       - ./volumes/storage:/var/lib/storage:z
@@ -417,7 +417,7 @@ services:
 
   meta:
     container_name: supabase-meta
-    image: supabase/postgres-meta:v0.96.6
+    image: supabase/postgres-meta:v0.99.0
     restart: unless-stopped
     depends_on:
       db:
@@ -434,7 +434,7 @@ services:
 
   functions:
     container_name: supabase-edge-functions
-    image: supabase/edge-runtime:v1.74.0
+    image: supabase/edge-runtime:v1.76.2
     restart: unless-stopped
     volumes:
       - ./volumes/functions:/home/deno/functions:z
@@ -531,7 +531,7 @@ services:
   # Update the DATABASE_URL if you are using an external Postgres database
   supavisor:
     container_name: supabase-pooler
-    image: supabase/supavisor:2.9.5
+    image: supabase/supavisor:2.9.12
     restart: unless-stopped
     ports:
       - ${POSTGRES_PORT}:5432

--- a/docker/versions.md
+++ b/docker/versions.md
@@ -1,5 +1,18 @@
 # Docker image version updates in docker-compose.yml
 
+## 2026-09-09
+- supabase/studio:2026.09.07-sha-7996410 (prev supabase/studio:2026.08.03-sha-022b374)
+- envoyproxy/envoy:v1.39.1 (prev envoyproxy/envoy:v1.39.0)
+- supabase/gotrue:v2.196.0 (prev supabase/gotrue:v2.189.0)
+- postgrest/postgrest:v14.17 (prev postgrest/postgrest:v14.12)
+- supabase/realtime:v2.134.10 (prev supabase/realtime:v2.102.3)
+- supabase/storage-api:v1.74.0 (prev supabase/storage-api:v1.60.4)
+- darthsim/imgproxy:v3.31.4 (prev darthsim/imgproxy:v3.30.1)
+- supabase/postgres-meta:v0.99.0 (prev supabase/postgres-meta:v0.96.6)
+- supabase/edge-runtime:v1.76.2 (prev supabase/edge-runtime:v1.74.0)
+- supabase/supavisor:2.9.12 (prev supabase/supavisor:2.9.5)
+- supabase/logflare:1.50.10 (prev supabase/logflare:1.43.1)
+
 ## 2026-08-03
 - supabase/studio:2026.08.03-sha-022b374 (prev supabase/studio:2026.07.07-sha-a6a04f2)
 - kong/kong:3.9.3 (prev kong/kong:3.9.1)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Update [self-hosted Supabase](https://supabase.com/docs/guides/self-hosting) components:
- docker-compose.yml
  - `supabase/studio:2026.09.07-sha-7996410 (prev supabase/studio:2026.08.03-sha-022b374)`
  - `envoyproxy/envoy:v1.39.1 (prev envoyproxy/envoy:v1.39.0)`
  - `supabase/gotrue:v2.196.0 (prev supabase/gotrue:v2.189.0)`
  - `postgrest/postgrest:v14.17 (prev postgrest/postgrest:v14.12)`
  - `supabase/realtime:v2.134.10 (prev supabase/realtime:v2.102.3)`
  - `supabase/storage-api:v1.74.0 (prev supabase/storage-api:v1.60.4)`
  - `darthsim/imgproxy:v3.31.4 (prev darthsim/imgproxy:v3.30.1)`
  - `supabase/postgres-meta:v0.99.0 (prev supabase/postgres-meta:v0.96.6)`
  - `supabase/edge-runtime:v1.76.2 (prev supabase/edge-runtime:v1.74.0)`
  - `supabase/supavisor:2.9.12 (prev supabase/supavisor:2.9.5)`
  - `supabase/logflare:1.50.10 (prev supabase/logflare:1.43.1)`
- Overrides:
  - `envoyproxy/envoy:v1.39.1`
  - `jonasal/nginx-certbot:6.2.0-nginx1.31.5`
  - `rustfs/rustfs:v1.0.0-rc.5`

Update [versions.md](https://github.com/supabase/supabase/blob/master/docker/versions.md) and [CHANGELOG.md](https://github.com/supabase/supabase/blob/master/docker/CHANGELOG.md) to include changes since [self-hosted/v0.8.0](https://github.com/supabase/supabase/releases/tag/self-hosted%2Fv0.8.0)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated service container images across the platform, including Studio, authentication, REST, realtime, storage, database tools, edge runtime, analytics, and proxy services.
  * Updated the nginx and RustFS service images.
  * No service configuration or environment settings were changed.

* **Documentation**
  * Added release notes and a version record for the September 9, 2026 image updates.
  * Standardized Envoy and RustFS version formatting and added the Envoy release link.
  * Updated the self-hosting guide to reference release `v0.8.1`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->