### PR TITLE
fix(reports): migrate shared api charts to clickhouse

### DIFF
--- a/apps/studio/components/interfaces/Reports/Reports.utils.otel.test.ts
+++ b/apps/studio/components/interfaces/Reports/Reports.utils.otel.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+
+import { API_REPORT_QUERIES_OTEL, generateReportFiltersOtel } from './Reports.utils.otel'
+
+const compact = (sql: string) => sql.replace(/\s+/g, ' ').trim()
+
+describe('OTEL report filters', () => {
+  it('keeps nested attributes and numeric-looking string values intact', () => {
+    expect(
+      generateReportFiltersOtel([
+        { key: 'request.headers.x_client_info', compare: 'is', value: '001' },
+        { key: 'identifier', compare: 'is', value: '0123' },
+      ])
+    ).toBe(
+      "and log_attributes['request.headers.x_client_info'] = '001' and log_attributes['identifier'] = '0123'"
+    )
+  })
+
+  it('escapes regex values and maps function paths', () => {
+    expect(
+      generateReportFiltersOtel(
+        [{ key: 'request.path', compare: 'matches', value: "a'\\b" }],
+        'function_edge_logs'
+      )
+    ).toBe("and match(log_attributes['request.pathname'], 'a''\\\\b')")
+  })
+
+  it.each(['>=', '<=', '>', '<', '!='] as const)(
+    'compares status codes numerically with %s',
+    (compare) => {
+      expect(
+        generateReportFiltersOtel([{ key: 'response.status_code', compare, value: '400' }])
+      ).toBe(`and toFloat64OrZero(log_attributes['response.status_code']) ${compare} 400`)
+    }
+  )
+
+  it('handles no filters', () => {
+    expect(generateReportFiltersOtel([])).toBe('')
+  })
+})
+
+describe('OTEL report queries', () => {
+  it.each(Object.entries(API_REPORT_QUERIES_OTEL))('scopes and limits %s', (_, builder) => {
+    const sql = compact(builder.safeSql([], 'function_edge_logs'))
+    expect(sql).toContain("from logs where source = 'function_edge_logs'")
+    expect(sql).toMatch(/limit \d+$/)
+    expect(sql).not.toMatch(/unnest|count\(\*\)|timestamp_trunc/)
+  })
+
+  it('groups counts into hours', () => {
+    expect(compact(API_REPORT_QUERIES_OTEL.totalRequests.safeSql([]))).toBe(
+      "select formatDateTime(toStartOfHour(logs.timestamp), '%Y-%m-%dT%H:%i:%SZ', 'UTC') as timestamp, toFloat64(count()) as count from logs where source = 'edge_logs' group by toStartOfHour(logs.timestamp) order by timestamp asc limit 10000"
+    )
+  })
+
+  it('preserves route aliases and filters error statuses numerically', () => {
+    const sql = API_REPORT_QUERIES_OTEL.topErrorRoutes.safeSql([], 'function_edge_logs')
+    expect(sql).toContain("log_attributes['request.pathname'] as path")
+    expect(sql).toContain("toInt32OrZero(log_attributes['response.status_code']) as status_code")
+    expect(sql).toContain("toInt32OrZero(log_attributes['response.status_code']) >= 400")
+    expect(sql).toContain('group by path, method, search, status_code')
+  })
+
+  it('coerces timing and byte strings before aggregation', () => {
+    expect(API_REPORT_QUERIES_OTEL.responseSpeed.safeSql([])).toContain(
+      "avg(toFloat64OrNull(log_attributes['response.origin_time'])) as avg"
+    )
+    const sql = API_REPORT_QUERIES_OTEL.networkTraffic.safeSql([])
+    expect(sql).toContain(
+      "sum(toFloat64OrZero(log_attributes['request.headers.content_length'])) / 1000000 as ingress_mb"
+    )
+    expect(sql).toContain(
+      "sum(toFloat64OrZero(log_attributes['response.headers.content_length'])) / 1000000 as egress_mb"
+    )
+  })
+})

--- a/apps/studio/components/interfaces/Reports/Reports.utils.otel.ts
+++ b/apps/studio/components/interfaces/Reports/Reports.utils.otel.ts
@@ -1,0 +1,117 @@
+import type { ReportFilterItem } from './Reports.types'
+import {
+  analyticsLiteral,
+  joinSqlFragments,
+  safeSql,
+  type SafeLogSqlFragment,
+} from '@/data/logs/safe-analytics-sql'
+
+const statusCode = safeSql`toInt32OrZero(log_attributes['response.status_code'])`
+const originTime = safeSql`toFloat64OrNull(log_attributes['response.origin_time'])`
+const hour = safeSql`toStartOfHour(logs.timestamp)`
+
+export function generateReportFiltersOtel(filters: ReportFilterItem[], source = 'edge_logs') {
+  const conditions = filters.map(({ key, value, compare }) => {
+    let attribute = key.replace(/^metadata\./, '')
+    if (attribute.startsWith('headers.')) attribute = `request.${attribute}`
+    if (attribute.startsWith('cf.')) attribute = `request.${attribute}`
+    if (source === 'function_edge_logs' && attribute === 'request.path') {
+      attribute = 'request.pathname'
+    }
+    const field = safeSql`log_attributes[${analyticsLiteral(attribute)}]`
+    if (compare === 'matches') return safeSql`match(${field}, ${analyticsLiteral(String(value))})`
+    const isNumeric = attribute === 'response.status_code' || typeof value === 'number'
+    const column = isNumeric ? safeSql`toFloat64OrZero(${field})` : field
+    const literal = isNumeric ? analyticsLiteral(Number(value)) : analyticsLiteral(String(value))
+    switch (compare) {
+      case '!=':
+        return safeSql`${column} != ${literal}`
+      case '>=':
+        return safeSql`${column} >= ${literal}`
+      case '<=':
+        return safeSql`${column} <= ${literal}`
+      case '>':
+        return safeSql`${column} > ${literal}`
+      case '<':
+        return safeSql`${column} < ${literal}`
+      default:
+        return safeSql`${column} = ${literal}`
+    }
+  })
+  return conditions.length ? safeSql`and ${joinSqlFragments(conditions, ' and ')}` : safeSql``
+}
+
+function timeline(
+  filters: ReportFilterItem[],
+  source: string,
+  metric: SafeLogSqlFragment,
+  errors = false
+) {
+  return safeSql`
+    select formatDateTime(${hour}, '%Y-%m-%dT%H:%i:%SZ', 'UTC') as timestamp, ${metric}
+    from logs
+    where source = ${analyticsLiteral(source)}
+      ${errors ? safeSql`and ${statusCode} >= 400` : safeSql``}
+      ${generateReportFiltersOtel(filters, source)}
+    group by ${hour}
+    order by timestamp asc
+    limit 10000
+  `
+}
+
+function routes(filters: ReportFilterItem[], source: string, mode: 'count' | 'errors' | 'slow') {
+  const path = source === 'function_edge_logs' ? 'request.pathname' : 'request.path'
+  return safeSql`
+    select
+      log_attributes[${analyticsLiteral(path)}] as path,
+      log_attributes['request.method'] as method,
+      log_attributes['request.search'] as search,
+      ${statusCode} as status_code,
+      toFloat64(count()) as count
+      ${mode === 'slow' ? safeSql`, avg(${originTime}) as avg` : safeSql``}
+    from logs
+    where source = ${analyticsLiteral(source)}
+      ${mode === 'errors' ? safeSql`and ${statusCode} >= 400` : safeSql``}
+      ${generateReportFiltersOtel(filters, source)}
+    group by path, method, search, status_code
+    order by ${mode === 'slow' ? safeSql`avg` : safeSql`count`} desc
+    limit 10
+  `
+}
+
+export const API_REPORT_QUERIES_OTEL = {
+  totalRequests: {
+    safeSql: (filters: ReportFilterItem[], source = 'edge_logs') =>
+      timeline(filters, source, safeSql`toFloat64(count()) as count`),
+  },
+  topRoutes: {
+    safeSql: (filters: ReportFilterItem[], source = 'edge_logs') =>
+      routes(filters, source, 'count'),
+  },
+  errorCounts: {
+    safeSql: (filters: ReportFilterItem[], source = 'edge_logs') =>
+      timeline(filters, source, safeSql`toFloat64(count()) as count`, true),
+  },
+  topErrorRoutes: {
+    safeSql: (filters: ReportFilterItem[], source = 'edge_logs') =>
+      routes(filters, source, 'errors'),
+  },
+  responseSpeed: {
+    safeSql: (filters: ReportFilterItem[], source = 'edge_logs') =>
+      timeline(filters, source, safeSql`avg(${originTime}) as avg`),
+  },
+  topSlowRoutes: {
+    safeSql: (filters: ReportFilterItem[], source = 'edge_logs') => routes(filters, source, 'slow'),
+  },
+  networkTraffic: {
+    safeSql: (filters: ReportFilterItem[], source = 'edge_logs') =>
+      timeline(
+        filters,
+        source,
+        safeSql`
+      sum(toFloat64OrZero(log_attributes['request.headers.content_length'])) / 1000000 as ingress_mb,
+      sum(toFloat64OrZero(log_attributes['response.headers.content_length'])) / 1000000 as egress_mb
+    `
+      ),
+  },
+}

--- a/apps/studio/components/interfaces/Reports/SharedAPIReport/SharedAPIReport.constants.ts
+++ b/apps/studio/components/interfaces/Reports/SharedAPIReport/SharedAPIReport.constants.ts
@@ -1,12 +1,14 @@
 import * as Sentry from '@sentry/nextjs'
 import { useQueries, useQueryClient } from '@tanstack/react-query'
-import { useParams } from 'common'
+import { useFlag, useParams } from 'common'
 import { isEqual } from 'lodash'
 import { useState } from 'react'
 
 import { generateRegexpWhereSafe } from '../Reports.constants'
 import { ReportFilterItem } from '../Reports.types'
+import { API_REPORT_QUERIES_OTEL } from '../Reports.utils.otel'
 import { executeAnalyticsSql } from '@/data/logs/execute-analytics-sql'
+import { logsAllEndpointUrl } from '@/data/logs/logs-endpoint'
 import { safeSql, type SafeLogSqlFragment } from '@/data/logs/safe-analytics-sql'
 
 const SOURCE_TABLE: Record<string, SafeLogSqlFragment> = {
@@ -225,6 +227,8 @@ export const useSharedAPIReport = ({
   const { ref } = useParams() as { ref: string }
   const [filters, setFilters] = useState<ReportFilterItem[]>([])
   const queryClient = useQueryClient()
+  const useOtel = useFlag('otelLegacyLogs')
+  const reportQueries = useOtel ? API_REPORT_QUERIES_OTEL : SHARED_API_REPORT_SQL
   const filterByMapSource = {
     functions: 'function_edge_logs',
     realtime: 'edge_logs',
@@ -252,9 +256,10 @@ export const useSharedAPIReport = ({
   const allFilters = [baseFilter, ...filters]
 
   const queries = useQueries({
-    queries: Object.entries(SHARED_API_REPORT_SQL).map(([key, value]) => ({
+    queries: Object.entries(reportQueries).map(([key, value]) => ({
       queryKey: [
         ...DEFAULT_KEYS,
+        { otel: useOtel },
         filterBy,
         key,
         filterByMapSource[filterBy],
@@ -268,7 +273,7 @@ export const useSharedAPIReport = ({
         try {
           const data = await executeAnalyticsSql({
             projectRef: ref,
-            endpoint: '/platform/projects/{ref}/analytics/endpoints/logs.all',
+            endpoint: logsAllEndpointUrl(useOtel),
             sql: value.safeSql(allFilters, filterByMapSource[filterBy]),
             iso_timestamp_start: start,
             iso_timestamp_end: end,
@@ -334,28 +339,13 @@ export const useSharedAPIReport = ({
   const isLoadingData = Object.values(isLoading).some(Boolean)
 
   const SQLMap: Record<SharedAPIReportKey, SafeLogSqlFragment> = {
-    totalRequests: SHARED_API_REPORT_SQL.totalRequests.safeSql(
-      allFilters,
-      filterByMapSource[filterBy]
-    ),
-    topRoutes: SHARED_API_REPORT_SQL.topRoutes.safeSql(allFilters, filterByMapSource[filterBy]),
-    errorCounts: SHARED_API_REPORT_SQL.errorCounts.safeSql(allFilters, filterByMapSource[filterBy]),
-    topErrorRoutes: SHARED_API_REPORT_SQL.topErrorRoutes.safeSql(
-      allFilters,
-      filterByMapSource[filterBy]
-    ),
-    responseSpeed: SHARED_API_REPORT_SQL.responseSpeed.safeSql(
-      allFilters,
-      filterByMapSource[filterBy]
-    ),
-    topSlowRoutes: SHARED_API_REPORT_SQL.topSlowRoutes.safeSql(
-      allFilters,
-      filterByMapSource[filterBy]
-    ),
-    networkTraffic: SHARED_API_REPORT_SQL.networkTraffic.safeSql(
-      allFilters,
-      filterByMapSource[filterBy]
-    ),
+    totalRequests: reportQueries.totalRequests.safeSql(allFilters, filterByMapSource[filterBy]),
+    topRoutes: reportQueries.topRoutes.safeSql(allFilters, filterByMapSource[filterBy]),
+    errorCounts: reportQueries.errorCounts.safeSql(allFilters, filterByMapSource[filterBy]),
+    topErrorRoutes: reportQueries.topErrorRoutes.safeSql(allFilters, filterByMapSource[filterBy]),
+    responseSpeed: reportQueries.responseSpeed.safeSql(allFilters, filterByMapSource[filterBy]),
+    topSlowRoutes: reportQueries.topSlowRoutes.safeSql(allFilters, filterByMapSource[filterBy]),
+    networkTraffic: reportQueries.networkTraffic.safeSql(allFilters, filterByMapSource[filterBy]),
   }
 
   return {


### PR DESCRIPTION
## Problem

Shared Auth, PostgREST, and Realtime API charts hardcode `logs.all`.

## Change

Select matching SQL and endpoint with `otelLegacyLogs`, isolate cache entries by engine, and add the seven shared ClickHouse report builders.

Stacked on #50176, with base branch `jordi/query-insights-otel`.

## Validation

- Populated Auth, Data API, and Realtime report metrics matched staging for the same project and applied date range.
- Shared filter and SQL builder tests passed as part of the 55-test focused migration suite. Local TypeScript reported no diagnostics in changed files; the full check remains blocked by existing dependency and generated-type errors. CI is ongoing.
- To reproduce, visit each report, apply the same date range in preview and staging, and compare metrics. Toggle `otelLegacyLogs` to verify flag-on uses `logs.all.otel` and flag-off preserves `logs.all`.

Split from #50173.
