### PR TITLE
fix(docs): a11y alt text on Colab badge

### DIFF
--- a/apps/docs/content/guides/ai/google-colab.mdx
+++ b/apps/docs/content/guides/ai/google-colab.mdx
@@ -10,7 +10,7 @@ sidebar_label: 'Google Colab'
   className="w-64"
   href="https://colab.research.google.com/github/supabase/supabase/blob/master/examples/ai/vector_hello_world.ipynb"
 >
-  <img src="/docs/img/ai/colab-badge.svg" />
+  <img src="/docs/img/ai/colab-badge.svg" alt="Open in Colab" />
 </a>
 
 Google Colab is a hosted Jupyter Notebook service. It provides free access to computing resources, including GPUs and TPUs, and is well-suited to machine learning, data science, and education. We can use Colab to manage collections using [Supabase Vecs](/docs/guides/ai/vecs-python-client).

--- a/apps/docs/content/guides/ai/integrations/llamaindex.mdx
+++ b/apps/docs/content/guides/ai/integrations/llamaindex.mdx
@@ -17,7 +17,7 @@ Launch our [LlamaIndex](https://github.com/supabase/supabase/blob/master/example
   className="w-64"
   href="https://colab.research.google.com/github/supabase/supabase/blob/master/examples/ai/llamaindex/llamaindex.ipynb"
 >
-  <img src="/docs/img/ai/colab-badge.svg" />
+  <img src="/docs/img/ai/colab-badge.svg" alt="Open in Colab" />
 </a>
 
 At the top of the notebook, you'll see a button `Copy to Drive`. Click this button to copy the notebook to your Google Drive.

--- a/apps/docs/content/guides/ai/quickstarts/face-similarity.mdx
+++ b/apps/docs/content/guides/ai/quickstarts/face-similarity.mdx
@@ -22,7 +22,7 @@ Launch our [`semantic_text_deduplication`](https://github.com/supabase/supabase/
   className="w-64"
   href="https://colab.research.google.com/github/supabase/supabase/blob/master/examples/ai/face_similarity.ipynb"
 >
-  <img src="/docs/img/ai/colab-badge.svg" />
+  <img src="/docs/img/ai/colab-badge.svg" alt="Open in Colab" />
 </a>
 
 At the top of the notebook, you'll see a button `Copy to Drive`. Click this button to copy the notebook to your Google Drive.

--- a/apps/docs/content/guides/ai/quickstarts/hello-world.mdx
+++ b/apps/docs/content/guides/ai/quickstarts/hello-world.mdx
@@ -23,7 +23,7 @@ Launch our [`vector_hello_world`](https://github.com/supabase/supabase/blob/mast
   className="w-64"
   href="https://colab.research.google.com/github/supabase/supabase/blob/master/examples/ai/vector_hello_world.ipynb"
 >
-  <img src="/docs/img/ai/colab-badge.svg" />
+  <img src="/docs/img/ai/colab-badge.svg" alt="Open in Colab" />
 </a>
 
 At the top of the notebook, you'll see a button `Copy to Drive`. Click this button to copy the notebook to your Google Drive.

--- a/apps/docs/content/guides/ai/quickstarts/text-deduplication.mdx
+++ b/apps/docs/content/guides/ai/quickstarts/text-deduplication.mdx
@@ -23,7 +23,7 @@ Launch our [`semantic_text_deduplication`](https://github.com/supabase/supabase/
   className="w-64"
   href="https://colab.research.google.com/github/supabase/supabase/blob/master/examples/ai/semantic_text_deduplication.ipynb"
 >
-  <img src="/docs/img/ai/colab-badge.svg" />
+  <img src="/docs/img/ai/colab-badge.svg" alt="Open in Colab" />
 </a>
 
 At the top of the notebook, you'll see a button `Copy to Drive`. Click this button to copy the notebook to your Google Drive.


### PR DESCRIPTION
## What kind of change does this PR introduce?

a11y fix

## What is the current behavior?

Colab badge image is missing alt attribute leaving both image and the link unnamed _ screen reader users have no way to tell what the link does

## What is the new behavior?

- adds `alt="Open in Colab"`, matching the text rendered inside the SVG so voice control users can activate it by its visible label

## Test
1. visit [/docs/guides/ai/google-colab](https://supabase.com/docs/guides/ai/google-colab)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved accessibility across AI guides and quickstarts by adding descriptive alternative text to “Open in Colab” badge images.
  - Updated Google Colab, LlamaIndex, face similarity, hello world, and text deduplication documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->