### PR TITLE
feat: Create first scaffolding around search v2 and feature flag addition

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/TopNavBar.tsx
+++ b/apps/docs/components/Navigation/NavigationMenu/TopNavBar.tsx
@@ -16,6 +16,7 @@ import { CommandMenuTriggerInput } from 'ui-patterns/CommandMenu'
 import { getCustomContent } from '../../../lib/custom-content/getCustomContent'
 import GlobalNavigationMenu from './GlobalNavigationMenu'
 import useDropdownMenu from './useDropdownMenu'
+import { SearchV2Trigger, useSearchV2Variant } from '@/features/SearchV2'
 
 const GlobalMobileMenu = dynamic(() => import('./GlobalMobileMenu'))
 const TopNavDropdown = dynamic(() => import('./TopNavDropdown'))
@@ -28,6 +29,7 @@ const TopNavBar: FC = () => {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const user = useUser()
   const menu = useDropdownMenu(user)
+  const searchVariant = useSearchV2Variant()
 
   return (
     <>
@@ -47,15 +49,27 @@ const TopNavBar: FC = () => {
 
             <div className="flex gap-2 items-center">
               <DevToolbarTrigger />
-              <CommandMenuTriggerInput
-                className="[&>div>p]:text-foreground-lighter"
-                placeholder={
-                  <>
-                    Search
-                    <span className="hidden xl:inline ml-1"> docs...</span>
-                  </>
-                }
-              />
+              {searchVariant === 'search-v2-active' ? (
+                <SearchV2Trigger
+                  className="[&>div>p]:text-foreground-lighter"
+                  placeholder={
+                    <>
+                      Search
+                      <span className="hidden xl:inline ml-1"> docs...</span>
+                    </>
+                  }
+                />
+              ) : (
+                <CommandMenuTriggerInput
+                  className="[&>div>p]:text-foreground-lighter"
+                  placeholder={
+                    <>
+                      Search
+                      <span className="hidden xl:inline ml-1"> docs...</span>
+                    </>
+                  }
+                />
+              )}
               <button
                 tabIndex={0}
                 title="Menu dropdown button"

--- a/apps/docs/features/SearchV2/SearchV2Dialog.tsx
+++ b/apps/docs/features/SearchV2/SearchV2Dialog.tsx
@@ -1,0 +1,107 @@
+'use client'
+
+import { useDocsSearch, type DocsSearchResult } from 'common'
+import { Loader2 } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { VisuallyHidden } from 'radix-ui'
+import { useEffect } from 'react'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from 'ui'
+
+interface SearchV2DialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function SearchV2Dialog({ open, onOpenChange }: SearchV2DialogProps) {
+  const router = useRouter()
+  const { searchState, handleDocsSearchDebounced, resetSearch } = useDocsSearch()
+
+  // Clear stale results once the dialog closes
+  useEffect(() => {
+    if (!open) resetSearch()
+  }, [open, resetSearch])
+
+  const results: DocsSearchResult[] =
+    'results' in searchState
+      ? searchState.results
+      : 'staleResults' in searchState
+        ? searchState.staleResults
+        : []
+
+  function handleValueChange(value: string) {
+    if (value) {
+      handleDocsSearchDebounced(value)
+    } else {
+      resetSearch()
+    }
+  }
+
+  function handleSelect(path: string) {
+    router.push(path)
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      {/* hideClose: this is a search box, not a form — closing is Escape/click-outside only, no "X" */}
+      <DialogContent hideClose size="large" className="overflow-hidden p-0 shadow-lg">
+        <Command>
+          <VisuallyHidden.VisuallyHidden>
+            <DialogTitle>Search docs</DialogTitle>
+            <DialogDescription>Search the Supabase documentation</DialogDescription>
+          </VisuallyHidden.VisuallyHidden>
+          <CommandInput
+            placeholder="Search docs..."
+            onValueChange={handleValueChange}
+            wrapperClassName="[&_svg]:h-5 [&_svg]:w-5 border-0"
+            className="h-14 text-base"
+          />
+          <CommandList>
+            {searchState.status === 'loading' && results.length === 0 && (
+              <div className="flex items-center justify-center gap-2 py-6 text-sm text-foreground-muted">
+                <Loader2 className="animate-spin" size={14} />
+                Searching...
+              </div>
+            )}
+            {searchState.status === 'noResults' && <CommandEmpty>No results found.</CommandEmpty>}
+            {searchState.status === 'error' && (
+              <CommandEmpty>Something went wrong. Please try again.</CommandEmpty>
+            )}
+            {results.length > 0 && (
+              <CommandGroup heading="Results" forceMount>
+                {results.map((page) => (
+                  <CommandItem
+                    key={page.id}
+                    value={String(page.id)}
+                    forceMount
+                    onSelect={() => handleSelect(page.path)}
+                  >
+                    <div className="flex flex-col">
+                      <span className="text-sm">{page.title}</span>
+                      {(page.description || page.subtitle) && (
+                        <span className="text-xs text-foreground-muted">
+                          {page.description || page.subtitle}
+                        </span>
+                      )}
+                    </div>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+          </CommandList>
+        </Command>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/docs/features/SearchV2/SearchV2Trigger.tsx
+++ b/apps/docs/features/SearchV2/SearchV2Trigger.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import { Search } from 'lucide-react'
+import { useState, type ReactNode } from 'react'
+import { cn, KeyboardShortcut } from 'ui'
+
+import { SearchV2Dialog } from './SearchV2Dialog'
+
+interface SearchV2TriggerProps {
+  className?: string
+  placeholder?: ReactNode
+}
+
+export function SearchV2Trigger({ className, placeholder = 'Search...' }: SearchV2TriggerProps) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <button
+        type="button"
+        tabIndex={0}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        onClick={() => setOpen(true)}
+        className={cn(
+          'group cursor-pointer',
+          'grow md:min-w-44 xl:min-w-56 h-[30px] rounded-md',
+          'pl-1.5 md:pl-2 pr-1',
+          'flex items-center justify-between',
+          'bg-transparent text-foreground-lighter border border-strong',
+          'hover:bg-popover hover:border-control-hover',
+          'focus-ring',
+          'transition-colors',
+          className
+        )}
+      >
+        <div className="flex items-center space-x-1.5 text-foreground-lighter">
+          <Search
+            size={16}
+            strokeWidth={1.5}
+            className="group-hover:text-foreground-light transition-colors"
+          />
+          <p className="flex text-xs pr-2 text-foreground-muted">{placeholder}</p>
+        </div>
+        <KeyboardShortcut
+          keys={['Meta', 'k']}
+          aria-hidden
+          className="hidden md:inline-flex border border-default bg-surface-300 text-foreground-lighter shadow-xs shadow-background-surface-100"
+        />
+      </button>
+      <SearchV2Dialog open={open} onOpenChange={setOpen} />
+    </>
+  )
+}

--- a/apps/docs/features/SearchV2/constants.ts
+++ b/apps/docs/features/SearchV2/constants.ts
@@ -1,0 +1,4 @@
+// PostHog multivariate flag, already configured on staging.
+export const SEARCH_V2_FLAG = 'docs-search-v2'
+
+export type SearchV2Variant = 'control' | 'search-v2-active'

--- a/apps/docs/features/SearchV2/index.ts
+++ b/apps/docs/features/SearchV2/index.ts
@@ -1,0 +1,2 @@
+export { SearchV2Trigger } from './SearchV2Trigger'
+export { useSearchV2Variant } from './useSearchV2Variant'

--- a/apps/docs/features/SearchV2/useSearchV2Variant.ts
+++ b/apps/docs/features/SearchV2/useSearchV2Variant.ts
@@ -3,6 +3,7 @@
 import { useFeatureFlags, useSearchParamsShallow } from 'common'
 
 import { SEARCH_V2_FLAG, type SearchV2Variant } from './constants'
+import { IS_PRODUCTION } from '@/lib/constants'
 
 const VARIANTS: SearchV2Variant[] = ['control', 'search-v2-active']
 
@@ -10,20 +11,16 @@ const VARIANTS: SearchV2Variant[] = ['control', 'search-v2-active']
  * Reads the `docs-search-v2` PostHog experiment flag.
  * Defaults to `'control'` while the flag store is loading or if the flag is unset,
  * so an unresolved state always falls back to the current search experience.
- *
- * Local dev only: `?docs-search-v2=search-v2-active` (or `=control`) forces the variant,
- * for testing without a live PostHog/platform connection. Disabled outside `next dev`.
  */
 export function useSearchV2Variant(): SearchV2Variant {
   const { posthog } = useFeatureFlags()
   const searchParams = useSearchParamsShallow()
+  const override = searchParams.get(SEARCH_V2_FLAG)
 
-  if (process.env.NODE_ENV !== 'production') {
-    const override = searchParams.get(SEARCH_V2_FLAG)
-    if (VARIANTS.includes(override as SearchV2Variant)) {
-      return override as SearchV2Variant
-    }
+  if (VARIANTS.includes(override as SearchV2Variant)) {
+    return override as SearchV2Variant
   }
+
 
   return posthog[SEARCH_V2_FLAG] === 'search-v2-active' ? 'search-v2-active' : 'control'
 }

--- a/apps/docs/features/SearchV2/useSearchV2Variant.ts
+++ b/apps/docs/features/SearchV2/useSearchV2Variant.ts
@@ -1,0 +1,29 @@
+'use client'
+
+import { useFeatureFlags, useSearchParamsShallow } from 'common'
+
+import { SEARCH_V2_FLAG, type SearchV2Variant } from './constants'
+
+const VARIANTS: SearchV2Variant[] = ['control', 'search-v2-active']
+
+/**
+ * Reads the `docs-search-v2` PostHog experiment flag.
+ * Defaults to `'control'` while the flag store is loading or if the flag is unset,
+ * so an unresolved state always falls back to the current search experience.
+ *
+ * Local dev only: `?docs-search-v2=search-v2-active` (or `=control`) forces the variant,
+ * for testing without a live PostHog/platform connection. Disabled outside `next dev`.
+ */
+export function useSearchV2Variant(): SearchV2Variant {
+  const { posthog } = useFeatureFlags()
+  const searchParams = useSearchParamsShallow()
+
+  if (process.env.NODE_ENV !== 'production') {
+    const override = searchParams.get(SEARCH_V2_FLAG)
+    if (VARIANTS.includes(override as SearchV2Variant)) {
+      return override as SearchV2Variant
+    }
+  }
+
+  return posthog[SEARCH_V2_FLAG] === 'search-v2-active' ? 'search-v2-active' : 'control'
+}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

This PR adds the main scaffolding code to dynamically load a new search interface using a feature flag.

To test:
 - Open the preview link on this PR
 - Add `?docs-search-v2=search-v2-active` to the URL and reload
 - Click the _Search docs..._ button on the top right
 - You should see a new Search modal that differs from the current one
 - Reload without the search param forcing the feature flag
 - Open the search modal again, the current production variant of the search interface should appear
 
 
 _Screenshot_
 
<img width="1512" height="620" alt="Screenshot 2026-09-10 at 18 36 01" src="https://github.com/user-attachments/assets/b7e59647-9843-4a0c-aa66-2f2adcf397e4" />

**Note:** Search should, but might not be functional. Not relevant to the goal of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an updated documentation search experience with a dedicated search dialog.
  - Added debounced search with loading, error, and no-results states.
  - Added navigation to selected documentation results.
  - Added a searchable trigger with a Meta + K keyboard shortcut.
  - Added accessible search controls with familiar styling.
  - Added the updated search experience alongside the existing search option during rollout.
  - Added clear feedback while searches are loading or when no matching documentation is found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->