### PR TITLE
fix(auth): enable clickhouse report queries

### DIFF
--- a/apps/studio/data/reports/v2/auth.config.otel.test.ts
+++ b/apps/studio/data/reports/v2/auth.config.otel.test.ts
@@ -139,9 +139,9 @@ describe('AUTH_REPORT_SQL_OTEL', () => {
     expect(out).toContain("toInt32OrZero(log_attributes['response.status_code']) as status_code")
   })
 
-  it('selects the x_sb_error_code attribute for the by-code breakdown', () => {
+  it('preserves missing error codes as null so the report excludes uncategorized failures', () => {
     expect(sql(AUTH_REPORT_SQL_OTEL.ErrorsByAuthCode('1h'))).toContain(
-      "log_attributes['response.headers.x_sb_error_code'] as error_code"
+      "nullIf(log_attributes['response.headers.x_sb_error_code'], '') as error_code"
     )
   })
 

--- a/apps/studio/data/reports/v2/auth.config.otel.test.ts
+++ b/apps/studio/data/reports/v2/auth.config.otel.test.ts
@@ -16,24 +16,35 @@ describe('AUTH_REPORT_SQL_OTEL', () => {
 
   it('emits 16-digit unix-microsecond timestamps bucketed by granularity', () => {
     expect(sql(AUTH_REPORT_SQL_OTEL.ActiveUsers('1h'))).toContain(
-      'toUnixTimestamp(toStartOfHour(timestamp)) * 1000000 as timestamp'
+      'toUnixTimestamp(toStartOfHour(logs.timestamp)) * 1000000 as timestamp'
     )
     expect(sql(AUTH_REPORT_SQL_OTEL.ActiveUsers('1d'))).toContain(
-      'toUnixTimestamp(toStartOfDay(timestamp)) * 1000000 as timestamp'
+      'toUnixTimestamp(toStartOfDay(logs.timestamp)) * 1000000 as timestamp'
     )
     expect(sql(AUTH_REPORT_SQL_OTEL.ActiveUsers('5m'))).toContain(
-      'toUnixTimestamp(toStartOfMinute(timestamp)) * 1000000 as timestamp'
+      'toUnixTimestamp(toStartOfMinute(logs.timestamp)) * 1000000 as timestamp'
     )
   })
 
   it('groups and orders by the full bucket expression, not the timestamp alias', () => {
     const out = sql(AUTH_REPORT_SQL_OTEL.ActiveUsers('1h'))
 
-    expect(out).toContain('group by toUnixTimestamp(toStartOfHour(timestamp)) * 1000000')
-    expect(out).toContain('order by toUnixTimestamp(toStartOfHour(timestamp)) * 1000000 desc')
+    expect(out).toContain('group by toUnixTimestamp(toStartOfHour(logs.timestamp)) * 1000000')
+    expect(out).toContain('order by toUnixTimestamp(toStartOfHour(logs.timestamp)) * 1000000 desc')
     expect(out).not.toContain('group by timestamp')
     expect(out).not.toContain('order by timestamp desc')
   })
+
+  it.each(Object.entries(AUTH_REPORT_SQL_OTEL))(
+    '%s qualifies timestamp inputs to avoid substituting the numeric output alias',
+    (_, builder) => {
+      for (const interval of ['5m', '1h', '1d'] as const) {
+        const out = sql(builder(interval))
+        expect(out).toMatch(/toStartOf(?:Minute|Hour|Day)\(logs\.timestamp\)/)
+        expect(out).not.toMatch(/toStartOf(?:Minute|Hour|Day)\(timestamp\)/)
+      }
+    }
+  )
 
   it('reads auth_logs fields from the raw JSON event_message, not BigQuery json_value', () => {
     const out = sql(AUTH_REPORT_SQL_OTEL.ActiveUsers('1h'))

--- a/apps/studio/data/reports/v2/auth.config.ts
+++ b/apps/studio/data/reports/v2/auth.config.ts
@@ -527,7 +527,7 @@ export const AUTH_REPORT_SQL_OTEL: Record<
         select
           ${ts} as timestamp,
           count() as count,
-          log_attributes['response.headers.x_sb_error_code'] as error_code
+          nullIf(log_attributes['response.headers.x_sb_error_code'], '') as error_code
         from logs
         where source = 'edge_logs'
           and log_attributes['request.path'] like '%auth/v1%'

--- a/apps/studio/data/reports/v2/auth.config.ts
+++ b/apps/studio/data/reports/v2/auth.config.ts
@@ -306,9 +306,9 @@ const AUTH_REPORT_SQL: Record<
 
 // fillTimeseries/isUnixMicro expects a 16-digit unix-microsecond timestamp, matching BigQuery's timestamp_trunc.
 const OTEL_TIMESTAMP: Record<Granularity, SafeLogSqlFragment> = {
-  minute: safeSql`toUnixTimestamp(toStartOfMinute(timestamp)) * 1000000`,
-  hour: safeSql`toUnixTimestamp(toStartOfHour(timestamp)) * 1000000`,
-  day: safeSql`toUnixTimestamp(toStartOfDay(timestamp)) * 1000000`,
+  minute: safeSql`toUnixTimestamp(toStartOfMinute(logs.timestamp)) * 1000000`,
+  hour: safeSql`toUnixTimestamp(toStartOfHour(logs.timestamp)) * 1000000`,
+  day: safeSql`toUnixTimestamp(toStartOfDay(logs.timestamp)) * 1000000`,
 }
 
 const PROVIDER_SELECT_FRAGMENT_OTEL = safeSql`coalesce(nullIf(JSONExtractString(event_message, 'provider'), ''), 'unknown') as provider,`

--- a/apps/studio/pages/project/[ref]/observability/auth.tsx
+++ b/apps/studio/pages/project/[ref]/observability/auth.tsx
@@ -1,4 +1,4 @@
-import { useParams } from 'common'
+import { useFlag, useParams } from 'common'
 import dayjs from 'dayjs'
 import { ArrowRight, LogsIcon, RefreshCw } from 'lucide-react'
 import { useRouter } from 'next/router'
@@ -64,6 +64,7 @@ const REPORT_TITLE = 'Auth'
 
 const AuthUsage = () => {
   const { ref } = useParams()
+  const useOtel = useFlag('otelLegacyLogs')
   const chartSyncId = `auth-report`
 
   const {
@@ -139,6 +140,7 @@ const AuthUsage = () => {
 
   const usageReportConfig = createUsageReportConfig({
     projectRef: ref || '',
+    useOtel,
     startDate: selectedDateRange?.period_start?.date,
     endDate: selectedDateRange?.period_end?.date,
     interval: selectedDateRange?.interval,
@@ -147,6 +149,7 @@ const AuthUsage = () => {
 
   const errorsReportConfig = createErrorsReportConfig({
     projectRef: ref || '',
+    useOtel,
     startDate: selectedDateRange?.period_start?.date,
     endDate: selectedDateRange?.period_end?.date,
     interval: selectedDateRange?.interval,
@@ -155,6 +158,7 @@ const AuthUsage = () => {
 
   const latencyReportConfig = createLatencyReportConfig({
     projectRef: ref || '',
+    useOtel,
     startDate: selectedDateRange?.period_start?.date,
     endDate: selectedDateRange?.period_end?.date,
     interval: selectedDateRange?.interval,
@@ -287,6 +291,7 @@ const AuthUsage = () => {
                 <ReportChartV2
                   key={`${metric.id}`}
                   report={metric}
+                  queryGroup={useOtel ? 'auth-otel' : 'auth-bigquery'}
                   projectRef={ref!}
                   interval={selectedDateRange.interval}
                   startDate={selectedDateRange?.period_start?.date}
@@ -321,6 +326,7 @@ const AuthUsage = () => {
                 <ReportChartV2
                   key={`${metric.id}`}
                   report={metric}
+                  queryGroup={useOtel ? 'auth-otel' : 'auth-bigquery'}
                   projectRef={ref!}
                   interval={selectedDateRange.interval}
                   startDate={selectedDateRange?.period_start?.date}
@@ -345,6 +351,7 @@ const AuthUsage = () => {
                 <ReportChartV2
                   key={`${metric.id}`}
                   report={metric}
+                  queryGroup={useOtel ? 'auth-otel' : 'auth-bigquery'}
                   projectRef={ref!}
                   interval={selectedDateRange.interval}
                   startDate={selectedDateRange?.period_start?.date}


### PR DESCRIPTION
## Problem

Auth reports omit the migration flag and always select BigQuery. Enabling their ClickHouse queries also exposed an ambiguous timestamp alias and missing error codes being grouped as empty strings.

## Change

Pass `otelLegacyLogs` to the report configurations and isolate caches by engine. Qualify the source timestamp in bucket expressions and normalize missing error codes to null before grouping.

## Validation

- Corrected bucket SQL executed successfully against the live endpoint. The rebuilt report rendered without query errors, and populated gateway metrics matched staging for the same date range.
- The final rebuilt preview rendered without errors; gateway and error-code metrics matched staging. Auth-service usage and latency were empty in both environments, so populated validation of those charts remains outstanding.
- The combined migration suite passed 55 focused tests. Local TypeScript reported no diagnostics in changed files; the full check remains blocked by existing dependency and generated-type errors. CI is ongoing.
- To reproduce, toggle `otelLegacyLogs` on the Auth report and apply the same date range in preview and staging. Flag-on uses `logs.all.otel`; flag-off preserves `logs.all`.

Split from #50173. Targets `master` independently.

