### PR TITLE
fix(studio): update Swift package URL to official supabase org

### DIFF
--- a/apps/studio/components/interfaces/ConnectSheet/connect.schema.ts
+++ b/apps/studio/components/interfaces/ConnectSheet/connect.schema.ts
@@ -34,8 +34,7 @@ export const INSTALL_COMMANDS: Record<string, string> = {
   supabasejs: 'npm install @supabase/supabase-js',
   supabasepy: 'pip install supabase',
   supabaseflutter: 'flutter pub add supabase_flutter',
-  supabaseswift:
-    'swift package add-dependency https://github.com/supabase-community/supabase-swift',
+  supabaseswift: 'swift package add-dependency https://github.com/supabase/supabase-swift',
   supabasekt: 'implementation("io.github.jan-tennert.supabase:supabase-kt:VERSION")',
 }
 


### PR DESCRIPTION
## Summary
- The Studio Connect sheet's Swift install command pointed at `supabase-community/supabase-swift`, which is no longer where the package lives — it's now official under `supabase/supabase-swift`.
- Updated the URL in `INSTALL_COMMANDS.supabaseswift`.

## Test plan
- [x] Verified no other references to the old URL remain in Studio code (translated top-level READMEs under `i18n/` also reference the old URL but are out of scope for this fix)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the Swift installation command to reference the official Supabase Swift repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->