### PR TITLE
chore(docs): add Jason Voegele to humans.txt

### DIFF
--- a/apps/docs/public/humans.txt
+++ b/apps/docs/public/humans.txt
@@ -140,6 +140,7 @@ Ivan Vasilov
 Jamie Boyd
 Jared Patterson
 Jason Farber
+Jason Voegele
 Jean-Paul Argudo
 Jeff Smick
 Jefferson Venerando


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Adds new entry into `humans.txt`.

## What is the current behavior?

Jason Voegele is not in `humans.txt`.

## What is the new behavior?

Jason Voegele _is_ in `humans.txt` :)

## Additional context

This completes the onboarding task "Add yourself to humans.txt"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added Jason Voegele to the team member list in the site’s public credits file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->