### PR TITLE
Scoped PAT: show dependencies between permissions

### DIFF
--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/NewScopedTokenForm.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/NewScopedTokenForm.tsx
@@ -198,6 +198,7 @@ export const NewScopedTokenForm = forwardRef<
                   </div>
                   <Separator />
                   <PermissionsAccordion
+                    control={form.control}
                     selection={selection}
                     onChange={handlePermissionChange}
                     onApplyPreset={handleApplyPreset}

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/PermissionRow.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/PermissionRow.tsx
@@ -1,39 +1,101 @@
-import { Label, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from 'ui'
+import { Fragment, useEffect, useEffectEvent } from 'react'
+import { Control } from 'react-hook-form'
+import {
+  cn,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  useWatch,
+} from 'ui'
 
 import type { PermissionCatalogEntry, PermissionMode } from '../../AccessToken.permissions'
 import type { EntryAccess } from '../../AccessToken.roles'
 import { ExceedsRoleBadge } from '../ExceedsRoleBadge'
+import { TokenFormValues } from './NewScopedTokenForm.utils'
 import { RiskMarker } from './RiskMarker'
 
 interface PermissionRowProps {
+  control: Control<TokenFormValues>
   entry: PermissionCatalogEntry
   mode: PermissionMode
   onChange: (mode: PermissionMode) => void
   entryAccess?: EntryAccess
 }
 
-export const PermissionRow = ({ entry, mode, onChange, entryAccess }: PermissionRowProps) => {
+export const PermissionRow = ({
+  control,
+  entry,
+  mode,
+  onChange,
+  entryAccess,
+}: PermissionRowProps) => {
+  const isMissingDependencies = useWatch({
+    control,
+    name: 'permissions',
+    disabled: entry.dependencies.length === 0,
+    compute: (permissions) => {
+      let isMissingDependencies = false
+
+      for (const dependency of entry.dependencies) {
+        if (permissions[dependency.key] == null || permissions[dependency.key] == 'none') {
+          isMissingDependencies = true
+        }
+      }
+      return isMissingDependencies
+    },
+  })
+
+  const onChangeEvent = useEffectEvent(onChange)
+  useEffect(() => {
+    if (isMissingDependencies && mode !== 'none') {
+      onChangeEvent('none')
+    }
+  }, [isMissingDependencies, mode])
+
   return (
     <div className="flex items-center justify-between gap-4 py-4">
       <div className="min-w-0 flex flex-col gap-1">
         <span className="flex items-start md:items-center gap-2 flex-col-reverse md:flex-row">
           <Label htmlFor={`${entry.key}-permissions`}>
-            <span className="text-sm text-foreground">
+            <span
+              className={cn('text-sm text-foreground', isMissingDependencies && 'text-lighter')}
+            >
               {entry.name} <span className="sr-only">permissions</span>
             </span>
           </Label>
-          <RiskMarker entry={entry} />
+          <RiskMarker entry={entry} className={cn(isMissingDependencies && 'opacity-75')} />
           {entryAccess?.status === 'exceeds-role' && (
             <ExceedsRoleBadge entry={entry} mode={mode} access={entryAccess} />
           )}
         </span>
         <p id={`${entry.key}-permissions-description`} className="text-xs text-foreground-lighter">
           {entry.description}
+          {entry.dependencies.length > 0 ? (
+            <b>
+              {' '}
+              Requires{' '}
+              {entry.dependencies.map((dependency, index) => (
+                <Fragment key={dependency.key}>
+                  {dependency.label} set to{' '}
+                  {dependency.permissions === 'read' ? 'read' : 'read or read-write'}
+                  {index < entry.dependencies.length - 1 ? ', ' : null}
+                </Fragment>
+              ))}
+              .
+            </b>
+          ) : null}
         </p>
       </div>
 
       <div className="flex shrink-0 items-center gap-2">
-        <Select value={mode} onValueChange={(value) => onChange(value as PermissionMode)}>
+        <Select
+          disabled={isMissingDependencies}
+          value={mode}
+          onValueChange={(value) => onChange(value as PermissionMode)}
+        >
           <SelectTrigger
             className="w-36 shrink-0"
             id={`${entry.key}-permissions`}

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/PermissionsAccordion.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/PermissionsAccordion.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { Control } from 'react-hook-form'
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger, cn } from 'ui'
 import { Admonition } from 'ui-patterns/Admonition'
 import { FormLayout } from 'ui-patterns/form/Layout/FormLayout'
@@ -11,10 +12,12 @@ import {
 } from '../../AccessToken.permissions'
 import { getActivePreset, type PermissionPreset } from '../../AccessToken.presets'
 import type { TokenAccessEvaluation } from '../../AccessToken.roles'
+import { TokenFormValues } from './NewScopedTokenForm.utils'
 import { PermissionPresetSelect } from './PermissionPresetSelect'
 import { PermissionRow } from './PermissionRow'
 
 interface PermissionsAccordionProps {
+  control: Control<TokenFormValues>
   selection: PermissionSelection
   onChange: (key: string, mode: PermissionMode) => void
   onApplyPreset: (preset: PermissionPreset) => void
@@ -22,6 +25,7 @@ interface PermissionsAccordionProps {
 }
 
 export const PermissionsAccordion = ({
+  control,
   selection,
   onChange,
   onApplyPreset,
@@ -88,6 +92,7 @@ export const PermissionsAccordion = ({
                   {category.entries.map((entry) => (
                     <div className="px-4" key={entry.key}>
                       <PermissionRow
+                        control={control}
                         entry={entry}
                         mode={selection[entry.key] ?? 'none'}
                         onChange={(mode) => onChange(entry.key, mode)}

--- a/packages/shared-data/scoped-access-token-permissions.ts
+++ b/packages/shared-data/scoped-access-token-permissions.ts
@@ -89,6 +89,7 @@ interface ResourceMeta {
   riskReason: string
   allowsRead?: string[]
   allowsWrite?: string[]
+  dependencies?: string[]
 }
 
 /**
@@ -371,6 +372,7 @@ const RESOURCE_METADATA: Record<string, ResourceMeta> = {
     risk: 'high',
     riskReason: 'Read reveals the secret values of project API keys.',
     allowsRead: ['Reveal project API key secrets'],
+    dependencies: ['project:api_gateway_keys'],
   },
   'project:edge_functions': {
     category: 'appsvc',
@@ -442,6 +444,7 @@ const RESOURCE_METADATA: Record<string, ResourceMeta> = {
     risk: 'high',
     riskReason: 'Read exposes the JWT secret, which can be used to mint tokens for any role.',
     allowsRead: ['Read Data API JWT secret'],
+    dependencies: ['project:data_api_config'],
   },
 
   // --- Infrastructure and delivery ---
@@ -545,6 +548,8 @@ const toPermissionLevel = (scope: string): PermissionLevel => {
   return match
 }
 
+type PermissionDependency = { key: string; label: string; permissions: 'read' | 'read-write' }
+
 export interface PermissionCatalogEntry {
   /** Derived resource key, e.g. "project:database" */
   key: string
@@ -563,6 +568,7 @@ export interface PermissionCatalogEntry {
   readScopes: FgaScopeId[]
   /** Additional FGA scope ids granted at Read-write (write / create / delete). */
   writeScopes: FgaScopeId[]
+  dependencies: Array<PermissionDependency>
 }
 
 /** Action classes an FGA permission key's suffix can map to. */
@@ -612,6 +618,17 @@ const buildCatalog = (): PermissionCatalogEntry[] => {
   for (const [key, { level, title, readScopes, writeScopes }] of byResource.entries()) {
     const meta =
       RESOURCE_METADATA[key] ?? RESOURCE_METADATA_FALLBACK(key, title, writeScopes.length > 0)
+    const dependencies = (meta.dependencies ?? []).map((dependency) => {
+      return {
+        key: dependency,
+        label: RESOURCE_METADATA[dependency].name,
+        permissions:
+          RESOURCE_METADATA[dependency].allowsRead?.length &&
+          RESOURCE_METADATA[dependency].allowsWrite?.length
+            ? ('read-write' as const)
+            : ('read' as const),
+      }
+    })
     catalog.push({
       key,
       level,
@@ -626,6 +643,7 @@ const buildCatalog = (): PermissionCatalogEntry[] => {
       writable: writeScopes.length > 0,
       readScopes: readScopes as FgaScopeId[],
       writeScopes: writeScopes as FgaScopeId[],
+      dependencies,
     })
   }
   return catalog


### PR DESCRIPTION
## Problem

Some permissions require others to actually have an effect, for instance:

- `api_gateway_keys_secret_read` requires `api_gateway_keys_read` or `api_gateway_keys_write`
- `data_api_config_secret_read` requires `data_api_config_read` or `data_api_config_write`

This is not obvious from a user perspective.

## Solution

We decided to make these requirements explicit by:
- Adding a line in the permission item stating the dependency
- Disabling the permission if its dependency isn't met
- Resetting the permission if it was selected but the dependencies aren't met anymore

## How to test

- On [staging](https://studio-staging-git-gildasgarcia-fe-4380-dashboa-b2a227-supabase.vercel.app/dashboard/account/tokens)
- Create a new token
- Check that _API Key Secrets_ is greyed out and disabled
- Select _API Key_ read or read-write
-  _API Key Secrets_ shouldn't be greyed out and disabled
- Select a value for _API Key Secrets_
- Set _API Key_ to none
- Check that _API Key Secrets_ is greyed out, disabled and reset to none too
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added dependency-aware permissions for scoped access tokens.
  - Permission descriptions now show required dependencies and permission levels.
  - Dependent permissions automatically reset to “None” when requirements are not met.
  - Permission controls and unavailable selections reflect dependency requirements.
- **Accessibility**
  - Screen readers now receive an announcement when a permission is reset to “None” due to unmet dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->