### PR TITLE
fix(docs): reduce reference page response size

### DIFF
--- a/apps/docs/features/ui/CodeBlock/CodeBlock.client.tsx
+++ b/apps/docs/features/ui/CodeBlock/CodeBlock.client.tsx
@@ -6,12 +6,82 @@ import { type ThemedToken } from 'shiki'
 import { type NodeHover } from 'twoslash'
 import { Button, cn, copyToClipboard, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 
+import { getFontStyle } from './CodeBlock.utils'
+
+type CodeAnnotation = Pick<NodeHover, 'text' | 'docs' | 'tags'>
+export type CodeToken = [
+  content: string,
+  color: ThemedToken['color'],
+  fontStyle: number,
+  annotation?: {
+    annotations: Array<CodeAnnotation>
+    htmlStyle: ThemedToken['htmlStyle']
+  },
+]
+
+export function CodeBlockTokens({
+  lines,
+  lineNumbers,
+}: {
+  lines: Array<Array<CodeToken>>
+  lineNumbers: boolean
+}) {
+  return (
+    <pre>
+      <code
+        className={cn(
+          lineNumbers && 'grid grid-cols-[auto_1fr] w-fit min-w-full py-3',
+          '[--row-rest:var(--background-200)]',
+          '[--row-hover:color-mix(in_srgb,var(--foreground)_3%,var(--background-200))]'
+        )}
+      >
+        {lineNumbers ? (
+          lines.map((line, idx) => (
+            <div key={idx} className="group/row contents">
+              <div aria-hidden="true" className="code-line-number">
+                {idx + 1}
+              </div>
+              <div className="code-content code-line-content">
+                <CodeLine tokens={line} />
+              </div>
+            </div>
+          ))
+        ) : (
+          <div className="code-content p-6">
+            {lines.map((line, idx) => (
+              <CodeLine key={idx} tokens={line} />
+            ))}
+          </div>
+        )}
+      </code>
+    </pre>
+  )
+}
+
+function CodeLine({ tokens }: { tokens: Array<CodeToken> }) {
+  return (
+    <span className="block min-h-5 leading-5">
+      {tokens.map(([content, color, fontStyle, annotation], idx) =>
+        annotation ? (
+          <AnnotatedSpan key={idx} content={content} {...annotation} />
+        ) : (
+          <span key={idx} style={{ color, ...getFontStyle(fontStyle) }}>
+            {content}
+          </span>
+        )
+      )}
+    </span>
+  )
+}
+
 export function AnnotatedSpan({
-  token,
+  content,
+  htmlStyle,
   annotations,
 }: {
-  token: ThemedToken
-  annotations: Array<NodeHover>
+  content: string
+  htmlStyle: ThemedToken['htmlStyle']
+  annotations: Array<CodeAnnotation>
 }) {
   const [open, setOpen] = useState(false)
 
@@ -45,13 +115,13 @@ export function AnnotatedSpan({
       <TooltipTrigger asChild onClick={handleClick}>
         <button
           tabIndex={0}
-          style={token.htmlStyle}
+          style={htmlStyle}
           className={cn(
             isTouchDevice &&
               'underline underline-offset-4 decoration-dashed decoration-[rgba(from_currentColor_r_g_b/0.5)]'
           )}
         >
-          {token.content}
+          {content}
         </button>
       </TooltipTrigger>
       <TooltipContent className="max-w-[min(80vw,400px)] p-0 divide-y">
@@ -63,7 +133,7 @@ export function AnnotatedSpan({
   )
 }
 
-function Annotation({ annotation }: { annotation: NodeHover }) {
+function Annotation({ annotation }: { annotation: CodeAnnotation }) {
   const { text, docs, tags } = annotation
   return (
     <div className="flex flex-col gap-2">

--- a/apps/docs/features/ui/CodeBlock/CodeBlock.tsx
+++ b/apps/docs/features/ui/CodeBlock/CodeBlock.tsx
@@ -1,10 +1,10 @@
 import { type PropsWithChildren } from 'react'
-import { bundledLanguages, createHighlighter, type BundledLanguage, type ThemedToken } from 'shiki'
+import { bundledLanguages, createHighlighter, type BundledLanguage } from 'shiki'
 import { createTwoslasher, type ExtraFiles, type NodeHover } from 'twoslash'
 import { cn } from 'ui'
 
-import { AnnotatedSpan, CodeBlockControls } from './CodeBlock.client'
-import { getCodeBlockLabel, getFontStyle } from './CodeBlock.utils'
+import { CodeBlockControls, CodeBlockTokens, type CodeToken } from './CodeBlock.client'
+import { getCodeBlockLabel } from './CodeBlock.utils'
 import theme from './supabase-2.json' with { type: 'json' }
 import denoTypes from './types/lib.deno.d.ts.include'
 
@@ -83,90 +83,26 @@ export async function CodeBlock({
         aria-label={getCodeBlockLabel(lang, tokens.length)}
         tabIndex={0}
       >
-        <pre>
-          <code
-            className={cn(
-              lineNumbers && 'grid grid-cols-[auto_1fr] w-fit min-w-full py-3',
-              '[--row-rest:var(--background-200)]',
-              '[--row-hover:color-mix(in_srgb,var(--foreground)_3%,var(--background-200))]'
-            )}
-          >
-            {lineNumbers ? (
-              tokens.map((line, idx) => (
-                <div key={idx} className="group/row contents">
-                  <div
-                    aria-hidden="true"
-                    className={cn(
-                      'select-none text-right text-muted/70 pl-3 pr-2 min-h-5 leading-5',
-                      'bg-[var(--row-rest)]',
-                      'sticky left-0 z-10',
-                      'group-hover/row:text-muted group-hover/row:bg-[var(--row-hover)]',
-                      'after:pointer-events-none after:absolute after:inset-y-0 after:left-full after:w-4',
-                      '[--gutter-fade:var(--row-rest)] group-hover/row:[--gutter-fade:var(--row-hover)]',
-                      'after:bg-[image:linear-gradient(to_right,var(--gutter-fade)_0%,color-mix(in_srgb,var(--gutter-fade)_85%,transparent)_25%,color-mix(in_srgb,var(--gutter-fade)_50%,transparent)_50%,color-mix(in_srgb,var(--gutter-fade)_15%,transparent)_75%,transparent_100%)]'
-                    )}
-                  >
-                    {idx + 1}
-                  </div>
-                  <div
-                    className={cn(
-                      'code-content min-h-5 leading-5 pl-3 pr-18',
-                      'group-hover/row:bg-[var(--row-hover)]'
-                    )}
-                  >
-                    <CodeLine tokens={line} twoslash={twoslashed?.get(idx)} />
-                  </div>
-                </div>
-              ))
-            ) : (
-              <div className="code-content p-6">
-                {tokens.map((line, idx) => (
-                  <CodeLine key={idx} tokens={line} twoslash={twoslashed?.get(idx)} />
-                ))}
-              </div>
-            )}
-          </code>
-        </pre>
+        <CodeBlockTokens
+          lineNumbers={lineNumbers}
+          lines={tokens.map((line, lineIndex) => {
+            let offset = 0
+            return line.map(({ content, color, fontStyle, htmlStyle }): CodeToken => {
+              const annotations = twoslashed
+                ?.get(lineIndex)
+                ?.get(offset)
+                ?.map(({ text, docs, tags }) => ({ text, docs, tags }))
+              offset += content.length
+              return annotations
+                ? [content, color, fontStyle || 0, { annotations, htmlStyle }]
+                : [content, color, fontStyle || 0]
+            })
+          })}
+        />
       </div>
       {/* After the code so the block is named before its controls, and outside the scroller so they stay pinned */}
       {!hideControls && <CodeBlockControls content={code.trim()} />}
     </div>
-  )
-}
-
-function CodeLine({
-  tokens: rawTokens,
-  twoslash,
-}: {
-  tokens: Array<ThemedToken>
-  twoslash?: Map<number, Array<NodeHover>>
-}) {
-  let offset = 0
-  const tokens = rawTokens.map((token) => {
-    const newToken = { ...token, offset }
-    offset += token.content.length
-    return newToken
-  })
-
-  return (
-    <span className="block min-h-5 leading-5">
-      {tokens.map((token) =>
-        twoslash?.has(token.offset) ? (
-          <AnnotatedSpan
-            key={token.offset}
-            token={token}
-            annotations={twoslash.get(token.offset)!}
-          />
-        ) : (
-          <span
-            key={token.offset}
-            style={{ color: token.color, ...getFontStyle(token.fontStyle || 0) }}
-          >
-            {token.content}
-          </span>
-        )
-      )}
-    </span>
   )
 }
 

--- a/apps/docs/styles/globals.css
+++ b/apps/docs/styles/globals.css
@@ -34,6 +34,19 @@
   --font-weight-normal: 450;
 }
 
+@utility code-line-number {
+  @apply select-none text-right text-muted/70 pl-3 pr-2 min-h-5 leading-5;
+  @apply bg-[var(--row-rest)] sticky left-0 z-10;
+  @apply group-hover/row:text-muted group-hover/row:bg-[var(--row-hover)];
+  @apply after:pointer-events-none after:absolute after:inset-y-0 after:left-full after:w-4;
+  @apply [--gutter-fade:var(--row-rest)] group-hover/row:[--gutter-fade:var(--row-hover)];
+  @apply after:bg-[image:linear-gradient(to_right,var(--gutter-fade)_0%,color-mix(in_srgb,var(--gutter-fade)_85%,transparent)_25%,color-mix(in_srgb,var(--gutter-fade)_50%,transparent)_50%,color-mix(in_srgb,var(--gutter-fade)_15%,transparent)_75%,transparent_100%)];
+}
+
+@utility code-line-content {
+  @apply min-h-5 leading-5 pl-3 pr-18 group-hover/row:bg-[var(--row-hover)];
+}
+
 @layer utilities {
   .prose--remove-p-margin p {
     margin: 0;


### PR DESCRIPTION
## Problem

The JavaScript reference page can fail with Vercel’s `FALLBACK_BODY_TOO_LARGE` error. Syntax-highlighted examples serialize thousands of elements into the React payload, and each numbered line repeats a long gutter class string.

## Fix

Keep Shiki and Twoslash on the server, but send compact token tuples to a client renderer instead of serialized element trees. Move repeated gutter and row styles into shared Tailwind utilities, preserving server-rendered code, highlighting, annotations, and existing controls.

An isolated production build using the actual reference page and root layout reduced HTML from 15,252,466 to 8,862,330 bytes (42%) and RSC from 11,262,263 to 5,941,982 bytes (47%). Both builds used identical generated content and mocked Google Fonts responses; all 687 rendered code elements and 166 links matched. Production has larger generated SDK data, so confirm its artifact size in the preview deployment.

## How to test

- Open `/docs/reference/javascript/auth-admin-updateuserbyid` in the preview with a normal browser user agent and confirm it loads without a 502. Bot requests use a separate rendering path.
- Check syntax highlighting, sticky line numbers, row hover, copy, and wrapping on long examples. Check type tooltips on a guide with annotated TypeScript and code blocks without line numbers.
- Inspect the generated JavaScript reference HTML and confirm it stays below Vercel’s 10 MB fallback limit.
- Validation completed: docs TypeScript check, focused ESLint, Prettier, Tailwind compilation, code review, and the before/after production-render comparison.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved code block rendering with richer syntax highlighting, including token colors and font styles.
  - Added support for interactive code annotations and hover details.
  - Added consistent rendering for code blocks with or without line numbers.

- **Style**
  - Enhanced code line numbers with sticky positioning, muted styling, and hover states.
  - Improved code line spacing, padding, and hover backgrounds for clearer reading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->