### PR TITLE
fix(docs): prima guide yarn panel display npx

### DIFF
--- a/apps/docs/content/guides/database/prisma.mdx
+++ b/apps/docs/content/guides/database/prisma.mdx
@@ -103,9 +103,9 @@ If you plan to solely use Prisma instead of the Supabase Data API (PostgREST), t
               yarn add prisma tsx @types/pg --save-dev
               yarn add @prisma/client @prisma/adapter-pg dotenv pg
 
-              npx tsc --init
+              yarn tsc --init
 
-              npx prisma init
+              yarn prisma init
               ```
             </TabPanel>
             <TabPanel id="bun_initiate" label="bun">
@@ -285,8 +285,8 @@ If you plan to solely use Prisma instead of the Supabase Data API (PostgREST), t
             </TabPanel>
             <TabPanel id="yarn_migrate" label="yarn">
             ```bash
-            npx prisma migrate dev --name first_prisma_migration
-            npx prisma generate
+            yarn prisma migrate dev --name first_prisma_migration
+            yarn prisma generate
             ```
             </TabPanel>
             <TabPanel id="bun_migrate" label="bun">
@@ -368,7 +368,7 @@ If you plan to solely use Prisma instead of the Supabase Data API (PostgREST), t
 
           <TabPanel id="yarn_sync" label="yarn">
             ```bash
-            npx prisma db pull
+            yarn prisma db pull
             ```
 
             Create a migration file
@@ -378,7 +378,7 @@ If you plan to solely use Prisma instead of the Supabase Data API (PostgREST), t
 
             Synchronize the migrations
             ```bash
-              npx prisma migrate diff \
+              yarn prisma migrate diff \
               --from-empty \
               --to-schema prisma/schema.prisma \
               --script > prisma/migrations/0_init_supabase/migration.sql
@@ -390,8 +390,8 @@ If you plan to solely use Prisma instead of the Supabase Data API (PostgREST), t
             </Admonition>
 
             ```bash
-            npx prisma migrate resolve --applied 0_init_supabase
-            npx prisma generate
+            yarn prisma migrate resolve --applied 0_init_supabase
+            yarn prisma generate
             ```
           </TabPanel>
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

bug fix in prisma guide page code example

## What is the current behavior?

yarn panel display `npx` command in code example

## What is the new behavior?

favor `yarn` command in yarn panel code example

| state | preview |
| -------|------|
| before | <img width="760" height="315" alt="image" src="https://github.com/user-attachments/assets/d7dc9004-9618-48ff-9b6c-4b7da4e8c44e" /> |
| after | <img width="760" height="315" alt="image" src="https://github.com/user-attachments/assets/a7cee65f-2038-4f5a-81e3-1cb627cb73b9" /> | 

## Test
1. visit `/docs/guides/database/prisma`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Yarn Prisma command examples to use Yarn-specific syntax for project initialization, migrations, database pulls, migration diffs, migration resolution, and client generation.
  * npm, pnpm, and Bun examples remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->