### PR TITLE
Standardize icon for maximise in editor panel

### DIFF
--- a/apps/studio/components/ui/EditorPanel/EditorPanel.tsx
+++ b/apps/studio/components/ui/EditorPanel/EditorPanel.tsx
@@ -9,7 +9,7 @@ import {
   CheckCircle2,
   FolderOpen,
   Loader2,
-  Maximize2,
+  Maximize,
   PlusIcon,
   X,
 } from 'lucide-react'
@@ -461,12 +461,12 @@ export const EditorPanel = () => {
           <ButtonTooltip
             variant="text"
             className="w-7 h-7 p-0"
-            icon={<Maximize2 strokeWidth={1.5} />}
-            aria-label={isExplorerEnabled ? 'Open in Explorer' : 'Expand to SQL editor'}
+            icon={<Maximize strokeWidth={1.5} />}
+            aria-label={isExplorerEnabled ? 'Open in Explorer' : 'Open in SQL editor'}
             tooltip={{
               content: {
                 side: 'bottom',
-                text: isExplorerEnabled ? 'Open in Explorer' : 'Expand to SQL editor',
+                text: isExplorerEnabled ? 'Open in Explorer' : 'Open in SQL editor',
               },
             }}
             onClick={handleExpand}


### PR DESCRIPTION
### Context

Just a tiny UI nit to standardise the maximise icon in Editor Panel, matching that of the Assistant Panel

<img width="443" height="138" alt="image" src="https://github.com/user-attachments/assets/b1827b86-03c0-4312-b7b2-c6e2f5761a96" />
<img width="438" height="147" alt="image" src="https://github.com/user-attachments/assets/fc33d4d5-931d-49bd-b46d-d39e45860c52" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the maximize control icon for a clearer visual representation.

- **Accessibility**
  - Updated the control label and tooltip to say “Open in SQL editor” for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->