### PR TITLE
fix(studio): use configured gp3 max-IOPS ceiling

### DIFF
--- a/apps/studio/components/interfaces/DiskManagement/DiskManagement.test.ts
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagement.test.ts
@@ -70,13 +70,17 @@ describe('DiskManagement utils', () => {
 
 describe('calculateMaxIopsAllowedForDiskSizeWithGp3', () => {
   // Regression: old code returned `3000 * size`, letting a 2 GB disk request 6000 IOPS
-  // which the platform rejects. The real ceiling is 500 IOPS/GB capped at 16 000.
+  // which the platform rejects. The real ceiling is 500 IOPS/GB capped at DISK_LIMITS.gp3.maxIops.
   test('caps a sub-6 GB disk at the 3000 IOPS floor (not 3000 × size)', () => {
     expect(calculateMaxIopsAllowedForDiskSizeWithGp3(2)).toBe(3000)
   })
 
-  test('caps large disks at 16 000 IOPS', () => {
-    expect(calculateMaxIopsAllowedForDiskSizeWithGp3(100)).toBe(16000)
+  test('scales linearly with disk size below the gp3 max IOPS ceiling', () => {
+    expect(calculateMaxIopsAllowedForDiskSizeWithGp3(100)).toBe(50000)
+  })
+
+  test('caps large disks at the gp3 max IOPS ceiling (80 000)', () => {
+    expect(calculateMaxIopsAllowedForDiskSizeWithGp3(1000)).toBe(80000)
   })
 })
 

--- a/apps/studio/components/interfaces/DiskManagement/DiskManagement.utils.ts
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagement.utils.ts
@@ -281,8 +281,9 @@ export function getAvailableComputeOptions(
   return computeOptions
 }
 
+const MAX_GP3_IOPS = DISK_LIMITS[DiskType.GP3]['maxIops']
 export const calculateMaxIopsAllowedForDiskSizeWithGp3 = (totalSize: number) => {
-  return Math.max(3000, Math.min(500 * totalSize, 16000))
+  return Math.max(3000, Math.min(500 * totalSize, MAX_GP3_IOPS))
 }
 
 export const calculateDiskSizeRequiredForIopsWithGp3 = (iops: number) => {


### PR DESCRIPTION
## Summary

* GP3 IOPS calculation was hardcoded to 16,000 instead of reading from DISK_LIMITS config
* AWS updated the real ceiling to 80,000, making the hardcoded constant stale
* Users with large multi-TB GP3 disks were incorrectly blocked from provisioning above 16,000 IOPS

## Test plan

- [X] Updated unit tests for `calculateMaxIopsAllowedForDiskSizeWithGp3` now assert correct behavior: scaling linearly (100 GB → 50,000 IOPS) and capping at new 80,000 ceiling (1000 GB → 80,000 IOPS)
- [X] All 26 tests in DiskManagement.test.ts pass locally
- [X] Manually verify Infrastructure Settings > Disk IOPS field no longer blocks GP3 disks above 16,000 IOPS up to 80,000

Closes [FE-4379](https://linear.app/supabase/issue/FE-4379/update-iops-limits-for-new-aws-disk-capacity)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated GP3 disk performance calculations to support up to 80,000 IOPS.
  - Disk sizes below the minimum threshold continue to receive the correct 3,000 IOPS floor.
  - Larger disks now scale linearly until reaching the updated maximum IOPS limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->