### PR TITLE
chore: add @supabase/ai as code owners for studio AI paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,4 +22,7 @@
 /apps/studio/components/interfaces/Organization/Documents/          @supabase/security
 /apps/studio/pages/new/index.tsx                                    @supabase/security
 
+/apps/studio/lib/ai/                                                @supabase/ai
+/apps/studio/pages/api/ai/                                          @supabase/ai
+
 /packages/shared-data/compute-disk-limits.ts @supabase/platform


### PR DESCRIPTION
Adds @supabase/ai as code owners for `apps/studio/lib/ai` and `apps/studio/pages/api/ai`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project ownership rules for AI-related areas.
  * Future changes in these areas will be routed to the designated AI maintainers for review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->