### PR TITLE
fix(ui-patterns): a11y accessible names for ExpandableVideo

### DIFF
--- a/apps/docs/components/GuidesSidebar.tsx
+++ b/apps/docs/components/GuidesSidebar.tsx
@@ -109,10 +109,12 @@ function AiTools({ className }: { className?: string }) {
 const GuidesSidebar = ({
   className,
   video,
+  videoTitle,
   hideToc,
 }: {
   className?: string
   video?: string
+  videoTitle?: string
   hideToc?: boolean
 }) => {
   const pathname = usePathname()
@@ -125,7 +127,7 @@ const GuidesSidebar = ({
       <div className="w-full relative border-l flex flex-col gap-6 lg:gap-8 px-2 h-fit">
         {video && (
           <div className="relative pl-5">
-            <ExpandableVideo imgUrl={tocVideoPreview} videoId={video} />
+            <ExpandableVideo imgUrl={tocVideoPreview} videoId={video} videoTitle={videoTitle} />
           </div>
         )}
         {showFeedback && (

--- a/apps/docs/features/docs/GuidesMdx.template.tsx
+++ b/apps/docs/features/docs/GuidesMdx.template.tsx
@@ -6,6 +6,7 @@ import type { WithRequired } from '~/features/helpers.types'
 import { resolveBreadcrumbs } from '~/lib/breadcrumbs'
 import { type GuideFrontmatter } from '~/lib/docs'
 import { breadcrumbListSchema, serializeJsonLd } from '~/lib/json-ld'
+import { mdToPlainText } from '~/lib/md-to-plain-text'
 import { SerializeOptions } from '~/types/next-mdx-remote-serialize'
 import { ExternalLink } from 'lucide-react'
 import { type ReactNode } from 'react'
@@ -135,7 +136,7 @@ const GuideTemplate = ({
         </div>
         <GuidesSidebar
           video={meta?.tocVideo}
-          videoTitle={meta?.title}
+          videoTitle={meta?.title ? mdToPlainText(meta.title) : undefined}
           hideToc={hideToc}
           className={cn(
             'hidden md:flex',

--- a/apps/docs/features/docs/GuidesMdx.template.tsx
+++ b/apps/docs/features/docs/GuidesMdx.template.tsx
@@ -135,6 +135,7 @@ const GuideTemplate = ({
         </div>
         <GuidesSidebar
           video={meta?.tocVideo}
+          videoTitle={meta?.title}
           hideToc={hideToc}
           className={cn(
             'hidden md:flex',

--- a/apps/docs/features/ui/guide/Guide.tsx
+++ b/apps/docs/features/ui/guide/Guide.tsx
@@ -3,6 +3,7 @@
 import GuidesTableOfContents from '~/components/GuidesSidebar'
 import { TocAnchorsProvider } from '~/features/docs/GuidesMdx.client'
 import { type GuideFrontmatter } from '~/lib/docs'
+import { mdToPlainText } from '~/lib/md-to-plain-text'
 import { createContext, useContext, type ReactNode } from 'react'
 import { cn } from 'ui'
 
@@ -46,7 +47,7 @@ export function Guide({ meta, children, className }: GuideProps) {
           {!hideToc && (
             <GuidesTableOfContents
               video={meta?.tocVideo}
-              videoTitle={meta?.title}
+              videoTitle={meta?.title ? mdToPlainText(meta.title) : undefined}
               className={cn(
                 'hidden md:flex',
                 'md:col-span-3 md:col-start-10',

--- a/apps/docs/features/ui/guide/Guide.tsx
+++ b/apps/docs/features/ui/guide/Guide.tsx
@@ -46,6 +46,7 @@ export function Guide({ meta, children, className }: GuideProps) {
           {!hideToc && (
             <GuidesTableOfContents
               video={meta?.tocVideo}
+              videoTitle={meta?.title}
               className={cn(
                 'hidden md:flex',
                 'md:col-span-3 md:col-start-10',

--- a/apps/docs/lib/md-to-plain-text.test.ts
+++ b/apps/docs/lib/md-to-plain-text.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+
+import { mdToPlainText } from './md-to-plain-text'
+
+describe('mdToPlainText', () => {
+  it('strips code spans from a real title', () => {
+    expect(mdToPlainText('Handling errors in `supabase-js`')).toBe('Handling errors in supabase-js')
+  })
+
+  it('keeps underscores in extension names', () => {
+    expect(mdToPlainText('pg_cron: Schedule Recurring Jobs')).toBe(
+      'pg_cron: Schedule Recurring Jobs'
+    )
+  })
+})

--- a/apps/docs/lib/md-to-plain-text.ts
+++ b/apps/docs/lib/md-to-plain-text.ts
@@ -1,0 +1,4 @@
+import { fromMarkdown } from 'mdast-util-from-markdown'
+import { toString } from 'mdast-util-to-string'
+
+export const mdToPlainText = (markdown: string): string => toString(fromMarkdown(markdown))

--- a/apps/www/app/partners/catalog/[slug]/PartnerCatalogDetail.tsx
+++ b/apps/www/app/partners/catalog/[slug]/PartnerCatalogDetail.tsx
@@ -343,6 +343,7 @@ function PartnerDetails({
             videoId={activeListing.youtubeId}
             imgUrl={`https://img.youtube.com/vi/${activeListing.youtubeId}/0.jpg`}
             imgOverlayText="Watch an introductory video"
+            videoTitle={`Introduction to ${partner.title}`}
             triggerContainerClassName="w-full"
           />
         )}

--- a/packages/ui-patterns/src/ExpandableVideo/index.tsx
+++ b/packages/ui-patterns/src/ExpandableVideo/index.tsx
@@ -10,6 +10,7 @@ interface ExpandableVideoProps {
   imgOverlayText?: string
   triggerContainerClassName?: string
   imgAltText?: string
+  videoTitle?: string
   trigger?: ReactNode
   onOpenCallback?: any
   priority?: boolean
@@ -21,6 +22,7 @@ export function ExpandableVideo({
   imgOverlayText,
   triggerContainerClassName = '',
   imgAltText,
+  videoTitle,
   trigger,
   onOpenCallback,
   priority = false,
@@ -55,7 +57,8 @@ export function ExpandableVideo({
       </div>
       <Image
         src={imgUrl ?? '/images/blur.png'}
-        alt={imgAltText ?? 'Video guide preview'}
+        // no fallback as alt text here would repeat it
+        alt={imgAltText ?? ''}
         fill
         sizes="100%"
         priority={priority}
@@ -74,6 +77,7 @@ export function ExpandableVideo({
               setExpandVideo(true)
             }}
             className={['w-full', triggerContainerClassName].join(' ').trim()}
+            aria-label={videoTitle ? `Play video: ${videoTitle}` : undefined}
           >
             {trigger ?? <CliccablePreview />}
           </button>
@@ -90,6 +94,7 @@ export function ExpandableVideo({
               <div className="video-container rounded-lg! border-none! overflow-hidden!">
                 <iframe
                   src={`https://www.youtube-nocookie.com/embed/${videoId}`}
+                  title={videoTitle ?? 'Video player'}
                   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
                   allowFullScreen
                 />


### PR DESCRIPTION
## What kind of change does this PR introduce?

bug fix a11y `ExapndableVideo` 

## What is the current behavior?

`ExpandableVideo` blurred thumbnail has `alt="Video guide preview"` sitting behind an overlay that already reads "Watch video guide" making screen readers announcing the same thing twice

## What is the new behavior?

- adds an optional `videoTitle` prop that names the video once and feeds both the button's `aria-label` and the player's `title`.

## Test
1. visit `/docs/guides/functions`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Video previews in guides now display the relevant guide title.
  - Partner introduction videos now include a descriptive title.
  - Video controls and embedded players provide more specific accessibility labels when titles are available.
  - Preview images without meaningful alternative text are treated as decorative to reduce redundant screen-reader output.
- **Bug Fixes**
  - Guide titles with Markdown formatting now appear as clean, readable text in video labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->