### PR TITLE
feat(www): add Select Hackathon day-of go page

### DIFF
--- a/apps/www/_go/events/select-2026/hackathon-2026-schedule.tsx
+++ b/apps/www/_go/events/select-2026/hackathon-2026-schedule.tsx
@@ -1,0 +1,66 @@
+import type { GoPageInput } from 'marketing'
+
+const todaySql = `-- SELECT HACKATHON  ·  October 3, 2026  ·  YC
+-- presented by Supabase, with support from Claude, Stripe and Vercel
+
+SELECT * FROM today WHERE you = 'building';
+
+-- RUN OF SHOW
+-- +---------+-----------------------------------+
+-- | time    | event                             |
+-- +---------+-----------------------------------+
+-- | 9:30 AM | doors open + check-in             |
+-- | 9:45 AM | kickoff (theme drops on stage)    |
+-- | 1:00 PM | lunch                             |
+-- | 5:30 PM | !! submissions close + happy hour |
+-- | 6:15 PM | demos (top teams)                 |
+-- | 7:30 PM | awards                            |
+-- +---------+-----------------------------------+
+
+-- CONNECT
+-- host:     [wifi network]
+-- password: [wifi password]
+
+-- SUBMIT  (before 5:30 PM) — one submission per team, at hackathon.supabase.com
+INSERT INTO submissions (demo_video, screenshots, github_repo)
+VALUES (...);
+
+-- PRIZES  (API credits, per full team of 4)
+-- +-----------------+------------------------------------------+
+-- | place           | reward                                   |
+-- +-----------------+------------------------------------------+
+-- | grand           | up to 16,000 credits + founder breakfast |
+-- | 2nd             | up to 8,000 credits                      |
+-- | 3rd             | up to 4,000 credits                      |
+-- | best use of ... | 1,000 credits (Claude / Stripe / Vercel) |
+-- +-----------------+------------------------------------------+
+
+-- HELP  (mentors roaming all day)
+SELECT * FROM mentors WHERE you.stuck = true;
+-- help desk: [location]  ·  YC 560 hacking  ·  YC 580 demos
+
+-- hackathon.supabase.com`
+
+const page: GoPageInput = {
+  template: 'lead-gen',
+  slug: 'select-2026/hackathon-2026-schedule',
+  metadata: {
+    title: 'Supabase Select Hackathon 2026',
+    description:
+      'Day-of one-pager for the Select Hackathon at YC, October 3, 2026. Run of show, wifi, how to submit, and prizes.',
+  },
+  hero: {
+    title: 'Supabase Select Hackathon 2026',
+  },
+  sections: [
+    {
+      type: 'code-block',
+      id: 'today',
+      filename: 'selecthackathon2026.sql',
+      language: 'sql',
+      code: todaySql,
+    },
+  ],
+}
+
+export default page

--- a/apps/www/_go/events/select-2026/hackathon-2026-schedule.tsx
+++ b/apps/www/_go/events/select-2026/hackathon-2026-schedule.tsx
@@ -9,7 +9,8 @@ SELECT * FROM today WHERE you = 'building';
 -- +---------+-----------------------------------+
 -- | time    | event                             |
 -- +---------+-----------------------------------+
--- | 9:30 AM | doors open + check-in             |
+-- | 9:00 AM | sponsors arrive                   |
+-- | 9:15 AM | doors open + check-in             |
 -- | 9:45 AM | kickoff (theme drops on stage)    |
 -- | 1:00 PM | lunch                             |
 -- | 5:30 PM | !! submissions close + happy hour |

--- a/apps/www/_go/index.tsx
+++ b/apps/www/_go/index.tsx
@@ -12,6 +12,7 @@ import postgresSummit2026Contest from './events/postgres-summit-2026/contest'
 import postgresSummit2026ContestThankYou from './events/postgres-summit-2026/contest-thank-you'
 import postgresconfContest from './events/postgresconf-sjc-2026/contest'
 import postgresconfContestThankYou from './events/postgresconf-sjc-2026/contest-thank-you'
+import selectHackathon2026Schedule from './events/select-2026/hackathon-2026-schedule'
 import selectPartnerDay from './events/select-2026/partner-day'
 import selectPartnerDayThankYou from './events/select-2026/partner-day-thank-you'
 import selectVipDinner from './events/select-2026/vip-dinner'
@@ -68,6 +69,7 @@ const pages: GoPageInput[] = [
   selectVipExperienceThankYou, // remove after Select 2026
   selectPartnerDay, // remove after Select 2026
   selectPartnerDayThankYou, // remove after Select 2026
+  selectHackathon2026Schedule, // remove after Select 2026
   startupGrindContest, // remove after May 31, 2026
   vercelShipSydneyContest, // remove after July 31, 2026
   vercelShipSydneyContestThankYou, // remove after July 31, 2026


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- Adds a new `/go` page for the Select Hackathon (Oct 3, 2026, YC) at `supabase.com/go/select-2026/hackathon`
- New page definition `apps/www/_go/events/select-2026/hackathon.tsx` (`lead-gen` template)
- Registers it in the go page registry `apps/www/_go/index.tsx`

## What is the current behavior?

There is no day-of one-pager for the Select Hackathon on the site.

## What is the new behavior?

- A day-of one-pager rendered as a `selecthackathon2026.sql` code-block section (run of show, wifi, how to submit, prizes)
- `noIndex` by default (day-of page, not for search)
- Removable after Select 2026 (tagged in the registry alongside the other `select-2026` go pages)

## Additional context

`hackathon.supabase.com` is handled at DNS/Vercel and can point at this path. wifi network/password and help-desk location are still placeholders pending final details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Supabase Select Hackathon 2026 schedule page.
  * Includes event timing, Wi‑Fi details, submission instructions, prize information, and mentor support guidance.
  * Updated the run of show to list sponsor arrival at 9:00 AM and doors opening/check-in at 9:15 AM.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->