### PR TITLE
docs(database): correct the dashboard_user and storage admin role descriptions

### DIFF
--- a/apps/docs/content/guides/database/postgres/roles.mdx
+++ b/apps/docs/content/guides/database/postgres/roles.mdx
@@ -125,7 +125,7 @@ This role:
 
 ### `dashboard_user`
 
-A legacy role. Queries you run in the Supabase Dashboard execute as `postgres` and include a `-- source: dashboard` comment, which you can use to [find them in the Postgres logs](/docs/guides/troubleshooting/how-to-interpret-and-explore-the-postgres-logs-OuCIOj).
+The Supabase Dashboard doesn't connect as this role. Queries you run in the Dashboard execute as `postgres` and include a `-- source: dashboard` comment, which you can use to [find them in the Postgres logs](/docs/guides/troubleshooting/how-to-interpret-and-explore-the-postgres-logs-OuCIOj).
 
 ### `supabase_admin`
 

--- a/apps/docs/content/guides/database/postgres/roles.mdx
+++ b/apps/docs/content/guides/database/postgres/roles.mdx
@@ -109,7 +109,7 @@ Used by the Auth middleware to connect to the database and run migration. Access
 
 ### `supabase_storage_admin`
 
-Used by the Auth middleware to connect to the database and run migration. Access is scoped to the `storage` schema.
+Used by the Storage middleware to connect to the database and run migration. Access is scoped to the `storage` schema.
 
 ### `supabase_etl_admin`
 
@@ -125,7 +125,7 @@ This role:
 
 ### `dashboard_user`
 
-For running commands via the Supabase UI.
+A legacy role. Queries you run in the Supabase Dashboard execute as `postgres` and include a `-- source: dashboard` comment, which you can use to [find them in the Postgres logs](/docs/guides/troubleshooting/how-to-interpret-and-explore-the-postgres-logs-OuCIOj).
 
 ### `supabase_admin`
 

--- a/apps/studio/components/interfaces/QueryPerformance/QueryPerformance.constants.ts
+++ b/apps/studio/components/interfaces/QueryPerformance/QueryPerformance.constants.ts
@@ -60,7 +60,7 @@ export const QUERY_PERFORMANCE_ROLE_DESCRIPTION = [
   {
     name: 'dashboard_user',
     description:
-      'A legacy role. Queries run from the Supabase Dashboard execute as postgres and include a "-- source: dashboard" comment.',
+      'The Supabase Dashboard doesn\'t connect as this role. Dashboard queries execute as postgres and include a "-- source: dashboard" comment.',
   },
   {
     name: 'supabase_admin',

--- a/apps/studio/components/interfaces/QueryPerformance/QueryPerformance.constants.ts
+++ b/apps/studio/components/interfaces/QueryPerformance/QueryPerformance.constants.ts
@@ -55,9 +55,13 @@ export const QUERY_PERFORMANCE_ROLE_DESCRIPTION = [
   {
     name: 'supabase_storage_admin',
     description:
-      'Used by the Auth middleware to connect to the database and run migration. Access is scoped to the storage schema.',
+      'Used by the Storage middleware to connect to the database and run migration. Access is scoped to the storage schema.',
   },
-  { name: 'dashboard_user', description: 'For running commands via the Supabase UI.' },
+  {
+    name: 'dashboard_user',
+    description:
+      'A legacy role. Queries run from the Supabase Dashboard execute as postgres and include a "-- source: dashboard" comment.',
+  },
   {
     name: 'supabase_admin',
     description:


### PR DESCRIPTION
Closes DOCS-1387

## Problem

The Postgres roles guide describes `dashboard_user` as "For running commands via the Supabase UI." That was the original intent, not current behavior. Dashboard queries run as `postgres` and carry a `-- source: dashboard` comment, which the [Postgres logs troubleshooting guide](https://supabase.com/docs/guides/troubleshooting/how-to-interpret-and-explore-the-postgres-logs-OuCIOj) already documents. The two pages contradict each other.

Two smaller problems in the same list:

- `supabase_storage_admin` is described as an Auth middleware role, copied from the `supabase_auth_admin` entry above it.
- Studio ships both stale strings in its own role tooltips. The docs list and `QUERY_PERFORMANCE_ROLE_DESCRIPTION` are near-verbatim copies of each other.

## Solution

- Replace the `dashboard_user` description with what the Dashboard connects as instead, and point readers to the `-- source: dashboard` comment for finding Dashboard queries in the logs.
- Attribute `supabase_storage_admin` to the Storage middleware.
- Apply both corrections to the Query Performance and Query Insights role tooltips.

## Manual testing

1. Open the [roles guide on the deploy preview](https://docs-git-docs-dashboard-user-role-supabase.vercel.app/docs/guides/database/postgres/roles).
2. Scroll to `dashboard_user`. It states that the Dashboard doesn't connect as the role, and that Dashboard queries execute as `postgres` with a `-- source: dashboard` comment.
3. Select **find them in the Postgres logs**. The Postgres logs troubleshooting guide loads.
4. Scroll to `supabase_storage_admin`. It reads "Used by the Storage middleware," not "Auth middleware."
5. In Studio, open **Observability > Query Performance** and hover a `dashboard_user` or `supabase_storage_admin` value in the **Role** column. The tooltip shows the same two corrected descriptions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected the description of the `supabase_storage_admin` role to reference Storage middleware.
  - Clarified that the Dashboard does not connect using the `dashboard_user` role.
  - Documented that Dashboard queries run as `postgres` and can be identified in Postgres logs with a `source: dashboard` comment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->