### PR TITLE
fix(workers): filter logs by subservice FE-4358

### DIFF
--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.constants.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.constants.tsx
@@ -34,7 +34,7 @@ type LogType = keyof typeof LOG_TYPES_LABELS
 export const LOG_TYPES = Object.keys(LOG_TYPES_LABELS) as [LogType, ...LogType[]]
 export const DEFAULT_LOG_TYPES = ['postgres', 'edge'] as const
 
-export const LOG_TYPE_TO_SOURCE: Record<Exclude<LogType, 'workers'>, string> = {
+export const LOG_TYPE_TO_SOURCE: Record<LogType, string> = {
   edge: 'edge_logs',
   postgrest: 'postgrest_logs',
   storage: 'storage_logs',
@@ -45,6 +45,7 @@ export const LOG_TYPE_TO_SOURCE: Record<Exclude<LogType, 'workers'>, string> = {
   supavisor: 'supavisor_logs',
   pgbouncer: 'pgbouncer_logs',
   multigres: 'multigres_logs',
+  workers: 'worker_logs',
 }
 
 const parseAsSort = createParser({

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.test.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.test.ts
@@ -46,34 +46,32 @@ describe('UnifiedLogs.queries (OTEL flat)', () => {
       expect(where).not.toContain(`log_attributes['request.path'] LIKE '%/storage/%'`)
     })
 
-    it('routes the `workers` log type to every worker OTEL stream', () => {
-      const sql = getUnifiedLogsQuery(withFilters('log_type:eq:workers'))
-      const where = sql.split(/\bWHERE\b/)[1] ?? ''
-      expect(where).toContain(
-        `log_attributes['source'] IN ('worker_ingress_logs','worker_guest_logs','worker_api_logs')`
-      )
-      expect(where).not.toContain(`source = 'workers'`)
-    })
+    it.each([getUnifiedLogsQuery, getLogsCountQuery, getLogsChartQuery])(
+      'routes the workers log type to worker_logs in %s',
+      (getQuery) => {
+        const sql = getQuery(withFilters('log_type:eq:workers'))
+        const where = sql.split(/\bWHERE\b/)[1] ?? ''
+        expect(where).toContain(`source = 'worker_logs'`)
+        expect(where).not.toContain(`source = 'workers'`)
+        expect(sql).not.toContain("log_attributes['source']")
+        expect(sql).not.toContain('subservice')
+      }
+    )
 
-    it('classifies every worker OTEL stream as workers in the projected log type', () => {
+    it('classifies the worker_logs source as workers in the projected log type', () => {
       const sql = getUnifiedLogsQuery(baseSearch)
-      expect(sql).toContain(
-        `WHEN log_attributes['source'] IN ('worker_ingress_logs','worker_guest_logs','worker_api_logs') THEN 'workers'`
-      )
+      expect(sql).toContain(`WHEN source = 'worker_logs' THEN 'workers'`)
     })
 
-    it('excludes every worker OTEL stream when the workers log type is negated', () => {
+    it('excludes the worker_logs source when the workers log type is negated', () => {
       const sql = getUnifiedLogsQuery(withFilters('log_type:neq:workers'))
       const where = sql.split(/\bWHERE\b/)[1] ?? ''
-      expect(where).toContain(
-        `NOT (log_attributes['source'] IN ('worker_ingress_logs','worker_guest_logs','worker_api_logs'))`
-      )
+      expect(where).toContain(`NOT (source = 'worker_logs')`)
     })
 
     it('projects only Workers fields that exist on worker logs', () => {
       const sql = getUnifiedLogsQuery(withFilters('log_type:eq:workers'))
-      const workerCondition =
-        "log_attributes['source'] IN ('worker_ingress_logs','worker_guest_logs','worker_api_logs')"
+      const workerCondition = "source = 'worker_logs'"
 
       expect(sql).toContain(`WHEN ${workerCondition} THEN null`)
       expect(sql).toContain(`if(${workerCondition}, null, log_attributes['request.method'])`)
@@ -300,8 +298,7 @@ describe('UnifiedLogs.queries (OTEL flat)', () => {
 
     it('does not classify Workers rows into a severity bucket', () => {
       const sql = getLogsChartQuery(withFilters('log_type:eq:workers'))
-      const workerCondition =
-        "log_attributes['source'] IN ('worker_ingress_logs','worker_guest_logs','worker_api_logs')"
+      const workerCondition = "source = 'worker_logs'"
 
       expect(sql).toContain(`WHEN ${workerCondition} THEN null`)
       expect(sql).not.toContain(`WHEN ${workerCondition} THEN 'success'`)

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
@@ -13,7 +13,6 @@ import {
   safeSql,
   type SafeLogSqlFragment,
 } from '@/data/logs/safe-analytics-sql'
-import { WORKER_LOG_SOURCES } from '@/lib/constants/workers'
 
 // Operator fragments for SQL emission. `safeSql` rejects plain strings, so we
 // pre-brand the keywords we want to switch between.
@@ -55,21 +54,12 @@ const HTTP_STATUS_EXPR: SafeLogSqlFragment = safeSql`if(source = 'auth_logs', lo
  * logs from postgREST / storage-api and are intentionally not part of unified
  * logs; the UI surfaces gateway HTTP traffic for those buckets.
  */
-const WORKER_LOG_SOURCE_VALUES = Object.values(WORKER_LOG_SOURCES)
-const WORKER_LOG_SOURCE_CONDITION = safeSql`log_attributes['source'] IN (${joinSqlFragments(
-  WORKER_LOG_SOURCE_VALUES.map((source) => lit(source)),
-  ','
-)})`
-
-const LOG_TYPE_CONDITION: Record<string, SafeLogSqlFragment> = {
-  ...Object.fromEntries(
-    Object.entries(LOG_TYPE_TO_SOURCE).map(([type, source]) => [
-      type,
-      safeSql`source = ${lit(source)}`,
-    ])
-  ),
-  workers: WORKER_LOG_SOURCE_CONDITION,
-}
+const LOG_TYPE_CONDITION: Record<string, SafeLogSqlFragment> = Object.fromEntries(
+  Object.entries(LOG_TYPE_TO_SOURCE).map(([type, source]) => [
+    type,
+    safeSql`source = ${lit(source)}`,
+  ])
+)
 
 // Derived `log_type` column for SELECT / GROUP BY / countIf use.
 // WHEN source = 'edge_logs' AND ${ATTR.path} LIKE '%/rest/%' THEN 'postgrest'
@@ -85,7 +75,7 @@ const LOG_TYPE_EXPR: SafeLogSqlFragment = safeSql`CASE
       WHEN source = 'supavisor_logs' THEN 'supavisor'
       WHEN source = 'pgbouncer_logs' THEN 'pgbouncer'
       WHEN source = 'multigres_logs' THEN 'multigres'
-      WHEN ${WORKER_LOG_SOURCE_CONDITION} THEN 'workers'
+      WHEN source = 'worker_logs' THEN 'workers'
       ELSE source
     END`
 
@@ -93,14 +83,14 @@ const LOG_TYPE_EXPR: SafeLogSqlFragment = safeSql`CASE
 // auth-service `status` attribute for auth rows, and the Postgres
 // `parsed.sql_state_code` (e.g. `42P01`) for postgres rows.
 const STATUS_EXPR: SafeLogSqlFragment = safeSql`CASE
-      WHEN ${WORKER_LOG_SOURCE_CONDITION} THEN null
+      WHEN source = 'worker_logs' THEN null
       WHEN source = 'postgres_logs' THEN toString(log_attributes['parsed.sql_state_code'])
       ELSE toString((${HTTP_STATUS_EXPR}))
     END`
 
-const METHOD_EXPR: SafeLogSqlFragment = safeSql`if(${WORKER_LOG_SOURCE_CONDITION}, null, ${ATTR.method})`
-const PATHNAME_EXPR: SafeLogSqlFragment = safeSql`if(${WORKER_LOG_SOURCE_CONDITION}, null, ${ATTR.path})`
-const METADATA_EXPR: SafeLogSqlFragment = safeSql`if(${WORKER_LOG_SOURCE_CONDITION}, log_attributes, map())`
+const METHOD_EXPR: SafeLogSqlFragment = safeSql`if(source = 'worker_logs', null, ${ATTR.method})`
+const PATHNAME_EXPR: SafeLogSqlFragment = safeSql`if(source = 'worker_logs', null, ${ATTR.path})`
+const METADATA_EXPR: SafeLogSqlFragment = safeSql`if(source = 'worker_logs', log_attributes, map())`
 
 // SQL expression for derived `level`. Used inline (not as alias reference)
 // because the OTEL endpoint can't resolve aliases inside countIf when the
@@ -111,7 +101,7 @@ const METADATA_EXPR: SafeLogSqlFragment = safeSql`if(${WORKER_LOG_SOURCE_CONDITI
 // success/warning/error by status. Postgres-style severity is the
 // fallback for rows without a status code.
 const LEVEL_EXPR: SafeLogSqlFragment = safeSql`CASE
-      WHEN ${WORKER_LOG_SOURCE_CONDITION} THEN null
+      WHEN source = 'worker_logs' THEN null
       WHEN (${HTTP_STATUS_EXPR}) != '' AND toInt32OrZero((${HTTP_STATUS_EXPR})) >= 500 THEN 'error'
       WHEN (${HTTP_STATUS_EXPR}) != '' AND toInt32OrZero((${HTTP_STATUS_EXPR})) BETWEEN 400 AND 499 THEN 'warning'
       WHEN (${HTTP_STATUS_EXPR}) != '' AND toInt32OrZero((${HTTP_STATUS_EXPR})) BETWEEN 200 AND 299 THEN 'success'

--- a/apps/studio/data/workers/worker-logs-query.test.ts
+++ b/apps/studio/data/workers/worker-logs-query.test.ts
@@ -6,19 +6,25 @@ import { parseWorkerLogRows, workerLogsSql } from './worker-logs-query'
 describe('workerLogsSql', () => {
   it('reads one worker stream, newest first', () => {
     expect(workerLogsSql('embed', 'output')).toBe(
-      "select id, timestamp, severity_text as severity, event_message as message from logs where log_attributes['worker'] = 'embed' and log_attributes['source'] = 'worker_guest_logs' order by timestamp desc limit 100"
+      "select id, timestamp, severity_text as severity, event_message as message from logs where source = 'worker_logs' and log_attributes['worker'] = 'embed' and subservice = 'worker_guest_logs' order by timestamp desc limit 100"
     )
   })
 
   it('filters by event message before applying the limit', () => {
     expect(workerLogsSql('embed', 'requests', { message: 'timeout' })).toBe(
-      "select id, timestamp, severity_text as severity, event_message as message from logs where log_attributes['worker'] = 'embed' and log_attributes['source'] = 'worker_ingress_logs' and event_message ilike '%timeout%' order by timestamp desc limit 100"
+      "select id, timestamp, severity_text as severity, event_message as message from logs where source = 'worker_logs' and log_attributes['worker'] = 'embed' and subservice = 'worker_ingress_logs' and event_message ilike '%timeout%' order by timestamp desc limit 100"
     )
   })
 
-  it('names the right stream for each tab', () => {
-    expect(workerLogsSql('embed', 'requests')).toContain("'worker_ingress_logs'")
-    expect(workerLogsSql('embed', 'builds')).toContain("'worker_api_logs'")
+  it.each([
+    ['requests', 'worker_ingress_logs'],
+    ['output', 'worker_guest_logs'],
+    ['builds', 'worker_api_logs'],
+  ] as const)('filters the %s tab by its top-level subservice', (stream, subservice) => {
+    const sql = workerLogsSql('embed', stream)
+    expect(sql).toContain("source = 'worker_logs'")
+    expect(sql).toContain(`subservice = '${subservice}'`)
+    expect(sql).not.toContain("log_attributes['source']")
   })
 
   it('escapes a worker name rather than interpolating it raw', () => {

--- a/apps/studio/data/workers/worker-logs-query.ts
+++ b/apps/studio/data/workers/worker-logs-query.ts
@@ -8,9 +8,9 @@ import { executeAnalyticsSql } from '@/data/logs/execute-analytics-sql'
 import { logsAllEndpointUrl } from '@/data/logs/logs-endpoint'
 import { analyticsLiteral, safeSql } from '@/data/logs/safe-analytics-sql'
 import { IS_PLATFORM } from '@/lib/constants'
-import { WORKER_LOG_SOURCES } from '@/lib/constants/workers'
+import { WORKER_LOG_SUBSERVICES } from '@/lib/constants/workers'
 
-export type WorkerLogStream = keyof typeof WORKER_LOG_SOURCES
+export type WorkerLogStream = keyof typeof WORKER_LOG_SUBSERVICES
 
 export const WORKER_LOG_STREAM_LABEL: Record<WorkerLogStream, string> = {
   requests: 'Invocations',
@@ -18,10 +18,7 @@ export const WORKER_LOG_STREAM_LABEL: Record<WorkerLogStream, string> = {
   builds: 'Activity',
 }
 
-// Both are read from `log_attributes` rather than the endpoint's own `source` column:
-// that column is derived from a mapping which does not currently classify worker rows.
 const WORKER_NAME_KEY = 'worker'
-const STREAM_KEY = 'source'
 
 const LOG_LIMIT = 100
 
@@ -50,7 +47,7 @@ export const workerLogsSql = (
     ? safeSql` and event_message ilike ${analyticsLiteral(`%${message}%`)}`
     : safeSql``
 
-  return safeSql`select id, timestamp, severity_text as severity, event_message as message from logs where log_attributes[${analyticsLiteral(WORKER_NAME_KEY)}] = ${analyticsLiteral(name)} and log_attributes[${analyticsLiteral(STREAM_KEY)}] = ${analyticsLiteral(WORKER_LOG_SOURCES[stream])}${messageFilter} order by timestamp desc limit ${analyticsLiteral(LOG_LIMIT)}`
+  return safeSql`select id, timestamp, severity_text as severity, event_message as message from logs where source = 'worker_logs' and log_attributes[${analyticsLiteral(WORKER_NAME_KEY)}] = ${analyticsLiteral(name)} and subservice = ${analyticsLiteral(WORKER_LOG_SUBSERVICES[stream])}${messageFilter} order by timestamp desc limit ${analyticsLiteral(LOG_LIMIT)}`
 }
 
 export const parseWorkerLogRows = (result: unknown): LogData[] =>

--- a/apps/studio/lib/constants/workers.ts
+++ b/apps/studio/lib/constants/workers.ts
@@ -1,7 +1,7 @@
 export const PRODUCT_NAME = 'Workers'
 export const CLI_NAME = 'workers'
 
-export const WORKER_LOG_SOURCES = {
+export const WORKER_LOG_SUBSERVICES = {
   requests: 'worker_ingress_logs',
   output: 'worker_guest_logs',
   builds: 'worker_api_logs',


### PR DESCRIPTION
## Problem

Workers log filtering reads the deprecated metadata source field, which is being replaced by top-level `subservice`.

## Fix

Filter individual worker log tabs by `source = 'worker_logs'` and their top-level `subservice`. Use the single `worker_logs` source to filter and classify Workers in Unified Logs, including row, count, and chart queries.

Scoped to Workers. Deployment requires the unified logs endpoint to expose the new source and subservice fields.

Fixes [FE-4358](https://linear.app/supabase/issue/FE-4358).

## How to test

- Open a worker's Invocations, Logs, and Activity tabs. Each should show only that worker's corresponding subservice; message filtering should still work.
- In Unified Logs, include and exclude Workers. Rows, counts, and charts should use the `worker_logs` source.
- Automated: 69 focused worker and Unified Logs query tests passed. Prettier and diff whitespace checks passed; code review found no issues.
- Local ESLint could not initialize because the available dependencies lack `@eslint/compat`. Studio TypeScript validation reported errors outside the changed files, including missing `@tanstack/react-router`; no diagnostics referenced the six changed files. CI validation is pending.
