### PR TITLE
Assistant panel maximize CTA to open in explorer only if explorer preview is enabled

### DIFF
--- a/apps/studio/components/layouts/DefaultLayout.tsx
+++ b/apps/studio/components/layouts/DefaultLayout.tsx
@@ -52,6 +52,7 @@ export const DefaultLayout = ({
   const router = useRouter()
   const panelRef = usePanelRef()
   const isMobile = useBreakpoint('md')
+  const isSidebarOverlay = useBreakpoint('xl')
   const appSnap = useAppStateSnapshot()
   const { isMaximised, activeSidebar } = useSidebarManagerSnapshot()
   const { lastVisitedOrganization } = useLastVisitedOrganization()
@@ -77,13 +78,13 @@ export const DefaultLayout = ({
   }, [])
 
   useEffect(() => {
-    if (!isMounted || !panelRef.current || !activeSidebar || isMobile) return
+    if (!isMounted || !panelRef.current || !activeSidebar || isMobile || isSidebarOverlay) return
     if (isMaximised) {
       panelRef.current.collapse()
     } else {
       panelRef.current.resize(`${contentMaxSizePercentage}%`)
     }
-  }, [isMounted, isMaximised, panelRef, activeSidebar, isMobile])
+  }, [isMounted, isMaximised, panelRef, activeSidebar, isMobile, isSidebarOverlay])
 
   // This is required to prevent layout shift when rendering resizable panels (they initially render at 50%, then shift
   // to whatever is specified).

--- a/apps/studio/components/layouts/ProjectLayout/LayoutSidebar/index.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutSidebar/index.tsx
@@ -25,7 +25,7 @@ export const LayoutSidebar = ({
   defaultSize = '30',
 }: LayoutSidebarProps) => {
   const isMobile = useBreakpoint('md')
-  const { activeSidebar } = useSidebarManagerSnapshot()
+  const { activeSidebar, isMaximised } = useSidebarManagerSnapshot()
   const { content: sheetContent, setContent: setMobileSheetContent } = useMobileSheet()
 
   useEffect(() => {
@@ -55,8 +55,8 @@ export const LayoutSidebar = ({
         className={cn(
           'border-l bg fixed z-40 right-0 top-0 bottom-0',
           'h-dvh',
-          'md:absolute md:h-auto md:w-1/2',
-          'lg:w-2/5',
+          isMaximised ? 'md:absolute md:h-auto md:w-full' : 'md:absolute md:h-auto md:w-1/2',
+          !isMaximised && 'lg:w-2/5',
           'xl:relative xl:border-l-0'
         )}
       >

--- a/apps/studio/components/layouts/ProjectLayout/LayoutSidebar/index.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutSidebar/index.tsx
@@ -43,6 +43,9 @@ export const LayoutSidebar = ({
   if (!activeSidebar?.component) return null
   if (isMobile) return null
 
+  // `isMaximised` only has meaning for the AI Assistant sidebar
+  const isMaximisedSidebar = isMaximised && activeSidebar?.id === SIDEBAR_KEYS.AI_ASSISTANT
+
   return (
     <>
       <ResizableHandle withHandle />
@@ -55,8 +58,8 @@ export const LayoutSidebar = ({
         className={cn(
           'border-l bg fixed z-40 right-0 top-0 bottom-0',
           'h-dvh',
-          isMaximised ? 'md:absolute md:h-auto md:w-full' : 'md:absolute md:h-auto md:w-1/2',
-          !isMaximised && 'lg:w-2/5',
+          isMaximisedSidebar ? 'md:absolute md:h-auto md:w-full' : 'md:absolute md:h-auto md:w-1/2',
+          !isMaximisedSidebar && 'lg:w-2/5',
           'xl:relative xl:border-l-0'
         )}
       >

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistantHeader.test.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistantHeader.test.tsx
@@ -1,10 +1,14 @@
 import { fireEvent, screen } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { AIAssistantHeader } from './AIAssistantHeader'
 import { customRender } from '@/tests/lib/custom-render'
 
-const { openChat } = vi.hoisted(() => ({ openChat: vi.fn() }))
+const { openChat, toggleMaximise, useIsExplorerEnabled } = vi.hoisted(() => ({
+  openChat: vi.fn(),
+  toggleMaximise: vi.fn(),
+  useIsExplorerEnabled: vi.fn(),
+}))
 
 vi.mock('@/state/ai-assistant-state', () => ({
   useAiAssistantStateSnapshot: () => ({
@@ -16,6 +20,14 @@ vi.mock('@/state/ai-assistant-state', () => ({
 
 vi.mock('@/components/interfaces/Explorer/hooks', () => ({
   useCreateChat: () => ({ openChat }),
+}))
+
+vi.mock('@/components/interfaces/App/FeaturePreview/FeaturePreviewContext', () => ({
+  useIsExplorerEnabled,
+}))
+
+vi.mock('@/state/sidebar-manager-state', () => ({
+  useSidebarManagerSnapshot: () => ({ isMaximised: false, toggleMaximise }),
 }))
 
 vi.mock('@/state/shortcuts/useShortcut', () => ({ useShortcut: vi.fn() }))
@@ -43,7 +55,12 @@ const defaultProps = {
 }
 
 describe('AIAssistantHeader', () => {
-  it('opens the active chat in Explorer and closes the sidebar', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('opens the active chat in Explorer and closes the sidebar when Explorer preview is enabled', () => {
+    useIsExplorerEnabled.mockReturnValue(true)
     const onCloseAssistant = vi.fn()
     customRender(<AIAssistantHeader {...defaultProps} onCloseAssistant={onCloseAssistant} />)
 
@@ -52,5 +69,19 @@ describe('AIAssistantHeader', () => {
     expect(openChat).toHaveBeenCalledWith('chat-1')
     expect(onCloseAssistant).toHaveBeenCalledOnce()
     expect(screen.queryByRole('button', { name: 'Minimize' })).not.toBeInTheDocument()
+  })
+
+  it('shows a Maximize CTA that toggles the sidebar when Explorer preview is disabled', () => {
+    useIsExplorerEnabled.mockReturnValue(false)
+    const onCloseAssistant = vi.fn()
+    customRender(<AIAssistantHeader {...defaultProps} onCloseAssistant={onCloseAssistant} />)
+
+    expect(screen.queryByRole('button', { name: 'Open in Explorer' })).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Maximize' }))
+
+    expect(toggleMaximise).toHaveBeenCalledOnce()
+    expect(openChat).not.toHaveBeenCalled()
+    expect(onCloseAssistant).not.toHaveBeenCalled()
   })
 })

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistantHeader.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistantHeader.tsx
@@ -11,6 +11,7 @@ import { KeyboardEvent, useState } from 'react'
 import { toast } from 'sonner'
 import {
   Button,
+  cn,
   copyToClipboard,
   DropdownMenu,
   DropdownMenuContent,
@@ -178,7 +179,7 @@ export const AIAssistantHeader = ({
                 size="tiny"
                 icon={<Maximize />}
                 onClick={onSelectMaximise}
-                className="h-7 w-7 p-0"
+                className={cn('h-7 w-7 p-0', !isExplorerEnabled && 'hidden md:flex')}
               />
             </ShortcutTooltip>
 

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistantHeader.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistantHeader.tsx
@@ -61,6 +61,12 @@ export const AIAssistantHeader = ({
   const [isEditingName, setIsEditingName] = useState(false)
   const [isOptInModalOpen, setIsOptInModalOpen] = useState(false)
 
+  const maximiseLabel = isExplorerEnabled
+    ? 'Open in Explorer'
+    : isMaximised
+      ? 'Minimize'
+      : 'Maximize'
+
   const onSelectMaximise = () => {
     if (isExplorerEnabled) handleOpenInExplorer()
     else toggleMaximise()
@@ -163,12 +169,12 @@ export const AIAssistantHeader = ({
 
             <ShortcutTooltip
               side="bottom"
-              label={isExplorerEnabled ? 'Open in Explorer' : isMaximised ? 'Minimize' : 'Maximize'}
+              label={maximiseLabel}
               shortcutId={SHORTCUT_IDS.AI_ASSISTANT_MAXIMIZE}
             >
               <Button
                 variant="text"
-                aria-label="Open in Explorer"
+                aria-label={maximiseLabel}
                 size="tiny"
                 icon={<Maximize />}
                 onClick={onSelectMaximise}

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistantHeader.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistantHeader.tsx
@@ -24,10 +24,12 @@ import { ButtonTooltip } from '../ButtonTooltip'
 import { ShortcutPills, ShortcutTooltip } from '../ShortcutTooltip'
 import { AIAssistantChatSelector } from './AIAssistantChatSelector'
 import { AIAssistantMetadataWarning } from './AIAssistantMetadataWarning'
+import { useIsExplorerEnabled } from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
 import { useCreateChat } from '@/components/interfaces/Explorer/hooks'
 import { useAiAssistantStateSnapshot } from '@/state/ai-assistant-state'
 import { SHORTCUT_DEFINITIONS, SHORTCUT_IDS } from '@/state/shortcuts/registry'
 import { useShortcut } from '@/state/shortcuts/useShortcut'
+import { useSidebarManagerSnapshot } from '@/state/sidebar-manager-state'
 
 interface AIAssistantHeaderProps {
   isChatLoading: boolean
@@ -50,11 +52,19 @@ export const AIAssistantHeader = ({
   isHipaaProjectDisallowed,
   aiOptInLevel,
 }: AIAssistantHeaderProps) => {
-  const snap = useAiAssistantStateSnapshot()
   const { openChat } = useCreateChat()
+  const snap = useAiAssistantStateSnapshot()
+  const { isMaximised, toggleMaximise } = useSidebarManagerSnapshot()
+  const isExplorerEnabled = useIsExplorerEnabled()
+
   const [value, setValue] = useState(snap.activeChat?.name)
   const [isEditingName, setIsEditingName] = useState(false)
   const [isOptInModalOpen, setIsOptInModalOpen] = useState(false)
+
+  const onSelectMaximise = () => {
+    if (isExplorerEnabled) handleOpenInExplorer()
+    else toggleMaximise()
+  }
 
   const handleOpenInExplorer = () => {
     if (!snap.activeChatId) return
@@ -100,7 +110,7 @@ export const AIAssistantHeader = ({
     enabled: shortcutsEnabled && !isChatLoading,
   })
 
-  useShortcut(SHORTCUT_IDS.AI_ASSISTANT_MAXIMIZE, handleOpenInExplorer, {
+  useShortcut(SHORTCUT_IDS.AI_ASSISTANT_MAXIMIZE, onSelectMaximise, {
     enabled: shortcutsEnabled && !isChatLoading,
   })
 
@@ -153,7 +163,7 @@ export const AIAssistantHeader = ({
 
             <ShortcutTooltip
               side="bottom"
-              label="Open in Explorer"
+              label={isExplorerEnabled ? 'Open in Explorer' : isMaximised ? 'Minimize' : 'Maximize'}
               shortcutId={SHORTCUT_IDS.AI_ASSISTANT_MAXIMIZE}
             >
               <Button
@@ -161,7 +171,7 @@ export const AIAssistantHeader = ({
                 aria-label="Open in Explorer"
                 size="tiny"
                 icon={<Maximize />}
-                onClick={handleOpenInExplorer}
+                onClick={onSelectMaximise}
                 className="h-7 w-7 p-0"
               />
             </ShortcutTooltip>


### PR DESCRIPTION
### Context

As per PR title - currently the assistant panel's maximize CTA defaults to opening in explorer, which might be confusing for users who don't have the explorer feature preview enabled

<img width="581" height="190" alt="image" src="https://github.com/user-attachments/assets/9a9b6129-164e-4e3e-a14e-66ecafe8e5ff" />
<img width="574" height="157" alt="image" src="https://github.com/user-attachments/assets/ffff0a49-3357-4e5f-8cc0-be2f94263128" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the AI assistant’s maximize control with context-sensitive actions.
  * When Explorer preview is enabled, the control opens the active conversation in Explorer.
  * When Explorer preview is disabled, the control maximizes or minimizes the assistant panel.
  * Updated the control’s label, accessibility text, and keyboard shortcut to reflect the available action.
  * Maximized AI Assistant panels now use the full available width, while other sidebars retain responsive sizing.
* **Bug Fixes**
  * Improved sidebar behavior on mobile and overlay layouts to prevent unwanted resizing or collapsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->