### PR TITLE
fix(logs): migrate remaining studio analytics callers

### DIFF
--- a/apps/studio/components/interfaces/Auth/Overview/OverviewErrors.constants.ts
+++ b/apps/studio/components/interfaces/Auth/Overview/OverviewErrors.constants.ts
@@ -1,5 +1,7 @@
 import dayjs from 'dayjs'
+import { z } from 'zod'
 
+import { pickLogsQueryBuilder } from '@/data/logs/logs-endpoint'
 import { safeSql } from '@/data/logs/safe-analytics-sql'
 import { fetchLogs } from '@/data/reports/report.utils'
 
@@ -58,12 +60,68 @@ export const AUTH_TOP_ERROR_CODES_SQL = safeSql`
   limit 10
 `
 
-export const fetchTopResponseErrors = async (projectRef: string) => {
+export const AUTH_TOP_RESPONSE_ERRORS_SQL_OTEL = safeSql`
+  select
+    log_attributes['request.method'] as method,
+    log_attributes['request.path'] as path,
+    toInt32OrZero(log_attributes['response.status_code']) as status_code,
+    count() as count
+  from logs
+  where source = 'edge_logs'
+    and path like '%auth/v1%'
+    and status_code between 400 and 599
+  group by method, path, status_code
+  order by count desc
+  limit 10
+`
+
+export const AUTH_TOP_ERROR_CODES_SQL_OTEL = safeSql`
+  select
+    log_attributes['response.headers.x_sb_error_code'] as error_code,
+    count() as count
+  from logs
+  where source = 'edge_logs'
+    and log_attributes['request.path'] like '%auth/v1%'
+    and toInt32OrZero(log_attributes['response.status_code']) between 400 and 599
+    and error_code != ''
+  group by error_code
+  order by count desc
+  limit 10
+`
+
+const countSchema = z.union([z.number(), z.string().min(1)]).pipe(z.coerce.number().finite())
+const responseErrorSchema = z.object({
+  method: z.string(),
+  path: z.string(),
+  status_code: countSchema,
+  count: countSchema,
+})
+const authErrorCodeSchema = z.object({ error_code: z.string(), count: countSchema })
+
+export const parseResponseErrors = (rows: unknown[]): ResponseErrorRow[] =>
+  rows.flatMap((row) => {
+    const result = responseErrorSchema.safeParse(row)
+    return result.success ? [result.data] : []
+  })
+
+export const parseAuthErrorCodes = (rows: unknown[]): AuthErrorCodeRow[] =>
+  rows.flatMap((row) => {
+    const result = authErrorCodeSchema.safeParse(row)
+    return result.success ? [result.data] : []
+  })
+
+export const fetchTopResponseErrors = async (projectRef: string, useOtel = false) => {
   const { start, end } = getDateRange()
-  return await fetchLogs(projectRef, AUTH_TOP_RESPONSE_ERRORS_SQL, start, end)
+  const sql = pickLogsQueryBuilder(
+    useOtel,
+    AUTH_TOP_RESPONSE_ERRORS_SQL_OTEL,
+    AUTH_TOP_RESPONSE_ERRORS_SQL
+  )
+  return await fetchLogs(projectRef, sql, start, end, useOtel)
 }
 
-export const fetchTopAuthErrorCodes = async (projectRef: string) => {
+export const fetchTopAuthErrorCodes = async (projectRef: string, useOtel = false) => {
   const { start, end } = getDateRange()
-  return await fetchLogs(projectRef, AUTH_TOP_ERROR_CODES_SQL, start, end)
+  const sql = pickLogsQueryBuilder(useOtel, AUTH_TOP_ERROR_CODES_SQL_OTEL, AUTH_TOP_ERROR_CODES_SQL)
+  return await fetchLogs(projectRef, sql, start, end, useOtel)
 }

--- a/apps/studio/components/interfaces/Auth/Overview/OverviewMetrics.tsx
+++ b/apps/studio/components/interfaces/Auth/Overview/OverviewMetrics.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
-import { useParams } from 'common'
+import { useFlag, useParams } from 'common'
 import dayjs from 'dayjs'
 import { BarChart2, ChevronRight, ExternalLink, Telescope } from 'lucide-react'
 import Link from 'next/link'
@@ -29,6 +29,8 @@ import {
   AuthErrorCodeRow,
   fetchTopAuthErrorCodes,
   fetchTopResponseErrors,
+  parseAuthErrorCodes,
+  parseResponseErrors,
   ResponseErrorRow,
 } from './OverviewErrors.constants'
 import { OverviewTable } from './OverviewTable'
@@ -117,23 +119,6 @@ const LogsLink = ({ href }: { href: string }) => (
   </Tooltip>
 )
 
-function isResponseErrorRow(row: unknown): row is ResponseErrorRow {
-  if (!row || typeof row !== 'object') return false
-  const r = row as Record<string, unknown>
-  return (
-    typeof r.method === 'string' &&
-    typeof r.path === 'string' &&
-    typeof r.status_code === 'number' &&
-    typeof r.count === 'number'
-  )
-}
-
-function isAuthErrorCodeRow(row: unknown): row is AuthErrorCodeRow {
-  if (!row || typeof row !== 'object') return false
-  const r = row as Record<string, unknown>
-  return typeof r.error_code === 'string' && typeof r.count === 'number'
-}
-
 interface OverviewMetricsProps {
   metrics?: AuthMetricsResponse
   isLoading: boolean
@@ -142,6 +127,7 @@ interface OverviewMetricsProps {
 
 export const OverviewMetrics = ({ metrics, isLoading, error }: OverviewMetricsProps) => {
   const { ref } = useParams()
+  const useOtel = useFlag('otelLegacyLogs')
   const endDate = dayjs().toISOString()
   const startDate = dayjs().subtract(24, 'hour').toISOString()
   const aiSnap = useAiAssistantStateSnapshot()
@@ -175,22 +161,22 @@ export const OverviewMetrics = ({ metrics, isLoading, error }: OverviewMetricsPr
   )
 
   const { data: respErrData, isPending: isLoadingResp } = useQuery({
-    queryKey: ['auth-overview', ref, 'top-response-errors'],
-    queryFn: () => fetchTopResponseErrors(ref as string),
+    queryKey: ['auth-overview', ref, 'top-response-errors', { otel: useOtel }],
+    queryFn: () => fetchTopResponseErrors(ref as string, useOtel),
     enabled: !!ref,
   })
 
   const { data: codeErrData, isPending: isLoadingCodes } = useQuery({
-    queryKey: ['auth-overview', ref, 'top-auth-error-codes'],
-    queryFn: () => fetchTopAuthErrorCodes(ref as string),
+    queryKey: ['auth-overview', ref, 'top-auth-error-codes', { otel: useOtel }],
+    queryFn: () => fetchTopAuthErrorCodes(ref as string, useOtel),
     enabled: !!ref,
   })
 
   const responseErrors: ResponseErrorRow[] = Array.isArray(respErrData?.result)
-    ? (respErrData?.result as unknown[]).filter(isResponseErrorRow)
+    ? parseResponseErrors(respErrData.result)
     : []
   const errorCodes: AuthErrorCodeRow[] = Array.isArray(codeErrData?.result)
-    ? (codeErrData?.result as unknown[]).filter(isAuthErrorCodeRow)
+    ? parseAuthErrorCodes(codeErrData.result)
     : []
 
   const errorCodesActions = [

--- a/apps/studio/components/interfaces/QueryInsights/QueryInsights.constants.ts
+++ b/apps/studio/components/interfaces/QueryInsights/QueryInsights.constants.ts
@@ -1,3 +1,5 @@
+import { analyticsLiteral, safeSql } from '@/data/logs/safe-analytics-sql'
+
 export const SUPAMONITOR_EXCLUDED_ROLES = [
   'supabase_admin',
   'supabase_auth_admin',
@@ -22,7 +24,7 @@ export const getSupamonitorLogsQuery = (startTime: string, endTime: string) => {
   const safeStart = new Date(startTime).toISOString()
   const safeEnd = new Date(endTime).toISOString()
 
-  return `
+  return safeSql`
 -- This query is run by Supabase Query Insights to aggregate pg_stat_statements
 -- data collected by the supamonitor extension. It reads from Logflare and groups
 -- execution metrics (timing, call counts, percentiles) by query and minute so
@@ -58,9 +60,46 @@ from supamonitor_logs as sml
 cross join unnest(sml.metadata) as sml_metadata
 cross join unnest(sml_metadata.supamonitor) as sml_parsed
 WHERE sml.event_message = 'log'
-  AND sml.timestamp >= CAST('${safeStart}' AS TIMESTAMP)
-  AND sml.timestamp <= CAST('${safeEnd}' AS TIMESTAMP)
+  AND sml.timestamp >= CAST(${analyticsLiteral(safeStart)} AS TIMESTAMP)
+  AND sml.timestamp <= CAST(${analyticsLiteral(safeEnd)} AS TIMESTAMP)
 GROUP BY timestamp, user_name, database_name, application_name, query_id, query
 ORDER BY timestamp DESC
-`.trim()
+`
+}
+
+export const getSupamonitorLogsQueryOtel = (startTime: string, endTime: string) => {
+  const safeStart = new Date(startTime).toISOString()
+  const safeEnd = new Date(endTime).toISOString()
+
+  return safeSql`
+select
+  formatDateTime(toStartOfMinute(logs.timestamp), '%Y-%m-%dT%H:%i:%SZ', 'UTC') as timestamp,
+  log_attributes['supamonitor.application_name'] as application_name,
+  sum(toInt64OrZero(log_attributes['supamonitor.calls'])) as calls,
+  log_attributes['supamonitor.database_name'] as database_name,
+  log_attributes['supamonitor.query'] as query,
+  log_attributes['supamonitor.query_id'] as query_id,
+  sum(toFloat64OrNull(log_attributes['supamonitor.total_exec_time'])) as total_exec_time,
+  sum(toFloat64OrNull(log_attributes['supamonitor.total_plan_time'])) as total_plan_time,
+  log_attributes['supamonitor.user_name'] as user_name,
+  if(calls > 0, total_exec_time / calls, 0) as mean_exec_time,
+  min(nullIf(toFloat64OrNull(log_attributes['supamonitor.total_exec_time']), 0)) as min_exec_time,
+  max(toFloat64OrNull(log_attributes['supamonitor.total_exec_time'])) as max_exec_time,
+  if(calls > 0, total_plan_time / calls, 0) as mean_plan_time,
+  min(nullIf(toFloat64OrNull(log_attributes['supamonitor.total_plan_time']), 0)) as min_plan_time,
+  max(toFloat64OrNull(log_attributes['supamonitor.total_plan_time'])) as max_plan_time,
+  quantile(0.50)(toFloat64OrNull(log_attributes['supamonitor.total_exec_time'])) as p50_exec_time,
+  quantile(0.95)(toFloat64OrNull(log_attributes['supamonitor.total_exec_time'])) as p95_exec_time,
+  quantile(0.50)(toFloat64OrNull(log_attributes['supamonitor.total_plan_time'])) as p50_plan_time,
+  quantile(0.95)(toFloat64OrNull(log_attributes['supamonitor.total_plan_time'])) as p95_plan_time
+from logs
+where source = 'supamonitor_logs'
+  and event_message = 'log'
+  and logs.timestamp >= parseDateTime64BestEffort(${analyticsLiteral(safeStart)})
+  and logs.timestamp <= parseDateTime64BestEffort(${analyticsLiteral(safeEnd)})
+group by formatDateTime(toStartOfMinute(logs.timestamp), '%Y-%m-%dT%H:%i:%SZ', 'UTC'),
+  user_name, database_name, application_name, query_id, query
+order by timestamp desc
+limit 10000
+`
 }

--- a/apps/studio/components/interfaces/QueryInsights/QueryInsights.tsx
+++ b/apps/studio/components/interfaces/QueryInsights/QueryInsights.tsx
@@ -1,10 +1,10 @@
-import { useParams } from 'common'
+import { useFlag, useParams } from 'common'
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import { useMemo, useState } from 'react'
 
 import { useSupamonitorIndexAdvisor } from './hooks/useSupamonitorIndexAdvisor'
-import { getSupamonitorLogsQuery } from './QueryInsights.constants'
+import { getSupamonitorLogsQuery, getSupamonitorLogsQueryOtel } from './QueryInsights.constants'
 import { QueryInsightsChart } from './QueryInsightsChart/QueryInsightsChart'
 import { QueryInsightsHealth } from './QueryInsightsHealth/QueryInsightsHealth'
 import { QueryInsightsTable } from './QueryInsightsTable/QueryInsightsTable'
@@ -14,6 +14,7 @@ import {
   parseSupamonitorLogs,
   transformLogsToChartData,
 } from './utils/supamonitor.utils'
+import { pickLogsQueryBuilder } from '@/data/logs/logs-endpoint'
 import { useLogsQuery } from '@/hooks/analytics/useLogsQuery'
 
 dayjs.extend(utc)
@@ -28,6 +29,7 @@ interface QueryInsightsProps {
 
 export const QueryInsights = ({ dateRange }: QueryInsightsProps) => {
   const { ref } = useParams()
+  const useOtel = useFlag('otelLegacyLogs')
 
   const effectiveDateRange = useMemo(() => {
     if (dateRange) {
@@ -46,17 +48,19 @@ export const QueryInsights = ({ dateRange }: QueryInsightsProps) => {
 
   const sql = useMemo(
     () =>
-      getSupamonitorLogsQuery(
-        effectiveDateRange.iso_timestamp_start,
-        effectiveDateRange.iso_timestamp_end
-      ),
-    [effectiveDateRange]
+      pickLogsQueryBuilder(
+        useOtel,
+        getSupamonitorLogsQueryOtel,
+        getSupamonitorLogsQuery
+      )(effectiveDateRange.iso_timestamp_start, effectiveDateRange.iso_timestamp_end),
+    [effectiveDateRange, useOtel]
   )
 
   const { logData, isLoading } = useLogsQuery({
     projectRef: ref as string,
+    options: { useOtel },
+    sql,
     initialParams: {
-      sql,
       iso_timestamp_start: effectiveDateRange.iso_timestamp_start,
       iso_timestamp_end: effectiveDateRange.iso_timestamp_end,
     },

--- a/apps/studio/components/interfaces/Reports/Reports.utils.otel.test.ts
+++ b/apps/studio/components/interfaces/Reports/Reports.utils.otel.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  API_REPORT_QUERIES_OTEL,
+  generateReportFiltersOtel,
+  requestsByCountryOtel,
+  STORAGE_REPORT_QUERIES_OTEL,
+} from './Reports.utils.otel'
+
+const compact = (sql: string) => sql.replace(/\s+/g, ' ').trim()
+
+describe('OTEL report filters', () => {
+  it('keeps nested attributes and numeric-looking string values intact', () => {
+    expect(
+      generateReportFiltersOtel([
+        { key: 'request.headers.x_client_info', compare: 'is', value: '001' },
+        { key: 'identifier', compare: 'is', value: '0123' },
+      ])
+    ).toBe(
+      "and log_attributes['request.headers.x_client_info'] = '001' and log_attributes['identifier'] = '0123'"
+    )
+  })
+
+  it('escapes regex values and maps function paths', () => {
+    expect(
+      generateReportFiltersOtel(
+        [{ key: 'request.path', compare: 'matches', value: "a'\\b" }],
+        'function_edge_logs'
+      )
+    ).toBe("and match(log_attributes['request.pathname'], 'a''\\\\b')")
+  })
+
+  it.each(['>=', '<=', '>', '<', '!='] as const)(
+    'compares status codes numerically with %s',
+    (compare) => {
+      expect(
+        generateReportFiltersOtel([{ key: 'response.status_code', compare, value: '400' }])
+      ).toBe(`and toFloat64OrZero(log_attributes['response.status_code']) ${compare} 400`)
+    }
+  )
+
+  it('handles no filters', () => {
+    expect(generateReportFiltersOtel([])).toBe('')
+  })
+})
+
+describe('OTEL report queries', () => {
+  it.each(Object.entries(API_REPORT_QUERIES_OTEL))('scopes and limits %s', (_, builder) => {
+    const sql = compact(builder.safeSql([], 'function_edge_logs'))
+    expect(sql).toContain("from logs where source = 'function_edge_logs'")
+    expect(sql).toMatch(/limit \d+$/)
+    expect(sql).not.toMatch(/unnest|count\(\*\)|timestamp_trunc/)
+  })
+
+  it('groups counts into hours', () => {
+    expect(compact(API_REPORT_QUERIES_OTEL.totalRequests.safeSql([]))).toBe(
+      "select formatDateTime(toStartOfHour(logs.timestamp), '%Y-%m-%dT%H:%i:%SZ', 'UTC') as timestamp, toFloat64(count()) as count from logs where source = 'edge_logs' group by toStartOfHour(logs.timestamp) order by timestamp asc limit 10000"
+    )
+  })
+
+  it('preserves route aliases and filters error statuses numerically', () => {
+    const sql = API_REPORT_QUERIES_OTEL.topErrorRoutes.safeSql([], 'function_edge_logs')
+    expect(sql).toContain("log_attributes['request.pathname'] as path")
+    expect(sql).toContain("toInt32OrZero(log_attributes['response.status_code']) as status_code")
+    expect(sql).toContain("toInt32OrZero(log_attributes['response.status_code']) >= 400")
+    expect(sql).toContain('group by path, method, search, status_code')
+  })
+
+  it('coerces timing and byte strings before aggregation', () => {
+    expect(API_REPORT_QUERIES_OTEL.responseSpeed.safeSql([])).toContain(
+      "avg(toFloat64OrNull(log_attributes['response.origin_time'])) as avg"
+    )
+    const sql = API_REPORT_QUERIES_OTEL.networkTraffic.safeSql([])
+    expect(sql).toContain(
+      "sum(toFloat64OrZero(log_attributes['request.headers.content_length'])) / 1000000 as ingress_mb"
+    )
+    expect(sql).toContain(
+      "sum(toFloat64OrZero(log_attributes['response.headers.content_length'])) / 1000000 as egress_mb"
+    )
+  })
+
+  it('uses the full country attribute', () => {
+    expect(requestsByCountryOtel([])).toContain("log_attributes['request.cf.country'] as country")
+  })
+
+  it('returns microsecond timestamps expected by the storage cache chart', () => {
+    const sql = STORAGE_REPORT_QUERIES_OTEL.cacheHitRate.safeSql()
+    expect(sql).toContain(
+      'toUnixTimestamp64Micro(toDateTime64(toStartOfHour(logs.timestamp), 6)) as timestamp'
+    )
+    expect(sql).toContain("startsWith(log_attributes['request.path'], '/storage/v1/object')")
+    expect(sql).toContain("log_attributes['request.method'] = 'GET'")
+    expect(sql).toContain('as hit_count')
+    expect(sql).toContain('as miss_count')
+  })
+
+  it('restricts top misses to uncached storage GET requests', () => {
+    const sql = compact(STORAGE_REPORT_QUERIES_OTEL.topCacheMisses.safeSql())
+    expect(sql).toContain(
+      "log_attributes['response.headers.cf_cache_status'] in ('MISS', 'NONE/UNKNOWN', 'EXPIRED', 'BYPASS', 'DYNAMIC')"
+    )
+    expect(sql).toContain('group by path, search order by count desc limit 12')
+  })
+})

--- a/apps/studio/components/interfaces/Reports/Reports.utils.otel.ts
+++ b/apps/studio/components/interfaces/Reports/Reports.utils.otel.ts
@@ -1,0 +1,159 @@
+import type { ReportFilterItem } from './Reports.types'
+import {
+  analyticsLiteral,
+  joinSqlFragments,
+  safeSql,
+  type SafeLogSqlFragment,
+} from '@/data/logs/safe-analytics-sql'
+
+const statusCode = safeSql`toInt32OrZero(log_attributes['response.status_code'])`
+const originTime = safeSql`toFloat64OrNull(log_attributes['response.origin_time'])`
+const hour = safeSql`toStartOfHour(logs.timestamp)`
+
+export function generateReportFiltersOtel(filters: ReportFilterItem[], source = 'edge_logs') {
+  const conditions = filters.map(({ key, value, compare }) => {
+    let attribute = key.replace(/^metadata\./, '')
+    if (attribute.startsWith('headers.')) attribute = `request.${attribute}`
+    if (attribute.startsWith('cf.')) attribute = `request.${attribute}`
+    if (source === 'function_edge_logs' && attribute === 'request.path') {
+      attribute = 'request.pathname'
+    }
+    const field = safeSql`log_attributes[${analyticsLiteral(attribute)}]`
+    if (compare === 'matches') return safeSql`match(${field}, ${analyticsLiteral(String(value))})`
+    const isNumeric = attribute === 'response.status_code' || typeof value === 'number'
+    const column = isNumeric ? safeSql`toFloat64OrZero(${field})` : field
+    const literal = isNumeric ? analyticsLiteral(Number(value)) : analyticsLiteral(String(value))
+    switch (compare) {
+      case '!=':
+        return safeSql`${column} != ${literal}`
+      case '>=':
+        return safeSql`${column} >= ${literal}`
+      case '<=':
+        return safeSql`${column} <= ${literal}`
+      case '>':
+        return safeSql`${column} > ${literal}`
+      case '<':
+        return safeSql`${column} < ${literal}`
+      default:
+        return safeSql`${column} = ${literal}`
+    }
+  })
+  return conditions.length ? safeSql`and ${joinSqlFragments(conditions, ' and ')}` : safeSql``
+}
+
+function timeline(
+  filters: ReportFilterItem[],
+  source: string,
+  metric: SafeLogSqlFragment,
+  errors = false
+) {
+  return safeSql`
+    select formatDateTime(${hour}, '%Y-%m-%dT%H:%i:%SZ', 'UTC') as timestamp, ${metric}
+    from logs
+    where source = ${analyticsLiteral(source)}
+      ${errors ? safeSql`and ${statusCode} >= 400` : safeSql``}
+      ${generateReportFiltersOtel(filters, source)}
+    group by ${hour}
+    order by timestamp asc
+    limit 10000
+  `
+}
+
+function routes(filters: ReportFilterItem[], source: string, mode: 'count' | 'errors' | 'slow') {
+  const path = source === 'function_edge_logs' ? 'request.pathname' : 'request.path'
+  return safeSql`
+    select
+      log_attributes[${analyticsLiteral(path)}] as path,
+      log_attributes['request.method'] as method,
+      log_attributes['request.search'] as search,
+      ${statusCode} as status_code,
+      toFloat64(count()) as count
+      ${mode === 'slow' ? safeSql`, avg(${originTime}) as avg` : safeSql``}
+    from logs
+    where source = ${analyticsLiteral(source)}
+      ${mode === 'errors' ? safeSql`and ${statusCode} >= 400` : safeSql``}
+      ${generateReportFiltersOtel(filters, source)}
+    group by path, method, search, status_code
+    order by ${mode === 'slow' ? safeSql`avg` : safeSql`count`} desc
+    limit 10
+  `
+}
+
+export const API_REPORT_QUERIES_OTEL = {
+  totalRequests: {
+    safeSql: (filters: ReportFilterItem[], source = 'edge_logs') =>
+      timeline(filters, source, safeSql`toFloat64(count()) as count`),
+  },
+  topRoutes: {
+    safeSql: (filters: ReportFilterItem[], source = 'edge_logs') =>
+      routes(filters, source, 'count'),
+  },
+  errorCounts: {
+    safeSql: (filters: ReportFilterItem[], source = 'edge_logs') =>
+      timeline(filters, source, safeSql`toFloat64(count()) as count`, true),
+  },
+  topErrorRoutes: {
+    safeSql: (filters: ReportFilterItem[], source = 'edge_logs') =>
+      routes(filters, source, 'errors'),
+  },
+  responseSpeed: {
+    safeSql: (filters: ReportFilterItem[], source = 'edge_logs') =>
+      timeline(filters, source, safeSql`avg(${originTime}) as avg`),
+  },
+  topSlowRoutes: {
+    safeSql: (filters: ReportFilterItem[], source = 'edge_logs') => routes(filters, source, 'slow'),
+  },
+  networkTraffic: {
+    safeSql: (filters: ReportFilterItem[], source = 'edge_logs') =>
+      timeline(
+        filters,
+        source,
+        safeSql`
+      sum(toFloat64OrZero(log_attributes['request.headers.content_length'])) / 1000000 as ingress_mb,
+      sum(toFloat64OrZero(log_attributes['response.headers.content_length'])) / 1000000 as egress_mb
+    `
+      ),
+  },
+}
+
+export const requestsByCountryOtel = (filters: ReportFilterItem[]) => safeSql`
+  select log_attributes['request.cf.country'] as country, toFloat64(count()) as count
+  from logs
+  where source = 'edge_logs' and log_attributes['request.cf.country'] != ''
+    ${generateReportFiltersOtel(filters)}
+  group by country
+  limit 1000
+`
+
+const storageFilter = safeSql`
+  source = 'edge_logs'
+  and startsWith(log_attributes['request.path'], '/storage/v1/object')
+  and log_attributes['request.method'] = 'GET'
+`
+const cacheMiss = safeSql`log_attributes['response.headers.cf_cache_status'] in ('MISS', 'NONE/UNKNOWN', 'EXPIRED', 'BYPASS', 'DYNAMIC')`
+
+export const STORAGE_REPORT_QUERIES_OTEL = {
+  cacheHitRate: {
+    safeSql: () => safeSql`
+      select toUnixTimestamp64Micro(toDateTime64(${hour}, 6)) as timestamp,
+        toFloat64(countIf(log_attributes['response.headers.cf_cache_status'] in ('HIT', 'STALE', 'REVALIDATED', 'UPDATING'))) as hit_count,
+        toFloat64(countIf(${cacheMiss})) as miss_count
+      from logs
+      where ${storageFilter}
+      group by ${hour}
+      order by timestamp desc
+      limit 10000
+    `,
+  },
+  topCacheMisses: {
+    safeSql: () => safeSql`
+      select log_attributes['request.path'] as path, log_attributes['request.search'] as search,
+        toFloat64(count()) as count
+      from logs
+      where ${storageFilter} and ${cacheMiss}
+      group by path, search
+      order by count desc
+      limit 12
+    `,
+  },
+}

--- a/apps/studio/components/interfaces/Reports/SharedAPIReport/SharedAPIReport.constants.ts
+++ b/apps/studio/components/interfaces/Reports/SharedAPIReport/SharedAPIReport.constants.ts
@@ -1,12 +1,14 @@
 import * as Sentry from '@sentry/nextjs'
 import { useQueries, useQueryClient } from '@tanstack/react-query'
-import { useParams } from 'common'
+import { useFlag, useParams } from 'common'
 import { isEqual } from 'lodash'
 import { useState } from 'react'
 
 import { generateRegexpWhereSafe } from '../Reports.constants'
 import { ReportFilterItem } from '../Reports.types'
+import { API_REPORT_QUERIES_OTEL } from '../Reports.utils.otel'
 import { executeAnalyticsSql } from '@/data/logs/execute-analytics-sql'
+import { logsAllEndpointUrl } from '@/data/logs/logs-endpoint'
 import { safeSql, type SafeLogSqlFragment } from '@/data/logs/safe-analytics-sql'
 
 const SOURCE_TABLE: Record<string, SafeLogSqlFragment> = {
@@ -225,6 +227,8 @@ export const useSharedAPIReport = ({
   const { ref } = useParams() as { ref: string }
   const [filters, setFilters] = useState<ReportFilterItem[]>([])
   const queryClient = useQueryClient()
+  const useOtel = useFlag('otelLegacyLogs')
+  const reportQueries = useOtel ? API_REPORT_QUERIES_OTEL : SHARED_API_REPORT_SQL
   const filterByMapSource = {
     functions: 'function_edge_logs',
     realtime: 'edge_logs',
@@ -252,9 +256,10 @@ export const useSharedAPIReport = ({
   const allFilters = [baseFilter, ...filters]
 
   const queries = useQueries({
-    queries: Object.entries(SHARED_API_REPORT_SQL).map(([key, value]) => ({
+    queries: Object.entries(reportQueries).map(([key, value]) => ({
       queryKey: [
         ...DEFAULT_KEYS,
+        { otel: useOtel },
         filterBy,
         key,
         filterByMapSource[filterBy],
@@ -268,7 +273,7 @@ export const useSharedAPIReport = ({
         try {
           const data = await executeAnalyticsSql({
             projectRef: ref,
-            endpoint: '/platform/projects/{ref}/analytics/endpoints/logs.all',
+            endpoint: logsAllEndpointUrl(useOtel),
             sql: value.safeSql(allFilters, filterByMapSource[filterBy]),
             iso_timestamp_start: start,
             iso_timestamp_end: end,
@@ -334,28 +339,13 @@ export const useSharedAPIReport = ({
   const isLoadingData = Object.values(isLoading).some(Boolean)
 
   const SQLMap: Record<SharedAPIReportKey, SafeLogSqlFragment> = {
-    totalRequests: SHARED_API_REPORT_SQL.totalRequests.safeSql(
-      allFilters,
-      filterByMapSource[filterBy]
-    ),
-    topRoutes: SHARED_API_REPORT_SQL.topRoutes.safeSql(allFilters, filterByMapSource[filterBy]),
-    errorCounts: SHARED_API_REPORT_SQL.errorCounts.safeSql(allFilters, filterByMapSource[filterBy]),
-    topErrorRoutes: SHARED_API_REPORT_SQL.topErrorRoutes.safeSql(
-      allFilters,
-      filterByMapSource[filterBy]
-    ),
-    responseSpeed: SHARED_API_REPORT_SQL.responseSpeed.safeSql(
-      allFilters,
-      filterByMapSource[filterBy]
-    ),
-    topSlowRoutes: SHARED_API_REPORT_SQL.topSlowRoutes.safeSql(
-      allFilters,
-      filterByMapSource[filterBy]
-    ),
-    networkTraffic: SHARED_API_REPORT_SQL.networkTraffic.safeSql(
-      allFilters,
-      filterByMapSource[filterBy]
-    ),
+    totalRequests: reportQueries.totalRequests.safeSql(allFilters, filterByMapSource[filterBy]),
+    topRoutes: reportQueries.topRoutes.safeSql(allFilters, filterByMapSource[filterBy]),
+    errorCounts: reportQueries.errorCounts.safeSql(allFilters, filterByMapSource[filterBy]),
+    topErrorRoutes: reportQueries.topErrorRoutes.safeSql(allFilters, filterByMapSource[filterBy]),
+    responseSpeed: reportQueries.responseSpeed.safeSql(allFilters, filterByMapSource[filterBy]),
+    topSlowRoutes: reportQueries.topSlowRoutes.safeSql(allFilters, filterByMapSource[filterBy]),
+    networkTraffic: reportQueries.networkTraffic.safeSql(allFilters, filterByMapSource[filterBy]),
   }
 
   return {

--- a/apps/studio/data/reports/api-report-query.ts
+++ b/apps/studio/data/reports/api-report-query.ts
@@ -1,32 +1,89 @@
-import { useParams } from 'common'
+import { useFlag, useParams } from 'common'
 import { isEqual } from 'lodash'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 
 import { PRESET_CONFIG } from '@/components/interfaces/Reports/Reports.constants'
 import { ReportFilterItem } from '@/components/interfaces/Reports/Reports.types'
-import { getLogsSql, queriesFactory } from '@/components/interfaces/Reports/Reports.utils'
+import { getLogsSql } from '@/components/interfaces/Reports/Reports.utils'
+import {
+  API_REPORT_QUERIES_OTEL,
+  requestsByCountryOtel,
+} from '@/components/interfaces/Reports/Reports.utils.otel'
 import type { LogsEndpointParams } from '@/components/interfaces/Settings/Logs/Logs.types'
+import { useLogsQuery } from '@/hooks/analytics/useLogsQuery'
 import { useDatabaseSelectorStateSnapshot } from '@/state/database-selector'
 
 export const useApiReport = () => {
   const { ref: projectRef } = useParams()
+  const useOtel = useFlag('otelLegacyLogs')
   const state = useDatabaseSelectorStateSnapshot()
 
   const identifier = state.selectedDatabaseId
   const [filters, setFilters] = useState<ReportFilterItem[]>([])
 
-  const queryHooks = queriesFactory<keyof typeof PRESET_CONFIG.api.queries>(
-    PRESET_CONFIG.api.queries,
-    projectRef ?? 'default'
-  )
-  const totalRequests = queryHooks.totalRequests()
-  const topRoutes = queryHooks.topRoutes()
-  const errorCounts = queryHooks.errorCounts()
-  const topErrorRoutes = queryHooks.topErrorRoutes()
-  const responseSpeed = queryHooks.responseSpeed()
-  const topSlowRoutes = queryHooks.topSlowRoutes()
-  const networkTraffic = queryHooks.networkTraffic()
-  const requestsByCountry = queryHooks.requestsByCountry()
+  const formattedFilters: ReportFilterItem[] = [
+    ...filters,
+    ...(identifier !== undefined
+      ? [{ key: 'identifier', value: identifier, compare: 'is' } as ReportFilterItem]
+      : []),
+  ]
+
+  const totalRequests = useLogsQuery({
+    projectRef,
+    sql: useOtel
+      ? API_REPORT_QUERIES_OTEL.totalRequests.safeSql(formattedFilters)
+      : getLogsSql(PRESET_CONFIG.api.queries.totalRequests, formattedFilters),
+    options: { useOtel },
+  })
+  const topRoutes = useLogsQuery({
+    projectRef,
+    sql: useOtel
+      ? API_REPORT_QUERIES_OTEL.topRoutes.safeSql(formattedFilters)
+      : getLogsSql(PRESET_CONFIG.api.queries.topRoutes, formattedFilters),
+    options: { useOtel },
+  })
+  const errorCounts = useLogsQuery({
+    projectRef,
+    sql: useOtel
+      ? API_REPORT_QUERIES_OTEL.errorCounts.safeSql(formattedFilters)
+      : getLogsSql(PRESET_CONFIG.api.queries.errorCounts, formattedFilters),
+    options: { useOtel },
+  })
+  const topErrorRoutes = useLogsQuery({
+    projectRef,
+    sql: useOtel
+      ? API_REPORT_QUERIES_OTEL.topErrorRoutes.safeSql(formattedFilters)
+      : getLogsSql(PRESET_CONFIG.api.queries.topErrorRoutes, formattedFilters),
+    options: { useOtel },
+  })
+  const responseSpeed = useLogsQuery({
+    projectRef,
+    sql: useOtel
+      ? API_REPORT_QUERIES_OTEL.responseSpeed.safeSql(formattedFilters)
+      : getLogsSql(PRESET_CONFIG.api.queries.responseSpeed, formattedFilters),
+    options: { useOtel },
+  })
+  const topSlowRoutes = useLogsQuery({
+    projectRef,
+    sql: useOtel
+      ? API_REPORT_QUERIES_OTEL.topSlowRoutes.safeSql(formattedFilters)
+      : getLogsSql(PRESET_CONFIG.api.queries.topSlowRoutes, formattedFilters),
+    options: { useOtel },
+  })
+  const networkTraffic = useLogsQuery({
+    projectRef,
+    sql: useOtel
+      ? API_REPORT_QUERIES_OTEL.networkTraffic.safeSql(formattedFilters)
+      : getLogsSql(PRESET_CONFIG.api.queries.networkTraffic, formattedFilters),
+    options: { useOtel },
+  })
+  const requestsByCountry = useLogsQuery({
+    projectRef,
+    sql: useOtel
+      ? requestsByCountryOtel(formattedFilters)
+      : getLogsSql(PRESET_CONFIG.api.queries.requestsByCountry, formattedFilters),
+    options: { useOtel },
+  })
   const activeHooks = [
     totalRequests,
     topRoutes,
@@ -61,57 +118,6 @@ export const useApiReport = () => {
       return prev.filter((f) => !toRemove.find((r) => isEqual(f, r)))
     })
   }
-
-  // [Joshen] Keeping database selector separate from filter state, and merging them here for simplicity
-  const formattedFilters: ReportFilterItem[] = [
-    ...filters,
-    ...(identifier !== undefined
-      ? [{ key: 'identifier', value: identifier, compare: 'is' } as ReportFilterItem]
-      : []),
-  ]
-
-  useEffect(() => {
-    // update sql for each query
-    if (totalRequests.changeQuery) {
-      totalRequests.changeQuery(
-        getLogsSql(PRESET_CONFIG.api.queries.totalRequests, formattedFilters)
-      )
-    }
-    if (topRoutes.changeQuery) {
-      topRoutes.changeQuery(getLogsSql(PRESET_CONFIG.api.queries.topRoutes, formattedFilters))
-    }
-    if (errorCounts.changeQuery) {
-      errorCounts.changeQuery(getLogsSql(PRESET_CONFIG.api.queries.errorCounts, formattedFilters))
-    }
-
-    if (topErrorRoutes.changeQuery) {
-      topErrorRoutes.changeQuery(
-        getLogsSql(PRESET_CONFIG.api.queries.topErrorRoutes, formattedFilters)
-      )
-    }
-    if (responseSpeed.changeQuery) {
-      responseSpeed.changeQuery(
-        getLogsSql(PRESET_CONFIG.api.queries.responseSpeed, formattedFilters)
-      )
-    }
-
-    if (topSlowRoutes.changeQuery) {
-      topSlowRoutes.changeQuery(
-        getLogsSql(PRESET_CONFIG.api.queries.topSlowRoutes, formattedFilters)
-      )
-    }
-
-    if (networkTraffic.changeQuery) {
-      networkTraffic.changeQuery(
-        getLogsSql(PRESET_CONFIG.api.queries.networkTraffic, formattedFilters)
-      )
-    }
-    if (requestsByCountry.changeQuery) {
-      requestsByCountry.changeQuery(
-        getLogsSql(PRESET_CONFIG.api.queries.requestsByCountry, formattedFilters)
-      )
-    }
-  }, [JSON.stringify(formattedFilters)])
 
   const handleRefresh = async () => {
     activeHooks.forEach((hook) => hook.runQuery())

--- a/apps/studio/data/reports/storage-report-query.ts
+++ b/apps/studio/data/reports/storage-report-query.ts
@@ -1,37 +1,96 @@
-import { useParams } from 'common'
+import { useFlag, useParams } from 'common'
 import isEqual from 'lodash/isEqual'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 
 import { PRESET_CONFIG } from '@/components/interfaces/Reports/Reports.constants'
 import { ReportFilterItem } from '@/components/interfaces/Reports/Reports.types'
-import { getLogsSql, queriesFactory } from '@/components/interfaces/Reports/Reports.utils'
+import { getLogsSql } from '@/components/interfaces/Reports/Reports.utils'
+import {
+  API_REPORT_QUERIES_OTEL,
+  STORAGE_REPORT_QUERIES_OTEL,
+} from '@/components/interfaces/Reports/Reports.utils.otel'
 import type { LogsEndpointParams } from '@/components/interfaces/Settings/Logs/Logs.types'
+import { useLogsQuery } from '@/hooks/analytics/useLogsQuery'
 import { useDatabaseSelectorStateSnapshot } from '@/state/database-selector'
 
 export const useStorageReport = () => {
   const { ref: projectRef } = useParams()
+  const useOtel = useFlag('otelLegacyLogs')
   const [filters, setFilters] = useState<ReportFilterItem[]>([])
   const state = useDatabaseSelectorStateSnapshot()
 
   const identifier = state.selectedDatabaseId
 
-  const queryHooks = queriesFactory<keyof typeof PRESET_CONFIG.api.queries>(
-    PRESET_CONFIG.api.queries,
-    projectRef ?? 'default'
-  )
-  const storageQueryHooks = queriesFactory<keyof typeof PRESET_CONFIG.storage.queries>(
-    PRESET_CONFIG.storage.queries,
-    projectRef ?? 'default'
-  )
-  const totalRequests = queryHooks.totalRequests()
-  const topRoutes = queryHooks.topRoutes()
-  const errorCounts = queryHooks.errorCounts()
-  const topErrorRoutes = queryHooks.topErrorRoutes()
-  const responseSpeed = queryHooks.responseSpeed()
-  const topSlowRoutes = queryHooks.topSlowRoutes()
-  const networkTraffic = queryHooks.networkTraffic()
-  const cacheHitRate = storageQueryHooks.cacheHitRate()
-  const topCacheMisses = storageQueryHooks.topCacheMisses()
+  const formattedFilters: ReportFilterItem[] = [
+    ...filters,
+    ...(identifier !== undefined
+      ? [{ key: 'identifier', value: identifier, compare: 'is' } as ReportFilterItem]
+      : []),
+  ]
+
+  const totalRequests = useLogsQuery({
+    projectRef,
+    sql: useOtel
+      ? API_REPORT_QUERIES_OTEL.totalRequests.safeSql(formattedFilters)
+      : getLogsSql(PRESET_CONFIG.api.queries.totalRequests, formattedFilters),
+    options: { useOtel },
+  })
+  const topRoutes = useLogsQuery({
+    projectRef,
+    sql: useOtel
+      ? API_REPORT_QUERIES_OTEL.topRoutes.safeSql(formattedFilters)
+      : getLogsSql(PRESET_CONFIG.api.queries.topRoutes, formattedFilters),
+    options: { useOtel },
+  })
+  const errorCounts = useLogsQuery({
+    projectRef,
+    sql: useOtel
+      ? API_REPORT_QUERIES_OTEL.errorCounts.safeSql(formattedFilters)
+      : getLogsSql(PRESET_CONFIG.api.queries.errorCounts, formattedFilters),
+    options: { useOtel },
+  })
+  const topErrorRoutes = useLogsQuery({
+    projectRef,
+    sql: useOtel
+      ? API_REPORT_QUERIES_OTEL.topErrorRoutes.safeSql(formattedFilters)
+      : getLogsSql(PRESET_CONFIG.api.queries.topErrorRoutes, formattedFilters),
+    options: { useOtel },
+  })
+  const responseSpeed = useLogsQuery({
+    projectRef,
+    sql: useOtel
+      ? API_REPORT_QUERIES_OTEL.responseSpeed.safeSql(formattedFilters)
+      : getLogsSql(PRESET_CONFIG.api.queries.responseSpeed, formattedFilters),
+    options: { useOtel },
+  })
+  const topSlowRoutes = useLogsQuery({
+    projectRef,
+    sql: useOtel
+      ? API_REPORT_QUERIES_OTEL.topSlowRoutes.safeSql(formattedFilters)
+      : getLogsSql(PRESET_CONFIG.api.queries.topSlowRoutes, formattedFilters),
+    options: { useOtel },
+  })
+  const networkTraffic = useLogsQuery({
+    projectRef,
+    sql: useOtel
+      ? API_REPORT_QUERIES_OTEL.networkTraffic.safeSql(formattedFilters)
+      : getLogsSql(PRESET_CONFIG.api.queries.networkTraffic, formattedFilters),
+    options: { useOtel },
+  })
+  const cacheHitRate = useLogsQuery({
+    projectRef,
+    sql: useOtel
+      ? STORAGE_REPORT_QUERIES_OTEL.cacheHitRate.safeSql()
+      : getLogsSql(PRESET_CONFIG.storage.queries.cacheHitRate, []),
+    options: { useOtel },
+  })
+  const topCacheMisses = useLogsQuery({
+    projectRef,
+    sql: useOtel
+      ? STORAGE_REPORT_QUERIES_OTEL.topCacheMisses.safeSql()
+      : getLogsSql(PRESET_CONFIG.storage.queries.topCacheMisses, []),
+    options: { useOtel },
+  })
   const activeHooks = [
     totalRequests,
     topRoutes,
@@ -76,58 +135,6 @@ export const useStorageReport = () => {
       return prev.filter((f) => !toRemove.find((r) => isEqual(f, r)))
     })
   }
-
-  const formattedFilters: ReportFilterItem[] = [
-    ...filters,
-    ...(identifier !== undefined
-      ? [{ key: 'identifier', value: identifier, compare: 'is' } as ReportFilterItem]
-      : []),
-  ]
-
-  useEffect(() => {
-    if (totalRequests.changeQuery) {
-      totalRequests.changeQuery(
-        getLogsSql(PRESET_CONFIG.api.queries.totalRequests, formattedFilters)
-      )
-    }
-    if (topRoutes.changeQuery) {
-      topRoutes.changeQuery(getLogsSql(PRESET_CONFIG.api.queries.topRoutes, formattedFilters))
-    }
-    if (errorCounts.changeQuery) {
-      errorCounts.changeQuery(getLogsSql(PRESET_CONFIG.api.queries.errorCounts, formattedFilters))
-    }
-
-    if (topErrorRoutes.changeQuery) {
-      topErrorRoutes.changeQuery(
-        getLogsSql(PRESET_CONFIG.api.queries.topErrorRoutes, formattedFilters)
-      )
-    }
-    if (responseSpeed.changeQuery) {
-      responseSpeed.changeQuery(
-        getLogsSql(PRESET_CONFIG.api.queries.responseSpeed, formattedFilters)
-      )
-    }
-
-    if (topSlowRoutes.changeQuery) {
-      topSlowRoutes.changeQuery(
-        getLogsSql(PRESET_CONFIG.api.queries.topSlowRoutes, formattedFilters)
-      )
-    }
-
-    if (networkTraffic.changeQuery) {
-      networkTraffic.changeQuery(
-        getLogsSql(PRESET_CONFIG.api.queries.networkTraffic, formattedFilters)
-      )
-    }
-
-    if (cacheHitRate.changeQuery) {
-      cacheHitRate.changeQuery(getLogsSql(PRESET_CONFIG.storage.queries.cacheHitRate, []))
-    }
-
-    if (topCacheMisses.changeQuery) {
-      topCacheMisses.changeQuery(getLogsSql(PRESET_CONFIG.storage.queries.topCacheMisses, []))
-    }
-  }, [JSON.stringify(formattedFilters)])
 
   const isLoading = activeHooks.some((hook) => hook.isLoading)
 

--- a/apps/studio/hooks/analytics/useLogsQuery.test.tsx
+++ b/apps/studio/hooks/analytics/useLogsQuery.test.tsx
@@ -1,0 +1,83 @@
+import { QueryClient } from '@tanstack/react-query'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import { describe, expect, it } from 'vitest'
+
+import { useLogsQuery } from './useLogsQuery'
+import type { paths } from '@/data/api'
+import { safeSql } from '@/data/logs/safe-analytics-sql'
+import { customRender } from '@/tests/lib/custom-render'
+import { addAPIMock, mswServer } from '@/tests/lib/msw'
+
+type LogsResponse =
+  paths['/platform/projects/{ref}/analytics/endpoints/logs.all']['get']['responses'][200]['content']['application/json']
+
+const bigQuerySql = safeSql`select count(id) as count from edge_logs limit 1`
+const otelSql = safeSql`select count() as count from logs where source = 'edge_logs' limit 1`
+const start = '2026-09-01T00:00:00.000Z'
+const end = '2026-09-02T00:00:00.000Z'
+
+function Report({ useOtel }: { useOtel: boolean }) {
+  const { logData, params, setParams } = useLogsQuery({
+    projectRef: 'default',
+    sql: useOtel ? otelSql : bigQuerySql,
+    initialParams: { iso_timestamp_start: start, iso_timestamp_end: end },
+    options: { useOtel },
+  })
+
+  return (
+    <>
+      <output>{logData[0]?.count?.toString()}</output>
+      <span>{params.sql}</span>
+      <button onClick={() => setParams((previous) => ({ ...previous, iso_timestamp_start: end }))}>
+        Change range
+      </button>
+    </>
+  )
+}
+
+describe('useLogsQuery controlled SQL', () => {
+  it('switches SQL and endpoint together and keeps the engine caches separate', async () => {
+    mswServer.use(
+      http.get('*/api/enabled-features-overrides', () =>
+        HttpResponse.json<{ disabled_features: string[] }>({ disabled_features: [] })
+      )
+    )
+    const requests: { engine: string; sql: string | null; start: string | null }[] = []
+    for (const engine of ['logs.all', 'logs.all.otel'] as const) {
+      addAPIMock({
+        method: 'get',
+        path: `/platform/projects/:ref/analytics/endpoints/${engine}`,
+        response: ({ request }) => {
+          const search = new URL(request.url).searchParams
+          requests.push({
+            engine,
+            sql: search.get('sql'),
+            start: search.get('iso_timestamp_start'),
+          })
+          return HttpResponse.json<LogsResponse>({
+            result: [{ count: engine === 'logs.all' ? 1 : 2 }],
+          })
+        },
+      })
+    }
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const { rerender } = customRender(<Report useOtel={false} />, { queryClient })
+    await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('1'))
+
+    rerender(<Report useOtel />)
+    await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('2'))
+    expect(requests).toEqual([
+      { engine: 'logs.all', sql: bigQuerySql, start },
+      { engine: 'logs.all.otel', sql: otelSql, start },
+    ])
+    expect(
+      queryClient.getQueryCache().findAll({ queryKey: ['projects', 'default', 'logs'] })
+    ).toHaveLength(2)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Change range' }))
+    await waitFor(() => expect(requests).toHaveLength(3))
+    expect(requests[2]).toEqual({ engine: 'logs.all.otel', sql: otelSql, start: end })
+  })
+})

--- a/apps/studio/hooks/analytics/useLogsQuery.tsx
+++ b/apps/studio/hooks/analytics/useLogsQuery.tsx
@@ -16,7 +16,9 @@ import {
   checkForWithClause,
 } from '@/components/interfaces/Settings/Logs/Logs.utils'
 import { get } from '@/data/fetchers'
+import { executeAnalyticsSql } from '@/data/logs/execute-analytics-sql'
 import { logsAllEndpointUrl } from '@/data/logs/logs-endpoint'
+import type { SafeLogSqlFragment } from '@/data/logs/safe-analytics-sql'
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
 import { DOCS_URL } from '@/lib/constants'
 
@@ -35,17 +37,19 @@ export interface LogsQueryHook {
 export const useLogsQuery = ({
   projectRef,
   initialParams = {},
+  sql,
   enabled = true,
   options = {},
 }: {
   projectRef?: string
   initialParams?: Partial<LogsEndpointParams>
+  sql?: SafeLogSqlFragment
   enabled?: boolean
   options?: { useOtel?: boolean }
 }): LogsQueryHook => {
   const { useOtel = false } = options
   const defaultHelper = getDefaultHelper(EXPLORER_DATEPICKER_HELPERS)
-  const [params, setParams] = useState<LogsEndpointParams>({
+  const [storedParams, setParams] = useState<LogsEndpointParams>({
     sql: initialParams?.sql || '',
     iso_timestamp_start: initialParams.iso_timestamp_start
       ? initialParams.iso_timestamp_start
@@ -67,6 +71,8 @@ export const useLogsQuery = ({
     }))
   }, [initialParams.sql, initialParams.iso_timestamp_start, initialParams.iso_timestamp_end])
 
+  const params = { ...storedParams, sql: sql ?? storedParams.sql }
+
   const _enabled = enabled && typeof projectRef !== 'undefined' && Boolean(params.sql)
 
   const usesWith = checkForWithClause(params.sql || '')
@@ -81,13 +87,32 @@ export const useLogsQuery = ({
   } = useQuery({
     queryKey: ['projects', projectRef, 'logs', params, { otel: useOtel }],
     queryFn: async ({ signal }) => {
-      const { data, error } = await get(logsAllEndpointUrl(useOtel), {
-        params: {
-          path: { ref: projectRef! },
-          query: params,
-        },
-        signal,
-      })
+      if (!projectRef) throw new Error('projectRef is required')
+      const { iso_timestamp_start, iso_timestamp_end } = params
+      if (!iso_timestamp_start || !iso_timestamp_end) {
+        throw new Error('A start and end timestamp are required')
+      }
+      const { data, error } =
+        sql !== undefined
+          ? {
+              data: await executeAnalyticsSql({
+                projectRef,
+                endpoint: logsAllEndpointUrl(useOtel),
+                sql,
+                iso_timestamp_start,
+                iso_timestamp_end,
+                method: 'get',
+                signal,
+              }),
+              error: undefined,
+            }
+          : await get(logsAllEndpointUrl(useOtel), {
+              params: {
+                path: { ref: projectRef },
+                query: params,
+              },
+              signal,
+            })
       if (error) {
         throw error
       }

--- a/apps/studio/pages/project/[ref]/observability/auth.tsx
+++ b/apps/studio/pages/project/[ref]/observability/auth.tsx
@@ -1,4 +1,4 @@
-import { useParams } from 'common'
+import { useFlag, useParams } from 'common'
 import dayjs from 'dayjs'
 import { ArrowRight, LogsIcon, RefreshCw } from 'lucide-react'
 import { useRouter } from 'next/router'
@@ -64,6 +64,7 @@ const REPORT_TITLE = 'Auth'
 
 const AuthUsage = () => {
   const { ref } = useParams()
+  const useOtel = useFlag('otelLegacyLogs')
   const chartSyncId = `auth-report`
 
   const {
@@ -139,6 +140,7 @@ const AuthUsage = () => {
 
   const usageReportConfig = createUsageReportConfig({
     projectRef: ref || '',
+    useOtel,
     startDate: selectedDateRange?.period_start?.date,
     endDate: selectedDateRange?.period_end?.date,
     interval: selectedDateRange?.interval,
@@ -147,6 +149,7 @@ const AuthUsage = () => {
 
   const errorsReportConfig = createErrorsReportConfig({
     projectRef: ref || '',
+    useOtel,
     startDate: selectedDateRange?.period_start?.date,
     endDate: selectedDateRange?.period_end?.date,
     interval: selectedDateRange?.interval,
@@ -155,6 +158,7 @@ const AuthUsage = () => {
 
   const latencyReportConfig = createLatencyReportConfig({
     projectRef: ref || '',
+    useOtel,
     startDate: selectedDateRange?.period_start?.date,
     endDate: selectedDateRange?.period_end?.date,
     interval: selectedDateRange?.interval,
@@ -287,6 +291,7 @@ const AuthUsage = () => {
                 <ReportChartV2
                   key={`${metric.id}`}
                   report={metric}
+                  queryGroup={useOtel ? 'auth-otel' : 'auth-bigquery'}
                   projectRef={ref!}
                   interval={selectedDateRange.interval}
                   startDate={selectedDateRange?.period_start?.date}
@@ -321,6 +326,7 @@ const AuthUsage = () => {
                 <ReportChartV2
                   key={`${metric.id}`}
                   report={metric}
+                  queryGroup={useOtel ? 'auth-otel' : 'auth-bigquery'}
                   projectRef={ref!}
                   interval={selectedDateRange.interval}
                   startDate={selectedDateRange?.period_start?.date}
@@ -345,6 +351,7 @@ const AuthUsage = () => {
                 <ReportChartV2
                   key={`${metric.id}`}
                   report={metric}
+                  queryGroup={useOtel ? 'auth-otel' : 'auth-bigquery'}
                   projectRef={ref!}
                   interval={selectedDateRange.interval}
                   startDate={selectedDateRange?.period_start?.date}

--- a/apps/studio/tests/components/Auth/OverviewErrors.test.ts
+++ b/apps/studio/tests/components/Auth/OverviewErrors.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  AUTH_TOP_ERROR_CODES_SQL_OTEL,
+  AUTH_TOP_RESPONSE_ERRORS_SQL_OTEL,
+  parseAuthErrorCodes,
+  parseResponseErrors,
+} from '@/components/interfaces/Auth/Overview/OverviewErrors.constants'
+
+describe('Auth overview ClickHouse queries', () => {
+  it('filters gateway failures and preserves the nested error header path', () => {
+    expect(AUTH_TOP_RESPONSE_ERRORS_SQL_OTEL).toContain("source = 'edge_logs'")
+    expect(AUTH_TOP_RESPONSE_ERRORS_SQL_OTEL).toContain('status_code between 400 and 599')
+    expect(AUTH_TOP_ERROR_CODES_SQL_OTEL).toContain('response.headers.x_sb_error_code')
+    expect(AUTH_TOP_ERROR_CODES_SQL_OTEL).toContain("error_code != ''")
+    for (const sql of [AUTH_TOP_ERROR_CODES_SQL_OTEL, AUTH_TOP_RESPONSE_ERRORS_SQL_OTEL]) {
+      expect(sql).toContain('count()')
+      expect(sql).toContain('limit 10')
+      expect(sql).not.toContain('unnest')
+    }
+  })
+
+  it('accepts ClickHouse string counts and legacy numeric counts', () => {
+    expect(
+      parseAuthErrorCodes([
+        { error_code: 'bad_jwt', count: '12' },
+        { error_code: 'expired', count: 3 },
+      ])
+    ).toEqual([
+      { error_code: 'bad_jwt', count: 12 },
+      { error_code: 'expired', count: 3 },
+    ])
+    expect(
+      parseResponseErrors([
+        { method: 'GET', path: '/auth/v1/user', status_code: '401', count: '4' },
+      ])
+    ).toEqual([{ method: 'GET', path: '/auth/v1/user', status_code: 401, count: 4 }])
+  })
+
+  it('drops malformed rows and counts', () => {
+    expect(
+      parseAuthErrorCodes([
+        null,
+        {},
+        { error_code: 'error', count: 'oops' },
+        { error_code: 'error', count: null },
+      ])
+    ).toEqual([])
+    expect(
+      parseResponseErrors([
+        null,
+        {},
+        { method: 'GET', path: '/', status_code: 401, count: Infinity },
+      ])
+    ).toEqual([])
+  })
+})

--- a/apps/studio/tests/components/QueryInsights/QueryInsights.constants.test.ts
+++ b/apps/studio/tests/components/QueryInsights/QueryInsights.constants.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  getSupamonitorLogsQuery,
+  getSupamonitorLogsQueryOtel,
+} from '@/components/interfaces/QueryInsights/QueryInsights.constants'
+
+const start = '2026-09-09T08:00:00Z'
+const end = '2026-09-09T09:00:00Z'
+
+describe('Supamonitor log queries', () => {
+  it('retains BigQuery SQL for the legacy endpoint', () => {
+    expect(getSupamonitorLogsQuery(start, end)).toContain('from supamonitor_logs as sml')
+    expect(getSupamonitorLogsQuery(start, end)).toContain(
+      "CAST('2026-09-09T08:00:00.000Z' AS TIMESTAMP)"
+    )
+  })
+
+  it('preserves nested fields, decimal timings, and UTC minute buckets in ClickHouse', () => {
+    const sql = getSupamonitorLogsQueryOtel(start, end)
+    expect(sql).toContain("source = 'supamonitor_logs'")
+    expect(sql).toContain("toFloat64OrNull(log_attributes['supamonitor.total_exec_time'])")
+    expect(sql).toContain("toInt64OrZero(log_attributes['supamonitor.calls'])")
+    expect(sql).toContain(
+      "formatDateTime(toStartOfMinute(logs.timestamp), '%Y-%m-%dT%H:%i:%SZ', 'UTC')"
+    )
+    expect(sql).toContain("parseDateTime64BestEffort('2026-09-09T08:00:00.000Z')")
+    expect(sql).toContain('quantile(0.95)')
+    expect(sql).toContain('limit 10000')
+    expect(sql).not.toContain('unnest')
+  })
+
+  it.each([getSupamonitorLogsQuery, getSupamonitorLogsQueryOtel])(
+    'rejects invalid time input',
+    (builder) => {
+      expect(() => builder("'; drop table logs;", end)).toThrow(RangeError)
+      expect(() => builder(start, '')).toThrow(RangeError)
+    }
+  )
+})


### PR DESCRIPTION
Superseded by six smaller draft PRs:

- Auth overview errors: https://github.com/supabase/supabase/pull/50174
- Auth reports: https://github.com/supabase/supabase/pull/50175
- Query Insights: https://github.com/supabase/supabase/pull/50176
- Shared API reports: https://github.com/supabase/supabase/pull/50177
- API overview: https://github.com/supabase/supabase/pull/50178
- Storage reports: https://github.com/supabase/supabase/pull/50179

Auth overview and Auth reports are independent. Merge the remaining stack in order: Query Insights, Shared API reports, API overview, Storage reports. The split preserves the original combined changes.
