### PR TITLE
Explorer home to run query in query tab if input in chat form is a sql query

### DIFF
--- a/apps/studio/components/interfaces/Explorer/ExplorerHomeTab.tsx
+++ b/apps/studio/components/interfaces/Explorer/ExplorerHomeTab.tsx
@@ -2,6 +2,7 @@ import { NotebookText, SquareCode } from 'lucide-react'
 import { useState } from 'react'
 import { cn } from 'ui'
 
+import { isSqlStatement } from './ExplorerHomeTab.utils'
 import { useCreateChat, useCreateNotebook, useCreateQuery } from './hooks'
 import { NOTEBOOK_TEMPLATES } from './templates'
 import { ActionCard } from '@/components/layouts/Tabs/ActionCard'
@@ -35,7 +36,11 @@ export const ExplorerHomeTab = () => {
             placeholder="Explore your data, check project health, create a notebook..."
             value={value}
             onValueChange={(e) => setValue(e.target.value)}
-            onSubmit={(message) => createChat({ initialMessage: message })}
+            onSubmit={(message) =>
+              isSqlStatement(message)
+                ? createQuery({ sql: message, autoRun: true })
+                : createChat({ initialMessage: message })
+            }
           />
           <AssistantAgentHarnessFooter />
 

--- a/apps/studio/components/interfaces/Explorer/ExplorerHomeTab.utils.test.ts
+++ b/apps/studio/components/interfaces/Explorer/ExplorerHomeTab.utils.test.ts
@@ -17,7 +17,7 @@ describe('isSqlStatement', () => {
     'create policy my_policy on profiles for select using (true)',
     'show search_path',
     'SHOW ALL;',
-    "set search_path to public",
+    'set search_path to public',
     "SET TIME ZONE 'UTC'",
   ])('returns true for %s', (message) => {
     expect(isSqlStatement(message)).toBe(true)

--- a/apps/studio/components/interfaces/Explorer/ExplorerHomeTab.utils.test.ts
+++ b/apps/studio/components/interfaces/Explorer/ExplorerHomeTab.utils.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { isSqlStatement } from './ExplorerHomeTab.utils'
+
+describe('isSqlStatement', () => {
+  it.each([
+    'select * from profiles',
+    'SELECT id FROM profiles WHERE id = 1;',
+    "insert into logs (msg) values ('hi')",
+    'update profiles set name = null',
+    'delete from profiles where id = 1',
+    'with recent as (select 1) select * from recent',
+    '  \n  select 1',
+    '-- get everyone\nselect * from profiles',
+  ])('returns true for %s', (message) => {
+    expect(isSqlStatement(message)).toBe(true)
+  })
+
+  it.each([
+    '',
+    '   ',
+    'How do I add a new column to my table?',
+    'What indexes exist on my users table?',
+    'Explain how RLS works',
+    'Can you help me select the right plan for my project?',
+  ])('returns false for %s', (message) => {
+    expect(isSqlStatement(message)).toBe(false)
+  })
+})

--- a/apps/studio/components/interfaces/Explorer/ExplorerHomeTab.utils.test.ts
+++ b/apps/studio/components/interfaces/Explorer/ExplorerHomeTab.utils.test.ts
@@ -12,6 +12,13 @@ describe('isSqlStatement', () => {
     'with recent as (select 1) select * from recent',
     '  \n  select 1',
     '-- get everyone\nselect * from profiles',
+    'create table users (id serial primary key)',
+    'CREATE OR REPLACE FUNCTION foo() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql',
+    'create policy my_policy on profiles for select using (true)',
+    'show search_path',
+    'SHOW ALL;',
+    "set search_path to public",
+    "SET TIME ZONE 'UTC'",
   ])('returns true for %s', (message) => {
     expect(isSqlStatement(message)).toBe(true)
   })
@@ -23,6 +30,10 @@ describe('isSqlStatement', () => {
     'What indexes exist on my users table?',
     'Explain how RLS works',
     'Can you help me select the right plan for my project?',
+    'Create a new table for storing user profiles',
+    'Show me my tables',
+    'Set up RLS on my users table',
+    'With my current schema, what tables should I add?',
   ])('returns false for %s', (message) => {
     expect(isSqlStatement(message)).toBe(false)
   })

--- a/apps/studio/components/interfaces/Explorer/ExplorerHomeTab.utils.ts
+++ b/apps/studio/components/interfaces/Explorer/ExplorerHomeTab.utils.ts
@@ -3,13 +3,31 @@ import { removeCommentsFromSql } from '@/lib/helpers'
 // [Joshen] `explain` is deliberately excluded even though it's a real SQL keyword - "Explain
 // how RLS works" is a common natural-language prompt, and colliding with it would misroute
 // a normal chat question into a query tab.
-const SQL_STATEMENT_REGEX =
-  /^\s*(select|insert|update|delete|create|alter|drop|truncate|with|grant|revoke|begin|vacuum|analyze|merge|call|copy|lock|reindex|refresh|show|set|execute|prepare|deallocate|comment)\b/i
+const UNAMBIGUOUS_SQL_STATEMENT_REGEX =
+  /^\s*(select|insert|update|delete|alter|drop|truncate|grant|revoke|begin|vacuum|analyze|merge|call|copy|lock|reindex|refresh|execute|prepare|deallocate|comment)\b/i
+
+// `create`, `show`, `set`, and `with` are also common natural-language sentence openers
+// ("Create a table for me", "Show me my indexes", "Set up RLS", "With my current schema...").
+// Matching the bare keyword alone would misroute those into a query tab, so each requires
+// syntax that only shows up in the real SQL statement.
+const CREATE_STATEMENT_REGEX =
+  /^\s*create\s+(or\s+replace\s+)?(table|unique\s+index|index|view|materialized\s+view|function|procedure|trigger|schema|extension|role|user|policy|type|sequence|database|domain|rule|publication|foreign\s+table)\b/i
+const SHOW_STATEMENT_REGEX = /^\s*show\s+(all|[a-zA-Z_][a-zA-Z0-9_.]*)\s*;?\s*$/i
+const SET_STATEMENT_REGEX =
+  /^\s*set\s+(session\s+|local\s+)?(time\s+zone\b|[a-zA-Z_][a-zA-Z0-9_.]*\s*(=|to)\s*\S)/i
+const WITH_STATEMENT_REGEX = /^\s*with\s+(recursive\s+)?[a-zA-Z_][a-zA-Z0-9_]*\s+as\s*\(/i
 
 /**
  * Whether `message` looks like a SQL statement rather than a natural-language chat prompt,
  * so the Explorer home tab can route it to a query tab instead of creating an AI chat.
  */
 export function isSqlStatement(message: string): boolean {
-  return SQL_STATEMENT_REGEX.test(removeCommentsFromSql(message))
+  const sql = removeCommentsFromSql(message)
+  return (
+    UNAMBIGUOUS_SQL_STATEMENT_REGEX.test(sql) ||
+    CREATE_STATEMENT_REGEX.test(sql) ||
+    SHOW_STATEMENT_REGEX.test(sql) ||
+    SET_STATEMENT_REGEX.test(sql) ||
+    WITH_STATEMENT_REGEX.test(sql)
+  )
 }

--- a/apps/studio/components/interfaces/Explorer/ExplorerHomeTab.utils.ts
+++ b/apps/studio/components/interfaces/Explorer/ExplorerHomeTab.utils.ts
@@ -1,0 +1,15 @@
+import { removeCommentsFromSql } from '@/lib/helpers'
+
+// [Joshen] `explain` is deliberately excluded even though it's a real SQL keyword - "Explain
+// how RLS works" is a common natural-language prompt, and colliding with it would misroute
+// a normal chat question into a query tab.
+const SQL_STATEMENT_REGEX =
+  /^\s*(select|insert|update|delete|create|alter|drop|truncate|with|grant|revoke|begin|vacuum|analyze|merge|call|copy|lock|reindex|refresh|show|set|execute|prepare|deallocate|comment)\b/i
+
+/**
+ * Whether `message` looks like a SQL statement rather than a natural-language chat prompt,
+ * so the Explorer home tab can route it to a query tab instead of creating an AI chat.
+ */
+export function isSqlStatement(message: string): boolean {
+  return SQL_STATEMENT_REGEX.test(removeCommentsFromSql(message))
+}

--- a/apps/studio/components/interfaces/Explorer/ExplorerQueryTab.tsx
+++ b/apps/studio/components/interfaces/Explorer/ExplorerQueryTab.tsx
@@ -80,6 +80,7 @@ export const ExplorerQueryTab = () => {
   const draft = stateDraft?.projectRef === ref ? stateDraft : undefined
   const result = draft && id ? querySnap.results[id] : undefined
   const queryKey = id && ref ? `${ref}:${id}` : undefined
+  const isDraftReady = !!queryKey && restoredQueryKey === queryKey
 
   const roleImpersonationState = useControlledRoleImpersonationState(
     draft?._tag === 'database' ? draft.role : undefined,
@@ -98,6 +99,13 @@ export const ExplorerQueryTab = () => {
     explorerQueryState.restoreDraft({ id, projectRef: ref })
     setRestoredQueryKey(`${ref}:${id}`)
   }, [id, ref])
+
+  useEffect(() => {
+    if (!id || !isDraftReady || !draft?.pendingAutoRun) return
+
+    queryEditorRef.current?.run()
+    explorerQueryState.clearPendingAutoRun({ id })
+  }, [id, isDraftReady, draft?.pendingAutoRun])
 
   if (!queryKey || restoredQueryKey !== queryKey) {
     return (

--- a/apps/studio/components/interfaces/Explorer/__tests__/QueryTab.test.tsx
+++ b/apps/studio/components/interfaces/Explorer/__tests__/QueryTab.test.tsx
@@ -1,3 +1,4 @@
+import { QueryClient } from '@tanstack/react-query'
 import { act, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { HttpResponse } from 'msw'
@@ -5,6 +6,7 @@ import { useEffect, useRef, type ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ExplorerQueryTab } from '../ExplorerQueryTab'
+import { projectKeys } from '@/data/projects/keys'
 import type { ReadReplicasData } from '@/data/read-replicas/replicas-query'
 import { explorerQueryState } from '@/state/explorer-query'
 import { createTabId, createTabsState, TabsStateContext } from '@/state/tabs'
@@ -155,12 +157,45 @@ vi.mock('../QueryEditor/QueryResultChart', () => ({
   QueryResultChart: () => <div>Chart results</div>,
 }))
 
-const renderQueryTab = (tabsState = createTabsState('default')) =>
+const renderQueryTab = (tabsState = createTabsState('default'), queryClient?: QueryClient) =>
   customRender(
     <TabsStateContext.Provider value={tabsState}>
       <ExplorerQueryTab />
-    </TabsStateContext.Provider>
+    </TabsStateContext.Provider>,
+    { queryClient }
   )
+
+/**
+ * By the time a query tab can auto-run, its project is already cached - the Explorer home tab
+ * that created the draft required the same project data to do so. Priming the cache here
+ * mirrors that instead of racing this test against a cold fetch of `/platform/projects/:ref`.
+ */
+const createWarmProjectQueryClient = (ref: string = 'default') => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  queryClient.setQueryData(projectKeys.detail(ref), {
+    id: 1,
+    ref,
+    organization_id: 1,
+    name: 'Test Project',
+    status: 'ACTIVE_HEALTHY',
+    cloud_provider: 'AWS',
+    region: 'us-east-1',
+    db_host: `db.${ref}.supabase.co`,
+    restUrl: `https://${ref}.supabase.co/rest/v1/`,
+    inserted_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+    subscription_id: 'sub_123',
+    is_branch_enabled: false,
+    is_physical_backups_enabled: false,
+    high_availability: false,
+    integration_source: null,
+    connectionString: 'postgresql://postgres@localhost:5432/postgres',
+    is_hibernating: false,
+  })
+  return queryClient
+}
 
 const createDraft = (
   source:
@@ -169,7 +204,8 @@ const createDraft = (
         _tag: 'logs'
         time_range: { _tag: 'relative_time_range'; amount: number; unit: 'hour' }
       },
-  sql: string = 'select 1'
+  sql: string = 'select 1',
+  { autoRun = false }: { autoRun?: boolean } = {}
 ) => {
   explorerQueryState.removeDraft({ id: 'query-test', projectRef: 'default' })
   explorerQueryState.createDraft({
@@ -177,6 +213,7 @@ const createDraft = (
     projectRef: 'default',
     sql,
     source,
+    autoRun,
   })
 }
 
@@ -198,6 +235,29 @@ describe('QueryTab execution', () => {
 
     expect(screen.getByRole('status', { name: 'Loading query' })).toBeInTheDocument()
     expect(screen.queryByText('Query draft not found')).not.toBeInTheDocument()
+  })
+
+  it('auto-runs a draft created with autoRun, then clears the flag', async () => {
+    // `/platform/pg-meta/:ref/query` is also hit by unrelated background metadata fetches
+    // (autocomplete definitions, event triggers, ...), so the run is asserted via the stored
+    // result it produces rather than by counting requests to that shared endpoint.
+    createDraft({ _tag: 'database' }, 'select 1', { autoRun: true })
+
+    renderQueryTab(createTabsState('default'), createWarmProjectQueryClient())
+
+    await waitFor(() => expect(explorerQueryState.results['query-test']).toBeDefined())
+    expect(explorerQueryState.results['query-test']).toMatchObject({ rows: [] })
+    expect(explorerQueryState.drafts['query-test']?.pendingAutoRun).toBe(false)
+  })
+
+  it('does not auto-run a draft created without autoRun', async () => {
+    createDraft({ _tag: 'database' })
+
+    renderQueryTab()
+    await screen.findByRole('button', { name: 'Run' })
+
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(explorerQueryState.results['query-test']).toBeUndefined()
   })
 
   it('records an unavailable error and skips the logs endpoint when the flag is off', async () => {

--- a/apps/studio/components/interfaces/Explorer/__tests__/hooks.test.tsx
+++ b/apps/studio/components/interfaces/Explorer/__tests__/hooks.test.tsx
@@ -142,4 +142,17 @@ describe('useCreateQuery', () => {
       name: undefined,
     })
   })
+
+  it('forwards autoRun to the draft so its query tab can run itself once mounted', () => {
+    const { result } = renderHook(() => useCreateQuery())
+
+    result.current.createQuery({ sql: 'select 1', autoRun: true })
+    expect(mockCreateDraft).toHaveBeenCalledWith({
+      id: 'query-new',
+      projectRef: 'default',
+      sql: 'select 1',
+      name: undefined,
+      autoRun: true,
+    })
+  })
 })

--- a/apps/studio/components/interfaces/Explorer/hooks.ts
+++ b/apps/studio/components/interfaces/Explorer/hooks.ts
@@ -187,11 +187,15 @@ export const useCreateQuery = () => {
   const { data: project } = useSelectedProjectQuery()
   const querySnap = useExplorerQueryStateSnapshot()
 
-  const createQuery = ({ sql, name }: { sql?: string; name?: string } = {}) => {
+  const createQuery = ({
+    sql,
+    name,
+    autoRun,
+  }: { sql?: string; name?: string; autoRun?: boolean } = {}) => {
     if (!project) return console.error('Project is required')
 
     const id = generateUuid()
-    querySnap.createDraft({ id, projectRef: project.ref, sql, name })
+    querySnap.createDraft({ id, projectRef: project.ref, sql, name, autoRun })
 
     router.push(`/project/${project.ref}/explorer/query/${id}`)
 

--- a/apps/studio/state/explorer-query.ts
+++ b/apps/studio/state/explorer-query.ts
@@ -27,6 +27,7 @@ type ExplorerQueryDraftBase = {
   updatedAt: number
   view: QueryDisplay['view']
   chart?: QueryDisplay['chart']
+  pendingAutoRun?: boolean
 }
 
 /**
@@ -241,6 +242,7 @@ export const createExplorerQueryState = (storage: StorageLike = safeLocalStorage
       sql = '',
       source = createDefaultSourceBinding('database'),
       rowLimit = DEFAULT_CELL_ROW_LIMIT,
+      autoRun = false,
     }: {
       id: string
       projectRef: string
@@ -248,6 +250,7 @@ export const createExplorerQueryState = (storage: StorageLike = safeLocalStorage
       sql?: string
       source?: QuerySourceBinding
       rowLimit?: number
+      autoRun?: boolean
     }) => {
       const draft = toDraft({
         id,
@@ -261,11 +264,17 @@ export const createExplorerQueryState = (storage: StorageLike = safeLocalStorage
           view: 'table',
         },
       })
+      draft.pendingAutoRun = autoRun
 
       state.drafts[id] = draft
       persistDraft(draft)
 
       return id
+    },
+
+    clearPendingAutoRun: ({ id }: { id: string }) => {
+      const draft = state.drafts[id]
+      if (draft) draft.pendingAutoRun = false
     },
 
     restoreDraft: ({ id, projectRef }: { id: string; projectRef: string }) => {


### PR DESCRIPTION
### Context

As per PR title - figured this might be a nice convenience. Submitting a SQL query in the chat form on the explorer home page will open the query in a query tab and run it

<img width="854" height="632" alt="image" src="https://github.com/user-attachments/assets/57dc7538-74b5-4801-a7ed-83c1cfaf123f" />
<img width="872" height="519" alt="image" src="https://github.com/user-attachments/assets/597ce0eb-76d4-4f12-83db-20b628c03904" />

### To test
- [ ] Run a couple of SQL statements in the home tab - should open it in query tab and run it
- [ ] Run a couple of non-SQL statements in the home tab, should default to opening in a chat tab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - SQL statements submitted from the Explorer home screen now open in a query tab and run automatically.
  - Natural-language prompts continue to open in the chat experience.
  - Queries restored from drafts can automatically run once the editor is ready.

- **Bug Fixes**
  - Improved recognition of SQL with leading whitespace, comments, and common statement formats while avoiding misclassification of conversational prompts.
  - Draft-based auto-run behavior now waits until the query editor is ready.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->