### PR TITLE
fix: update inbound links to the pooling guide

### DIFF
--- a/apps/studio/components/interfaces/ConnectSheet/Connect.constants.ts
+++ b/apps/studio/components/interfaces/ConnectSheet/Connect.constants.ts
@@ -369,7 +369,7 @@ export const ORMS: ConnectionType[] = [
     key: 'drizzle',
     label: 'Drizzle',
     icon: 'drizzle',
-    guideLink: `${DOCS_URL}/guides/database/connecting-to-postgres#connecting-with-drizzle`,
+    guideLink: `${DOCS_URL}/guides/database/drizzle`,
     children: [],
   },
 ]

--- a/apps/studio/components/interfaces/Settings/Database/ConnectionPooling/ConnectionPooling.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/ConnectionPooling/ConnectionPooling.tsx
@@ -165,7 +165,7 @@ export const ConnectionPooling = () => {
         </PageSectionSummary>
         <PageSectionAside>
           <DocsButton
-            href={`${DOCS_URL}/guides/database/connecting-to-postgres#connection-pooler`}
+            href={`${DOCS_URL}/guides/database/connecting-to-postgres/pooling-and-limits#how-connection-pooling-works`}
           />
         </PageSectionAside>
       </PageSectionMeta>

--- a/apps/studio/components/interfaces/Settings/Database/PoolingModesModal.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/PoolingModesModal.tsx
@@ -51,7 +51,7 @@ export const PoolingModesModal = () => {
             <div className="w-full flex items-center justify-between">
               <p className="max-w-2xl">Which pooling mode should I use?</p>
               <DocsButton
-                href={`${DOCS_URL}/guides/database/connecting-to-postgres#how-connection-pooling-works`}
+                href={`${DOCS_URL}/guides/database/connecting-to-postgres/pooling-and-limits#how-connection-pooling-works`}
               />
             </div>
           </DialogTitle>

--- a/apps/www/_alternatives/supabase-vs-heroku-postgres.mdx
+++ b/apps/www/_alternatives/supabase-vs-heroku-postgres.mdx
@@ -21,7 +21,7 @@ Supabase also offers managed Postgres, the main difference is that with each dep
 - Auth - [users can log in and out of your application](https://supabase.com/auth)
 - Functions - [deploy custom logic to the edge](https://supabase.com/edge-functions)
 - Storage - [serve large files and folders](https://supabase.com/storage)
-- Supavisor - [connection pooling useful for serverless computing](https://supabase.com/docs/guides/database/connecting-to-postgres#connection-pooler)
+- Supavisor - [connection pooling useful for serverless computing](https://supabase.com/docs/guides/database/connecting-to-postgres/pooling-and-limits#how-connection-pooling-works)
 
 ## How are they similar?
 
@@ -42,7 +42,7 @@ Heroku Postgres and Supabase both offer:
 These are some of the key differences between Heroku Postgres and Supabase in terms of features:
 
 - Supabase is more than just the raw database, it also comes with:
-  - [Connection pooling](https://supabase.com/docs/guides/database/connecting-to-postgres#connection-pool) so that you won’t run out of connections in a serverless environment.
+  - [Connection pooling](https://supabase.com/docs/guides/database/connecting-to-postgres/pooling-and-limits#how-connection-pooling-works) so that you won’t run out of connections in a serverless environment.
   - [Auto-generated APIs](https://supabase.com/docs/guides/api#rest-api-overview) based on your schema, so you can communicate with your database directly from the client.
   - [Realtime API](https://supabase.com/docs/reference/dart/subscribe) is useful for when you want to subscribe to changes to your database over websockets.
   - [Auth API](https://supabase.com/auth) can be used to leverage Postgres’s Row Level Security model, and control access to sensitive data on a per user, or per group level.

--- a/apps/www/_blog/2023-08-11-supavisor-1-million.mdx
+++ b/apps/www/_blog/2023-08-11-supavisor-1-million.mdx
@@ -17,7 +17,7 @@ imgThumb: launch-week-8/day-5/supavisor-thumb.jpg
 
 One of the most [widely-discussed shortcomings](https://news.ycombinator.com/item?id=24735012) of Postgres is it's connection system. Every Postgres connection has a reasonably high memory footprint, and determining the maximum number of connections your database can handle is a [bit of an art](https://momjian.us/main/blogs/pgblog/2020.html#April_22_2020).
 
-A common solution is [connection pooling](https://supabase.com/docs/guides/database/connecting-to-postgres#how-connection-pooling-works). Supabase currently offers [pgbouncer](http://www.pgbouncer.org/) which is single-threaded, making it difficult to scale. We've seen some [novel ways](https://twitter.com/viggy28/status/1677674197664038912?s=12&t=_WCn3v_QJ7tkQLvOvkZkqg) to scale pgbouncer, but we have a [few other goals](https://github.com/supabase/supavisor#motivation) in mind for our platform.
+A common solution is [connection pooling](https://supabase.com/docs/guides/database/connecting-to-postgres/pooling-and-limits#how-connection-pooling-works). Supabase currently offers [pgbouncer](http://www.pgbouncer.org/) which is single-threaded, making it difficult to scale. We've seen some [novel ways](https://twitter.com/viggy28/status/1677674197664038912?s=12&t=_WCn3v_QJ7tkQLvOvkZkqg) to scale pgbouncer, but we have a [few other goals](https://github.com/supabase/supavisor#motivation) in mind for our platform.
 
 And so we've built [Supavisor](https://github.com/supabase/supavisor), a Postgres connection pooler that can handle millions of connections.
 

--- a/apps/www/_blog/2024-01-16-ipv6.mdx
+++ b/apps/www/_blog/2024-01-16-ipv6.mdx
@@ -54,7 +54,7 @@ After your ISP receives this address, it is responsible for routing all traffic 
 Here are some of the ways that you will be affected when domains/servers start resolving to IPv6 instead of IPv4, if your ISP doesn't support IPv6:
 
 - Do you have a web server set up in AWS? You won't be able to SSH into it.
-- Are you connected to a Supabase database from your local machine using the [direct connection](https://supabase.com/docs/guides/database/connecting-to-postgres#direct-connections)? You need to use the [connection pooler](https://supabase.com/docs/guides/database/connecting-to-postgres#connection-pooler) which will resolve as IPv4 instead (we will pay for IPv4 addresses on these).
+- Are you connected to a Supabase database from your local machine using the [direct connection](https://supabase.com/docs/guides/database/connecting-to-postgres#direct-connection)? You need to use the [connection pooler](https://supabase.com/docs/guides/database/connecting-to-postgres/pooling-and-limits#how-connection-pooling-works) which will resolve as IPv4 instead (we will pay for IPv4 addresses on these).
 - Are you connecting to any AWS server from Vercel? That will start [failing](https://github.com/orgs/vercel/discussions/47) soon if you don't set up an IPv4 address for that server.
 
 ## Tooling support

--- a/apps/www/_blog/2025-03-07-dedicated-poolers.mdx
+++ b/apps/www/_blog/2025-03-07-dedicated-poolers.mdx
@@ -17,7 +17,7 @@ Today we're announcing **Dedicated Poolers** - a Postgres connection pooler that
 
 <Admonition type="info">
 
-Don't know what a Pooler is? Check out our [docs](/docs/guides/database/connecting-to-postgres#serverside-poolers).
+Don't know what a Pooler is? Check out our [docs](/docs/guides/database/connecting-to-postgres/pooling-and-limits#how-connection-pooling-works).
 
 </Admonition>
 

--- a/apps/www/data/features.tsx
+++ b/apps/www/data/features.tsx
@@ -600,7 +600,8 @@ Dedicated Poolers provide an alternative to Supavisor for specific use cases, gi
     icon: Database,
     products: [PRODUCT_SHORTNAMES.DATABASE],
     heroImage: '',
-    docsUrl: 'https://supabase.com/docs/guides/database/connecting-to-postgres#serverside-poolers',
+    docsUrl:
+      'https://supabase.com/docs/guides/database/connecting-to-postgres/pooling-and-limits#shared-pooler',
     slug: 'dedicated-poolers',
     status: {
       stage: PRODUCT_STAGES.GA,


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix. Link string changes only, no content changes.

## What is the current behavior?

Nine inbound links in `apps/www` and `apps/studio` point at anchors on the connecting to Postgres guide that don't exist. All nine are already broken on production today: `#connection-pooler`, `#connection-pool`, `#how-connection-pooling-works`, `#serverside-poolers`, and `#connecting-with-drizzle` are all missing from the live page.

#49869 moves the pooling content to a child page, so these links need current destinations either way.

## What is the new behavior?

Point each link at the page that holds the content now.

- **Studio, 3 links.** The Connect sheet's Drizzle link goes to the Drizzle guide. The connection pooling and pooling modes links go to `pooling-and-limits#how-connection-pooling-works`.
- **www, 6 links.** Three blog posts, the Heroku comparison page, and the Dedicated poolers feature entry go to `pooling-and-limits`. The feature entry uses `#shared-pooler`.

## Additional context

Split out of #49869. These paths belong to `@supabase/marketing` and `@supabase/Dashboard` in CODEOWNERS, and pulling both teams into a docs-only restructure for nine link strings isn't a good trade.

Merge after #49928. The destinations don't exist on production until the docs pages land.

## Manual testing

1. Open [Supavisor: Scaling Postgres to 1 Million Connections](https://zone-www-dot-com-git-fix-pooler-docs-links-supabase.vercel.app/blog/supavisor-1-million). The "connection pooling" link in the opening paragraph resolves to `connecting-to-postgres/pooling-and-limits#how-connection-pooling-works`.
2. Open [Dedicated poolers](https://zone-www-dot-com-git-fix-pooler-docs-links-supabase.vercel.app/features/dedicated-poolers). The docs link resolves to `pooling-and-limits#shared-pooler`.
3. Open [Supabase vs Heroku Postgres](https://zone-www-dot-com-git-fix-pooler-docs-links-supabase.vercel.app/alternatives/supabase-vs-heroku-postgres). Both connection pooling links resolve to `pooling-and-limits#how-connection-pooling-works`.
4. Open [Connection pooling and limits](https://docs-git-docs-connecting-to-postgres-technical-supabase.vercel.app/docs/guides/database/connecting-to-postgres/pooling-and-limits) on the #49928 docs preview. The `how-connection-pooling-works` and `shared-pooler` headings both render with those IDs.
5. Open the Connect dialog on any project. Under Drizzle, the docs link opens the Drizzle guide.
6. Open Database settings, then Connection pooling. The pooler link opens Connection pooling and limits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated connection pooling links across Studio, product pages, blogs, and comparison content to point to the relevant pooling guidance.
  * Refined links for Drizzle ORM, dedicated poolers, direct connections, and shared poolers.
  * Improved navigation to specific documentation sections explaining connection pooling modes and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->