### PR TITLE
fix(studio): serialize SQL folder deletion IDs

### DIFF
--- a/apps/studio/data/content/sql-folders-delete-mutation.test.ts
+++ b/apps/studio/data/content/sql-folders-delete-mutation.test.ts
@@ -1,0 +1,27 @@
+import { HttpResponse } from 'msw'
+import { describe, expect, it } from 'vitest'
+
+import { deleteSQLSnippetFolders } from './sql-folders-delete-mutation'
+import { addAPIMock } from '@/tests/lib/msw'
+
+describe('deleteSQLSnippetFolders', () => {
+  it('sends folder IDs as the comma-delimited query value required by the API', async () => {
+    let ids: string | null = null
+
+    addAPIMock({
+      method: 'delete',
+      path: '/platform/projects/:ref/content/folders',
+      response: ({ request }) => {
+        ids = new URL(request.url).searchParams.get('ids')
+        return HttpResponse.json({})
+      },
+    })
+
+    await deleteSQLSnippetFolders({
+      projectRef: 'default',
+      ids: ['folder-one', 'folder-two'],
+    })
+
+    expect(ids).toBe('folder-one,folder-two')
+  })
+})

--- a/apps/studio/data/content/sql-folders-delete-mutation.ts
+++ b/apps/studio/data/content/sql-folders-delete-mutation.ts
@@ -15,8 +15,8 @@ export async function deleteSQLSnippetFolders(
   signal?: AbortSignal
 ) {
   const { data, error } = await del('/platform/projects/{ref}/content/folders', {
-    // @ts-ignore [Joshen] API codegen issue
-    params: { path: { ref: projectRef }, query: { ids } },
+    // @ts-expect-error The generated endpoint type omits its required `{ref}` path parameter.
+    params: { path: { ref: projectRef }, query: { ids: ids.join(',') } },
     signal,
   })
 


### PR DESCRIPTION
## Summary

* serialize SQL folder IDs as the comma-delimited API query value
* add regression coverage for the folder deletion request

## Testing

* `pnpm --filter studio exec vitest run data/content/sql-folders-delete-mutation.test.ts`
* `pnpm exec prettier --check apps/studio/data/content/sql-folders-delete-mutation.ts apps/studio/data/content/sql-folders-delete-mutation.test.ts`
* `pnpm --filter studio exec eslint data/content/sql-folders-delete-mutation.ts data/content/sql-folders-delete-mutation.test.ts`
* `pnpm --filter studio exec tsc --noEmit --pretty false`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SQL snippet folder deletion requests so multiple selected folders are processed correctly.
  * Improved request handling by formatting folder identifiers consistently when submitting bulk deletions.

* **Tests**
  * Added coverage to verify that deleting multiple SQL snippet folders sends the expected folder identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->