### PR TITLE
fix(studio): refine Explorer query surfaces and tab styling

### DIFF
--- a/apps/studio/components/interfaces/Explorer/ExplorerNotebookTab.tsx
+++ b/apps/studio/components/interfaces/Explorer/ExplorerNotebookTab.tsx
@@ -450,16 +450,20 @@ export const ExplorerNotebookTab = () => {
               </DropdownMenuContent>
             </DropdownMenu>
           </ExplorerToolbarActions>
-          <ExplorerToolbarAction
+          <ButtonTooltip
+            type="button"
+            variant="default"
+            size="tiny"
+            className="ml-1"
             aria-label="Run notebook"
             icon={<Play size={16} strokeWidth={2} />}
-            tooltip="Run notebook"
+            tooltip={{ content: { side: 'bottom', text: 'Run notebook' } }}
             loading={isRunningNotebook}
             disabled={queryCellIds.length === 0}
             onClick={handleRunNotebook}
           >
             Run
-          </ExplorerToolbarAction>
+          </ButtonTooltip>
         </ExplorerToolbarActions>
       </ExplorerToolbar>
 

--- a/apps/studio/components/interfaces/Explorer/ExplorerQuery.tsx
+++ b/apps/studio/components/interfaces/Explorer/ExplorerQuery.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { cn } from 'ui'
 
-const explorerQueryClassName = 'flex flex-col overflow-hidden bg-muted'
+const explorerQueryClassName = 'flex flex-col overflow-hidden'
 
 export type ExplorerQueryProps = React.ComponentProps<'div'>
 
@@ -15,7 +15,11 @@ const ExplorerQuery = ({ className, ...props }: ExplorerQueryProps) => (
   <div
     data-slot="explorer-query"
     data-variant="embedded"
-    className={cn(explorerQueryClassName, 'min-h-64 rounded-md border shadow-xs', className)}
+    className={cn(
+      explorerQueryClassName,
+      'min-h-64 rounded-md border bg-card dark:bg-muted shadow-xs',
+      className
+    )}
     {...props}
   />
 )
@@ -31,7 +35,7 @@ const ExplorerQueryViewport = ({ className, ...props }: ExplorerQueryViewportPro
   <div
     data-slot="explorer-query"
     data-variant="viewport"
-    className={cn(explorerQueryClassName, 'h-full min-h-0', className)}
+    className={cn(explorerQueryClassName, 'h-full min-h-0 bg-card dark:bg-muted', className)}
     {...props}
   />
 )

--- a/apps/studio/components/interfaces/Explorer/QueryEditor/QueryRunButton.tsx
+++ b/apps/studio/components/interfaces/Explorer/QueryEditor/QueryRunButton.tsx
@@ -26,7 +26,7 @@ export const QueryRunButton = ({
   onRunSelected,
 }: QueryRunButtonProps) => {
   return (
-    <div className="flex w-fit">
+    <div className="ml-1 flex w-fit">
       <ButtonTooltip
         type="button"
         variant="default"

--- a/apps/studio/components/layouts/Tabs/SortableTab.tsx
+++ b/apps/studio/components/layouts/Tabs/SortableTab.tsx
@@ -79,7 +79,7 @@ export const SortableTab = ({
       layoutId={tab.id}
       transition={{ duration: 0.045 }}
       animate={{ opacity: isDragging ? 0 : 1 }}
-      className={cn('flex items-center h-(--header-height) first-of-type:border-l')}
+      className={cn('flex items-center h-(--header-height)', index === 0 && 'border-l')}
     >
       <div className="group/tab relative flex h-full min-w-0 items-center">
         <TabsTrigger


### PR DESCRIPTION
Explorer query surfaces now use `bg-card` in light mode and `bg-muted` in dark mode, including embedded notebook/chat queries and query tab toolbars. Notebook Run buttons match query tabs, with `ml-1` spacing on both. Fix doubled tab separators by applying the leading border only to the first tab.

### How to test

1. Open Explorer with multiple query, notebook, and chat tabs. Switch, reorder, and close tabs; confirm each separator stays one pixel wide.
2. In light and dark mode, inspect query tabs and embedded notebook/chat queries: backgrounds should be card in light mode and muted in dark mode, including their toolbars.
3. Compare notebook and query Run buttons: matching default styling and spacing. Run a read-only query such as `select 1` in both and check loading and results.
4. Check SQL Editor and Table Editor tab separators, since the tab component is shared.

Validation: Prettier passed for all four changed files. Manual checks above have not been run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Refined notebook and query run button styling, including spacing and tooltip placement.
  - Improved query editor panel backgrounds across light and dark themes.
  - Updated tab border rendering for more consistent visual alignment.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->