### PR TITLE
docs: Clarify private flag for broadcast from database

### DIFF
--- a/apps/docs/content/guides/realtime/broadcast.mdx
+++ b/apps/docs/content/guides/realtime/broadcast.mdx
@@ -510,7 +510,7 @@ select
     jsonb_build_object('hello', 'world'), -- JSONB Payload
     'event', -- Event name
     'topic', -- Topic
-    false -- Public / Private flag
+    false    -- Private flag - true: Private (default), false: Public
   );
 ```
 
@@ -531,7 +531,7 @@ select
     '\x012345'::bytea, -- bytea payload
     'event',           -- Event name
     'topic',           -- Topic
-    true               -- Private / Public flag (defaults to true)
+    true               -- Private flag - true: Private (default), false: Public
   );
 ```
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Doc update

## What is the current behavior?

The description of the private flag for broadcast from database functions is inconsistent and a bit confusing.

## What is the new behavior?

Use the same language on both examples and clarify the default, and what true and false map to.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the meaning of boolean privacy flags in realtime SQL examples: `true` indicates Private (the default), while `false` indicates Public.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->