### PR TITLE
Add copy notebook as markdown action

### DIFF
--- a/apps/studio/components/interfaces/Explorer/ExplorerNotebookTab.tsx
+++ b/apps/studio/components/interfaces/Explorer/ExplorerNotebookTab.tsx
@@ -315,15 +315,20 @@ export const ExplorerNotebookTab = () => {
     }
   }
 
-  const handleCopyAsMarkdown = () => {
-    copyToClipboard(
-      notebookToMarkdown({
-        name: name ?? '',
-        cells,
-        getResult: (cellId) => queryCellRefs.current.get(cellId)?.getResult(),
-      }),
-      () => toast.success('Copied notebook as Markdown to clipboard')
-    )
+  const handleCopyAsMarkdown = async () => {
+    try {
+      await copyToClipboard(
+        notebookToMarkdown({
+          name: name ?? '',
+          cells,
+          getResult: (cellId) => queryCellRefs.current.get(cellId)?.getResult(),
+        }),
+        () => toast.success('Copied notebook as Markdown to clipboard')
+      )
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err)
+      toast.error('Failed to copy notebook as Markdown: ' + message)
+    }
   }
 
   const handleConfirmDeleteNotebook = () => {

--- a/apps/studio/components/interfaces/Explorer/ExplorerNotebookTab.tsx
+++ b/apps/studio/components/interfaces/Explorer/ExplorerNotebookTab.tsx
@@ -316,8 +316,13 @@ export const ExplorerNotebookTab = () => {
   }
 
   const handleCopyAsMarkdown = () => {
-    copyToClipboard(notebookToMarkdown({ name: name ?? '', cells }), () =>
-      toast.success('Copied notebook as Markdown to clipboard')
+    copyToClipboard(
+      notebookToMarkdown({
+        name: name ?? '',
+        cells,
+        getResult: (cellId) => queryCellRefs.current.get(cellId)?.getResult(),
+      }),
+      () => toast.success('Copied notebook as Markdown to clipboard')
     )
   }
 

--- a/apps/studio/components/interfaces/Explorer/ExplorerNotebookTab.tsx
+++ b/apps/studio/components/interfaces/Explorer/ExplorerNotebookTab.tsx
@@ -16,6 +16,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { LOCAL_STORAGE_KEYS, useParams } from 'common'
 import {
   Check,
+  Copy,
   FileText,
   Keyboard,
   Loader2,
@@ -36,6 +37,7 @@ import {
   Badge,
   Button,
   Checkbox,
+  copyToClipboard,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -49,6 +51,7 @@ import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import {
   findQueryCellsMatchingSql,
   isMutatingSql,
+  notebookToMarkdown,
   type QueryCellSummary,
 } from './ExplorerNotebookTab.utils'
 import {
@@ -312,6 +315,12 @@ export const ExplorerNotebookTab = () => {
     }
   }
 
+  const handleCopyAsMarkdown = () => {
+    copyToClipboard(notebookToMarkdown({ name: name ?? '', cells }), () =>
+      toast.success('Copied notebook as Markdown to clipboard')
+    )
+  }
+
   const handleConfirmDeleteNotebook = () => {
     if (!ref || !id) return
     deleteNotebook({ projectRef: ref, ids: [id] })
@@ -418,6 +427,10 @@ export const ExplorerNotebookTab = () => {
                     <span>Intellisense enabled</span>
                   </div>
                   {isIntellisenseEnabled && <Check className="text-brand" size={16} />}
+                </DropdownMenuItem>
+                <DropdownMenuItem className="gap-x-2" onClick={handleCopyAsMarkdown}>
+                  <Copy size={14} />
+                  <span>Copy as Markdown</span>
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem className="gap-x-2" onClick={() => setIsDeleteModalOpen(true)}>

--- a/apps/studio/components/interfaces/Explorer/ExplorerNotebookTab.utils.test.ts
+++ b/apps/studio/components/interfaces/Explorer/ExplorerNotebookTab.utils.test.ts
@@ -1,10 +1,16 @@
 import { untrustedSql } from '@supabase/pg-meta'
+import dayjs from 'dayjs'
 import { describe, expect, it } from 'vitest'
 
-import { findQueryCellsMatchingSql, isMutatingSql } from './ExplorerNotebookTab.utils'
+import {
+  findQueryCellsMatchingSql,
+  isMutatingSql,
+  notebookToMarkdown,
+} from './ExplorerNotebookTab.utils'
 import { checkDestructiveQuery } from '@/components/interfaces/SQLEditor/SQLEditor.utils'
 import { type Cell } from '@/data/content/notebooks/notebook-schema'
 import { untrustedLogSql } from '@/data/logs/safe-analytics-sql'
+import { isoDateTimeString } from '@/lib/iso-datetime'
 
 describe('isMutatingSql', () => {
   it('returns false for a read-only query', () => {
@@ -190,5 +196,77 @@ describe('findQueryCellsMatchingSql', () => {
         matchers: { destructiveQueries: checkDestructiveQuery },
       }).destructiveQueries
     ).toEqual([{ id: 'cell-1', title: 'Signups' }])
+  })
+})
+
+describe('notebookToMarkdown', () => {
+  const markdownCell: Cell = {
+    _tag: 'markdown_cell',
+    _id: 'cell-1',
+    text: '## Notes\n\nSome context here.',
+  }
+
+  const databaseCell: Cell = {
+    _tag: 'database_cell',
+    _id: 'cell-2',
+    title: 'Signups',
+    view: 'table',
+    unchecked_sql: untrustedSql('select * from auth.users'),
+    row_limit: 50,
+  }
+
+  const relativeLogCell: Cell = {
+    _tag: 'log_cell',
+    _id: 'cell-3',
+    title: 'Edge errors',
+    view: 'table',
+    unchecked_sql: untrustedLogSql("select * from edge_logs where status_code >= 500"),
+    time_range: { _tag: 'relative_time_range', unit: 'hour', amount: 24 },
+  }
+
+  const absoluteRangeStart = isoDateTimeString('2026-01-01T00:00:00.000Z')!
+  const absoluteRangeEnd = isoDateTimeString('2026-01-02T00:00:00.000Z')!
+
+  const absoluteLogCell: Cell = {
+    _tag: 'log_cell',
+    _id: 'cell-4',
+    title: undefined,
+    view: 'table',
+    unchecked_sql: untrustedLogSql('select * from postgres_logs'),
+    time_range: {
+      _tag: 'absolute_time_range',
+      start: absoluteRangeStart,
+      end: absoluteRangeEnd,
+    },
+  }
+
+  it('renders the notebook name as a heading followed by each cell in order', () => {
+    const result = notebookToMarkdown({ name: 'My notebook', cells: [markdownCell, databaseCell] })
+
+    expect(result).toBe(
+      [
+        '# My notebook',
+        '## Notes\n\nSome context here.',
+        '### Signups (Postgres)\n\n```sql\nselect * from auth.users\n```',
+      ].join('\n\n')
+    )
+  })
+
+  it('falls back to "Untitled query" when a query cell has no title', () => {
+    const result = notebookToMarkdown({ name: 'Notebook', cells: [absoluteLogCell] })
+    expect(result).toContain('### Untitled query (Logs — ClickHouse)')
+  })
+
+  it('labels a relative time range in plain English', () => {
+    const result = notebookToMarkdown({ name: 'Notebook', cells: [relativeLogCell] })
+    expect(result).toContain('_Time range: Last 24 hours_')
+  })
+
+  it('formats an absolute time range as a start → end pair in local time', () => {
+    const result = notebookToMarkdown({ name: 'Notebook', cells: [absoluteLogCell] })
+    const expectedBound = (value: string) => dayjs(value).format('MMM D, YYYY h:mm A')
+    expect(result).toContain(
+      `_Time range: ${expectedBound(absoluteRangeStart)} → ${expectedBound(absoluteRangeEnd)}_`
+    )
   })
 })

--- a/apps/studio/components/interfaces/Explorer/ExplorerNotebookTab.utils.test.ts
+++ b/apps/studio/components/interfaces/Explorer/ExplorerNotebookTab.utils.test.ts
@@ -269,4 +269,47 @@ describe('notebookToMarkdown', () => {
       `_Time range: ${expectedBound(absoluteRangeStart)} → ${expectedBound(absoluteRangeEnd)}_`
     )
   })
+
+  it('omits the results section when the cell has not been run this session', () => {
+    const result = notebookToMarkdown({
+      name: 'Notebook',
+      cells: [databaseCell],
+      getResult: () => undefined,
+    })
+    expect(result).not.toContain('**Results:**')
+    expect(result).not.toContain('**Error:**')
+  })
+
+  it('renders the last result as a markdown table when present', () => {
+    const result = notebookToMarkdown({
+      name: 'Notebook',
+      cells: [databaseCell],
+      getResult: (cellId) =>
+        cellId === 'cell-2' ? { rows: [{ id: 1, email: 'a@example.com' }] } : undefined,
+    })
+
+    expect(result).toContain(
+      '**Results:**\n\n| id | email         |\n| -- | ------------- |\n| 1  | a@example.com |'
+    )
+  })
+
+  it('omits the results section when the cell ran but returned no rows', () => {
+    const result = notebookToMarkdown({
+      name: 'Notebook',
+      cells: [databaseCell],
+      getResult: () => ({ rows: [] }),
+    })
+    expect(result).not.toContain('**Results:**')
+  })
+
+  it('shows the error instead of a results table when the last run failed', () => {
+    const result = notebookToMarkdown({
+      name: 'Notebook',
+      cells: [databaseCell],
+      getResult: () => ({ error: { message: 'relation "foo" does not exist' } }),
+    })
+
+    expect(result).toContain('**Error:** relation "foo" does not exist')
+    expect(result).not.toContain('**Results:**')
+  })
 })

--- a/apps/studio/components/interfaces/Explorer/ExplorerNotebookTab.utils.test.ts
+++ b/apps/studio/components/interfaces/Explorer/ExplorerNotebookTab.utils.test.ts
@@ -220,7 +220,7 @@ describe('notebookToMarkdown', () => {
     _id: 'cell-3',
     title: 'Edge errors',
     view: 'table',
-    unchecked_sql: untrustedLogSql("select * from edge_logs where status_code >= 500"),
+    unchecked_sql: untrustedLogSql('select * from edge_logs where status_code >= 500'),
     time_range: { _tag: 'relative_time_range', unit: 'hour', amount: 24 },
   }
 

--- a/apps/studio/components/interfaces/Explorer/ExplorerNotebookTab.utils.test.ts
+++ b/apps/studio/components/interfaces/Explorer/ExplorerNotebookTab.utils.test.ts
@@ -285,7 +285,9 @@ describe('notebookToMarkdown', () => {
       name: 'Notebook',
       cells: [databaseCell],
       getResult: (cellId) =>
-        cellId === 'cell-2' ? { rows: [{ id: 1, email: 'a@example.com' }] } : undefined,
+        cellId === 'cell-2'
+          ? { sql: databaseCell.unchecked_sql, rows: [{ id: 1, email: 'a@example.com' }] }
+          : undefined,
     })
 
     expect(result).toContain(
@@ -297,7 +299,7 @@ describe('notebookToMarkdown', () => {
     const result = notebookToMarkdown({
       name: 'Notebook',
       cells: [databaseCell],
-      getResult: () => ({ rows: [] }),
+      getResult: () => ({ sql: databaseCell.unchecked_sql, rows: [] }),
     })
     expect(result).not.toContain('**Results:**')
   })
@@ -306,10 +308,23 @@ describe('notebookToMarkdown', () => {
     const result = notebookToMarkdown({
       name: 'Notebook',
       cells: [databaseCell],
-      getResult: () => ({ error: { message: 'relation "foo" does not exist' } }),
+      getResult: () => ({
+        sql: databaseCell.unchecked_sql,
+        error: { message: 'relation "foo" does not exist' },
+      }),
     })
 
     expect(result).toContain('**Error:** relation "foo" does not exist')
+    expect(result).not.toContain('**Results:**')
+  })
+
+  it('omits a stale result whose recorded SQL no longer matches the cell', () => {
+    const result = notebookToMarkdown({
+      name: 'Notebook',
+      cells: [databaseCell],
+      getResult: () => ({ sql: 'select * from auth.identities', rows: [{ id: 1 }] }),
+    })
+
     expect(result).not.toContain('**Results:**')
   })
 

--- a/apps/studio/components/interfaces/Explorer/ExplorerNotebookTab.utils.test.ts
+++ b/apps/studio/components/interfaces/Explorer/ExplorerNotebookTab.utils.test.ts
@@ -312,4 +312,16 @@ describe('notebookToMarkdown', () => {
     expect(result).toContain('**Error:** relation "foo" does not exist')
     expect(result).not.toContain('**Results:**')
   })
+
+  it('widens the code fence when the SQL contains a comment or string with embedded backticks', () => {
+    const sql = "select 1 -- a ```sql``` code block\nunion all select '`literal`'"
+    const cellWithBackticks: Cell = {
+      ...databaseCell,
+      unchecked_sql: untrustedSql(sql),
+    }
+
+    const result = notebookToMarkdown({ name: 'Notebook', cells: [cellWithBackticks] })
+
+    expect(result).toContain(`\`\`\`\`sql\n${sql}\n\`\`\`\``)
+  })
 })

--- a/apps/studio/components/interfaces/Explorer/ExplorerNotebookTab.utils.ts
+++ b/apps/studio/components/interfaces/Explorer/ExplorerNotebookTab.utils.ts
@@ -79,6 +79,15 @@ function formatQueryResult(result: QueryResult | undefined): string | undefined 
 }
 
 /**
+ * A backtick fence long enough to enclose `content` without being closed early by a run of
+ * backticks inside it (e.g. a SQL comment or string literal quoting markdown).
+ */
+function getCodeFence(content: string): string {
+  const longestBacktickRun = Math.max(0, ...(content.match(/`+/g)?.map((run) => run.length) ?? []))
+  return '`'.repeat(Math.max(3, longestBacktickRun + 1))
+}
+
+/**
  * Renders a notebook as a markdown document meant to be pasted into an external agent:
  * markdown cells verbatim, query cells as a labelled SQL block. A log cell's `time_range`
  * is called out separately since it's applied as a request parameter rather than baked
@@ -104,9 +113,11 @@ export function notebookToMarkdown({
             ? `### ${cell.title ?? 'Untitled query'} (Postgres)`
             : `### ${cell.title ?? 'Untitled query'} (Logs — ClickHouse)\n\n_Time range: ${formatTimeRange(cell.time_range)}_`
 
+        const fence = getCodeFence(cell.unchecked_sql)
+
         return [
           header,
-          `\`\`\`sql\n${cell.unchecked_sql}\n\`\`\``,
+          `${fence}sql\n${cell.unchecked_sql}\n${fence}`,
           formatQueryResult(getResult?.(cell._id)),
         ]
           .filter((part): part is string => part !== undefined)

--- a/apps/studio/components/interfaces/Explorer/ExplorerNotebookTab.utils.ts
+++ b/apps/studio/components/interfaces/Explorer/ExplorerNotebookTab.utils.ts
@@ -91,7 +91,6 @@ export function notebookToMarkdown({
 }: {
   name: string
   cells: readonly Snapshot<Cell>[]
-  /** Looks up a query cell's last in-session result, if any (see `formatQueryResult`). */
   getResult?: (cellId: string) => QueryResult | undefined
 }): string {
   const sections = cells.map((cell) => {

--- a/apps/studio/components/interfaces/Explorer/ExplorerNotebookTab.utils.ts
+++ b/apps/studio/components/interfaces/Explorer/ExplorerNotebookTab.utils.ts
@@ -1,5 +1,7 @@
 import { type Snapshot } from 'valtio'
 
+import { type QueryResult } from './types'
+import { convertResultsToMarkdown } from '@/components/interfaces/SQLEditor/UtilityPanel/Results.utils'
 import { formatTimeRange } from '@/components/ui/AIAssistantPanel/AssistantNotebookPreview.utils'
 import { type Cell } from '@/data/content/notebooks/notebook-schema'
 import { removeCommentsFromSql } from '@/lib/helpers'
@@ -63,27 +65,54 @@ export function isMutatingSql(sql: string): boolean {
 }
 
 /**
+ * A query cell's last in-session result rendered as a markdown table, or its error if the
+ * last run failed — whichever is more useful to paste. Undefined when the cell hasn't been
+ * run this session, since results aren't persisted with the notebook (see QueryCell's local
+ * result state).
+ */
+function formatQueryResult(result: QueryResult | undefined): string | undefined {
+  if (!result) return undefined
+  if (result.error) return `**Error:** ${result.error.message}`
+
+  const table = result.rows ? convertResultsToMarkdown([...result.rows]) : undefined
+  return table ? `**Results:**\n\n${table}` : undefined
+}
+
+/**
  * Renders a notebook as a markdown document meant to be pasted into an external agent:
- * markdown cells verbatim, query cells as a labelled SQL block. Query results are never
- * included since they aren't persisted with the notebook (see QueryCell's local result
- * state) and a log cell's `time_range` is called out separately since it's applied as a
- * request parameter rather than baked into the SQL text.
+ * markdown cells verbatim, query cells as a labelled SQL block. A log cell's `time_range`
+ * is called out separately since it's applied as a request parameter rather than baked
+ * into the SQL text.
  */
 export function notebookToMarkdown({
   name,
   cells,
+  getResult,
 }: {
   name: string
   cells: readonly Snapshot<Cell>[]
+  /** Looks up a query cell's last in-session result, if any (see `formatQueryResult`). */
+  getResult?: (cellId: string) => QueryResult | undefined
 }): string {
   const sections = cells.map((cell) => {
     switch (cell._tag) {
       case 'markdown_cell':
         return cell.text
       case 'database_cell':
-        return `### ${cell.title ?? 'Untitled query'} (Postgres)\n\n\`\`\`sql\n${cell.unchecked_sql}\n\`\`\``
-      case 'log_cell':
-        return `### ${cell.title ?? 'Untitled query'} (Logs — ClickHouse)\n\n_Time range: ${formatTimeRange(cell.time_range)}_\n\n\`\`\`sql\n${cell.unchecked_sql}\n\`\`\``
+      case 'log_cell': {
+        const header =
+          cell._tag === 'database_cell'
+            ? `### ${cell.title ?? 'Untitled query'} (Postgres)`
+            : `### ${cell.title ?? 'Untitled query'} (Logs — ClickHouse)\n\n_Time range: ${formatTimeRange(cell.time_range)}_`
+
+        return [
+          header,
+          `\`\`\`sql\n${cell.unchecked_sql}\n\`\`\``,
+          formatQueryResult(getResult?.(cell._id)),
+        ]
+          .filter((part): part is string => part !== undefined)
+          .join('\n\n')
+      }
     }
   })
 

--- a/apps/studio/components/interfaces/Explorer/ExplorerNotebookTab.utils.ts
+++ b/apps/studio/components/interfaces/Explorer/ExplorerNotebookTab.utils.ts
@@ -67,11 +67,16 @@ export function isMutatingSql(sql: string): boolean {
 /**
  * A query cell's last in-session result rendered as a markdown table, or its error if the
  * last run failed — whichever is more useful to paste. Undefined when the cell hasn't been
- * run this session, since results aren't persisted with the notebook (see QueryCell's local
- * result state).
+ * run this session (results aren't persisted with the notebook, see QueryCell's local result
+ * state), or when `currentSql` has since diverged from the SQL that produced the result —
+ * e.g. the cell was edited but not rerun — since pairing stale results with the current SQL
+ * would misrepresent what that query actually returns.
  */
-function formatQueryResult(result: QueryResult | undefined): string | undefined {
-  if (!result) return undefined
+function formatQueryResult(
+  result: QueryResult | undefined,
+  currentSql: string
+): string | undefined {
+  if (!result || result.sql !== currentSql) return undefined
   if (result.error) return `**Error:** ${result.error.message}`
 
   const table = result.rows ? convertResultsToMarkdown([...result.rows]) : undefined
@@ -118,7 +123,7 @@ export function notebookToMarkdown({
         return [
           header,
           `${fence}sql\n${cell.unchecked_sql}\n${fence}`,
-          formatQueryResult(getResult?.(cell._id)),
+          formatQueryResult(getResult?.(cell._id), cell.unchecked_sql),
         ]
           .filter((part): part is string => part !== undefined)
           .join('\n\n')

--- a/apps/studio/components/interfaces/Explorer/ExplorerNotebookTab.utils.ts
+++ b/apps/studio/components/interfaces/Explorer/ExplorerNotebookTab.utils.ts
@@ -1,5 +1,6 @@
 import { type Snapshot } from 'valtio'
 
+import { formatTimeRange } from '@/components/ui/AIAssistantPanel/AssistantNotebookPreview.utils'
 import { type Cell } from '@/data/content/notebooks/notebook-schema'
 import { removeCommentsFromSql } from '@/lib/helpers'
 
@@ -59,4 +60,32 @@ export function findQueryCellsMatchingSql<T extends SqlMatchers>({
 export function isMutatingSql(sql: string): boolean {
   const cleanedSql = removeCommentsFromSql(sql)
   return cleanedSql.split(';').some((statement) => MUTATING_STATEMENT_REGEX.test(statement))
+}
+
+/**
+ * Renders a notebook as a markdown document meant to be pasted into an external agent:
+ * markdown cells verbatim, query cells as a labelled SQL block. Query results are never
+ * included since they aren't persisted with the notebook (see QueryCell's local result
+ * state) and a log cell's `time_range` is called out separately since it's applied as a
+ * request parameter rather than baked into the SQL text.
+ */
+export function notebookToMarkdown({
+  name,
+  cells,
+}: {
+  name: string
+  cells: readonly Snapshot<Cell>[]
+}): string {
+  const sections = cells.map((cell) => {
+    switch (cell._tag) {
+      case 'markdown_cell':
+        return cell.text
+      case 'database_cell':
+        return `### ${cell.title ?? 'Untitled query'} (Postgres)\n\n\`\`\`sql\n${cell.unchecked_sql}\n\`\`\``
+      case 'log_cell':
+        return `### ${cell.title ?? 'Untitled query'} (Logs — ClickHouse)\n\n_Time range: ${formatTimeRange(cell.time_range)}_\n\n\`\`\`sql\n${cell.unchecked_sql}\n\`\`\``
+    }
+  })
+
+  return [`# ${name}`, ...sections].join('\n\n')
 }

--- a/apps/studio/components/interfaces/Explorer/QueryCell/QueryCell.utils.test.ts
+++ b/apps/studio/components/interfaces/Explorer/QueryCell/QueryCell.utils.test.ts
@@ -8,6 +8,7 @@ import {
   getCellDisplay,
   setCellRowLimit,
   setCellSql,
+  shouldInvalidateResultOnSourceChange,
   toQueryModel,
 } from './QueryCell.utils'
 import { type ChartConfig, type QueryCell } from '@/data/content/notebooks/notebook-schema'
@@ -107,6 +108,53 @@ describe('changeCellSource', () => {
 
     expect(next.chart).toEqual(CHART)
     expect(next.chart).not.toBe(DATABASE_CELL.chart)
+  })
+})
+
+describe('shouldInvalidateResultOnSourceChange', () => {
+  it('invalidates when the backend changes from database to logs', () => {
+    expect(
+      shouldInvalidateResultOnSourceChange(DATABASE_CELL, {
+        _tag: 'logs',
+        time_range: LOG_CELL.time_range,
+      })
+    ).toBe(true)
+  })
+
+  it('invalidates when the backend changes from logs to database', () => {
+    expect(
+      shouldInvalidateResultOnSourceChange(LOG_CELL, {
+        _tag: 'database',
+        database_identifier: undefined,
+      })
+    ).toBe(true)
+  })
+
+  it('invalidates a log cell result when the time range changes', () => {
+    expect(
+      shouldInvalidateResultOnSourceChange(LOG_CELL, {
+        _tag: 'logs',
+        time_range: { _tag: 'relative_time_range', unit: 'day', amount: 7 },
+      })
+    ).toBe(true)
+  })
+
+  it('keeps a log cell result when the time range is unchanged', () => {
+    expect(
+      shouldInvalidateResultOnSourceChange(LOG_CELL, {
+        _tag: 'logs',
+        time_range: { ...LOG_CELL.time_range },
+      })
+    ).toBe(false)
+  })
+
+  it('keeps a database cell result when only the connected database changes', () => {
+    expect(
+      shouldInvalidateResultOnSourceChange(DATABASE_CELL, {
+        _tag: 'database',
+        database_identifier: 'replica-2',
+      })
+    ).toBe(false)
   })
 })
 

--- a/apps/studio/components/interfaces/Explorer/QueryCell/QueryCell.utils.ts
+++ b/apps/studio/components/interfaces/Explorer/QueryCell/QueryCell.utils.ts
@@ -1,4 +1,5 @@
 import { untrustedSql } from '@supabase/pg-meta'
+import isEqual from 'lodash/isEqual'
 import { type Snapshot } from 'valtio'
 
 import { type ExplorerQueryModel } from '../QueryEditor'
@@ -89,6 +90,24 @@ export function changeCellSource(cell: Snapshot<QueryCell>, source: QuerySourceB
     row_limit: cell._tag === 'database_cell' ? cell.row_limit : DEFAULT_CELL_ROW_LIMIT,
     database_identifier: source.database_identifier,
   }
+}
+
+/**
+ * Whether a source change makes a cell's last in-session result stale enough to clear.
+ * A backend change (database ↔ logs) invalidates outright, since another engine returns
+ * unrelated columns. A log cell's time range is a request parameter rather than part of the
+ * SQL text (see notebookToMarkdown), so a plain SQL-text comparison wouldn't catch a result
+ * that's stale only because the range moved — that has to be checked here instead.
+ */
+export function shouldInvalidateResultOnSourceChange(
+  cell: Snapshot<QueryCell>,
+  source: QuerySourceBinding
+): boolean {
+  const isBackendChange = (source._tag === 'logs') !== (cell._tag === 'log_cell')
+  const isTimeRangeChange =
+    source._tag === 'logs' && cell._tag === 'log_cell' && !isEqual(source.time_range, cell.time_range)
+
+  return isBackendChange || isTimeRangeChange
 }
 
 /**

--- a/apps/studio/components/interfaces/Explorer/QueryCell/QueryCell.utils.ts
+++ b/apps/studio/components/interfaces/Explorer/QueryCell/QueryCell.utils.ts
@@ -105,7 +105,9 @@ export function shouldInvalidateResultOnSourceChange(
 ): boolean {
   const isBackendChange = (source._tag === 'logs') !== (cell._tag === 'log_cell')
   const isTimeRangeChange =
-    source._tag === 'logs' && cell._tag === 'log_cell' && !isEqual(source.time_range, cell.time_range)
+    source._tag === 'logs' &&
+    cell._tag === 'log_cell' &&
+    !isEqual(source.time_range, cell.time_range)
 
   return isBackendChange || isTimeRangeChange
 }

--- a/apps/studio/components/interfaces/Explorer/QueryCell/index.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryCell/index.tsx
@@ -15,6 +15,7 @@ import {
   getCellDisplay,
   setCellRowLimit,
   setCellSql,
+  shouldInvalidateResultOnSourceChange,
   toQueryModel,
 } from './QueryCell.utils'
 import { SortableSection } from '@/components/ui/SortableSection'
@@ -77,11 +78,8 @@ export const QueryCell = forwardRef<QueryEditorHandle, QueryCellProps>(function 
 
   const handleSourceChange = (source: QuerySourceBinding) => {
     // The query text carries over (see `changeCellSource`), so the editor's buffer stays
-    // valid — but a result the old backend produced does not, since another engine
-    // returns unrelated columns.
-    const isBackendChange = (source._tag === 'logs') !== (cell._tag === 'log_cell')
-    if (isBackendChange) setResult(undefined)
-
+    // valid — but a result run against the old source (backend or time range) does not.
+    if (shouldInvalidateResultOnSourceChange(cell, source)) setResult(undefined)
     updateQueryCell((candidate) => changeCellSource(candidate, source))
   }
 

--- a/apps/studio/components/interfaces/Explorer/QueryEditor/QueryResultRenderer.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryEditor/QueryResultRenderer.tsx
@@ -49,7 +49,7 @@ export const QueryResultRenderer = ({
   }
 
   if ((rows ?? []).length === 0) {
-    return <p className="text-xs text-foreground-lighter py-8">Success. No rows returned</p>
+    return <p className="text-xs text-foreground-lighter p-3">Success. No rows returned</p>
   }
 
   if (rows && rows.length > 0) {

--- a/apps/studio/components/interfaces/Explorer/QueryEditor/index.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryEditor/index.tsx
@@ -116,6 +116,8 @@ export type QueryEditorHandle = {
   getSql: () => string
   /** Formats the editor's SQL in place and commits the result, same as the SQL Editor's Prettify SQL action. */
   prettify: () => Promise<void>
+  /** The last result this cell produced in this session, or undefined if it hasn't been run. */
+  getResult: () => QueryResult | undefined
 }
 
 type QueryEditorProps = {
@@ -379,6 +381,7 @@ export const QueryEditor = forwardRef<QueryEditorHandle, QueryEditorProps>(funct
     run: (force = false) => handleRunQuery({ shouldForce: force }),
     getSql: () => sqlRef.current,
     prettify: handlePrettify,
+    getResult: () => result,
   }))
 
   useEffect(() => {

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/Results.utils.test.ts
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/Results.utils.test.ts
@@ -60,6 +60,21 @@ describe('Results.utils', () => {
       const md = convertResultsToMarkdown(results)
       expect(md).toContain('{"role":"admin"}')
     })
+
+    it('should escape pipe characters so a value cannot split into extra columns', () => {
+      const results = [{ id: 1, name: 'a|b' }]
+      const md = convertResultsToMarkdown(results)
+      const rows = md!.split('\n')
+      // header + separator + one data row, not more
+      expect(rows).toHaveLength(3)
+      expect(rows[2]).toContain('a\\|b')
+    })
+
+    it('should escape backslashes so an escaped pipe cannot be forged', () => {
+      const results = [{ id: 1, name: 'a\\|b' }]
+      const md = convertResultsToMarkdown(results)
+      expect(md).toContain('a\\\\\\|b')
+    })
   })
 
   describe('convertResultsToJSON', () => {

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/Results.utils.test.ts
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/Results.utils.test.ts
@@ -75,6 +75,21 @@ describe('Results.utils', () => {
       const md = convertResultsToMarkdown(results)
       expect(md).toContain('a\\\\\\|b')
     })
+
+    it('should replace newlines with <br> so a multiline value cannot create extra table rows', () => {
+      const results = [
+        { id: 1, query: 'select 1;\nselect 2;' },
+        { id: 2, query: 'select 3;\r\nselect 4;' },
+        { id: 3, query: 'select 5;\rselect 6;' },
+      ]
+      const md = convertResultsToMarkdown(results)
+      const rows = md!.split('\n')
+      // header + separator + 3 data rows, not more
+      expect(rows).toHaveLength(5)
+      expect(rows[2]).toContain('select 1;<br>select 2;')
+      expect(rows[3]).toContain('select 3;<br>select 4;')
+      expect(rows[4]).toContain('select 5;<br>select 6;')
+    })
   })
 
   describe('convertResultsToJSON', () => {

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/Results.utils.ts
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/Results.utils.ts
@@ -22,7 +22,11 @@ export function convertResultsToMarkdown(results: ResultRow[]): string | undefin
   if (formatted.length === 0) return undefined
 
   const columns = Object.keys(formatted[0])
-  const escapeCell = (value: string) => value.replace(/\\/g, '\\\\').replace(/\|/g, '\\|')
+  const escapeCell = (value: string) =>
+    value
+      .replace(/\\/g, '\\\\')
+      .replace(/\|/g, '\\|')
+      .replace(/\r\n|\r|\n/g, '<br>')
   const rows = formatted.map((row) => columns.map((col) => escapeCell(String(row[col] ?? ''))))
   const table = [columns.map(escapeCell), ...rows]
   return markdownTable(table)

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/Results.utils.ts
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/Results.utils.ts
@@ -22,8 +22,9 @@ export function convertResultsToMarkdown(results: ResultRow[]): string | undefin
   if (formatted.length === 0) return undefined
 
   const columns = Object.keys(formatted[0])
-  const rows = formatted.map((row) => columns.map((col) => String(row[col] ?? '')))
-  const table = [columns, ...rows]
+  const escapeCell = (value: string) => value.replace(/\\/g, '\\\\').replace(/\|/g, '\\|')
+  const rows = formatted.map((row) => columns.map((col) => escapeCell(String(row[col] ?? ''))))
+  const table = [columns.map(escapeCell), ...rows]
   return markdownTable(table)
 }
 


### PR DESCRIPTION
## Context

Adds a "Copy as Markdown" CTA for notebooks
<img width="265" height="198" alt="image" src="https://github.com/user-attachments/assets/5eccf36e-24ea-4d2f-b1cf-72d5353b70a2" />

Query cell titles will be rendered as h3 tags and labelled either Postgres or Logs - Clickhouse (with time range)
The query content will then be rendered as triple backticks with `sql`
e.g `
```sql...```
`

Query results will be copied to markdown if the query has been run, will otherwise be omitted
Also, if the query was updated (e.g content, source, etc) after it was run (as the result is hence stale), result will also be omitted
e.g:
| Notebook | Markdown |
| --- | --- |
| <img width="1291" height="630" alt="image" src="https://github.com/user-attachments/assets/c49f23e5-c70b-46dd-a298-6e1a90cd30d7" /> | <img width="731" height="536" alt="image" src="https://github.com/user-attachments/assets/4bbe3041-bd8e-42d3-86d2-1691e7a6bc7b" /> |
| <img width="1220" height="832" alt="image" src="https://github.com/user-attachments/assets/67de523a-18f7-4f1b-b764-7f0f3152f9e7" /> | <img width="757" height="803" alt="image" src="https://github.com/user-attachments/assets/d217504b-bee6-4088-9049-87ff647b9bc7" /> |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Markdown export for notebook queries, results, errors, and time ranges.
  * Added error notifications when copying notebook content fails.

* **Bug Fixes**
  * Prevented stale query results after relevant source or time-range changes.
  * Improved Markdown export for queries containing backticks.
  * Escaped backslashes, pipes, and line breaks in Markdown tables.

* **Style**
  * Adjusted spacing for empty query-result messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->