### PR TITLE
fix(pg-meta): match IS filter values case-insensitively

### DIFF
--- a/packages/pg-meta/src/query/Query.utils.ts
+++ b/packages/pg-meta/src/query/Query.utils.ts
@@ -295,7 +295,7 @@ function inTupleFilterSql(filter: Filter) {
 }
 
 function isFilterSql(filter: Filter) {
-  const filterValueTxt = String(filter.value)
+  const filterValueTxt = String(filter.value).trim().toLowerCase()
   switch (filterValueTxt) {
     case 'null':
     case 'false':

--- a/packages/pg-meta/test/query/query.test.ts
+++ b/packages/pg-meta/test/query/query.test.ts
@@ -444,6 +444,23 @@ describe('Query.utils', () => {
         expect(result).toBe('select * from public.users where active is true;')
       })
 
+      test('should handle "is" operator values case-insensitively', () => {
+        const cases: Array<[string, string]> = [
+          ['NULL', 'email is null'],
+          ['Null', 'email is null'],
+          ['NOT NULL', 'email is not null'],
+          ['Not Null', 'email is not null'],
+          ['TRUE', 'active is true'],
+          ['FALSE', 'active is false'],
+        ]
+        for (const [value, expectedWhere] of cases) {
+          const column = expectedWhere.split(' ')[0]
+          const filters: Filter[] = [{ column, operator: 'is', value }]
+          const result = QueryUtils.selectQuery(table, safeSql`*`, { filters: filters })
+          expect(result).toBe(`select * from public.users where ${expectedWhere};`)
+        }
+      })
+
       test('should correctly escape string values in filters', () => {
         const filters: Filter[] = [{ column: 'name', operator: '=', value: "O'Reilly" }]
         const result = QueryUtils.selectQuery(table, safeSql`*`, { filters: filters })


### PR DESCRIPTION
Uppercase `is`-filter values (`NULL`, `NOT NULL`, `TRUE`, `FALSE`) were quoted as string literals, producing invalid SQL (`where email is 'NULL'`).

Normalizes the value with `trim().toLowerCase()` before matching, so any casing emits the valid unquoted keyword. Lowercase input renders exactly as before.

Adds a regression test covering `NULL`, `Null`, `NOT NULL`, `Not Null`, `TRUE`, `FALSE`.
Verified: `pg-format`, `query`, and `table-row-query` suites pass (159 tests).

Fixes #50201.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Filter values for SQL literals such as `NULL`, `TRUE`, `FALSE`, and `NOT NULL` are now recognized regardless of capitalization.

* **Tests**
  * Added coverage confirming case-insensitive handling for SQL literal filter values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->