### PR TITLE
ci(api-types): summarize production type differences

### DIFF
--- a/packages/api-types/scripts/verify-production-types.mjs
+++ b/packages/api-types/scripts/verify-production-types.mjs
@@ -1,5 +1,5 @@
 import { execFile } from 'node:child_process'
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { appendFile, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -66,6 +66,56 @@ export async function findMismatchedTypes(
   return mismatches.filter((filename) => filename !== undefined)
 }
 
+export async function reportTypeDifferences(
+  filenames,
+  {
+    generatedTypesDirectory,
+    typesDirectory,
+    summaryPath = process.env.GITHUB_STEP_SUMMARY,
+    log = console.log,
+  }
+) {
+  const summary = [
+    '## Production API type differences',
+    '',
+    'Committed types differ from production. `-` lines are committed; `+` lines are production.',
+    '',
+  ]
+
+  for (const filename of filenames) {
+    let diff
+    try {
+      const result = await run(
+        'diff',
+        [
+          '-u',
+          '--label',
+          `committed/${filename}`,
+          '--label',
+          `production/${filename}`,
+          join(typesDirectory, filename),
+          join(generatedTypesDirectory, filename),
+        ],
+        { maxBuffer: 32 * 1024 * 1024 }
+      )
+      diff = result.stdout
+    } catch (error) {
+      if (error.code !== 1) throw error
+      diff = error.stdout
+    }
+
+    log(`${filename}\n${diff}`)
+    const preview = diff.slice(0, 60_000)
+    const escaped = preview.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;')
+    summary.push(`### ${filename}`, '', `<pre>${escaped}</pre>`, '')
+    if (preview.length < diff.length) {
+      summary.push('Diff preview truncated. See the verification step logs for the full diff.', '')
+    }
+  }
+
+  if (summaryPath) await appendFile(summaryPath, `${summary.join('\n')}\n`)
+}
+
 export async function verifyProductionTypes() {
   const temporaryDirectory = await mkdtemp(join(tmpdir(), 'api-types-'))
   const generatedTypesDirectory = join(temporaryDirectory, 'types')
@@ -109,6 +159,7 @@ export async function verifyProductionTypes() {
     })
 
     if (changedTypes.length > 0) {
+      await reportTypeDifferences(changedTypes, { generatedTypesDirectory, typesDirectory })
       throw new Error(`Committed API types do not match production: ${changedTypes.join(', ')}`)
     }
   } finally {

--- a/packages/api-types/scripts/verify-production-types.test.mjs
+++ b/packages/api-types/scripts/verify-production-types.test.mjs
@@ -1,7 +1,63 @@
 import assert from 'node:assert/strict'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import test from 'node:test'
 
-import { fetchOpenApiSpecifications, findMismatchedTypes } from './verify-production-types.mjs'
+import {
+  fetchOpenApiSpecifications,
+  findMismatchedTypes,
+  reportTypeDifferences,
+} from './verify-production-types.mjs'
+
+test('reports unified diffs in logs and appends an escaped, bounded Actions summary', async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), 'api-types-report-'))
+  t.after(() => rm(directory, { recursive: true, force: true }))
+  const typesDirectory = join(directory, 'committed')
+  const generatedTypesDirectory = join(directory, 'production')
+  const summaryPath = join(directory, 'summary.md')
+  await mkdir(typesDirectory)
+  await mkdir(generatedTypesDirectory)
+  await writeFile(summaryPath, 'Existing summary\n')
+  await writeFile(join(typesDirectory, 'api-v1.d.ts'), 'type A = string\n')
+  await writeFile(join(generatedTypesDirectory, 'api-v1.d.ts'), 'type A = Array<number>\n')
+  await writeFile(join(typesDirectory, 'platform.d.ts'), 'old\n')
+  await writeFile(join(generatedTypesDirectory, 'platform.d.ts'), 'new\n'.repeat(20_000))
+  const logs = []
+  await reportTypeDifferences(['api-v1.d.ts', 'platform.d.ts'], {
+    typesDirectory,
+    generatedTypesDirectory,
+    summaryPath,
+    log: (value) => logs.push(value),
+  })
+  assert.equal(logs.length, 2)
+  assert.match(logs[0], /--- committed\/api-v1.d.ts\n\+\+\+ production\/api-v1.d.ts/)
+  assert.match(logs[0], /@@ -1 \+1 @@/)
+  assert.match(logs[0], /-type A = string\n\+type A = Array<number>/)
+  assert.ok(logs[1].length > 60_000)
+  const summary = await readFile(summaryPath, 'utf8')
+  assert.ok(summary.startsWith('Existing summary\n'))
+  assert.match(summary, /Array&lt;number&gt;/)
+  assert.match(summary, /### platform.d.ts/)
+  assert.match(summary, /Diff preview truncated/)
+  assert.ok(summary.length < 62_000)
+
+  await reportTypeDifferences(['api-v1.d.ts'], {
+    typesDirectory,
+    generatedTypesDirectory,
+    summaryPath: '',
+    log: () => {},
+  })
+  await assert.rejects(
+    reportTypeDifferences(['missing.d.ts'], {
+      typesDirectory,
+      generatedTypesDirectory,
+      summaryPath: '',
+      log: () => {},
+    }),
+    (error) => error.code === 2
+  )
+})
 
 const specifications = [
   { name: 'api-v1', url: 'https://example.com/api/v1-json' },


### PR DESCRIPTION
## Problem

The production API types check reports mismatched filenames without showing which declarations differ, making drift difficult to diagnose.

## Fix
<img width="1771" height="1012" alt="Shotbase Capture-AB6E5CC9-905B-46E3-AD7B-A2DE868D9E95" src="https://github.com/user-attachments/assets/81666e89-b79f-4456-a187-43af16ce2bec" />

Print a unified diff for each mismatched file with line numbers and committed/production labels. Append escaped, bounded previews to the GitHub Actions summary, with full diffs in the step logs, while preserving the failing check.

## How to test

- Run `node --test packages/api-types/scripts/verify-production-types.test.mjs` (all six tests pass).
- Tests cover diff direction and line numbers, multiple files, summary appending and escaping, preview truncation, local logging without an Actions summary, and diff command failures.
- Both changed files were formatted with the repository Prettier configuration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detailed difference reporting when generated production types do not match committed types.
  * CI logs now include readable unified diffs, with large outputs safely truncated and escaped.
  * GitHub Actions summaries can include mismatched type files and their differences while preserving existing summary content.

* **Bug Fixes**
  * Improved diagnostics for missing type files and type verification failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->