### PR TITLE
fix(logs): migrate query insights to clickhouse

### DIFF
--- a/apps/studio/components/interfaces/QueryInsights/QueryInsights.constants.ts
+++ b/apps/studio/components/interfaces/QueryInsights/QueryInsights.constants.ts
@@ -1,3 +1,5 @@
+import { analyticsLiteral, safeSql } from '@/data/logs/safe-analytics-sql'
+
 export const SUPAMONITOR_EXCLUDED_ROLES = [
   'supabase_admin',
   'supabase_auth_admin',
@@ -22,7 +24,7 @@ export const getSupamonitorLogsQuery = (startTime: string, endTime: string) => {
   const safeStart = new Date(startTime).toISOString()
   const safeEnd = new Date(endTime).toISOString()
 
-  return `
+  return safeSql`
 -- This query is run by Supabase Query Insights to aggregate pg_stat_statements
 -- data collected by the supamonitor extension. It reads from Logflare and groups
 -- execution metrics (timing, call counts, percentiles) by query and minute so
@@ -58,9 +60,46 @@ from supamonitor_logs as sml
 cross join unnest(sml.metadata) as sml_metadata
 cross join unnest(sml_metadata.supamonitor) as sml_parsed
 WHERE sml.event_message = 'log'
-  AND sml.timestamp >= CAST('${safeStart}' AS TIMESTAMP)
-  AND sml.timestamp <= CAST('${safeEnd}' AS TIMESTAMP)
+  AND sml.timestamp >= CAST(${analyticsLiteral(safeStart)} AS TIMESTAMP)
+  AND sml.timestamp <= CAST(${analyticsLiteral(safeEnd)} AS TIMESTAMP)
 GROUP BY timestamp, user_name, database_name, application_name, query_id, query
 ORDER BY timestamp DESC
-`.trim()
+`
+}
+
+export const getSupamonitorLogsQueryOtel = (startTime: string, endTime: string) => {
+  const safeStart = new Date(startTime).toISOString()
+  const safeEnd = new Date(endTime).toISOString()
+
+  return safeSql`
+select
+  formatDateTime(toStartOfMinute(logs.timestamp), '%Y-%m-%dT%H:%i:%SZ', 'UTC') as timestamp,
+  log_attributes['supamonitor.application_name'] as application_name,
+  sum(toInt64OrZero(log_attributes['supamonitor.calls'])) as calls,
+  log_attributes['supamonitor.database_name'] as database_name,
+  log_attributes['supamonitor.query'] as query,
+  log_attributes['supamonitor.query_id'] as query_id,
+  sum(toFloat64OrNull(log_attributes['supamonitor.total_exec_time'])) as total_exec_time,
+  sum(toFloat64OrNull(log_attributes['supamonitor.total_plan_time'])) as total_plan_time,
+  log_attributes['supamonitor.user_name'] as user_name,
+  if(calls > 0, total_exec_time / calls, 0) as mean_exec_time,
+  min(nullIf(toFloat64OrNull(log_attributes['supamonitor.total_exec_time']), 0)) as min_exec_time,
+  max(toFloat64OrNull(log_attributes['supamonitor.total_exec_time'])) as max_exec_time,
+  if(calls > 0, total_plan_time / calls, 0) as mean_plan_time,
+  min(nullIf(toFloat64OrNull(log_attributes['supamonitor.total_plan_time']), 0)) as min_plan_time,
+  max(toFloat64OrNull(log_attributes['supamonitor.total_plan_time'])) as max_plan_time,
+  quantile(0.50)(toFloat64OrNull(log_attributes['supamonitor.total_exec_time'])) as p50_exec_time,
+  quantile(0.95)(toFloat64OrNull(log_attributes['supamonitor.total_exec_time'])) as p95_exec_time,
+  quantile(0.50)(toFloat64OrNull(log_attributes['supamonitor.total_plan_time'])) as p50_plan_time,
+  quantile(0.95)(toFloat64OrNull(log_attributes['supamonitor.total_plan_time'])) as p95_plan_time
+from logs
+where source = 'supamonitor_logs'
+  and event_message = 'log'
+  and logs.timestamp >= parseDateTime64BestEffort(${analyticsLiteral(safeStart)})
+  and logs.timestamp <= parseDateTime64BestEffort(${analyticsLiteral(safeEnd)})
+group by formatDateTime(toStartOfMinute(logs.timestamp), '%Y-%m-%dT%H:%i:%SZ', 'UTC'),
+  user_name, database_name, application_name, query_id, query
+order by timestamp desc
+limit 10000
+`
 }

--- a/apps/studio/components/interfaces/QueryInsights/QueryInsights.tsx
+++ b/apps/studio/components/interfaces/QueryInsights/QueryInsights.tsx
@@ -1,10 +1,10 @@
-import { useParams } from 'common'
+import { useFlag, useParams } from 'common'
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import { useMemo, useState } from 'react'
 
 import { useSupamonitorIndexAdvisor } from './hooks/useSupamonitorIndexAdvisor'
-import { getSupamonitorLogsQuery } from './QueryInsights.constants'
+import { getSupamonitorLogsQuery, getSupamonitorLogsQueryOtel } from './QueryInsights.constants'
 import { QueryInsightsChart } from './QueryInsightsChart/QueryInsightsChart'
 import { QueryInsightsHealth } from './QueryInsightsHealth/QueryInsightsHealth'
 import { QueryInsightsTable } from './QueryInsightsTable/QueryInsightsTable'
@@ -14,6 +14,7 @@ import {
   parseSupamonitorLogs,
   transformLogsToChartData,
 } from './utils/supamonitor.utils'
+import { pickLogsQueryBuilder } from '@/data/logs/logs-endpoint'
 import { useLogsQuery } from '@/hooks/analytics/useLogsQuery'
 
 dayjs.extend(utc)
@@ -28,6 +29,7 @@ interface QueryInsightsProps {
 
 export const QueryInsights = ({ dateRange }: QueryInsightsProps) => {
   const { ref } = useParams()
+  const useOtel = useFlag('otelLegacyLogs')
 
   const effectiveDateRange = useMemo(() => {
     if (dateRange) {
@@ -46,17 +48,19 @@ export const QueryInsights = ({ dateRange }: QueryInsightsProps) => {
 
   const sql = useMemo(
     () =>
-      getSupamonitorLogsQuery(
-        effectiveDateRange.iso_timestamp_start,
-        effectiveDateRange.iso_timestamp_end
-      ),
-    [effectiveDateRange]
+      pickLogsQueryBuilder(
+        useOtel,
+        getSupamonitorLogsQueryOtel,
+        getSupamonitorLogsQuery
+      )(effectiveDateRange.iso_timestamp_start, effectiveDateRange.iso_timestamp_end),
+    [effectiveDateRange, useOtel]
   )
 
   const { logData, isLoading } = useLogsQuery({
     projectRef: ref as string,
+    options: { useOtel },
+    sql,
     initialParams: {
-      sql,
       iso_timestamp_start: effectiveDateRange.iso_timestamp_start,
       iso_timestamp_end: effectiveDateRange.iso_timestamp_end,
     },

--- a/apps/studio/hooks/analytics/useLogsQuery.test.tsx
+++ b/apps/studio/hooks/analytics/useLogsQuery.test.tsx
@@ -1,0 +1,83 @@
+import { QueryClient } from '@tanstack/react-query'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import { describe, expect, it } from 'vitest'
+
+import { useLogsQuery } from './useLogsQuery'
+import type { paths } from '@/data/api'
+import { safeSql } from '@/data/logs/safe-analytics-sql'
+import { customRender } from '@/tests/lib/custom-render'
+import { addAPIMock, mswServer } from '@/tests/lib/msw'
+
+type LogsResponse =
+  paths['/platform/projects/{ref}/analytics/endpoints/logs.all']['get']['responses'][200]['content']['application/json']
+
+const bigQuerySql = safeSql`select count(id) as count from edge_logs limit 1`
+const otelSql = safeSql`select count() as count from logs where source = 'edge_logs' limit 1`
+const start = '2026-09-01T00:00:00.000Z'
+const end = '2026-09-02T00:00:00.000Z'
+
+function Report({ useOtel }: { useOtel: boolean }) {
+  const { logData, params, setParams } = useLogsQuery({
+    projectRef: 'default',
+    sql: useOtel ? otelSql : bigQuerySql,
+    initialParams: { iso_timestamp_start: start, iso_timestamp_end: end },
+    options: { useOtel },
+  })
+
+  return (
+    <>
+      <output>{logData[0]?.count?.toString()}</output>
+      <span>{params.sql}</span>
+      <button onClick={() => setParams((previous) => ({ ...previous, iso_timestamp_start: end }))}>
+        Change range
+      </button>
+    </>
+  )
+}
+
+describe('useLogsQuery controlled SQL', () => {
+  it('switches SQL and endpoint together and keeps the engine caches separate', async () => {
+    mswServer.use(
+      http.get('*/api/enabled-features-overrides', () =>
+        HttpResponse.json<{ disabled_features: string[] }>({ disabled_features: [] })
+      )
+    )
+    const requests: { engine: string; sql: string | null; start: string | null }[] = []
+    for (const engine of ['logs.all', 'logs.all.otel'] as const) {
+      addAPIMock({
+        method: 'get',
+        path: `/platform/projects/:ref/analytics/endpoints/${engine}`,
+        response: ({ request }) => {
+          const search = new URL(request.url).searchParams
+          requests.push({
+            engine,
+            sql: search.get('sql'),
+            start: search.get('iso_timestamp_start'),
+          })
+          return HttpResponse.json<LogsResponse>({
+            result: [{ count: engine === 'logs.all' ? 1 : 2 }],
+          })
+        },
+      })
+    }
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const { rerender } = customRender(<Report useOtel={false} />, { queryClient })
+    await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('1'))
+
+    rerender(<Report useOtel />)
+    await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('2'))
+    expect(requests).toEqual([
+      { engine: 'logs.all', sql: bigQuerySql, start },
+      { engine: 'logs.all.otel', sql: otelSql, start },
+    ])
+    expect(
+      queryClient.getQueryCache().findAll({ queryKey: ['projects', 'default', 'logs'] })
+    ).toHaveLength(2)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Change range' }))
+    await waitFor(() => expect(requests).toHaveLength(3))
+    expect(requests[2]).toEqual({ engine: 'logs.all.otel', sql: otelSql, start: end })
+  })
+})

--- a/apps/studio/hooks/analytics/useLogsQuery.test.tsx
+++ b/apps/studio/hooks/analytics/useLogsQuery.test.tsx
@@ -1,7 +1,7 @@
 import { QueryClient } from '@tanstack/react-query'
 import { fireEvent, screen, waitFor } from '@testing-library/react'
 import { http, HttpResponse } from 'msw'
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 
 import { useLogsQuery } from './useLogsQuery'
 import type { paths } from '@/data/api'
@@ -17,11 +17,11 @@ const otelSql = safeSql`select count() as count from logs where source = 'edge_l
 const start = '2026-09-01T00:00:00.000Z'
 const end = '2026-09-02T00:00:00.000Z'
 
-function Report({ useOtel }: { useOtel: boolean }) {
+function Report({ useOtel, rangeEnd = end }: { useOtel: boolean; rangeEnd?: string }) {
   const { logData, params, setParams } = useLogsQuery({
     projectRef: 'default',
     sql: useOtel ? otelSql : bigQuerySql,
-    initialParams: { iso_timestamp_start: start, iso_timestamp_end: end },
+    initialParams: { iso_timestamp_start: start, iso_timestamp_end: rangeEnd },
     options: { useOtel },
   })
 
@@ -29,7 +29,10 @@ function Report({ useOtel }: { useOtel: boolean }) {
     <>
       <output>{logData[0]?.count?.toString()}</output>
       <span>{params.sql}</span>
-      <button onClick={() => setParams((previous) => ({ ...previous, iso_timestamp_start: end }))}>
+      <button
+        tabIndex={0}
+        onClick={() => setParams((previous) => ({ ...previous, iso_timestamp_start: end }))}
+      >
         Change range
       </button>
     </>
@@ -37,12 +40,15 @@ function Report({ useOtel }: { useOtel: boolean }) {
 }
 
 describe('useLogsQuery controlled SQL', () => {
-  it('switches SQL and endpoint together and keeps the engine caches separate', async () => {
+  beforeEach(() => {
     mswServer.use(
       http.get('*/api/enabled-features-overrides', () =>
         HttpResponse.json<{ disabled_features: string[] }>({ disabled_features: [] })
       )
     )
+  })
+
+  it('switches SQL and endpoint together and keeps the engine caches separate', async () => {
     const requests: { engine: string; sql: string | null; start: string | null }[] = []
     for (const engine of ['logs.all', 'logs.all.otel'] as const) {
       addAPIMock({
@@ -80,4 +86,47 @@ describe('useLogsQuery controlled SQL', () => {
     await waitFor(() => expect(requests).toHaveLength(3))
     expect(requests[2]).toEqual({ engine: 'logs.all.otel', sql: otelSql, start: end })
   })
+
+  it('uses the supplied range on the first request and follows range prop changes', async () => {
+    const ranges: (string | null)[] = []
+    addAPIMock({
+      method: 'get',
+      path: '/platform/projects/:ref/analytics/endpoints/logs.all.otel',
+      response: ({ request }) => {
+        ranges.push(new URL(request.url).searchParams.get('iso_timestamp_end'))
+        return HttpResponse.json<LogsResponse>({ result: [{ count: ranges.length }] })
+      },
+    })
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const { rerender } = customRender(<Report useOtel />, { queryClient })
+    await waitFor(() => expect(ranges).toEqual([end]))
+    rerender(<Report useOtel rangeEnd="2026-09-03T00:00:00.000Z" />)
+    await waitFor(() => expect(ranges).toEqual([end, '2026-09-03T00:00:00.000Z']))
+  })
+
+  it.each([false, true])(
+    'preserves the default open-ended range with branded SQL: %s',
+    async (branded) => {
+      const requests: (string | null)[] = []
+      addAPIMock({
+        method: 'get',
+        path: '/platform/projects/:ref/analytics/endpoints/logs.all',
+        response: ({ request }) => {
+          requests.push(new URL(request.url).searchParams.get('iso_timestamp_end'))
+          return HttpResponse.json<LogsResponse>({ result: [{ count: 1 }] })
+        },
+      })
+      function DefaultRangeReport() {
+        const { error, logData } = useLogsQuery({
+          projectRef: 'default',
+          ...(branded ? { sql: bigQuerySql } : { initialParams: { sql: bigQuerySql } }),
+        })
+        return <output>{error ? String(error) : logData[0]?.count?.toString()}</output>
+      }
+      const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      customRender(<DefaultRangeReport />, { queryClient })
+      await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('1'))
+      expect(requests).toEqual([''])
+    }
+  )
 })

--- a/apps/studio/hooks/analytics/useLogsQuery.tsx
+++ b/apps/studio/hooks/analytics/useLogsQuery.tsx
@@ -89,9 +89,6 @@ export const useLogsQuery = ({
     queryFn: async ({ signal }) => {
       if (!projectRef) throw new Error('projectRef is required')
       const { iso_timestamp_start, iso_timestamp_end } = params
-      if (!iso_timestamp_start || !iso_timestamp_end) {
-        throw new Error('A start and end timestamp are required')
-      }
       const { data, error } =
         sql !== undefined
           ? {
@@ -99,8 +96,8 @@ export const useLogsQuery = ({
                 projectRef,
                 endpoint: logsAllEndpointUrl(useOtel),
                 sql,
-                iso_timestamp_start,
-                iso_timestamp_end,
+                iso_timestamp_start: iso_timestamp_start ?? '',
+                iso_timestamp_end: iso_timestamp_end ?? '',
                 method: 'get',
                 signal,
               }),

--- a/apps/studio/hooks/analytics/useLogsQuery.tsx
+++ b/apps/studio/hooks/analytics/useLogsQuery.tsx
@@ -16,7 +16,9 @@ import {
   checkForWithClause,
 } from '@/components/interfaces/Settings/Logs/Logs.utils'
 import { get } from '@/data/fetchers'
+import { executeAnalyticsSql } from '@/data/logs/execute-analytics-sql'
 import { logsAllEndpointUrl } from '@/data/logs/logs-endpoint'
+import type { SafeLogSqlFragment } from '@/data/logs/safe-analytics-sql'
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
 import { DOCS_URL } from '@/lib/constants'
 
@@ -35,17 +37,19 @@ export interface LogsQueryHook {
 export const useLogsQuery = ({
   projectRef,
   initialParams = {},
+  sql,
   enabled = true,
   options = {},
 }: {
   projectRef?: string
   initialParams?: Partial<LogsEndpointParams>
+  sql?: SafeLogSqlFragment
   enabled?: boolean
   options?: { useOtel?: boolean }
 }): LogsQueryHook => {
   const { useOtel = false } = options
   const defaultHelper = getDefaultHelper(EXPLORER_DATEPICKER_HELPERS)
-  const [params, setParams] = useState<LogsEndpointParams>({
+  const [storedParams, setParams] = useState<LogsEndpointParams>({
     sql: initialParams?.sql || '',
     iso_timestamp_start: initialParams.iso_timestamp_start
       ? initialParams.iso_timestamp_start
@@ -67,6 +71,8 @@ export const useLogsQuery = ({
     }))
   }, [initialParams.sql, initialParams.iso_timestamp_start, initialParams.iso_timestamp_end])
 
+  const params = { ...storedParams, sql: sql ?? storedParams.sql }
+
   const _enabled = enabled && typeof projectRef !== 'undefined' && Boolean(params.sql)
 
   const usesWith = checkForWithClause(params.sql || '')
@@ -81,13 +87,32 @@ export const useLogsQuery = ({
   } = useQuery({
     queryKey: ['projects', projectRef, 'logs', params, { otel: useOtel }],
     queryFn: async ({ signal }) => {
-      const { data, error } = await get(logsAllEndpointUrl(useOtel), {
-        params: {
-          path: { ref: projectRef! },
-          query: params,
-        },
-        signal,
-      })
+      if (!projectRef) throw new Error('projectRef is required')
+      const { iso_timestamp_start, iso_timestamp_end } = params
+      if (!iso_timestamp_start || !iso_timestamp_end) {
+        throw new Error('A start and end timestamp are required')
+      }
+      const { data, error } =
+        sql !== undefined
+          ? {
+              data: await executeAnalyticsSql({
+                projectRef,
+                endpoint: logsAllEndpointUrl(useOtel),
+                sql,
+                iso_timestamp_start,
+                iso_timestamp_end,
+                method: 'get',
+                signal,
+              }),
+              error: undefined,
+            }
+          : await get(logsAllEndpointUrl(useOtel), {
+              params: {
+                path: { ref: projectRef },
+                query: params,
+              },
+              signal,
+            })
       if (error) {
         throw error
       }

--- a/apps/studio/tests/components/QueryInsights/QueryInsights.constants.test.ts
+++ b/apps/studio/tests/components/QueryInsights/QueryInsights.constants.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  getSupamonitorLogsQuery,
+  getSupamonitorLogsQueryOtel,
+} from '@/components/interfaces/QueryInsights/QueryInsights.constants'
+
+const start = '2026-09-09T08:00:00Z'
+const end = '2026-09-09T09:00:00Z'
+
+describe('Supamonitor log queries', () => {
+  it('retains BigQuery SQL for the legacy endpoint', () => {
+    expect(getSupamonitorLogsQuery(start, end)).toContain('from supamonitor_logs as sml')
+    expect(getSupamonitorLogsQuery(start, end)).toContain(
+      "CAST('2026-09-09T08:00:00.000Z' AS TIMESTAMP)"
+    )
+  })
+
+  it('preserves nested fields, decimal timings, and UTC minute buckets in ClickHouse', () => {
+    const sql = getSupamonitorLogsQueryOtel(start, end)
+    expect(sql).toContain("source = 'supamonitor_logs'")
+    expect(sql).toContain("toFloat64OrNull(log_attributes['supamonitor.total_exec_time'])")
+    expect(sql).toContain("toInt64OrZero(log_attributes['supamonitor.calls'])")
+    expect(sql).toContain(
+      "formatDateTime(toStartOfMinute(logs.timestamp), '%Y-%m-%dT%H:%i:%SZ', 'UTC')"
+    )
+    expect(sql).toContain("parseDateTime64BestEffort('2026-09-09T08:00:00.000Z')")
+    expect(sql).toContain('quantile(0.95)')
+    expect(sql).toContain('limit 10000')
+    expect(sql).not.toContain('unnest')
+  })
+
+  it.each([getSupamonitorLogsQuery, getSupamonitorLogsQueryOtel])(
+    'rejects invalid time input',
+    (builder) => {
+      expect(() => builder("'; drop table logs;", end)).toThrow(RangeError)
+      expect(() => builder(start, '')).toThrow(RangeError)
+    }
+  )
+})


### PR DESCRIPTION
## Problem

Query Insights uses BigQuery SQL and the legacy endpoint regardless of the migration flag. The shared logs hook must switch SQL and endpoint together without mixing cached results or rejecting legacy open-ended ranges.

## Change

Add branded ClickHouse SQL behind `otelLegacyLogs` and a controlled SQL input to `useLogsQuery`. Keep cache entries separate by engine and preserve empty end timestamps for legacy requests.

## Validation

- Four hook regression tests cover endpoint/SQL switching, cache separation, initial and changed date ranges, and branded/unbranded open-ended requests. Query Insights SQL tests also pass.
- The combined migration suite passed 55 focused tests. Local TypeScript reported no diagnostics in changed files; the full check remains blocked by existing dependency and generated-type errors. CI is ongoing.
- Populated Query Insights results remain unverified because the validation project does not have an available collector.
- To reproduce with a collecting project, toggle `otelLegacyLogs`, change dates, and compare populated Query Insights metrics over the same range. Flag-on uses `logs.all.otel`; flag-off preserves `logs.all`.

Split from #50173. Targets `master` independently; subsequent report PRs reuse the hook.
