### PR TITLE
fix(reports): migrate api overview to clickhouse

### DIFF
--- a/apps/studio/components/interfaces/Reports/Reports.utils.otel.test.ts
+++ b/apps/studio/components/interfaces/Reports/Reports.utils.otel.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { API_REPORT_QUERIES_OTEL, generateReportFiltersOtel } from './Reports.utils.otel'
+import {
+  API_REPORT_QUERIES_OTEL,
+  generateReportFiltersOtel,
+  requestsByCountryOtel,
+} from './Reports.utils.otel'
 
 const compact = (sql: string) => sql.replace(/\s+/g, ' ').trim()
 
@@ -72,5 +76,9 @@ describe('OTEL report queries', () => {
     expect(sql).toContain(
       "sum(toFloat64OrZero(log_attributes['response.headers.content_length'])) / 1000000 as egress_mb"
     )
+  })
+
+  it('uses the full country attribute', () => {
+    expect(requestsByCountryOtel([])).toContain("log_attributes['request.cf.country'] as country")
   })
 })

--- a/apps/studio/components/interfaces/Reports/Reports.utils.otel.ts
+++ b/apps/studio/components/interfaces/Reports/Reports.utils.otel.ts
@@ -115,3 +115,12 @@ export const API_REPORT_QUERIES_OTEL = {
       ),
   },
 }
+
+export const requestsByCountryOtel = (filters: ReportFilterItem[]) => safeSql`
+  select log_attributes['request.cf.country'] as country, toFloat64(count()) as count
+  from logs
+  where source = 'edge_logs' and log_attributes['request.cf.country'] != ''
+    ${generateReportFiltersOtel(filters)}
+  group by country
+  limit 1000
+`

--- a/apps/studio/data/reports/api-report-query.ts
+++ b/apps/studio/data/reports/api-report-query.ts
@@ -1,32 +1,89 @@
-import { useParams } from 'common'
+import { useFlag, useParams } from 'common'
 import { isEqual } from 'lodash'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 
 import { PRESET_CONFIG } from '@/components/interfaces/Reports/Reports.constants'
 import { ReportFilterItem } from '@/components/interfaces/Reports/Reports.types'
-import { getLogsSql, queriesFactory } from '@/components/interfaces/Reports/Reports.utils'
+import { getLogsSql } from '@/components/interfaces/Reports/Reports.utils'
+import {
+  API_REPORT_QUERIES_OTEL,
+  requestsByCountryOtel,
+} from '@/components/interfaces/Reports/Reports.utils.otel'
 import type { LogsEndpointParams } from '@/components/interfaces/Settings/Logs/Logs.types'
+import { useLogsQuery } from '@/hooks/analytics/useLogsQuery'
 import { useDatabaseSelectorStateSnapshot } from '@/state/database-selector'
 
 export const useApiReport = () => {
   const { ref: projectRef } = useParams()
+  const useOtel = useFlag('otelLegacyLogs')
   const state = useDatabaseSelectorStateSnapshot()
 
   const identifier = state.selectedDatabaseId
   const [filters, setFilters] = useState<ReportFilterItem[]>([])
 
-  const queryHooks = queriesFactory<keyof typeof PRESET_CONFIG.api.queries>(
-    PRESET_CONFIG.api.queries,
-    projectRef ?? 'default'
-  )
-  const totalRequests = queryHooks.totalRequests()
-  const topRoutes = queryHooks.topRoutes()
-  const errorCounts = queryHooks.errorCounts()
-  const topErrorRoutes = queryHooks.topErrorRoutes()
-  const responseSpeed = queryHooks.responseSpeed()
-  const topSlowRoutes = queryHooks.topSlowRoutes()
-  const networkTraffic = queryHooks.networkTraffic()
-  const requestsByCountry = queryHooks.requestsByCountry()
+  const formattedFilters: ReportFilterItem[] = [
+    ...filters,
+    ...(identifier !== undefined
+      ? [{ key: 'identifier', value: identifier, compare: 'is' } as ReportFilterItem]
+      : []),
+  ]
+
+  const totalRequests = useLogsQuery({
+    projectRef,
+    sql: useOtel
+      ? API_REPORT_QUERIES_OTEL.totalRequests.safeSql(formattedFilters)
+      : getLogsSql(PRESET_CONFIG.api.queries.totalRequests, formattedFilters),
+    options: { useOtel },
+  })
+  const topRoutes = useLogsQuery({
+    projectRef,
+    sql: useOtel
+      ? API_REPORT_QUERIES_OTEL.topRoutes.safeSql(formattedFilters)
+      : getLogsSql(PRESET_CONFIG.api.queries.topRoutes, formattedFilters),
+    options: { useOtel },
+  })
+  const errorCounts = useLogsQuery({
+    projectRef,
+    sql: useOtel
+      ? API_REPORT_QUERIES_OTEL.errorCounts.safeSql(formattedFilters)
+      : getLogsSql(PRESET_CONFIG.api.queries.errorCounts, formattedFilters),
+    options: { useOtel },
+  })
+  const topErrorRoutes = useLogsQuery({
+    projectRef,
+    sql: useOtel
+      ? API_REPORT_QUERIES_OTEL.topErrorRoutes.safeSql(formattedFilters)
+      : getLogsSql(PRESET_CONFIG.api.queries.topErrorRoutes, formattedFilters),
+    options: { useOtel },
+  })
+  const responseSpeed = useLogsQuery({
+    projectRef,
+    sql: useOtel
+      ? API_REPORT_QUERIES_OTEL.responseSpeed.safeSql(formattedFilters)
+      : getLogsSql(PRESET_CONFIG.api.queries.responseSpeed, formattedFilters),
+    options: { useOtel },
+  })
+  const topSlowRoutes = useLogsQuery({
+    projectRef,
+    sql: useOtel
+      ? API_REPORT_QUERIES_OTEL.topSlowRoutes.safeSql(formattedFilters)
+      : getLogsSql(PRESET_CONFIG.api.queries.topSlowRoutes, formattedFilters),
+    options: { useOtel },
+  })
+  const networkTraffic = useLogsQuery({
+    projectRef,
+    sql: useOtel
+      ? API_REPORT_QUERIES_OTEL.networkTraffic.safeSql(formattedFilters)
+      : getLogsSql(PRESET_CONFIG.api.queries.networkTraffic, formattedFilters),
+    options: { useOtel },
+  })
+  const requestsByCountry = useLogsQuery({
+    projectRef,
+    sql: useOtel
+      ? requestsByCountryOtel(formattedFilters)
+      : getLogsSql(PRESET_CONFIG.api.queries.requestsByCountry, formattedFilters),
+    options: { useOtel },
+  })
   const activeHooks = [
     totalRequests,
     topRoutes,
@@ -61,57 +118,6 @@ export const useApiReport = () => {
       return prev.filter((f) => !toRemove.find((r) => isEqual(f, r)))
     })
   }
-
-  // [Joshen] Keeping database selector separate from filter state, and merging them here for simplicity
-  const formattedFilters: ReportFilterItem[] = [
-    ...filters,
-    ...(identifier !== undefined
-      ? [{ key: 'identifier', value: identifier, compare: 'is' } as ReportFilterItem]
-      : []),
-  ]
-
-  useEffect(() => {
-    // update sql for each query
-    if (totalRequests.changeQuery) {
-      totalRequests.changeQuery(
-        getLogsSql(PRESET_CONFIG.api.queries.totalRequests, formattedFilters)
-      )
-    }
-    if (topRoutes.changeQuery) {
-      topRoutes.changeQuery(getLogsSql(PRESET_CONFIG.api.queries.topRoutes, formattedFilters))
-    }
-    if (errorCounts.changeQuery) {
-      errorCounts.changeQuery(getLogsSql(PRESET_CONFIG.api.queries.errorCounts, formattedFilters))
-    }
-
-    if (topErrorRoutes.changeQuery) {
-      topErrorRoutes.changeQuery(
-        getLogsSql(PRESET_CONFIG.api.queries.topErrorRoutes, formattedFilters)
-      )
-    }
-    if (responseSpeed.changeQuery) {
-      responseSpeed.changeQuery(
-        getLogsSql(PRESET_CONFIG.api.queries.responseSpeed, formattedFilters)
-      )
-    }
-
-    if (topSlowRoutes.changeQuery) {
-      topSlowRoutes.changeQuery(
-        getLogsSql(PRESET_CONFIG.api.queries.topSlowRoutes, formattedFilters)
-      )
-    }
-
-    if (networkTraffic.changeQuery) {
-      networkTraffic.changeQuery(
-        getLogsSql(PRESET_CONFIG.api.queries.networkTraffic, formattedFilters)
-      )
-    }
-    if (requestsByCountry.changeQuery) {
-      requestsByCountry.changeQuery(
-        getLogsSql(PRESET_CONFIG.api.queries.requestsByCountry, formattedFilters)
-      )
-    }
-  }, [JSON.stringify(formattedFilters)])
 
   const handleRefresh = async () => {
     activeHooks.forEach((hook) => hook.runQuery())

--- a/apps/studio/data/reports/api-report-query.ts
+++ b/apps/studio/data/reports/api-report-query.ts
@@ -13,7 +13,7 @@ import type { LogsEndpointParams } from '@/components/interfaces/Settings/Logs/L
 import { useLogsQuery } from '@/hooks/analytics/useLogsQuery'
 import { useDatabaseSelectorStateSnapshot } from '@/state/database-selector'
 
-export const useApiReport = () => {
+export const useApiReport = (initialParams: Partial<LogsEndpointParams>) => {
   const { ref: projectRef } = useParams()
   const useOtel = useFlag('otelLegacyLogs')
   const state = useDatabaseSelectorStateSnapshot()
@@ -30,6 +30,7 @@ export const useApiReport = () => {
 
   const totalRequests = useLogsQuery({
     projectRef,
+    initialParams,
     sql: useOtel
       ? API_REPORT_QUERIES_OTEL.totalRequests.safeSql(formattedFilters)
       : getLogsSql(PRESET_CONFIG.api.queries.totalRequests, formattedFilters),
@@ -37,6 +38,7 @@ export const useApiReport = () => {
   })
   const topRoutes = useLogsQuery({
     projectRef,
+    initialParams,
     sql: useOtel
       ? API_REPORT_QUERIES_OTEL.topRoutes.safeSql(formattedFilters)
       : getLogsSql(PRESET_CONFIG.api.queries.topRoutes, formattedFilters),
@@ -44,6 +46,7 @@ export const useApiReport = () => {
   })
   const errorCounts = useLogsQuery({
     projectRef,
+    initialParams,
     sql: useOtel
       ? API_REPORT_QUERIES_OTEL.errorCounts.safeSql(formattedFilters)
       : getLogsSql(PRESET_CONFIG.api.queries.errorCounts, formattedFilters),
@@ -51,6 +54,7 @@ export const useApiReport = () => {
   })
   const topErrorRoutes = useLogsQuery({
     projectRef,
+    initialParams,
     sql: useOtel
       ? API_REPORT_QUERIES_OTEL.topErrorRoutes.safeSql(formattedFilters)
       : getLogsSql(PRESET_CONFIG.api.queries.topErrorRoutes, formattedFilters),
@@ -58,6 +62,7 @@ export const useApiReport = () => {
   })
   const responseSpeed = useLogsQuery({
     projectRef,
+    initialParams,
     sql: useOtel
       ? API_REPORT_QUERIES_OTEL.responseSpeed.safeSql(formattedFilters)
       : getLogsSql(PRESET_CONFIG.api.queries.responseSpeed, formattedFilters),
@@ -65,6 +70,7 @@ export const useApiReport = () => {
   })
   const topSlowRoutes = useLogsQuery({
     projectRef,
+    initialParams,
     sql: useOtel
       ? API_REPORT_QUERIES_OTEL.topSlowRoutes.safeSql(formattedFilters)
       : getLogsSql(PRESET_CONFIG.api.queries.topSlowRoutes, formattedFilters),
@@ -72,6 +78,7 @@ export const useApiReport = () => {
   })
   const networkTraffic = useLogsQuery({
     projectRef,
+    initialParams,
     sql: useOtel
       ? API_REPORT_QUERIES_OTEL.networkTraffic.safeSql(formattedFilters)
       : getLogsSql(PRESET_CONFIG.api.queries.networkTraffic, formattedFilters),
@@ -79,6 +86,7 @@ export const useApiReport = () => {
   })
   const requestsByCountry = useLogsQuery({
     projectRef,
+    initialParams,
     sql: useOtel
       ? requestsByCountryOtel(formattedFilters)
       : getLogsSql(PRESET_CONFIG.api.queries.requestsByCountry, formattedFilters),

--- a/apps/studio/pages/project/[ref]/observability/api-overview.tsx
+++ b/apps/studio/pages/project/[ref]/observability/api-overview.tsx
@@ -28,7 +28,18 @@ import type { NextPageWithLayout } from '@/types'
 const REPORT_TITLE = 'API Gateway'
 
 export const ApiReport: NextPageWithLayout = () => {
-  const report = useApiReport()
+  const {
+    datePickerHelpers,
+    datePickerValue,
+    handleDatePickerChange: handleDatePickerChangeFromHook,
+    showUpgradePrompt,
+    setShowUpgradePrompt,
+  } = useReportDateRange(REPORT_DATERANGE_HELPER_LABELS.LAST_60_MINUTES)
+
+  const report = useApiReport({
+    iso_timestamp_start: datePickerValue.from,
+    iso_timestamp_end: datePickerValue.to,
+  })
 
   const {
     data,
@@ -41,14 +52,6 @@ export const ApiReport: NextPageWithLayout = () => {
     addFilter,
     refresh,
   } = report
-
-  const {
-    datePickerHelpers,
-    datePickerValue,
-    handleDatePickerChange: handleDatePickerChangeFromHook,
-    showUpgradePrompt,
-    setShowUpgradePrompt,
-  } = useReportDateRange(REPORT_DATERANGE_HELPER_LABELS.LAST_60_MINUTES)
 
   const handleDatepickerChange = useCallback(
     (vals: DatePickerValue) => {


### PR DESCRIPTION
## Problem

API overview queries default to the legacy endpoint. The report also starts queries without the date range selected by the page, causing the migrated hook to fail on initial load.

## Change

Use flag-selected shared ClickHouse builders, including requests by country, and initialize every query from the page's effective date range before the first request. Keep subsequent date changes synchronized.

Stacked on #50177, with base branch `jordi/shared-api-reports-otel`.

## Validation

- The rebuilt preview rendered populated request counts, latency, and traffic matching staging after explicitly applying the same date range in both UIs.
- Report builder and hook regressions passed as part of the 55-test focused migration suite. Local TypeScript reported no diagnostics in changed files; the full check remains blocked by existing dependency and generated-type errors. CI is ongoing.
- To reproduce, open API overview, apply matching dates in preview and staging, and compare metrics. Toggle `otelLegacyLogs` to verify flag-on uses `logs.all.otel` and flag-off preserves `logs.all`.

Split from #50173.
