### PR TITLE
docs: update terraform docs pinned version

### DIFF
--- a/apps/docs/scripts/federated-content/sources/terraform.ts
+++ b/apps/docs/scripts/federated-content/sources/terraform.ts
@@ -5,9 +5,9 @@ const terraform: FederatedContentSource = {
   section: 'deployment/terraform',
   org: 'supabase',
   repo: 'terraform-provider-supabase',
-  branch: 'v1.1.3',
+  branch: 'v1.11.0',
   docsDir: 'docs',
-  externalSite: 'https://github.com/supabase/terraform-provider-supabase/blob/v1.1.3',
+  externalSite: 'https://github.com/supabase/terraform-provider-supabase/blob/v1.11.0',
   rawFallback: true,
   pageMap: [
     {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

There have been [many updates](https://github.com/supabase/terraform-provider-supabase/compare/v1.1.3...v1.11.0) to our terraform provider since the docs were last updated. This PR updates the pinned version of [our terraform docs](https://supabase.com/docs/guides/deployment/terraform) to the latest version.

## What is the current behavior?

[Outdated terraform docs](https://supabase.com/docs/guides/deployment/terraform)

## What is the new behavior?

[Updated terraform docs](https://docs-git-kanad-2026-09-10-bump-terraform-docs-version-supabase.vercel.app/docs/guides/deployment/terraform)

## Additional context

n/a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Terraform documentation content to use provider version `v1.11.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->