### PR TITLE
Add role impersonation check for CSV imports

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
@@ -63,6 +63,7 @@ import { isObjectContainingKeys } from '@/lib/helpers'
 import type { SafePostgresTable } from '@/lib/postgres-types'
 import { useTrack } from '@/lib/telemetry/track'
 import type { DeepReadonly, Prettify } from '@/lib/type-helpers'
+import { useGetImpersonatedRoleState } from '@/state/role-impersonation-state'
 import { useTableEditorStateSnapshot, type TableEditorState } from '@/state/table-editor'
 import { createTabId, useTabsStateSnapshot } from '@/state/tabs'
 import type { Dictionary } from '@/types'
@@ -191,6 +192,7 @@ export const SidePanelEditor = ({
   const { data: project } = useSelectedProjectQuery()
   const isQueueOperationsEnabled = useIsQueueOperationsEnabled()
   const { updateRow, addRow, isEditPending } = useTableRowOperations()
+  const getImpersonatedRoleState = useGetImpersonatedRoleState()
   const scoped = !!useFlag(PG_META_SCOPED_INTROSPECTION_FLAG)
 
   const [isEdited, setIsEdited] = useState<boolean>(false)
@@ -824,6 +826,7 @@ export const SidePanelEditor = ({
         table: selectedTable,
         selectedHeaders,
         emptyStringAsNullHeaders,
+        roleImpersonationState: getImpersonatedRoleState(),
         onProgressUpdate: (progress: number) => {
           toast.loading(
             <SonnerProgress
@@ -849,6 +852,7 @@ export const SidePanelEditor = ({
         rows: importContent.rows,
         selectedHeaders,
         emptyStringAsNullHeaders,
+        roleImpersonationState: getImpersonatedRoleState(),
         onProgressUpdate: (progress: number) => {
           toast.loading(
             <SonnerProgress

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
@@ -978,9 +978,7 @@ export async function insertRowsViaSpreadsheet({
               projectRef,
               connectionString,
               sql: insertQuery,
-              isRoleImpersonationEnabled: isRoleImpersonationEnabled(
-                roleImpersonationState?.role
-              ),
+              isRoleImpersonationEnabled: isRoleImpersonationEnabled(roleImpersonationState?.role),
             })
           )
         } catch (error) {
@@ -1084,9 +1082,7 @@ export async function insertTableRows({
               projectRef,
               connectionString,
               sql: insertQuery,
-              isRoleImpersonationEnabled: isRoleImpersonationEnabled(
-                roleImpersonationState?.role
-              ),
+              isRoleImpersonationEnabled: isRoleImpersonationEnabled(roleImpersonationState?.role),
             })
           } catch (error) {
             insertError = error

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
@@ -47,8 +47,10 @@ import {
 import { getTables } from '@/data/tables/tables-query'
 import { isObject, isObjectContainingKeys, timeout, tryParseJson } from '@/lib/helpers'
 import type { SafePostgresColumn } from '@/lib/postgres-types'
+import { RoleImpersonationState, wrapWithRoleImpersonation } from '@/lib/role-impersonation'
 import type { useTrack } from '@/lib/telemetry/track'
 import type { DeepReadonly } from '@/lib/type-helpers'
+import { isRoleImpersonationEnabled } from '@/state/role-impersonation-state'
 import type { SidePanel } from '@/state/table-editor'
 
 const BATCH_SIZE = 1000
@@ -933,6 +935,7 @@ export async function insertRowsViaSpreadsheet({
   table,
   selectedHeaders,
   emptyStringAsNullHeaders = selectedHeaders,
+  roleImpersonationState,
   onProgressUpdate,
 }: {
   projectRef: string
@@ -941,6 +944,7 @@ export async function insertRowsViaSpreadsheet({
   table: RetrieveTableResult
   selectedHeaders: string[]
   emptyStringAsNullHeaders?: string[]
+  roleImpersonationState?: RoleImpersonationState
   onProgressUpdate: (progress: number) => void
 }): Promise<{ error: unknown }> {
   let chunkNumber = 0
@@ -964,10 +968,20 @@ export async function insertRowsViaSpreadsheet({
           emptyStringAsNullHeaders,
         })
 
-        const insertQuery = new Query().from(table.name, table.schema).insert(formattedData).toSql()
+        const insertQuery = wrapWithRoleImpersonation(
+          new Query().from(table.name, table.schema).insert(formattedData).toSql(),
+          roleImpersonationState
+        )
         try {
           await executeWithRetry(() =>
-            executeSql({ projectRef, connectionString, sql: insertQuery })
+            executeSql({
+              projectRef,
+              connectionString,
+              sql: insertQuery,
+              isRoleImpersonationEnabled: isRoleImpersonationEnabled(
+                roleImpersonationState?.role
+              ),
+            })
           )
         } catch (error) {
           console.warn(error)
@@ -1034,6 +1048,7 @@ export async function insertTableRows({
   rows,
   selectedHeaders,
   emptyStringAsNullHeaders = selectedHeaders,
+  roleImpersonationState,
   onProgressUpdate,
 }: {
   projectRef: string
@@ -1042,6 +1057,7 @@ export async function insertTableRows({
   rows: unknown[]
   selectedHeaders: string[]
   emptyStringAsNullHeaders?: string[]
+  roleImpersonationState?: RoleImpersonationState
   onProgressUpdate: (progress: number) => void
 }): Promise<{ error: unknown }> {
   let insertError: unknown = undefined
@@ -1059,9 +1075,19 @@ export async function insertTableRows({
     return () => {
       return Promise.race([
         new Promise(async (resolve, reject) => {
-          const insertQuery = new Query().from(table.name, table.schema).insert(batch).toSql()
+          const insertQuery = wrapWithRoleImpersonation(
+            new Query().from(table.name, table.schema).insert(batch).toSql(),
+            roleImpersonationState
+          )
           try {
-            await executeSql({ projectRef, connectionString, sql: insertQuery })
+            await executeSql({
+              projectRef,
+              connectionString,
+              sql: insertQuery,
+              isRoleImpersonationEnabled: isRoleImpersonationEnabled(
+                roleImpersonationState?.role
+              ),
+            })
           } catch (error) {
             insertError = error
             reject(error)


### PR DESCRIPTION
### Context

Resolves [https://github.com/supabase/supabase/issues/28820](<https://github.com/supabase/supabase/issues/28820>)

CSV imports via the table editor is currently missing the role impersonation check.

Assuming you've got a table that has a column which references `auth.users` + default values to `auth.uid() + not nullable` (e.g `user_id`), if you try to manually add a row while impersonating a user and leaving the `user_id` input field NULL, the newly inserted row will default to the user ID of the impersonated user

<img src="https://github.com/user-attachments/assets/f6eb7e24-50e4-42aa-b6e6-64c50e195be7 " alt="image" width="685" data-linear-height="255" />

However, because CSV imports are missing the role impersonation check, importing data with a CSV that has null values for `user_id` column will throw a NOT NULL postgres error.

PR here adds the role impersonation check and resolves ^ this particular behaviour

### To test

- [X] Create a table that references the `auth.users` table

```
create table public.empty (
  id uuid primary key default gen_random_uuid(),
  user_id uuid not null references auth.users(id) on delete cascade default auth.uid(),
  note text
);
```

- [ ] Import data via CSV via the table editor using this CSV while impersonating a user
  [empty_test_import_no_user_id.csv](<https://github.com/user-attachments/files/32053194/empty_test_import_no_user_id.csv>)
- [ ] Should pass without any errors, inserted rows should have `user_id` filled as the impersonated user's ID
  * Can also verify first on staging that doing this will throw a not null error

## Summary by CodeRabbit

* **Bug Fixes**
  * Spreadsheet imports in the table editor now respect the currently selected role-impersonation state, ensuring imported rows are processed with the appropriate permissions.
  * Manually inserted or pasted rows now use the active role-impersonation settings, providing consistent permission handling across table editing workflows.