### PR TITLE
fix(www): careers page error

### DIFF
--- a/apps/www/pages/careers.tsx
+++ b/apps/www/pages/careers.tsx
@@ -96,7 +96,11 @@ interface CareersPageProps {
   contributors: { login: string; avatar_url: string; html_url: string }[]
 }
 
-const CareerPage = ({ jobs, placeholderJob, contributors }: CareersPageProps) => {
+const CareerPage = ({
+  jobs = {},
+  placeholderJob = null,
+  contributors = [],
+}: Partial<CareersPageProps>) => {
   const { basePath } = useRouter()
   const { jobsCount } = staticContent
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

bug fix careers page on anchor link click

## What is the current behavior?

on `/careers`, clicking "open positions", scrolling down and back up, then clicking it again crashes the page

## What is the new behavior?

destructuring defaults on the page props, so an empty-props render is harmless instead of fatal _ prefetch still returns `{}`, but the sequence now renders normally instead of throwin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the careers page so it renders correctly when job listings, placeholder job details, or contributor information are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->