### PR TITLE
fix(storage): migrate reports to clickhouse

### DIFF
--- a/apps/studio/components/interfaces/Reports/Reports.utils.otel.test.ts
+++ b/apps/studio/components/interfaces/Reports/Reports.utils.otel.test.ts
@@ -4,6 +4,7 @@ import {
   API_REPORT_QUERIES_OTEL,
   generateReportFiltersOtel,
   requestsByCountryOtel,
+  STORAGE_REPORT_QUERIES_OTEL,
 } from './Reports.utils.otel'
 
 const compact = (sql: string) => sql.replace(/\s+/g, ' ').trim()
@@ -80,5 +81,24 @@ describe('OTEL report queries', () => {
 
   it('uses the full country attribute', () => {
     expect(requestsByCountryOtel([])).toContain("log_attributes['request.cf.country'] as country")
+  })
+
+  it('returns microsecond timestamps expected by the storage cache chart', () => {
+    const sql = STORAGE_REPORT_QUERIES_OTEL.cacheHitRate.safeSql()
+    expect(sql).toContain(
+      'toUnixTimestamp64Micro(toDateTime64(toStartOfHour(logs.timestamp), 6)) as timestamp'
+    )
+    expect(sql).toContain("startsWith(log_attributes['request.path'], '/storage/v1/object')")
+    expect(sql).toContain("log_attributes['request.method'] = 'GET'")
+    expect(sql).toContain('as hit_count')
+    expect(sql).toContain('as miss_count')
+  })
+
+  it('restricts top misses to uncached storage GET requests', () => {
+    const sql = compact(STORAGE_REPORT_QUERIES_OTEL.topCacheMisses.safeSql())
+    expect(sql).toContain(
+      "log_attributes['response.headers.cf_cache_status'] in ('MISS', 'NONE/UNKNOWN', 'EXPIRED', 'BYPASS', 'DYNAMIC')"
+    )
+    expect(sql).toContain('group by path, search order by count desc limit 12')
   })
 })

--- a/apps/studio/components/interfaces/Reports/Reports.utils.otel.ts
+++ b/apps/studio/components/interfaces/Reports/Reports.utils.otel.ts
@@ -124,3 +124,36 @@ export const requestsByCountryOtel = (filters: ReportFilterItem[]) => safeSql`
   group by country
   limit 1000
 `
+
+const storageFilter = safeSql`
+  source = 'edge_logs'
+  and startsWith(log_attributes['request.path'], '/storage/v1/object')
+  and log_attributes['request.method'] = 'GET'
+`
+const cacheMiss = safeSql`log_attributes['response.headers.cf_cache_status'] in ('MISS', 'NONE/UNKNOWN', 'EXPIRED', 'BYPASS', 'DYNAMIC')`
+
+export const STORAGE_REPORT_QUERIES_OTEL = {
+  cacheHitRate: {
+    safeSql: () => safeSql`
+      select toUnixTimestamp64Micro(toDateTime64(${hour}, 6)) as timestamp,
+        toFloat64(countIf(log_attributes['response.headers.cf_cache_status'] in ('HIT', 'STALE', 'REVALIDATED', 'UPDATING'))) as hit_count,
+        toFloat64(countIf(${cacheMiss})) as miss_count
+      from logs
+      where ${storageFilter}
+      group by ${hour}
+      order by timestamp desc
+      limit 10000
+    `,
+  },
+  topCacheMisses: {
+    safeSql: () => safeSql`
+      select log_attributes['request.path'] as path, log_attributes['request.search'] as search,
+        toFloat64(count()) as count
+      from logs
+      where ${storageFilter} and ${cacheMiss}
+      group by path, search
+      order by count desc
+      limit 12
+    `,
+  },
+}

--- a/apps/studio/data/reports/storage-report-query.ts
+++ b/apps/studio/data/reports/storage-report-query.ts
@@ -13,7 +13,7 @@ import type { LogsEndpointParams } from '@/components/interfaces/Settings/Logs/L
 import { useLogsQuery } from '@/hooks/analytics/useLogsQuery'
 import { useDatabaseSelectorStateSnapshot } from '@/state/database-selector'
 
-export const useStorageReport = () => {
+export const useStorageReport = (initialParams: Partial<LogsEndpointParams>) => {
   const { ref: projectRef } = useParams()
   const useOtel = useFlag('otelLegacyLogs')
   const [filters, setFilters] = useState<ReportFilterItem[]>([])
@@ -30,6 +30,7 @@ export const useStorageReport = () => {
 
   const totalRequests = useLogsQuery({
     projectRef,
+    initialParams,
     sql: useOtel
       ? API_REPORT_QUERIES_OTEL.totalRequests.safeSql(formattedFilters)
       : getLogsSql(PRESET_CONFIG.api.queries.totalRequests, formattedFilters),
@@ -37,6 +38,7 @@ export const useStorageReport = () => {
   })
   const topRoutes = useLogsQuery({
     projectRef,
+    initialParams,
     sql: useOtel
       ? API_REPORT_QUERIES_OTEL.topRoutes.safeSql(formattedFilters)
       : getLogsSql(PRESET_CONFIG.api.queries.topRoutes, formattedFilters),
@@ -44,6 +46,7 @@ export const useStorageReport = () => {
   })
   const errorCounts = useLogsQuery({
     projectRef,
+    initialParams,
     sql: useOtel
       ? API_REPORT_QUERIES_OTEL.errorCounts.safeSql(formattedFilters)
       : getLogsSql(PRESET_CONFIG.api.queries.errorCounts, formattedFilters),
@@ -51,6 +54,7 @@ export const useStorageReport = () => {
   })
   const topErrorRoutes = useLogsQuery({
     projectRef,
+    initialParams,
     sql: useOtel
       ? API_REPORT_QUERIES_OTEL.topErrorRoutes.safeSql(formattedFilters)
       : getLogsSql(PRESET_CONFIG.api.queries.topErrorRoutes, formattedFilters),
@@ -58,6 +62,7 @@ export const useStorageReport = () => {
   })
   const responseSpeed = useLogsQuery({
     projectRef,
+    initialParams,
     sql: useOtel
       ? API_REPORT_QUERIES_OTEL.responseSpeed.safeSql(formattedFilters)
       : getLogsSql(PRESET_CONFIG.api.queries.responseSpeed, formattedFilters),
@@ -65,6 +70,7 @@ export const useStorageReport = () => {
   })
   const topSlowRoutes = useLogsQuery({
     projectRef,
+    initialParams,
     sql: useOtel
       ? API_REPORT_QUERIES_OTEL.topSlowRoutes.safeSql(formattedFilters)
       : getLogsSql(PRESET_CONFIG.api.queries.topSlowRoutes, formattedFilters),
@@ -72,6 +78,7 @@ export const useStorageReport = () => {
   })
   const networkTraffic = useLogsQuery({
     projectRef,
+    initialParams,
     sql: useOtel
       ? API_REPORT_QUERIES_OTEL.networkTraffic.safeSql(formattedFilters)
       : getLogsSql(PRESET_CONFIG.api.queries.networkTraffic, formattedFilters),
@@ -79,6 +86,7 @@ export const useStorageReport = () => {
   })
   const cacheHitRate = useLogsQuery({
     projectRef,
+    initialParams,
     sql: useOtel
       ? STORAGE_REPORT_QUERIES_OTEL.cacheHitRate.safeSql()
       : getLogsSql(PRESET_CONFIG.storage.queries.cacheHitRate, []),
@@ -86,6 +94,7 @@ export const useStorageReport = () => {
   })
   const topCacheMisses = useLogsQuery({
     projectRef,
+    initialParams,
     sql: useOtel
       ? STORAGE_REPORT_QUERIES_OTEL.topCacheMisses.safeSql()
       : getLogsSql(PRESET_CONFIG.storage.queries.topCacheMisses, []),
@@ -169,6 +178,8 @@ export const useStorageReport = () => {
       topErrorRoute: topErrorRoutes.error,
       topSlowRoutes: topSlowRoutes.error,
       networkTraffic: networkTraffic.error,
+      cacheHitRate: cacheHitRate.error,
+      topCacheMisses: topCacheMisses.error,
     },
     mergeParams: handleSetParams,
     filters,

--- a/apps/studio/data/reports/storage-report-query.ts
+++ b/apps/studio/data/reports/storage-report-query.ts
@@ -1,37 +1,96 @@
-import { useParams } from 'common'
+import { useFlag, useParams } from 'common'
 import isEqual from 'lodash/isEqual'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 
 import { PRESET_CONFIG } from '@/components/interfaces/Reports/Reports.constants'
 import { ReportFilterItem } from '@/components/interfaces/Reports/Reports.types'
-import { getLogsSql, queriesFactory } from '@/components/interfaces/Reports/Reports.utils'
+import { getLogsSql } from '@/components/interfaces/Reports/Reports.utils'
+import {
+  API_REPORT_QUERIES_OTEL,
+  STORAGE_REPORT_QUERIES_OTEL,
+} from '@/components/interfaces/Reports/Reports.utils.otel'
 import type { LogsEndpointParams } from '@/components/interfaces/Settings/Logs/Logs.types'
+import { useLogsQuery } from '@/hooks/analytics/useLogsQuery'
 import { useDatabaseSelectorStateSnapshot } from '@/state/database-selector'
 
 export const useStorageReport = () => {
   const { ref: projectRef } = useParams()
+  const useOtel = useFlag('otelLegacyLogs')
   const [filters, setFilters] = useState<ReportFilterItem[]>([])
   const state = useDatabaseSelectorStateSnapshot()
 
   const identifier = state.selectedDatabaseId
 
-  const queryHooks = queriesFactory<keyof typeof PRESET_CONFIG.api.queries>(
-    PRESET_CONFIG.api.queries,
-    projectRef ?? 'default'
-  )
-  const storageQueryHooks = queriesFactory<keyof typeof PRESET_CONFIG.storage.queries>(
-    PRESET_CONFIG.storage.queries,
-    projectRef ?? 'default'
-  )
-  const totalRequests = queryHooks.totalRequests()
-  const topRoutes = queryHooks.topRoutes()
-  const errorCounts = queryHooks.errorCounts()
-  const topErrorRoutes = queryHooks.topErrorRoutes()
-  const responseSpeed = queryHooks.responseSpeed()
-  const topSlowRoutes = queryHooks.topSlowRoutes()
-  const networkTraffic = queryHooks.networkTraffic()
-  const cacheHitRate = storageQueryHooks.cacheHitRate()
-  const topCacheMisses = storageQueryHooks.topCacheMisses()
+  const formattedFilters: ReportFilterItem[] = [
+    ...filters,
+    ...(identifier !== undefined
+      ? [{ key: 'identifier', value: identifier, compare: 'is' } as ReportFilterItem]
+      : []),
+  ]
+
+  const totalRequests = useLogsQuery({
+    projectRef,
+    sql: useOtel
+      ? API_REPORT_QUERIES_OTEL.totalRequests.safeSql(formattedFilters)
+      : getLogsSql(PRESET_CONFIG.api.queries.totalRequests, formattedFilters),
+    options: { useOtel },
+  })
+  const topRoutes = useLogsQuery({
+    projectRef,
+    sql: useOtel
+      ? API_REPORT_QUERIES_OTEL.topRoutes.safeSql(formattedFilters)
+      : getLogsSql(PRESET_CONFIG.api.queries.topRoutes, formattedFilters),
+    options: { useOtel },
+  })
+  const errorCounts = useLogsQuery({
+    projectRef,
+    sql: useOtel
+      ? API_REPORT_QUERIES_OTEL.errorCounts.safeSql(formattedFilters)
+      : getLogsSql(PRESET_CONFIG.api.queries.errorCounts, formattedFilters),
+    options: { useOtel },
+  })
+  const topErrorRoutes = useLogsQuery({
+    projectRef,
+    sql: useOtel
+      ? API_REPORT_QUERIES_OTEL.topErrorRoutes.safeSql(formattedFilters)
+      : getLogsSql(PRESET_CONFIG.api.queries.topErrorRoutes, formattedFilters),
+    options: { useOtel },
+  })
+  const responseSpeed = useLogsQuery({
+    projectRef,
+    sql: useOtel
+      ? API_REPORT_QUERIES_OTEL.responseSpeed.safeSql(formattedFilters)
+      : getLogsSql(PRESET_CONFIG.api.queries.responseSpeed, formattedFilters),
+    options: { useOtel },
+  })
+  const topSlowRoutes = useLogsQuery({
+    projectRef,
+    sql: useOtel
+      ? API_REPORT_QUERIES_OTEL.topSlowRoutes.safeSql(formattedFilters)
+      : getLogsSql(PRESET_CONFIG.api.queries.topSlowRoutes, formattedFilters),
+    options: { useOtel },
+  })
+  const networkTraffic = useLogsQuery({
+    projectRef,
+    sql: useOtel
+      ? API_REPORT_QUERIES_OTEL.networkTraffic.safeSql(formattedFilters)
+      : getLogsSql(PRESET_CONFIG.api.queries.networkTraffic, formattedFilters),
+    options: { useOtel },
+  })
+  const cacheHitRate = useLogsQuery({
+    projectRef,
+    sql: useOtel
+      ? STORAGE_REPORT_QUERIES_OTEL.cacheHitRate.safeSql()
+      : getLogsSql(PRESET_CONFIG.storage.queries.cacheHitRate, []),
+    options: { useOtel },
+  })
+  const topCacheMisses = useLogsQuery({
+    projectRef,
+    sql: useOtel
+      ? STORAGE_REPORT_QUERIES_OTEL.topCacheMisses.safeSql()
+      : getLogsSql(PRESET_CONFIG.storage.queries.topCacheMisses, []),
+    options: { useOtel },
+  })
   const activeHooks = [
     totalRequests,
     topRoutes,
@@ -76,58 +135,6 @@ export const useStorageReport = () => {
       return prev.filter((f) => !toRemove.find((r) => isEqual(f, r)))
     })
   }
-
-  const formattedFilters: ReportFilterItem[] = [
-    ...filters,
-    ...(identifier !== undefined
-      ? [{ key: 'identifier', value: identifier, compare: 'is' } as ReportFilterItem]
-      : []),
-  ]
-
-  useEffect(() => {
-    if (totalRequests.changeQuery) {
-      totalRequests.changeQuery(
-        getLogsSql(PRESET_CONFIG.api.queries.totalRequests, formattedFilters)
-      )
-    }
-    if (topRoutes.changeQuery) {
-      topRoutes.changeQuery(getLogsSql(PRESET_CONFIG.api.queries.topRoutes, formattedFilters))
-    }
-    if (errorCounts.changeQuery) {
-      errorCounts.changeQuery(getLogsSql(PRESET_CONFIG.api.queries.errorCounts, formattedFilters))
-    }
-
-    if (topErrorRoutes.changeQuery) {
-      topErrorRoutes.changeQuery(
-        getLogsSql(PRESET_CONFIG.api.queries.topErrorRoutes, formattedFilters)
-      )
-    }
-    if (responseSpeed.changeQuery) {
-      responseSpeed.changeQuery(
-        getLogsSql(PRESET_CONFIG.api.queries.responseSpeed, formattedFilters)
-      )
-    }
-
-    if (topSlowRoutes.changeQuery) {
-      topSlowRoutes.changeQuery(
-        getLogsSql(PRESET_CONFIG.api.queries.topSlowRoutes, formattedFilters)
-      )
-    }
-
-    if (networkTraffic.changeQuery) {
-      networkTraffic.changeQuery(
-        getLogsSql(PRESET_CONFIG.api.queries.networkTraffic, formattedFilters)
-      )
-    }
-
-    if (cacheHitRate.changeQuery) {
-      cacheHitRate.changeQuery(getLogsSql(PRESET_CONFIG.storage.queries.cacheHitRate, []))
-    }
-
-    if (topCacheMisses.changeQuery) {
-      topCacheMisses.changeQuery(getLogsSql(PRESET_CONFIG.storage.queries.topCacheMisses, []))
-    }
-  }, [JSON.stringify(formattedFilters)])
 
   const isLoading = activeHooks.some((hook) => hook.isLoading)
 

--- a/apps/studio/pages/project/[ref]/observability/storage.tsx
+++ b/apps/studio/pages/project/[ref]/observability/storage.tsx
@@ -41,7 +41,19 @@ import type { NextPageWithLayout } from '@/types'
 const REPORT_TITLE = 'Storage'
 
 export const StorageReport: NextPageWithLayout = () => {
-  const report = useStorageReport()
+  const {
+    datePickerHelpers,
+    datePickerValue,
+    handleDatePickerChange: handleDatePickerChangeFromHook,
+    showUpgradePrompt,
+    setShowUpgradePrompt,
+    selectedDateRange,
+  } = useReportDateRange(REPORT_DATERANGE_HELPER_LABELS.LAST_60_MINUTES)
+
+  const report = useStorageReport({
+    iso_timestamp_start: datePickerValue.from,
+    iso_timestamp_end: datePickerValue.to,
+  })
 
   const {
     data,
@@ -54,15 +66,6 @@ export const StorageReport: NextPageWithLayout = () => {
     addFilter,
     refresh,
   } = report
-
-  const {
-    datePickerHelpers,
-    datePickerValue,
-    handleDatePickerChange: handleDatePickerChangeFromHook,
-    showUpgradePrompt,
-    setShowUpgradePrompt,
-    selectedDateRange,
-  } = useReportDateRange(REPORT_DATERANGE_HELPER_LABELS.LAST_60_MINUTES)
 
   const handleDatepickerChange = (vals: DatePickerValue) => {
     const promptShown = handleDatePickerChangeFromHook(vals)


### PR DESCRIPTION
## Problem

Storage reports default to the legacy endpoint and start queries without the page's selected date range. Cache-query errors are omitted from the report's error state.

## Change

Use flag-selected shared API queries and ClickHouse cache-hit/cache-miss builders. Initialize every query from the effective page date range, keep date changes synchronized, and surface cache-query errors. Preserve microsecond timestamps and numeric aggregate output.

Stacked on #50178, with base branch `jordi/api-overview-otel`.

## Validation

- The rebuilt preview rendered populated request counts, latency, and traffic matching staging after explicitly applying the same date range in both UIs. An upload/download check produced a populated cache-miss row in the rebuilt preview; the temporary object was removed afterward.
- Storage cache builders and hook regressions passed as part of the 55-test focused migration suite. Local TypeScript reported no diagnostics in changed files; the full check remains blocked by existing dependency and generated-type errors. CI is ongoing.
- To reproduce, open Storage reports, apply matching dates in preview and staging, and compare API and cache metrics. Toggle `otelLegacyLogs` to verify flag-on uses `logs.all.otel` and flag-off preserves `logs.all`.

Split from #50173.

