### PR TITLE
Chore/team members rendering optimizations

### DIFF
--- a/apps/studio/components/interfaces/Organization/TeamSettings/MemberActions.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/MemberActions.tsx
@@ -14,42 +14,34 @@ import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 
 import { LeaveTeamButton } from './LeaveTeamButton'
 import { useGetRolesManagementPermissions } from './TeamSettings.utils'
+import { useTeamSettingsData } from './TeamSettingsDataContext'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import { DropdownMenuItemTooltip } from '@/components/ui/DropdownMenuItemTooltip'
 import { useOrganizationCreateInvitationMutation } from '@/data/organization-members/organization-invitation-create-mutation'
 import { useOrganizationDeleteInvitationMutation } from '@/data/organization-members/organization-invitation-delete-mutation'
-import type { OrganizationRolesResponse } from '@/data/organization-members/organization-roles-query'
 import { useOrganizationMemberDeleteMutation } from '@/data/organizations/organization-member-delete-mutation'
 import type { OrganizationMember } from '@/data/organizations/organization-members-query'
-import type { OrganizationBase } from '@/data/organizations/organizations-query'
 import { doPermissionsCheck } from '@/hooks/misc/useCheckPermissions'
 import { IS_PLATFORM } from '@/lib/constants'
 import { useProfile } from '@/lib/profile'
-import type { Permission } from '@/types'
 
 interface MemberActionsProps {
   member: OrganizationMember
-  members: OrganizationMember[]
-  allRoles: OrganizationRolesResponse | undefined
-  permissions: Permission[] | undefined
-  selectedOrganization: OrganizationBase | undefined
-  organizationMembersDeletionEnabled: boolean
-  onManageAccess: (member: OrganizationMember) => void
 }
 
-export const MemberActions = ({
-  member,
-  members,
-  allRoles,
-  permissions,
-  selectedOrganization,
-  organizationMembersDeletionEnabled,
-  onManageAccess,
-}: MemberActionsProps) => {
+export const MemberActions = ({ member }: MemberActionsProps) => {
   const { slug } = useParams()
   const { profile } = useProfile()
   const isLoggedIn = useIsLoggedIn()
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
+  const {
+    members,
+    roles: allRoles,
+    permissions,
+    selectedOrganization,
+    organizationMembersDeletionEnabled,
+    onManageAccess,
+  } = useTeamSettingsData()
 
   const memberIsUser = member.gotrue_id == profile?.gotrue_id
   const orgScopedRoles = allRoles?.org_scoped_roles ?? []
@@ -201,6 +193,7 @@ export const MemberActions = ({
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
+              aria-label="More options"
               variant="text"
               className="px-1.5"
               disabled={isLoading}

--- a/apps/studio/components/interfaces/Organization/TeamSettings/MemberRow.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/MemberRow.tsx
@@ -15,46 +15,24 @@ import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 
 import { isInviteExpired } from '../Organization.utils'
 import { MemberActions } from './MemberActions'
+import { useTeamSettingsData } from './TeamSettingsDataContext'
 import PartnerIcon from '@/components/ui/PartnerIcon'
 import { ProfileImage } from '@/components/ui/ProfileImage'
-import {
-  OrganizationRole,
-  OrganizationRolesResponse,
-} from '@/data/organization-members/organization-roles-query'
+import { OrganizationRole } from '@/data/organization-members/organization-roles-query'
 import { OrganizationMember } from '@/data/organizations/organization-members-query'
-import { OrganizationBase } from '@/data/organizations/organizations-query'
-import { OrgProject } from '@/data/projects/org-projects-infinite-query'
 import { useProfile } from '@/lib/profile'
-import type { Permission } from '@/types'
 
 interface MemberRowProps {
   member: OrganizationMember
-  members: OrganizationMember[]
-  roles: OrganizationRolesResponse | undefined
-  isLoadingRoles: boolean
-  orgProjects: OrgProject[]
-  permissions: Permission[] | undefined
-  selectedOrganization: OrganizationBase | undefined
-  organizationMembersDeletionEnabled: boolean
-  onManageAccess: (member: OrganizationMember) => void
 }
 
 const MEMBER_ORIGIN_TO_MANAGED_BY = {
   vercel: 'vercel-marketplace',
 } as const
 
-export const MemberRow = memo(function MemberRow({
-  member,
-  members,
-  roles,
-  isLoadingRoles,
-  orgProjects,
-  permissions,
-  selectedOrganization,
-  organizationMembersDeletionEnabled,
-  onManageAccess,
-}: MemberRowProps) {
+export const MemberRow = memo(function MemberRow({ member }: MemberRowProps) {
   const { profile } = useProfile()
+  const { roles, isLoadingRoles, orgProjects } = useTeamSettingsData()
 
   const hasProjectScopedRoles = (roles?.project_scoped_roles ?? []).length > 0
 
@@ -119,7 +97,7 @@ export const MemberRow = memo(function MemberRow({
                 </Badge>
               )}
               {member.is_sso_user && <Badge variant="default">SSO</Badge>}
-              {(member.metadata as any)?.origin && (
+              {Boolean(member.metadata?.origin) && (
                 <PartnerIcon
                   organization={{
                     managed_by:
@@ -210,15 +188,7 @@ export const MemberRow = memo(function MemberRow({
       </TableCell>
 
       <TableCell>
-        <MemberActions
-          member={member}
-          members={members}
-          allRoles={roles}
-          permissions={permissions}
-          selectedOrganization={selectedOrganization}
-          organizationMembersDeletionEnabled={organizationMembersDeletionEnabled}
-          onManageAccess={onManageAccess}
-        />
+        <MemberActions member={member} />
       </TableCell>
     </TableRow>
   )

--- a/apps/studio/components/interfaces/Organization/TeamSettings/MemberRow.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/MemberRow.tsx
@@ -1,6 +1,6 @@
 import { ArrowRight, Check, ChevronRight, User, X } from 'lucide-react'
 import Link from 'next/link'
-import { memo } from 'react'
+import { memo, useMemo } from 'react'
 import {
   Badge,
   cn,
@@ -17,7 +17,10 @@ import { isInviteExpired } from '../Organization.utils'
 import { MemberActions } from './MemberActions'
 import PartnerIcon from '@/components/ui/PartnerIcon'
 import { ProfileImage } from '@/components/ui/ProfileImage'
-import { OrganizationRolesResponse } from '@/data/organization-members/organization-roles-query'
+import {
+  OrganizationRole,
+  OrganizationRolesResponse,
+} from '@/data/organization-members/organization-roles-query'
 import { OrganizationMember } from '@/data/organizations/organization-members-query'
 import { OrganizationBase } from '@/data/organizations/organizations-query'
 import { OrgProject } from '@/data/projects/org-projects-infinite-query'
@@ -59,6 +62,33 @@ export const MemberRow = memo(function MemberRow({
 
   // Use generic avatar for all team members instead of attempting to fetch from GitHub
   const profileImageUrl = undefined
+
+  const roleById = useMemo(() => {
+    const map = new Map<number, OrganizationRole>()
+    for (const role of roles?.org_scoped_roles ?? []) map.set(role.id, role)
+    for (const role of roles?.project_scoped_roles ?? []) map.set(role.id, role)
+    return map
+  }, [roles])
+
+  const projectNameByRef = useMemo(
+    () => new Map(orgProjects.map((p) => [p.ref, p.name])),
+    [orgProjects]
+  )
+
+  const roleRows = useMemo(() => {
+    return member.role_ids.map((id) => {
+      const role = roleById.get(id)
+      const roleName = (role?.name ?? '').split('_')[0]
+      const appliesToAllProjects = role?.projects.length === 0
+      const projectsApplied = appliesToAllProjects
+        ? orgProjects.map((p) => ({ ref: p.ref, name: p.name }))
+        : (role?.projects ?? [])
+            .map(({ ref }) => ({ ref, name: projectNameByRef.get(ref) ?? '' }))
+            .filter(({ name }) => name.length > 0)
+
+      return { id, roleName, appliesToAllProjects, projectsApplied }
+    })
+  }, [member.role_ids, roleById, orgProjects, projectNameByRef])
 
   return (
     <TableRow>
@@ -125,74 +155,57 @@ export const MemberRow = memo(function MemberRow({
         {isLoadingRoles ? (
           <ShimmeringLoader className="w-32" />
         ) : (
-          member.role_ids.map((id) => {
-            const orgScopedRole = (roles?.org_scoped_roles ?? []).find((role) => role.id === id)
-            const projectScopedRole = (roles?.project_scoped_roles ?? []).find(
-              (role) => role.id === id
-            )
-            const role = orgScopedRole || projectScopedRole
-            const roleName = (role?.name ?? '').split('_')[0]
-            const projectsApplied =
-              role?.projects.length === 0
-                ? (orgProjects?.map((p) => p.name) ?? [])
-                : (role?.projects ?? [])
-                    .map(({ ref }) => orgProjects?.find((p) => p.ref === ref)?.name ?? '')
-                    .filter((x) => x.length > 0)
-
-            return (
-              <div key={`role-${id}`} className="flex items-center gap-x-2">
-                <p className="text-foreground-light">{roleName}</p>
-                {hasProjectScopedRoles && (
-                  <>
-                    <ChevronRight className="text-foreground-muted/50" size={14} />
-                    {projectsApplied.length === 1 ? (
-                      <span className="text-foreground-light truncate" title={projectsApplied[0]}>
-                        {projectsApplied[0]}
-                      </span>
-                    ) : (
-                      <HoverCard openDelay={200}>
-                        <HoverCardTrigger asChild>
-                          <span className="text-foreground-light">
-                            {role?.projects.length === 0
-                              ? 'Organization'
-                              : `${projectsApplied.length} project${projectsApplied.length > 1 ? 's' : ''}`}
-                          </span>
-                        </HoverCardTrigger>
-                        <HoverCardContent className="p-0">
-                          <p className="p-2 text-xs">
-                            {roleName} role applies to {projectsApplied.length} project
-                            {projectsApplied.length > 1 ? 's' : ''}
-                          </p>
-                          <div className="border-t flex flex-col py-1">
-                            <ScrollArea
-                              className={cn(projectsApplied.length > 5 ? 'h-[130px]' : '')}
-                            >
-                              {projectsApplied.map((name) => {
-                                const ref = orgProjects?.find((p) => p.name === name)?.ref
-                                return (
-                                  <Link
-                                    key={name}
-                                    href={`/project/${ref}`}
-                                    className="px-2 py-1 group hover:bg-surface-300 hover:text-foreground transition flex items-center justify-between"
-                                  >
-                                    <span className="text-xs truncate max-w-[60%]">{name}</span>
-                                    <span className="text-xs text-foreground flex items-center gap-x-1 opacity-0 group-hover:opacity-100 transition">
-                                      Go to project
-                                      <ArrowRight size={14} />
-                                    </span>
-                                  </Link>
-                                )
-                              })}
-                            </ScrollArea>
-                          </div>
-                        </HoverCardContent>
-                      </HoverCard>
-                    )}
-                  </>
-                )}
-              </div>
-            )
-          })
+          roleRows.map(({ id, roleName, appliesToAllProjects, projectsApplied }) => (
+            <div key={`role-${id}`} className="flex items-center gap-x-2">
+              <p className="text-foreground-light">{roleName}</p>
+              {hasProjectScopedRoles && (
+                <>
+                  <ChevronRight className="text-foreground-muted/50" size={14} />
+                  {projectsApplied.length === 1 ? (
+                    <span
+                      className="text-foreground-light truncate"
+                      title={projectsApplied[0].name}
+                    >
+                      {projectsApplied[0].name}
+                    </span>
+                  ) : (
+                    <HoverCard openDelay={200}>
+                      <HoverCardTrigger asChild>
+                        <span className="text-foreground-light">
+                          {appliesToAllProjects
+                            ? 'Organization'
+                            : `${projectsApplied.length} project${projectsApplied.length > 1 ? 's' : ''}`}
+                        </span>
+                      </HoverCardTrigger>
+                      <HoverCardContent className="p-0">
+                        <p className="p-2 text-xs">
+                          {roleName} role applies to {projectsApplied.length} project
+                          {projectsApplied.length > 1 ? 's' : ''}
+                        </p>
+                        <div className="border-t flex flex-col py-1">
+                          <ScrollArea className={cn(projectsApplied.length > 5 ? 'h-[130px]' : '')}>
+                            {projectsApplied.map(({ ref, name }) => (
+                              <Link
+                                key={ref}
+                                href={`/project/${ref}`}
+                                className="px-2 py-1 group hover:bg-surface-300 hover:text-foreground transition flex items-center justify-between"
+                              >
+                                <span className="text-xs truncate max-w-[60%]">{name}</span>
+                                <span className="text-xs text-foreground flex items-center gap-x-1 opacity-0 group-hover:opacity-100 transition">
+                                  Go to project
+                                  <ArrowRight size={14} />
+                                </span>
+                              </Link>
+                            ))}
+                          </ScrollArea>
+                        </div>
+                      </HoverCardContent>
+                    </HoverCard>
+                  )}
+                </>
+              )}
+            </div>
+          ))
         )}
       </TableCell>
 

--- a/apps/studio/components/interfaces/Organization/TeamSettings/MemberRow.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/MemberRow.tsx
@@ -1,5 +1,6 @@
 import { ArrowRight, Check, ChevronRight, User, X } from 'lucide-react'
 import Link from 'next/link'
+import { memo } from 'react'
 import {
   Badge,
   cn,
@@ -39,7 +40,7 @@ const MEMBER_ORIGIN_TO_MANAGED_BY = {
   vercel: 'vercel-marketplace',
 } as const
 
-export const MemberRow = ({
+export const MemberRow = memo(function MemberRow({
   member,
   members,
   roles,
@@ -49,7 +50,7 @@ export const MemberRow = ({
   selectedOrganization,
   organizationMembersDeletionEnabled,
   onManageAccess,
-}: MemberRowProps) => {
+}: MemberRowProps) {
   const { profile } = useProfile()
 
   const hasProjectScopedRoles = (roles?.project_scoped_roles ?? []).length > 0
@@ -93,7 +94,7 @@ export const MemberRow = ({
                   organization={{
                     managed_by:
                       MEMBER_ORIGIN_TO_MANAGED_BY[
-                        (member.metadata as any).origin as keyof typeof MEMBER_ORIGIN_TO_MANAGED_BY
+                        member.metadata.origin as keyof typeof MEMBER_ORIGIN_TO_MANAGED_BY
                       ] ?? 'supabase',
                   }}
                   tooltipText="Managed by Vercel Marketplace."
@@ -208,4 +209,4 @@ export const MemberRow = ({
       </TableCell>
     </TableRow>
   )
-}
+})

--- a/apps/studio/components/interfaces/Organization/TeamSettings/MembersView.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/MembersView.tsx
@@ -1,7 +1,7 @@
 import { useParams } from 'common'
 import { partition } from 'lodash'
 import { AlertCircle } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import {
   Card,
   Loading,
@@ -34,9 +34,16 @@ export interface MembersViewProps {
   searchString: string
 }
 
-const MembersView = ({ searchString }: MembersViewProps) => {
+export const MembersView = ({ searchString }: MembersViewProps) => {
   const { slug } = useParams()
   const { profile } = useProfile()
+
+  const { data: selectedOrganization } = useSelectedOrganizationQuery()
+  const { data: permissions } = usePermissionsQuery()
+  const organizationMembersDeletionEnabled = useIsFeatureEnabled('organization_members:delete')
+
+  const [memberForRoleUpdate, setMemberForRoleUpdate] = useState<OrganizationMember>()
+  const [showRoleUpdatePanel, setShowRoleUpdatePanel] = useState(false)
 
   const {
     data: members = [],
@@ -54,10 +61,6 @@ const MembersView = ({ searchString }: MembersViewProps) => {
   } = useOrganizationRolesV2Query({
     slug,
   })
-
-  const { data: selectedOrganization } = useSelectedOrganizationQuery()
-  const { data: permissions } = usePermissionsQuery()
-  const organizationMembersDeletionEnabled = useIsFeatureEnabled('organization_members:delete')
 
   const { data: projectsData } = useOrgProjectsInfiniteQuery({ slug })
   const orgProjects = useMemo(
@@ -81,30 +84,32 @@ const MembersView = ({ searchString }: MembersViewProps) => {
         })
   }, [members, searchString])
 
-  const [[user], _otherMembers] = partition(
-    filteredMembers,
-    (m) => m.gotrue_id === profile?.gotrue_id
-  )
-
-  const [memberForRoleUpdate, setMemberForRoleUpdate] = useState<OrganizationMember>()
-  const [showRoleUpdatePanel, setShowRoleUpdatePanel] = useState(false)
-  const handleManageAccess = (member: OrganizationMember) => {
+  const handleManageAccess = useCallback((member: OrganizationMember) => {
     setMemberForRoleUpdate(member)
     setShowRoleUpdatePanel(true)
-  }
+  }, [])
 
   const userMember = members.find((m) => m.gotrue_id === profile?.gotrue_id)
   const orgScopedRoleIds = (roles?.org_scoped_roles ?? []).map((r) => r.id)
   const isOrgScopedRole = orgScopedRoleIds.includes(userMember?.role_ids?.[0] ?? -1)
 
-  // [Joshen] Temp wait on API level changes but I think it makes sense to hide invites for
-  // project scoped users since they can't see other members to begin with. Not a security issue nonetheless
-  const otherMembers = isOrgScopedRole
-    ? _otherMembers
-    : _otherMembers.filter((x) => !('invited_id' in x))
-  const sortedMembers = otherMembers.sort((a, b) =>
-    (a.primary_email ?? '').localeCompare(b.primary_email ?? '')
-  )
+  const { user, sortedMembers } = useMemo(() => {
+    const [[currentUser], _otherMembers] = partition(
+      filteredMembers,
+      (m) => m.gotrue_id === profile?.gotrue_id
+    )
+
+    // [Joshen] Temp wait on API level changes but I think it makes sense to hide invites for
+    // project scoped users since they can't see other members to begin with. Not a security issue nonetheless
+    const otherMembers = isOrgScopedRole
+      ? _otherMembers
+      : _otherMembers.filter((x) => !('invited_id' in x))
+    const sorted = [...otherMembers].sort((a, b) =>
+      (a.primary_email ?? '').localeCompare(b.primary_email ?? '')
+    )
+
+    return { user: currentUser, sortedMembers: sorted }
+  }, [filteredMembers, profile?.gotrue_id, isOrgScopedRole])
 
   return (
     <>
@@ -219,5 +224,3 @@ const MembersView = ({ searchString }: MembersViewProps) => {
     </>
   )
 }
-
-export default MembersView

--- a/apps/studio/components/interfaces/Organization/TeamSettings/MembersView.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/MembersView.tsx
@@ -163,9 +163,7 @@ export const MembersView = ({ searchString }: MembersViewProps) => {
                           </TableRow>,
                         ]
                       : []),
-                    ...(!!user
-                      ? [<MemberRow key={user.gotrue_id} member={user} />]
-                      : []),
+                    ...(!!user ? [<MemberRow key={user.gotrue_id} member={user} />] : []),
                     ...sortedMembers.map((member) => (
                       <MemberRow key={member.gotrue_id} member={member} />
                     )),

--- a/apps/studio/components/interfaces/Organization/TeamSettings/MembersView.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/MembersView.tsx
@@ -17,6 +17,7 @@ import { Admonition } from 'ui-patterns/Admonition'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 
 import { MemberRow } from './MemberRow'
+import { TeamSettingsDataProvider } from './TeamSettingsDataContext'
 import { UpdateRolesPanel } from './UpdateRolesPanel/UpdateRolesPanel'
 import { AlertError } from '@/components/ui/AlertError'
 import { useOrganizationRolesV2Query } from '@/data/organization-members/organization-roles-query'
@@ -112,7 +113,16 @@ export const MembersView = ({ searchString }: MembersViewProps) => {
   }, [filteredMembers, profile?.gotrue_id, isOrgScopedRole])
 
   return (
-    <>
+    <TeamSettingsDataProvider
+      members={members}
+      roles={roles}
+      isLoadingRoles={isLoadingRoles}
+      orgProjects={orgProjects}
+      permissions={permissions}
+      selectedOrganization={selectedOrganization}
+      organizationMembersDeletionEnabled={organizationMembersDeletionEnabled}
+      onManageAccess={handleManageAccess}
+    >
       {isLoadingMembers && <GenericSkeletonLoader />}
 
       {isErrorMembers && (
@@ -154,34 +164,10 @@ export const MembersView = ({ searchString }: MembersViewProps) => {
                         ]
                       : []),
                     ...(!!user
-                      ? [
-                          <MemberRow
-                            key={user.gotrue_id}
-                            member={user}
-                            members={members}
-                            roles={roles}
-                            isLoadingRoles={isLoadingRoles}
-                            orgProjects={orgProjects}
-                            permissions={permissions}
-                            selectedOrganization={selectedOrganization}
-                            organizationMembersDeletionEnabled={organizationMembersDeletionEnabled}
-                            onManageAccess={handleManageAccess}
-                          />,
-                        ]
+                      ? [<MemberRow key={user.gotrue_id} member={user} />]
                       : []),
                     ...sortedMembers.map((member) => (
-                      <MemberRow
-                        key={member.gotrue_id}
-                        member={member}
-                        members={members}
-                        roles={roles}
-                        isLoadingRoles={isLoadingRoles}
-                        orgProjects={orgProjects}
-                        permissions={permissions}
-                        selectedOrganization={selectedOrganization}
-                        organizationMembersDeletionEnabled={organizationMembersDeletionEnabled}
-                        onManageAccess={handleManageAccess}
-                      />
+                      <MemberRow key={member.gotrue_id} member={member} />
                     )),
                     ...(searchString.length > 0 && filteredMembers.length === 0
                       ? [
@@ -221,6 +207,6 @@ export const MembersView = ({ searchString }: MembersViewProps) => {
           onClose={() => setShowRoleUpdatePanel(false)}
         />
       )}
-    </>
+    </TeamSettingsDataProvider>
   )
 }

--- a/apps/studio/components/interfaces/Organization/TeamSettings/TeamSettings.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/TeamSettings.tsx
@@ -6,7 +6,7 @@ import { Admonition } from 'ui-patterns/Admonition'
 import { Input } from 'ui-patterns/DataInputs/Input'
 
 import { InviteMemberButton } from './InviteMemberButton'
-import MembersView from './MembersView'
+import { MembersView } from './MembersView'
 import {
   ScaffoldActionsContainer,
   ScaffoldActionsGroup,

--- a/apps/studio/components/interfaces/Organization/TeamSettings/TeamSettingsDataContext.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/TeamSettingsDataContext.tsx
@@ -1,0 +1,70 @@
+import type { PropsWithChildren } from 'react'
+import { createContext, useContext, useMemo } from 'react'
+
+import type { OrganizationRolesResponse } from '@/data/organization-members/organization-roles-query'
+import type { OrganizationMember } from '@/data/organizations/organization-members-query'
+import type { OrganizationBase } from '@/data/organizations/organizations-query'
+import type { OrgProject } from '@/data/projects/org-projects-infinite-query'
+import type { Permission } from '@/types'
+
+type TeamSettingsDataContextValue = {
+  members: OrganizationMember[]
+  roles: OrganizationRolesResponse | undefined
+  isLoadingRoles: boolean
+  orgProjects: OrgProject[]
+  permissions: Permission[] | undefined
+  selectedOrganization: OrganizationBase | undefined
+  organizationMembersDeletionEnabled: boolean
+  onManageAccess: (member: OrganizationMember) => void
+}
+
+const TeamSettingsDataContext = createContext<TeamSettingsDataContextValue | null>(null)
+
+export const useTeamSettingsData = () => {
+  const context = useContext(TeamSettingsDataContext)
+  if (!context) {
+    throw new Error('useTeamSettingsData must be used within TeamSettingsDataProvider')
+  }
+  return context
+}
+
+export const TeamSettingsDataProvider = ({
+  children,
+  members,
+  roles,
+  isLoadingRoles,
+  orgProjects,
+  permissions,
+  selectedOrganization,
+  organizationMembersDeletionEnabled,
+  onManageAccess,
+}: PropsWithChildren<TeamSettingsDataContextValue>) => {
+  const contextValue = useMemo(
+    () => ({
+      members,
+      roles,
+      isLoadingRoles,
+      orgProjects,
+      permissions,
+      selectedOrganization,
+      organizationMembersDeletionEnabled,
+      onManageAccess,
+    }),
+    [
+      members,
+      roles,
+      isLoadingRoles,
+      orgProjects,
+      permissions,
+      selectedOrganization,
+      organizationMembersDeletionEnabled,
+      onManageAccess,
+    ]
+  )
+
+  return (
+    <TeamSettingsDataContext.Provider value={contextValue}>
+      {children}
+    </TeamSettingsDataContext.Provider>
+  )
+}

--- a/apps/studio/data/organization-members/organization-roles-query.ts
+++ b/apps/studio/data/organization-members/organization-roles-query.ts
@@ -46,10 +46,10 @@ export const useOrganizationRolesV2Query = <TData = OrganizationRolesData>(
     select: (data) => {
       return {
         ...data,
-        org_scoped_roles: data.org_scoped_roles.sort((a, b) => {
+        org_scoped_roles: [...data.org_scoped_roles].sort((a, b) => {
           return FIXED_ROLE_ORDER.indexOf(a.name) - FIXED_ROLE_ORDER.indexOf(b.name)
         }),
-      } as any
+      } as TData
     },
     ...options,
   })


### PR DESCRIPTION
## Context

Follow up to https://github.com/supabase/supabase/pull/50238 which addressed some rendering issues for organization team settings. The changes in 50238 improved the performance of searching members, but there's still a bit of client side latency. There shouldn't be any functional changes from the changes here, just refactoring

- `MemberRow` wrapped in `memo` so unaffected rows skip re-rendering
- Memoized a number of variables in `MembersView` so they only recompute when filtered members/user/role actually change, not on every render
- In `MemberRow`, replaced per-role `.find()` chains with Map-based lookups and memoized the whole per-role derivation 
- Fixed a mutating in-place `.sort()` in `organization-roles-query.ts`'s select that was silently rewriting the shared RQ cache entry
- Added `TeamSettingsDataContext` + reduce prop drilling for `MemberRow` + `MemberActions`
- Removed an any cast on member.metadata?.origin in MemberRow, replaced with explicit Boolean(...) coercion

Organization team settings page should work as per status quo including searching. The searching was the main issue so these are hoping to alleviate the performance issues. It's quite hard to test unless you've got an organization with a 150 + members though (< 100 you don't really see any issues).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved the Team Settings member list for more consistent role and project information.
  - Member role links now provide more direct navigation to associated projects.
  - Improved performance when displaying and sorting team members.
  - Added an accessible label to the member actions menu.
- **Bug Fixes**
  - Prevented organization role data from being unexpectedly changed while it is sorted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->