### PR TITLE
fix(docs): guides table overflow

### DIFF
--- a/apps/docs/components/Table.tsx
+++ b/apps/docs/components/Table.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { TableHTMLAttributes, useEffect, useRef, useState } from 'react'
 import { cn } from 'ui'
 

--- a/apps/docs/content/guides/observability/log-field-reference.mdx
+++ b/apps/docs/content/guides/observability/log-field-reference.mdx
@@ -13,7 +13,7 @@ For example, the schema path `metadata.request.cf.country` is queried as `log_at
     <Tabs scrollable size="small" type="underlined" defaultActiveId="edge_logs" queryGroup="source">
       {logConstants.schemas.map((schema) => (
         <TabPanel id={schema.reference} key={schema.reference} label={schema.name}>
-          <table>
+          <Table>
             <thead>
               <tr>
                 <th className="font-bold">Schema path</th>
@@ -36,7 +36,7 @@ For example, the schema path `metadata.request.cf.country` is queried as `log_at
                   </tr>
                 ))}
             </tbody>
-          </table>
+          </Table>
         </TabPanel>
       ))}
     </Tabs>

--- a/apps/docs/features/docs/MdxBase.shared.tsx
+++ b/apps/docs/features/docs/MdxBase.shared.tsx
@@ -20,6 +20,7 @@ import { RealtimeLimitsEstimator } from '~/components/RealtimeLimitsEstimator'
 import { RegionsList, SmartRegionsList } from '~/components/RegionsList'
 import { SharedData } from '~/components/SharedData'
 import StepHikeCompact from '~/components/StepHikeCompact'
+import Table from '~/components/Table'
 import { TerraformProviderSchema } from '~/components/TerraformProviderSchema'
 import { WrapperDashboardIntegration } from '~/components/WrapperDashboardIntegration'
 import { CodeSampleDummy, CodeSampleWrapper } from '~/features/directives/CodeSample.client'
@@ -109,6 +110,7 @@ const components = {
   ShowUntil,
   SqlToRest,
   StepHikeCompact,
+  Table,
   Tabs,
   TabPanel,
   TerraformProviderSchema,
@@ -130,6 +132,7 @@ const components = {
     </Heading>
   ),
   pre: Pre,
+  table: Table,
   /**
    * Force inline code tags to go sync, this prevents Heading anchor resolution fail due to
    * our CodeBlock component being async. We need to find a better solution for more future


### PR DESCRIPTION
## What kind of change does this PR introduce?

bug fix of table usage within guides

## What is the current behavior?

table markup is used within the observability guide causing overflow of the content

## What is the new behavior?

favors table component usage within mdx guide to fix the overflow and enable scroll

| state | preview |
| -------|------|
| before | <img width="1171" height="668" alt="image" src="https://github.com/user-attachments/assets/bdbb905e-0ea9-4cde-b20b-84b4ef9a4137" /> |
| after | <img width="1171" height="668" alt="image" src="https://github.com/user-attachments/assets/9e062222-1dad-49da-bdbe-616d89703301" /> | 

## Test
1. visit [/docs/guides/observability/log-field-reference](https://supabase.com/docs/guides/observability/log-field-reference?queryGroups=source&source=edge_logs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved table rendering in the log field reference documentation.
  - Updated documentation tables to use the shared table presentation for a more consistent layout.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->