### PR TITLE
feat(studio): exhaustion banner links to metrics

### DIFF
--- a/apps/studio/components/ui/Charts/ComposedChartHandler.tsx
+++ b/apps/studio/components/ui/Charts/ComposedChartHandler.tsx
@@ -60,7 +60,7 @@ export interface ComposedChartHandlerProps {
 /**
  * Wrapper component that handles intersection observer logic for lazy loading
  */
-const LazyChartWrapper = ({ children }: PropsWithChildren) => {
+const LazyChartWrapper = ({ id, children }: PropsWithChildren<{ id: string }>) => {
   const [isVisible, setIsVisible] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
 
@@ -91,7 +91,7 @@ const LazyChartWrapper = ({ children }: PropsWithChildren) => {
   }, [])
 
   return (
-    <div ref={ref}>
+    <div ref={ref} id={id} className="scroll-mt-16">
       {React.cloneElement(children as React.ReactElement<{ isVisible: boolean }>, { isVisible })}
     </div>
   )
@@ -291,9 +291,8 @@ const ComposedChartHandler = ({
     <Panel
       noMargin
       noHideOverflow
-      className={cn('relative w-full scroll-mt-16', className)}
+      className={cn('relative w-full', className)}
       wrapWithLoading={false}
-      id={id ?? label.toLowerCase().replaceAll(' ', '-')}
     >
       <Panel.Content className="flex flex-col gap-4">
         <div className="absolute right-6 z-50 flex justify-between scroll-mt-16">{children}</div>
@@ -385,8 +384,9 @@ const useAttributeQueries = (
 export function LazyComposedChartHandler(props: ComposedChartHandlerProps) {
   if (props.hide) return null
 
+  const anchorId = props.id ?? props.label.toLowerCase().replaceAll(' ', '-')
   return (
-    <LazyChartWrapper>
+    <LazyChartWrapper id={anchorId}>
       <ComposedChartHandler {...props} />
     </LazyChartWrapper>
   )

--- a/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.constants.ts
+++ b/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.constants.ts
@@ -13,9 +13,8 @@ interface ResourceWarningMessage {
     critical: { title?: string; description?: string }
   }
   docsUrl?: string
-  // In-app destination for inspecting the metric (e.g. observability charts).
-  // [ref] is replaced with the current project ref at render time.
-  metricsHref?: string
+  resourceLabel?: string
+  metricsChartId?: string
   buttonText?: string
   aiPrompt?: string
   metric: string | null
@@ -78,10 +77,11 @@ export const RESOURCE_WARNING_MESSAGES: ResourceWarningMessages = {
       },
     },
     docsUrl: `${DOCS_URL}/guides/troubleshooting/exhaust-disk-io`,
-    metricsHref: '/project/[ref]/observability/database',
     buttonText: 'Upgrade compute',
     aiPrompt:
       'My database is running out of Disk IO budget. Can you query pg_stat_statements to find the top queries by shared blocks read and written, identify which are causing the most disk I/O, and suggest specific optimizations to reduce disk usage?',
+    resourceLabel: 'Disk IO',
+    metricsChartId: 'disk-throughput',
     metric: 'disk_io',
   },
   disk_space_exhaustion: {
@@ -110,6 +110,8 @@ export const RESOURCE_WARNING_MESSAGES: ResourceWarningMessages = {
     },
     docsUrl: `${DOCS_URL}/guides/platform/database-size#disk-management`,
     buttonText: undefined,
+    resourceLabel: 'Disk space',
+    metricsChartId: 'disk-size',
     metric: 'disk_space',
   },
   cpu_exhaustion: {
@@ -139,6 +141,8 @@ export const RESOURCE_WARNING_MESSAGES: ResourceWarningMessages = {
     buttonText: 'Upgrade compute',
     aiPrompt:
       'My database is experiencing high CPU usage. Can you query pg_stat_statements to find the top queries by total execution time and mean execution time, identify which are most CPU-intensive, and suggest specific optimizations such as missing indexes or query rewrites to reduce CPU load?',
+    resourceLabel: 'CPU',
+    metricsChartId: 'cpu-usage',
     metric: 'cpu',
   },
   memory_and_swap_exhaustion: {
@@ -169,6 +173,8 @@ export const RESOURCE_WARNING_MESSAGES: ResourceWarningMessages = {
     buttonText: 'Upgrade compute',
     aiPrompt:
       'My database is experiencing high memory and swap usage. Can you query pg_stat_statements to find the top queries by shared buffer hits and rows returned, identify which queries are putting the most pressure on memory, and suggest optimizations to reduce memory consumption?',
+    resourceLabel: 'Memory',
+    metricsChartId: 'ram-usage',
     metric: 'ram',
   },
   auth_rate_limit_exhaustion: {
@@ -197,18 +203,18 @@ export const RESOURCE_WARNING_MESSAGES: ResourceWarningMessages = {
     },
     docsUrl: `${DOCS_URL}/guides/platform/going-into-prod#auth-rate-limits`,
     buttonText: 'Enable custom SMTP',
+    resourceLabel: 'Auth rate limits',
     metric: 'auth_email_rate_limit',
   },
   multiple_resource_warnings: {
     bannerContent: {
       warning: {
-        title:
-          'Your project is currently exhausting multiple resources, and its performance is affected',
+        title: 'Your project is exhausting {resources}, which is affecting its performance',
         description:
           'Upgrade your compute or use the AI Assistant to identify and optimize the most expensive queries.',
       },
       critical: {
-        title: 'Your project has exhausted multiple resources, and its performance is affected',
+        title: 'Your project has exhausted {resources}, which is affecting its performance',
         description:
           'Upgrade your compute or use the AI Assistant to identify and optimize the most expensive queries.',
       },
@@ -226,7 +232,7 @@ export const RESOURCE_WARNING_MESSAGES: ResourceWarningMessages = {
     docsUrl: undefined,
     buttonText: 'Check usage',
     aiPrompt:
-      'My database is exhausting multiple resources (CPU, memory, and/or disk IO). Can you query pg_stat_statements to identify the most expensive queries overall, and suggest which optimizations would have the biggest impact on reducing resource consumption?',
+      'My database is exhausting multiple resources ({resources}). Can you query pg_stat_statements to identify the most expensive queries overall, and suggest which optimizations would have the biggest impact on reducing resource consumption?',
     metric: null,
   },
 }

--- a/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.test.tsx
+++ b/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event'
 import { platformComponents as components } from 'api-types'
 import { mockAnimationsApi } from 'jsdom-testing-mocks'
 import { HttpResponse } from 'msw'
-import { describe, expect, test, vi } from 'vitest'
+import { afterEach, describe, expect, test, vi } from 'vitest'
 
 import { ResourceExhaustionWarningBanner } from './ResourceExhaustionWarningBanner'
 import type { ProfileContextType } from '@/lib/profile'
@@ -17,7 +17,10 @@ type ProjectResourceWarningsResponse =
 
 const PROJECT_REF = 'project-ref'
 
-const { trackSpy } = vi.hoisted(() => ({ trackSpy: vi.fn() }))
+const { trackSpy, flags } = vi.hoisted(() => ({
+  trackSpy: vi.fn(),
+  flags: { showDiskIOBurstBalanceChart: false },
+}))
 
 vi.mock('common', async (importOriginal) => {
   const actual = await importOriginal<typeof import('common')>()
@@ -26,13 +29,17 @@ vi.mock('common', async (importOriginal) => {
     IS_PLATFORM: true,
     useIsLoggedIn: () => true,
     useParams: () => ({ ref: PROJECT_REF }),
-    useFlag: () => false,
+    useFlag: () => flags.showDiskIOBurstBalanceChart,
   }
 })
 
 vi.mock('@/lib/telemetry/track', () => ({ useTrack: () => trackSpy }))
 
 mockAnimationsApi()
+
+afterEach(() => {
+  flags.showDiskIOBurstBalanceChart = false
+})
 
 const PROFILE_CONTEXT: ProfileContextType = {
   profile: {
@@ -187,6 +194,17 @@ describe('ResourceExhaustionWarningBanner', () => {
     expect(menu.getByRole('menuitem', { name: 'View Disk IO metrics' })).toHaveAttribute(
       'href',
       metricsHref('disk-throughput')
+    )
+  })
+
+  test('disk IO links to the burst balance chart when the report renders it', async () => {
+    flags.showDiskIOBurstBalanceChart = true
+    renderBanner({ disk_io_exhaustion: 'warning' })
+
+    const menu = await openTroubleshootMenu()
+    expect(menu.getByRole('menuitem', { name: 'View metrics' })).toHaveAttribute(
+      'href',
+      metricsHref('disk-io-burst-balance')
     )
   })
 })

--- a/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.test.tsx
+++ b/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.test.tsx
@@ -1,0 +1,192 @@
+import { screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { platformComponents as components } from 'api-types'
+import { mockAnimationsApi } from 'jsdom-testing-mocks'
+import { HttpResponse } from 'msw'
+import { describe, expect, test, vi } from 'vitest'
+
+import { ResourceExhaustionWarningBanner } from './ResourceExhaustionWarningBanner'
+import type { ProfileContextType } from '@/lib/profile'
+import { createMockOrganizationResponse } from '@/tests/helpers'
+import { customRender } from '@/tests/lib/custom-render'
+import { addAPIMock } from '@/tests/lib/msw'
+
+type ProjectDetailResponse = components['schemas']['ProjectDetailResponse_Output']
+type ProjectResourceWarningsResponse =
+  components['schemas']['ProjectResourceWarningsResponse_Output']
+
+const PROJECT_REF = 'project-ref'
+
+const { trackSpy } = vi.hoisted(() => ({ trackSpy: vi.fn() }))
+
+vi.mock('common', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('common')>()
+  return {
+    ...actual,
+    IS_PLATFORM: true,
+    useIsLoggedIn: () => true,
+    useParams: () => ({ ref: PROJECT_REF }),
+    useFlag: () => false,
+  }
+})
+
+vi.mock('@/lib/telemetry/track', () => ({ useTrack: () => trackSpy }))
+
+mockAnimationsApi()
+
+const PROFILE_CONTEXT: ProfileContextType = {
+  profile: {
+    id: 1,
+    auth0_id: 'auth0|test',
+    gotrue_id: 'gotrue-test',
+    username: 'testuser',
+    primary_email: 'test@example.com',
+    first_name: null,
+    last_name: null,
+    mobile: null,
+    is_alpha_user: false,
+    is_sso_user: false,
+    disabled_features: [],
+    free_project_limit: null,
+  },
+  error: null,
+  isLoading: false,
+  isError: false,
+  isSuccess: true,
+}
+
+const PROJECT: ProjectDetailResponse = {
+  cloud_provider: 'AWS',
+  connectionString: 'postgresql://postgres:password@db.project-ref.supabase.co:5432/postgres',
+  db_host: 'db.project-ref.supabase.co',
+  dbVersion: 'supabase-postgres-15.1.0',
+  high_availability: false,
+  id: 1,
+  infra_compute_size: 'micro',
+  inserted_at: '2026-01-01T00:00:00.000Z',
+  integration_source: null,
+  is_branch_enabled: false,
+  is_physical_backups_enabled: false,
+  name: 'Production',
+  organization_id: 1,
+  ref: PROJECT_REF,
+  region: 'us-east-1',
+  restUrl: `https://${PROJECT_REF}.supabase.co`,
+  status: 'ACTIVE_HEALTHY',
+  subscription_id: 'subscription-1',
+  updated_at: '2026-01-01T00:00:00.000Z',
+}
+
+const NO_WARNINGS: ProjectResourceWarningsResponse = {
+  project: PROJECT_REF,
+  is_readonly_mode_enabled: false,
+  auth_email_offender: null,
+  auth_rate_limit_exhaustion: null,
+  auth_restricted_email_sending: null,
+  cpu_exhaustion: null,
+  disk_io_exhaustion: null,
+  disk_space_exhaustion: null,
+  memory_and_swap_exhaustion: null,
+  need_pitr: null,
+}
+
+const metricsHref = (chartId: string) =>
+  `/project/${PROJECT_REF}/observability/database?chart=${chartId}&isHelper=true&helperText=Last+3+hours`
+
+const renderBanner = (warnings: Partial<ProjectResourceWarningsResponse>) => {
+  addAPIMock({ method: 'get', path: '/platform/projects/:ref', response: PROJECT })
+  addAPIMock({
+    method: 'get',
+    path: '/platform/organizations',
+    response: [
+      createMockOrganizationResponse({
+        id: 1,
+        slug: 'acme',
+        plan: { id: 'pro', name: 'Pro' },
+        usage_billing_enabled: true,
+      }),
+    ],
+  })
+  addAPIMock({
+    method: 'get',
+    path: '/platform/projects-resource-warnings',
+    response: () =>
+      HttpResponse.json<ProjectResourceWarningsResponse[]>([{ ...NO_WARNINGS, ...warnings }]),
+  })
+
+  return customRender(<ResourceExhaustionWarningBanner />, { profileContext: PROFILE_CONTEXT })
+}
+
+const openTroubleshootMenu = async () => {
+  await userEvent.click(await screen.findByRole('button', { name: 'Troubleshoot' }))
+  return within(await screen.findByRole('menu'))
+}
+
+describe('ResourceExhaustionWarningBanner', () => {
+  test('multi-resource banner names each resource and links each to its chart', async () => {
+    renderBanner({ cpu_exhaustion: 'warning', disk_space_exhaustion: 'warning' })
+
+    expect(
+      await screen.findByText(
+        'Your project is exhausting CPU and Disk space, which is affecting its performance'
+      )
+    ).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Check usage' })).toHaveAttribute(
+      'href',
+      `/project/${PROJECT_REF}/settings/infrastructure`
+    )
+
+    const menu = await openTroubleshootMenu()
+    const itemLabels = menu.getAllByRole('menuitem').map((item) => item.textContent)
+    expect(itemLabels).toEqual([
+      'View CPU metrics',
+      'View Disk space metrics',
+      'CPU documentation',
+      'Disk space documentation',
+      'Ask AI Assistant',
+    ])
+
+    const cpuMetrics = menu.getByRole('menuitem', { name: 'View CPU metrics' })
+    expect(cpuMetrics).toHaveAttribute('href', metricsHref('cpu-usage'))
+
+    await userEvent.click(cpuMetrics)
+    expect(trackSpy).toHaveBeenCalledWith('resource_exhaustion_banner_troubleshoot_clicked', {
+      troubleshootAction: 'metrics',
+      warningType: 'cpu_exhaustion',
+      warningTypes: ['cpu_exhaustion', 'disk_space_exhaustion'],
+      destination: metricsHref('cpu-usage'),
+    })
+  })
+
+  test('single-resource banner keeps its title and adds View metrics', async () => {
+    renderBanner({ cpu_exhaustion: 'warning' })
+
+    expect(
+      await screen.findByText(
+        'Your project is currently facing high CPU usage, and its performance is affected'
+      )
+    ).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Upgrade compute' })).toBeInTheDocument()
+
+    const menu = await openTroubleshootMenu()
+    const itemLabels = menu.getAllByRole('menuitem').map((item) => item.textContent)
+    expect(itemLabels).toEqual(['View metrics', 'Documentation', 'Ask AI Assistant'])
+    expect(menu.getByRole('menuitem', { name: 'View metrics' })).toHaveAttribute(
+      'href',
+      metricsHref('cpu-usage')
+    )
+  })
+
+  test('all-compute multi banner keeps Upgrade compute and falls back to the throughput chart', async () => {
+    renderBanner({ cpu_exhaustion: 'warning', disk_io_exhaustion: 'warning' })
+
+    expect(await screen.findByRole('link', { name: 'Upgrade compute' })).toBeInTheDocument()
+
+    const menu = await openTroubleshootMenu()
+    expect(menu.getByRole('menuitem', { name: 'Ask AI Assistant' })).toBeInTheDocument()
+    expect(menu.getByRole('menuitem', { name: 'View Disk IO metrics' })).toHaveAttribute(
+      'href',
+      metricsHref('disk-throughput')
+    )
+  })
+})

--- a/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.tsx
+++ b/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.tsx
@@ -17,18 +17,67 @@ import {
 
 import { RESOURCE_WARNING_MESSAGES } from './ResourceExhaustionWarningBanner.constants'
 import {
+  applyResourceList,
+  getResourceWarningAiPrompt,
   getResourceWarningCorrectionUrl,
+  getTroubleshootItems,
   getWarningContent,
   isComputeUpgradeWarning,
+  type TroubleshootItem,
 } from './ResourceExhaustionWarningBanner.utils'
 import { mapComputeSizeNameToAddonVariantId } from '@/components/interfaces/DiskManagement/DiskManagement.utils'
 import { SIDEBAR_KEYS } from '@/components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider'
 import { useResourceWarningsQuery } from '@/data/usage/resource-warnings-query'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { useShowDiskIOBurstBalanceChart } from '@/hooks/misc/useShowDiskIOBurstBalanceChart'
 import { useTrack } from '@/lib/telemetry/track'
 import { useAiAssistantStateSnapshot } from '@/state/ai-assistant-state'
 import { useSidebarManagerSnapshot } from '@/state/sidebar-manager-state'
+
+type LinkedTroubleshootItem = Extract<TroubleshootItem, { kind: 'metrics' | 'docs' }>
+
+const TroubleshootMenuItem = ({
+  item,
+  onTroubleshootClick,
+  onAskAI,
+}: {
+  item: TroubleshootItem
+  onTroubleshootClick: (item: LinkedTroubleshootItem) => void
+  onAskAI: () => void
+}) => {
+  if (item.kind === 'ai') {
+    return (
+      <DropdownMenuItem className="flex items-center gap-x-2 cursor-pointer" onClick={onAskAI}>
+        <Sparkles size={14} />
+        {item.menuLabel}
+      </DropdownMenuItem>
+    )
+  }
+  if (item.kind === 'metrics') {
+    return (
+      <DropdownMenuItem asChild onClick={() => onTroubleshootClick(item)}>
+        <Link href={item.href} className="flex items-center gap-x-2 cursor-pointer">
+          <ChartLine size={14} />
+          {item.menuLabel}
+        </Link>
+      </DropdownMenuItem>
+    )
+  }
+  return (
+    <DropdownMenuItem asChild onClick={() => onTroubleshootClick(item)}>
+      <a
+        href={item.href}
+        target="_blank"
+        rel="noreferrer"
+        className="flex items-center gap-x-2 cursor-pointer"
+      >
+        <BookOpen size={14} />
+        {item.menuLabel}
+      </a>
+    </DropdownMenuItem>
+  )
+}
 
 export const ResourceExhaustionWarningBanner = () => {
   const { ref } = useParams()
@@ -45,6 +94,7 @@ export const ResourceExhaustionWarningBanner = () => {
   const { openSidebar } = useSidebarManagerSnapshot()
   const aiSnap = useAiAssistantStateSnapshot()
   const track = useTrack()
+  const showBurstBalanceChart = useShowDiskIOBurstBalanceChart()
   const { data: resourceWarnings } = useResourceWarningsQuery({ ref: ref })
   // [Joshen Cleanup] JFYI this client side filtering can be cleaned up once BE changes are live which will only return the warnings based on the provided ref
   const projectResourceWarnings = (resourceWarnings ?? [])?.find(
@@ -78,30 +128,26 @@ export const ResourceExhaustionWarningBanner = () => {
       : undefined
 
   const title = applyDiskIoBaseline(
-    activeWarnings.length > 1
-      ? RESOURCE_WARNING_MESSAGES.multiple_resource_warnings.bannerContent[
-          hasCriticalWarning ? 'critical' : 'warning'
-        ].title
-      : warningContent?.title
+    applyResourceList(
+      activeWarnings.length > 1
+        ? RESOURCE_WARNING_MESSAGES.multiple_resource_warnings.bannerContent[
+            hasCriticalWarning ? 'critical' : 'warning'
+          ].title
+        : warningContent?.title,
+      activeWarnings
+    )
   )
 
   const description = applyDiskIoBaseline(
-    activeWarnings.length > 1
-      ? RESOURCE_WARNING_MESSAGES.multiple_resource_warnings.bannerContent[
-          hasCriticalWarning ? 'critical' : 'warning'
-        ].description
-      : warningContent?.description
+    applyResourceList(
+      activeWarnings.length > 1
+        ? RESOURCE_WARNING_MESSAGES.multiple_resource_warnings.bannerContent[
+            hasCriticalWarning ? 'critical' : 'warning'
+          ].description
+        : warningContent?.description,
+      activeWarnings
+    )
   )
-
-  const learnMoreUrl =
-    activeWarnings.length > 1
-      ? RESOURCE_WARNING_MESSAGES.multiple_resource_warnings.docsUrl
-      : RESOURCE_WARNING_MESSAGES[activeWarnings[0] as keyof typeof RESOURCE_WARNING_MESSAGES]
-          ?.docsUrl
-
-  const singleWarningMessage =
-    activeWarnings.length === 1 ? RESOURCE_WARNING_MESSAGES[activeWarnings[0]] : undefined
-  const metricsHref = singleWarningMessage?.metricsHref?.replace('[ref]', ref ?? 'default')
 
   const metric =
     activeWarnings.length > 1
@@ -130,13 +176,17 @@ export const ResourceExhaustionWarningBanner = () => {
           ?.buttonText
   })()
 
-  const aiPrompt =
-    activeWarnings.length > 1
-      ? isComputeUpgradeMetric
-        ? RESOURCE_WARNING_MESSAGES.multiple_resource_warnings.aiPrompt
-        : undefined
-      : RESOURCE_WARNING_MESSAGES[activeWarnings[0] as keyof typeof RESOURCE_WARNING_MESSAGES]
-          ?.aiPrompt
+  const aiPrompt = getResourceWarningAiPrompt(activeWarnings)
+  const chartIdOverrides = showBurstBalanceChart
+    ? { disk_io_exhaustion: 'disk-io-burst-balance' }
+    : {}
+  const troubleshootItems = getTroubleshootItems({
+    activeWarnings,
+    projectRef: ref ?? 'default',
+    aiPrompt,
+    chartIdOverrides,
+  })
+  const soleTroubleshootItem = troubleshootItems.length === 1 ? troubleshootItems[0] : undefined
 
   const handleAskAI = () => {
     track('resource_exhaustion_banner_ai_assistant_clicked', {
@@ -144,6 +194,15 @@ export const ResourceExhaustionWarningBanner = () => {
     })
     openSidebar(SIDEBAR_KEYS.AI_ASSISTANT)
     aiSnap.newChat({ initialInput: aiPrompt })
+  }
+
+  const handleTroubleshootClick = (item: LinkedTroubleshootItem) => {
+    track('resource_exhaustion_banner_troubleshoot_clicked', {
+      troubleshootAction: item.kind,
+      warningType: item.warningType,
+      warningTypes: activeWarnings,
+      destination: item.href,
+    })
   }
 
   const hasNoWarnings = activeWarnings.length === 0
@@ -206,7 +265,7 @@ export const ResourceExhaustionWarningBanner = () => {
         <AlertDescription>{description}</AlertDescription>
       </div>
       <div className="flex items-center gap-x-2">
-        {learnMoreUrl !== undefined && aiPrompt !== undefined ? (
+        {troubleshootItems.length >= 2 && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button icon={<Wrench size={14} />} iconRight={<ChevronDown size={14} />}>
@@ -214,43 +273,40 @@ export const ResourceExhaustionWarningBanner = () => {
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
-              {metricsHref !== undefined && (
-                <DropdownMenuItem asChild>
-                  <Link href={metricsHref} className="flex items-center gap-x-2 cursor-pointer">
-                    <ChartLine size={14} />
-                    View metrics
-                  </Link>
-                </DropdownMenuItem>
-              )}
-              <DropdownMenuItem asChild>
-                <a
-                  href={learnMoreUrl}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="flex items-center gap-x-2 cursor-pointer"
-                >
-                  <BookOpen size={14} />
-                  Documentation
-                </a>
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                className="flex items-center gap-x-2 cursor-pointer"
-                onClick={handleAskAI}
-              >
-                <Sparkles size={14} />
-                Ask AI Assistant
-              </DropdownMenuItem>
+              {troubleshootItems.map((item) => (
+                <TroubleshootMenuItem
+                  key={item.kind === 'ai' ? 'ai' : `${item.kind}-${item.warningType}`}
+                  item={item}
+                  onTroubleshootClick={handleTroubleshootClick}
+                  onAskAI={handleAskAI}
+                />
+              ))}
             </DropdownMenuContent>
           </DropdownMenu>
-        ) : learnMoreUrl !== undefined ? (
-          <Button asChild icon={<BookOpen size={14} />}>
-            <a href={learnMoreUrl} target="_blank" rel="noreferrer">
-              Learn more
+        )}
+        {soleTroubleshootItem?.kind === 'metrics' && (
+          <Button
+            asChild
+            icon={<ChartLine size={14} />}
+            onClick={() => handleTroubleshootClick(soleTroubleshootItem)}
+          >
+            <Link href={soleTroubleshootItem.href}>{soleTroubleshootItem.buttonLabel}</Link>
+          </Button>
+        )}
+        {soleTroubleshootItem?.kind === 'docs' && (
+          <Button
+            asChild
+            icon={<BookOpen size={14} />}
+            onClick={() => handleTroubleshootClick(soleTroubleshootItem)}
+          >
+            <a href={soleTroubleshootItem.href} target="_blank" rel="noreferrer">
+              {soleTroubleshootItem.buttonLabel}
             </a>
           </Button>
-        ) : aiPrompt !== undefined ? (
-          <Button onClick={handleAskAI}>Ask AI Assistant</Button>
-        ) : null}
+        )}
+        {soleTroubleshootItem?.kind === 'ai' && (
+          <Button onClick={handleAskAI}>{soleTroubleshootItem.buttonLabel}</Button>
+        )}
         {correctionUrl !== undefined && (
           <Button
             asChild

--- a/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.tsx
+++ b/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.tsx
@@ -177,14 +177,11 @@ export const ResourceExhaustionWarningBanner = () => {
   })()
 
   const aiPrompt = getResourceWarningAiPrompt(activeWarnings)
-  const chartIdOverrides = showBurstBalanceChart
-    ? { disk_io_exhaustion: 'disk-io-burst-balance' }
-    : {}
   const troubleshootItems = getTroubleshootItems({
     activeWarnings,
     projectRef: ref ?? 'default',
     aiPrompt,
-    chartIdOverrides,
+    showBurstBalanceChart,
   })
   const soleTroubleshootItem = troubleshootItems.length === 1 ? troubleshootItems[0] : undefined
 

--- a/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.utils.test.ts
+++ b/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.utils.test.ts
@@ -118,12 +118,16 @@ describe('getResourceWarningMetricsHref', () => {
     )
   })
 
-  it('honors a chart override', () => {
-    expect(
-      getResourceWarningMetricsHref('disk_io_exhaustion', 'abc', {
-        disk_io_exhaustion: 'disk-io-burst-balance',
-      })
-    ).toContain('chart=disk-io-burst-balance')
+  it('targets the burst balance chart for disk IO when that chart is shown', () => {
+    expect(getResourceWarningMetricsHref('disk_io_exhaustion', 'abc', true)).toContain(
+      'chart=disk-io-burst-balance'
+    )
+  })
+
+  it('leaves other warnings alone when the burst balance chart is shown', () => {
+    expect(getResourceWarningMetricsHref('cpu_exhaustion', 'abc', true)).toContain(
+      'chart=cpu-usage'
+    )
   })
 
   it.each(['auth_rate_limit_exhaustion', 'is_readonly_mode_enabled'])(

--- a/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.utils.test.ts
+++ b/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.utils.test.ts
@@ -215,4 +215,10 @@ describe('getResourceWarningAiPrompt', () => {
       '(CPU and Disk space)'
     )
   })
+
+  it('offers no prompt when none of the tripped resources is a compute resource', () => {
+    expect(
+      getResourceWarningAiPrompt(['disk_space_exhaustion', 'auth_rate_limit_exhaustion'])
+    ).toBeUndefined()
+  })
 })

--- a/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.utils.test.ts
+++ b/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.utils.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from 'vitest'
 
+import { RESOURCE_WARNING_MESSAGES } from './ResourceExhaustionWarningBanner.constants'
 import {
+  applyResourceList,
+  formatResourceList,
+  getResourceWarningAiPrompt,
   getResourceWarningCorrectionUrl,
+  getResourceWarningLabels,
+  getResourceWarningMetricsHref,
+  getTroubleshootItems,
   isComputeUpgradeWarning,
 } from './ResourceExhaustionWarningBanner.utils'
 
@@ -75,5 +82,133 @@ describe('resource warning correction routes', () => {
         isFreePlan: false,
       })
     ).toBe('/project/project-ref/settings/infrastructure#custom_metric')
+  })
+})
+
+describe('formatResourceList', () => {
+  it('returns a single label as is', () => {
+    expect(formatResourceList(['CPU'])).toBe('CPU')
+  })
+
+  it('joins two labels with and', () => {
+    expect(formatResourceList(['CPU', 'Disk IO'])).toBe('CPU and Disk IO')
+  })
+
+  it('joins three labels with an Oxford comma', () => {
+    expect(formatResourceList(['CPU', 'Disk IO', 'Memory'])).toBe('CPU, Disk IO, and Memory')
+  })
+})
+
+describe('getResourceWarningLabels', () => {
+  it('drops response keys that have no config entry', () => {
+    expect(getResourceWarningLabels(['cpu_exhaustion', 'need_pitr'])).toEqual(['CPU'])
+  })
+})
+
+describe('getResourceWarningMetricsHref', () => {
+  it('links a warning to its chart over the last 3 hours', () => {
+    expect(getResourceWarningMetricsHref('cpu_exhaustion', 'abc')).toBe(
+      '/project/abc/observability/database?chart=cpu-usage&isHelper=true&helperText=Last+3+hours'
+    )
+  })
+
+  it('defaults disk IO to the always-rendered throughput chart', () => {
+    expect(getResourceWarningMetricsHref('disk_io_exhaustion', 'abc')).toContain(
+      'chart=disk-throughput'
+    )
+  })
+
+  it('honors a chart override', () => {
+    expect(
+      getResourceWarningMetricsHref('disk_io_exhaustion', 'abc', {
+        disk_io_exhaustion: 'disk-io-burst-balance',
+      })
+    ).toContain('chart=disk-io-burst-balance')
+  })
+
+  it.each(['auth_rate_limit_exhaustion', 'is_readonly_mode_enabled'])(
+    'returns undefined for %s, which has no chart',
+    (warningType) => {
+      expect(getResourceWarningMetricsHref(warningType, 'abc')).toBeUndefined()
+    }
+  )
+})
+
+describe('applyResourceList', () => {
+  it('fills the multi-resource title with the tripped resources', () => {
+    expect(
+      applyResourceList(
+        RESOURCE_WARNING_MESSAGES.multiple_resource_warnings.bannerContent.warning.title,
+        ['cpu_exhaustion', 'disk_space_exhaustion']
+      )
+    ).toBe('Your project is exhausting CPU and Disk space, which is affecting its performance')
+  })
+})
+
+describe('getTroubleshootItems', () => {
+  const kindsOf = (items: ReturnType<typeof getTroubleshootItems>) => items.map((item) => item.kind)
+
+  it('lists metrics, then docs, then AI for a multi-resource banner', () => {
+    const items = getTroubleshootItems({
+      activeWarnings: ['cpu_exhaustion', 'disk_space_exhaustion'],
+      projectRef: 'abc',
+      aiPrompt: 'prompt',
+    })
+    expect(kindsOf(items)).toEqual(['metrics', 'metrics', 'docs', 'docs', 'ai'])
+    expect(items[0].menuLabel).toBe('View CPU metrics')
+    expect(items[2].menuLabel).toBe('CPU documentation')
+    expect(items[3].menuLabel).toBe('Disk space documentation')
+  })
+
+  it('keeps the generic labels for a single-resource banner', () => {
+    const items = getTroubleshootItems({
+      activeWarnings: ['cpu_exhaustion'],
+      projectRef: 'abc',
+      aiPrompt: 'prompt',
+    })
+    expect(kindsOf(items)).toEqual(['metrics', 'docs', 'ai'])
+    expect(items[0].menuLabel).toBe('View metrics')
+  })
+
+  it('skips the metrics item for warnings without a chart', () => {
+    const items = getTroubleshootItems({
+      activeWarnings: ['auth_rate_limit_exhaustion'],
+      projectRef: 'abc',
+      aiPrompt: 'prompt',
+    })
+    expect(kindsOf(items)).toEqual(['docs', 'ai'])
+  })
+
+  it('leaves read-only mode with a single Learn more button', () => {
+    const items = getTroubleshootItems({
+      activeWarnings: ['is_readonly_mode_enabled'],
+      projectRef: 'abc',
+      aiPrompt: undefined,
+    })
+    expect(kindsOf(items)).toEqual(['docs'])
+    expect(items[0].buttonLabel).toBe('Learn more')
+  })
+
+  it('gives disk space a metrics and a docs item without an AI prompt', () => {
+    const items = getTroubleshootItems({
+      activeWarnings: ['disk_space_exhaustion'],
+      projectRef: 'abc',
+      aiPrompt: undefined,
+    })
+    expect(kindsOf(items)).toEqual(['metrics', 'docs'])
+  })
+})
+
+describe('getResourceWarningAiPrompt', () => {
+  it('uses the entry prompt for a single warning', () => {
+    expect(getResourceWarningAiPrompt(['cpu_exhaustion'])).toBe(
+      RESOURCE_WARNING_MESSAGES.cpu_exhaustion.aiPrompt
+    )
+  })
+
+  it('names the tripped resources for multiple warnings', () => {
+    expect(getResourceWarningAiPrompt(['cpu_exhaustion', 'disk_space_exhaustion'])).toContain(
+      '(CPU and Disk space)'
+    )
   })
 })

--- a/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.utils.ts
+++ b/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.utils.ts
@@ -76,8 +76,6 @@ export const getResourceWarningCorrectionUrl = ({
   return correctionUrlVariants[metric] ?? `${infrastructurePath}#${metric}`
 }
 
-export type ChartIdOverrides = Partial<Record<string, string>>
-
 export type TroubleshootItem =
   | { kind: 'metrics'; warningType: string; menuLabel: string; buttonLabel: string; href: string }
   | { kind: 'docs'; warningType: string; menuLabel: string; buttonLabel: string; href: string }
@@ -107,10 +105,12 @@ export const applyResourceList = (
 export const getResourceWarningMetricsHref = (
   warningType: string,
   projectRef: string,
-  chartIdOverrides: ChartIdOverrides = {}
+  showBurstBalanceChart = false
 ): string | undefined => {
   const chartId =
-    chartIdOverrides[warningType] ?? RESOURCE_WARNING_MESSAGES[warningType]?.metricsChartId
+    warningType === 'disk_io_exhaustion' && showBurstBalanceChart
+      ? 'disk-io-burst-balance'
+      : RESOURCE_WARNING_MESSAGES[warningType]?.metricsChartId
   if (chartId === undefined) return undefined
 
   const params = new URLSearchParams({
@@ -133,17 +133,17 @@ export const getTroubleshootItems = ({
   activeWarnings,
   projectRef,
   aiPrompt,
-  chartIdOverrides = {},
+  showBurstBalanceChart = false,
 }: {
   activeWarnings: string[]
   projectRef: string
   aiPrompt: string | undefined
-  chartIdOverrides?: ChartIdOverrides
+  showBurstBalanceChart?: boolean
 }): TroubleshootItem[] => {
   const isSingleWarning = activeWarnings.length === 1
 
   const metricsItems = activeWarnings.flatMap((warningType): TroubleshootItem[] => {
-    const href = getResourceWarningMetricsHref(warningType, projectRef, chartIdOverrides)
+    const href = getResourceWarningMetricsHref(warningType, projectRef, showBurstBalanceChart)
     const label = RESOURCE_WARNING_MESSAGES[warningType]?.resourceLabel
     if (href === undefined || (!isSingleWarning && label === undefined)) return []
     return [

--- a/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.utils.ts
+++ b/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.utils.ts
@@ -1,4 +1,5 @@
 import { RESOURCE_WARNING_MESSAGES } from './ResourceExhaustionWarningBanner.constants'
+import { REPORT_DATERANGE_HELPER_LABELS } from '@/components/interfaces/Reports/Reports.constants'
 import { getInfrastructurePath } from '@/components/interfaces/Settings/Infrastructure/Infrastructure.utils'
 import type { ResourceWarning } from '@/data/usage/resource-warnings-query'
 
@@ -73,4 +74,108 @@ export const getResourceWarningCorrectionUrl = ({
   if (metric === undefined) return undefined
   if (metric === null) return infrastructurePath
   return correctionUrlVariants[metric] ?? `${infrastructurePath}#${metric}`
+}
+
+export type ChartIdOverrides = Partial<Record<string, string>>
+
+export type TroubleshootItem =
+  | { kind: 'metrics'; warningType: string; menuLabel: string; buttonLabel: string; href: string }
+  | { kind: 'docs'; warningType: string; menuLabel: string; buttonLabel: string; href: string }
+  | { kind: 'ai'; menuLabel: string; buttonLabel: string }
+
+const resourceListFormatter = new Intl.ListFormat('en-US', { style: 'long', type: 'conjunction' })
+
+export const formatResourceList = (labels: string[]): string => resourceListFormatter.format(labels)
+
+export const getResourceWarningLabels = (activeWarnings: string[]): string[] =>
+  activeWarnings.flatMap((warningType) => {
+    const label = RESOURCE_WARNING_MESSAGES[warningType]?.resourceLabel
+    return label === undefined ? [] : [label]
+  })
+
+export const applyResourceList = (
+  text: string | undefined,
+  activeWarnings: string[]
+): string | undefined => {
+  if (text === undefined) return undefined
+  return text.replaceAll(
+    '{resources}',
+    formatResourceList(getResourceWarningLabels(activeWarnings))
+  )
+}
+
+export const getResourceWarningMetricsHref = (
+  warningType: string,
+  projectRef: string,
+  chartIdOverrides: ChartIdOverrides = {}
+): string | undefined => {
+  const chartId =
+    chartIdOverrides[warningType] ?? RESOURCE_WARNING_MESSAGES[warningType]?.metricsChartId
+  if (chartId === undefined) return undefined
+
+  const params = new URLSearchParams({
+    chart: chartId,
+    isHelper: 'true',
+    helperText: REPORT_DATERANGE_HELPER_LABELS.LAST_3_HOURS,
+  })
+  return `/project/${projectRef}/observability/database?${params}`
+}
+
+export const getResourceWarningAiPrompt = (activeWarnings: string[]): string | undefined => {
+  if (activeWarnings.length === 1) return RESOURCE_WARNING_MESSAGES[activeWarnings[0]]?.aiPrompt
+  return applyResourceList(
+    RESOURCE_WARNING_MESSAGES.multiple_resource_warnings.aiPrompt,
+    activeWarnings
+  )
+}
+
+export const getTroubleshootItems = ({
+  activeWarnings,
+  projectRef,
+  aiPrompt,
+  chartIdOverrides = {},
+}: {
+  activeWarnings: string[]
+  projectRef: string
+  aiPrompt: string | undefined
+  chartIdOverrides?: ChartIdOverrides
+}): TroubleshootItem[] => {
+  const isSingleWarning = activeWarnings.length === 1
+
+  const metricsItems = activeWarnings.flatMap((warningType): TroubleshootItem[] => {
+    const href = getResourceWarningMetricsHref(warningType, projectRef, chartIdOverrides)
+    const label = RESOURCE_WARNING_MESSAGES[warningType]?.resourceLabel
+    if (href === undefined || (!isSingleWarning && label === undefined)) return []
+    return [
+      {
+        kind: 'metrics',
+        warningType,
+        menuLabel: isSingleWarning ? 'View metrics' : `View ${label} metrics`,
+        buttonLabel: 'View metrics',
+        href,
+      },
+    ]
+  })
+
+  const docsItems = activeWarnings.flatMap((warningType): TroubleshootItem[] => {
+    const href = RESOURCE_WARNING_MESSAGES[warningType]?.docsUrl
+    const label = RESOURCE_WARNING_MESSAGES[warningType]?.resourceLabel
+    if (href === undefined || (!isSingleWarning && label === undefined)) return []
+    return [
+      {
+        kind: 'docs',
+        warningType,
+        menuLabel: isSingleWarning ? 'Documentation' : `${label} documentation`,
+        buttonLabel: 'Learn more',
+        href,
+      },
+    ]
+  })
+
+  const aiItems: TroubleshootItem[] =
+    aiPrompt === undefined
+      ? []
+      : [{ kind: 'ai', menuLabel: 'Ask AI Assistant', buttonLabel: 'Ask AI Assistant' }]
+
+  return [...metricsItems, ...docsItems, ...aiItems]
 }

--- a/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.utils.ts
+++ b/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.utils.ts
@@ -123,6 +123,11 @@ export const getResourceWarningMetricsHref = (
 
 export const getResourceWarningAiPrompt = (activeWarnings: string[]): string | undefined => {
   if (activeWarnings.length === 1) return RESOURCE_WARNING_MESSAGES[activeWarnings[0]]?.aiPrompt
+
+  const hasComputeWarning = activeWarnings.some((warningType) =>
+    COMPUTE_UPGRADE_WARNING_TYPES.includes(warningType)
+  )
+  if (!hasComputeWarning) return undefined
   return applyResourceList(
     RESOURCE_WARNING_MESSAGES.multiple_resource_warnings.aiPrompt,
     activeWarnings

--- a/apps/studio/data/reports/database-charts.test.ts
+++ b/apps/studio/data/reports/database-charts.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { getReportAttributesV2 } from './database-charts'
+import { getReportAttributesV2, shouldShowDiskIOBurstBalanceChart } from './database-charts'
 import { Project } from '@/data/projects/project-detail-query'
 
 const PROJECT: Project = {
@@ -115,5 +115,34 @@ describe('getReportAttributesV2 disk-io-burst-balance chart', () => {
 
   it('hides the chart for non burstable compute sizes', () => {
     expect(getBurstBalanceChart(buildProject({ infra_compute_size: '16xlarge' }))?.hide).toBe(true)
+  })
+})
+
+describe('shouldShowDiskIOBurstBalanceChart', () => {
+  it('shows the chart for burstable non high availability projects when the flag is on', () => {
+    expect(shouldShowDiskIOBurstBalanceChart(buildProject(), true)).toBe(true)
+  })
+
+  it('hides the chart when the flag is off', () => {
+    expect(shouldShowDiskIOBurstBalanceChart(buildProject(), false)).toBe(false)
+  })
+
+  it('hides the chart for non burstable compute sizes', () => {
+    expect(
+      shouldShowDiskIOBurstBalanceChart(buildProject({ infra_compute_size: '4xlarge' }), true)
+    ).toBe(false)
+  })
+
+  it('hides the chart for high availability projects', () => {
+    expect(
+      shouldShowDiskIOBurstBalanceChart(
+        buildProject({ high_availability: true, infra_compute_size: 'large' }),
+        true
+      )
+    ).toBe(false)
+  })
+
+  it('hides the chart when the project is unknown', () => {
+    expect(shouldShowDiskIOBurstBalanceChart(undefined, true)).toBe(false)
   })
 })

--- a/apps/studio/data/reports/database-charts.ts
+++ b/apps/studio/data/reports/database-charts.ts
@@ -13,6 +13,14 @@ import { resolveHighAvailability } from '@/hooks/misc/useHighAvailability.consta
 import { DOCS_URL } from '@/lib/constants'
 import { formatBytes, formatBytesMinMB } from '@/lib/helpers'
 
+// High Availability projects run on volumes without a burst credit pool, so the
+// Disk IO Burst Balance chart has no data to show for them.
+export const shouldShowDiskIOBurstBalanceChart = (
+  project: Project | undefined,
+  isFlagEnabled: boolean
+): boolean =>
+  isFlagEnabled && hasBurstableIO(project?.infra_compute_size) && !resolveHighAvailability(project)
+
 export const getReportAttributesV2: (
   entitledFeatures: string[],
   project: Project,
@@ -42,12 +50,10 @@ export const getReportAttributesV2: (
     typeof provisionedDiskIops === 'number' && typeof computeIopsLimit === 'number'
       ? Math.min(provisionedDiskIops, computeIopsLimit)
       : provisionedDiskIops
-  // High Availability projects run on volumes without a burst credit pool, so the
-  // Disk IO Burst Balance chart has no data to show for them.
-  const showBurstBalanceChart =
-    !!showDiskIOBurstBalanceChart &&
-    hasBurstableIO(project?.infra_compute_size) &&
-    !isHighAvailability
+  const showBurstBalanceChart = shouldShowDiskIOBurstBalanceChart(
+    project,
+    !!showDiskIOBurstBalanceChart
+  )
   const baselineThroughputMBps = COMPUTE_DISK[computeVariantId]?.baselineThroughputMBps
   const baselineThroughputLabel =
     typeof baselineThroughputMBps === 'number' ? `${baselineThroughputMBps} MB/s` : 'its baseline'

--- a/apps/studio/hooks/misc/__tests__/useReportDateRange.test.ts
+++ b/apps/studio/hooks/misc/__tests__/useReportDateRange.test.ts
@@ -1,8 +1,9 @@
 import dayjs from 'dayjs'
 import { describe, expect, test } from 'vitest'
 
+import { REPORT_DATERANGE_HELPER_LABELS } from '@/components/interfaces/Reports/Reports.constants'
 import { analyticsIntervalToGranularity } from '@/data/reports/report.utils'
-import { getIntervalGranularity } from '@/hooks/misc/useReportDateRange'
+import { getIntervalGranularity, resolveHelperFromUrl } from '@/hooks/misc/useReportDateRange'
 
 const rangeOf = (value: number, unit: dayjs.ManipulateType) => {
   const to = dayjs()
@@ -31,5 +32,21 @@ describe('getIntervalGranularity', () => {
   ])('leaves a %s-%s range on the %s interval', (value, unit, expected) => {
     const { from, to } = rangeOf(value, unit)
     expect(getIntervalGranularity(from, to)).toBe(expected)
+  })
+})
+
+describe('resolveHelperFromUrl', () => {
+  test('returns the helper named by the URL when the helper flag is set', () => {
+    expect(resolveHelperFromUrl(true, 'Last 3 hours')?.text).toBe(
+      REPORT_DATERANGE_HELPER_LABELS.LAST_3_HOURS
+    )
+  })
+
+  test('ignores the label when the helper flag is off', () => {
+    expect(resolveHelperFromUrl(false, 'Last 3 hours')).toBeUndefined()
+  })
+
+  test('ignores labels that are not a known helper', () => {
+    expect(resolveHelperFromUrl(true, 'Last 3 fortnights')).toBeUndefined()
   })
 })

--- a/apps/studio/hooks/misc/useReportDateRange.ts
+++ b/apps/studio/hooks/misc/useReportDateRange.ts
@@ -23,6 +23,26 @@ export const getIntervalGranularity = (from: string, to: string): AnalyticsInter
   return '1d'
 }
 
+export const resolveHelperFromUrl = (
+  isHelper: boolean,
+  helperText: string
+): ReportsDatetimeHelper | undefined => {
+  if (!isHelper || helperText === '') return undefined
+  return REPORTS_DATEPICKER_HELPERS.find((helper) => helper.text === helperText)
+}
+
+const resolveHelperFromArgument = (
+  defaultHelper: REPORT_DATERANGE_HELPER_LABELS | string | ReportsDatetimeHelper
+): ReportsDatetimeHelper | undefined => {
+  if (typeof defaultHelper === 'string') {
+    return REPORTS_DATEPICKER_HELPERS.find((helper) => helper.text === defaultHelper)
+  }
+  if (defaultHelper && typeof defaultHelper === 'object' && 'text' in defaultHelper) {
+    return defaultHelper
+  }
+  return undefined
+}
+
 export const DATERANGE_LIMITS: { [key: string]: number } = {
   free: 1,
   pro: 7,
@@ -91,15 +111,9 @@ export const useReportDateRange = (
   )
 
   const getDefaultHelper = useCallback(() => {
-    let targetHelper: ReportsDatetimeHelper | undefined
-
-    if (typeof defaultHelper === 'string') {
-      // Find helper by text (supports both enum values and direct strings)
-      targetHelper = REPORTS_DATEPICKER_HELPERS.find((helper) => helper.text === defaultHelper)
-    } else if (defaultHelper && typeof defaultHelper === 'object' && 'text' in defaultHelper) {
-      // Use the provided helper object directly
-      targetHelper = defaultHelper
-    }
+    const targetHelper =
+      resolveHelperFromUrl(isHelperValue, helperTextValue) ??
+      resolveHelperFromArgument(defaultHelper)
 
     // Check if the target helper is available for the current entitlement
     if (targetHelper && hasAccessToHelper(targetHelper)) {
@@ -142,7 +156,7 @@ export const useReportDateRange = (
       end: defaultEnd,
       helper: { isHelper: false },
     }
-  }, [defaultHelper, hasAccessToHelper])
+  }, [defaultHelper, hasAccessToHelper, helperTextValue, isHelperValue])
 
   // Get current effective values (from URL or defaults, but don't set URL)
   const timestampStart = useMemo(() => {

--- a/apps/studio/hooks/misc/useReportDateRange.ts
+++ b/apps/studio/hooks/misc/useReportDateRange.ts
@@ -112,7 +112,7 @@ export const useReportDateRange = (
 
   const getDefaultHelper = useCallback(() => {
     const targetHelper =
-      resolveHelperFromUrl(isHelperValue, helperTextValue) ??
+      resolveHelperFromUrl(Boolean(isHelperValue), helperTextValue ?? '') ??
       resolveHelperFromArgument(defaultHelper)
 
     // Check if the target helper is available for the current entitlement

--- a/apps/studio/hooks/misc/useShowDiskIOBurstBalanceChart.ts
+++ b/apps/studio/hooks/misc/useShowDiskIOBurstBalanceChart.ts
@@ -1,0 +1,10 @@
+import { useFlag } from 'common'
+
+import { shouldShowDiskIOBurstBalanceChart } from '@/data/reports/database-charts'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+
+export const useShowDiskIOBurstBalanceChart = (): boolean => {
+  const isFlagEnabled = useFlag('showDiskIOBurstBalanceChart')
+  const { data: project } = useSelectedProjectQuery()
+  return shouldShowDiskIOBurstBalanceChart(project, !!isFlagEnabled)
+}

--- a/apps/studio/pages/project/[ref]/observability/database.tsx
+++ b/apps/studio/pages/project/[ref]/observability/database.tsx
@@ -220,13 +220,27 @@ const DatabaseUsage = () => {
         state.setSelectedDatabaseId(db)
       }, 100)
     }
-    if (chart !== undefined) {
-      setTimeout(() => {
-        const el = document.getElementById(chart)
-        if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' })
-      }, 200)
-    }
-  }, [db, chart, state])
+  }, [db, state])
+
+  // Charts below the fold mount lazily and the query string is empty on the first client render
+  // of a hard load, so the target can appear well after mount.
+  const hasScrolledToChartRef = useRef(false)
+  useEffect(() => {
+    if (chart === undefined || hasScrolledToChartRef.current) return
+
+    let attempts = 0
+    const pollForChart = window.setInterval(() => {
+      attempts += 1
+      const target = document.getElementById(chart)
+      if (target) {
+        target.scrollIntoView({ behavior: 'smooth', block: 'center' })
+        hasScrolledToChartRef.current = true
+      }
+      if (target || attempts >= 25) window.clearInterval(pollForChart)
+    }, 200)
+
+    return () => window.clearInterval(pollForChart)
+  }, [chart])
 
   return (
     <>

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -3657,7 +3657,7 @@ export interface ResourceExhaustionBannerAiAssistantClickedEvent {
 }
 
 /**
- * User clicked a "View metrics" or documentation item in the Troubleshoot menu of a resource exhaustion warning banner.
+ * User clicked a metrics or documentation link on a resource exhaustion warning banner (Troubleshoot menu item or single-action button).
  *
  * @group Events
  * @source studio

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -3657,6 +3657,23 @@ export interface ResourceExhaustionBannerAiAssistantClickedEvent {
 }
 
 /**
+ * User clicked a "View metrics" or documentation item in the Troubleshoot menu of a resource exhaustion warning banner.
+ *
+ * @group Events
+ * @source studio
+ */
+export interface ResourceExhaustionBannerTroubleshootClickedEvent {
+  action: 'resource_exhaustion_banner_troubleshoot_clicked'
+  groups: TelemetryGroups
+  properties: {
+    troubleshootAction: 'metrics' | 'docs'
+    warningType: string
+    warningTypes: string[]
+    destination: string
+  }
+}
+
+/**
  * User clicked a row in the Unified Logs interface.
  *
  * @group Events
@@ -4059,6 +4076,7 @@ export type TelemetryEvent =
   | AccessTokenDoneButtonClickedEvent
   | ResourceExhaustionBannerUpgradeClickedEvent
   | ResourceExhaustionBannerAiAssistantClickedEvent
+  | ResourceExhaustionBannerTroubleshootClickedEvent
   | UnifiedLogsRowClickedEvent
   | HeaderHomeLogoClickedEvent
   | HeaderBackToDashboardClickedEvent


### PR DESCRIPTION
I updated the resource exhaustion banner to name each affected resource and link directly to its relevant metrics or documentation. I made metrics links open the Database report with the last three hours selected and keep the requested chart visible while lazy charts above it finish loading.

**Changed:**
- **Actionable troubleshooting:** I added per-resource metrics, documentation, and AI Assistant actions for single and multi-resource banners, with telemetry for each linked action.
- **Stable metrics deep links:** I moved chart anchors onto the lazy wrapper, honored the helper date range from the URL, and re-centered a requested chart only when lazy loading pushed it outside the report viewport. I added the chart fragment to metrics URLs, so following the same link again re-scrolls after the user moves away. I made user interaction cancel both pending chart lookup and layout re-centering, so late-loading charts cannot pull the page back after the user moves.
- **Accurate banner guidance:** I changed multi-resource warnings without an AI action to direct users to the Troubleshoot menu instead of recommending compute upgrades or the AI Assistant. I also exclude API warning fields with no active banner configuration before deriving titles, actions, or telemetry.
- **Correct Disk IO target:** I made Disk IO links target Burst Balance when that chart is available, with Disk throughput as the fallback.

**Note:** I changed `disk_space_exhaustion` to use the Troubleshoot menu because it has a metrics destination.

## To test
Fake warning states from the dev toolbar, Resource Warnings tab, on a paid-plan project.

Test on preview:
- [x] Open the Disk Usage metrics link with Last 3 hours selected, expect the complete card to remain inside the report viewport after one, four, and seven seconds.
- [x] Open the CPU, Memory, and Disk IO metrics links, expect each target card to land inside the report viewport with Last 3 hours selected. Disk IO targeted Burst Balance on the nano, non-HA test project.
- [x] Set `disk_space_exhaustion` and `auth_rate_limit_exhaustion`, expect the description to direct users to Troubleshoot with no AI Assistant wording in the banner.
- [x] Replace Auth rate limits with `cpu_exhaustion`, expect the existing AI Assistant guidance to remain in the banner.
- [x] Reset the warning simulator to real data, expect the resource exhaustion banner to disappear.
- [ ] Follow a chart deep link and scroll elsewhere within ten seconds, expect late-loading charts not to return you to the target.
- [ ] From a `?chart=cpu-usage` report URL, scroll away and follow View CPU metrics again, expect the CPU card to re-center without reloading.
- [ ] Open the Troubleshoot menu and navigate between CPU and Disk space without reloading. While the warning simulator is open, its modal prevents report interaction, and closing it clears the fake warnings.
- [ ] Click View CPU metrics and inspect `resource_exhaustion_banner_troubleshoot_clicked`. The simulator lifecycle prevents banner clicks while fake warnings are active.

## Linear
- fixes GROWTH-1204


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Resource exhaustion warnings now identify affected resources and offer relevant metrics, documentation, and AI troubleshooting actions.
  - Disk I/O warnings can link directly to the burst-balance chart when applicable.
  - Report date-range helpers can be selected through URL parameters.
  - Database chart links smoothly scroll to and keep the selected chart visible as the page loads.

- **Bug Fixes**
  - Improved chart deep-link behavior when charts resize or become available.
  - Added tracking for metrics and documentation interactions from resource warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
