### PR TITLE
docs: update remaining Flutter Google sign-in samples to google_sign_in v7

### DIFF
--- a/apps/docs/content/guides/auth/auth-identity-linking.mdx
+++ b/apps/docs/content/guides/auth/auth-identity-linking.mdx
@@ -142,6 +142,10 @@ For Flutter applications, you can link an identity using an ID token obtained fr
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+/// TODO: update the client IDs with the ones you registered with Google Cloud.
+const webClientId = 'my-web.apps.googleusercontent.com';
+const iosClientId = 'my-ios.apps.googleusercontent.com';
+
 // First, obtain the ID token from the native provider
 final scopes = ['email', 'profile'];
 final googleSignIn = GoogleSignIn.instance;
@@ -156,11 +160,16 @@ final googleUser = await googleSignIn.authenticate();
 final authorization =
     await googleUser.authorizationClient.authorizationForScopes(scopes) ??
     await googleUser.authorizationClient.authorizeScopes(scopes);
+final idToken = googleUser.authentication.idToken;
+
+if (idToken == null) {
+  throw AuthException('No ID Token found.');
+}
 
 // Link the Google identity to the current user
 final response = await supabase.auth.linkIdentityWithIdToken(
   provider: OAuthProvider.google,
-  idToken: googleUser.authentication.idToken!,
+  idToken: idToken,
   accessToken: authorization.accessToken,
 );
 ```

--- a/apps/docs/content/guides/auth/auth-identity-linking.mdx
+++ b/apps/docs/content/guides/auth/auth-identity-linking.mdx
@@ -143,18 +143,25 @@ import 'package:google_sign_in/google_sign_in.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 // First, obtain the ID token from the native provider
-final GoogleSignIn googleSignIn = GoogleSignIn(
+final scopes = ['email', 'profile'];
+final googleSignIn = GoogleSignIn.instance;
+
+// Call `initialize` exactly once, before any other `GoogleSignIn` method
+await googleSignIn.initialize(
   clientId: iosClientId,
   serverClientId: webClientId,
 );
-final googleUser = await googleSignIn.signIn();
-final googleAuth = await googleUser!.authentication;
+final googleUser = await googleSignIn.authenticate();
+
+final authorization =
+    await googleUser.authorizationClient.authorizationForScopes(scopes) ??
+    await googleUser.authorizationClient.authorizeScopes(scopes);
 
 // Link the Google identity to the current user
 final response = await supabase.auth.linkIdentityWithIdToken(
   provider: OAuthProvider.google,
-  idToken: googleAuth.idToken!,
-  accessToken: googleAuth.accessToken!,
+  idToken: googleUser.authentication.idToken!,
+  accessToken: authorization.accessToken,
 );
 ```
 

--- a/apps/docs/spec/supabase_dart_v2.yml
+++ b/apps/docs/spec/supabase_dart_v2.yml
@@ -609,20 +609,22 @@ functions:
 
           const webClientId = '<web client ID that you registered on Google Cloud, for example my-web.apps.googleusercontent.com>';
 
-          const iosClientId = '<iOS client ID that you registered on Google Cloud, for example my-ios.apps.googleusercontent.com';
+          const iosClientId = '<iOS client ID that you registered on Google Cloud, for example my-ios.apps.googleusercontent.com>';
 
-          final GoogleSignIn googleSignIn = GoogleSignIn(
+          final scopes = ['email', 'profile'];
+          final googleSignIn = GoogleSignIn.instance;
+
+          await googleSignIn.initialize(
             clientId: iosClientId,
             serverClientId: webClientId,
           );
-          final googleUser = await googleSignIn.signIn();
-          final googleAuth = await googleUser!.authentication;
-          final accessToken = googleAuth.accessToken;
-          final idToken = googleAuth.idToken;
+          final googleUser = await googleSignIn.authenticate();
 
-          if (accessToken == null) {
-            throw 'No Access Token found.';
-          }
+          final authorization =
+              await googleUser.authorizationClient.authorizationForScopes(scopes) ??
+              await googleUser.authorizationClient.authorizeScopes(scopes);
+          final idToken = googleUser.authentication.idToken;
+
           if (idToken == null) {
             throw 'No ID Token found.';
           }
@@ -630,7 +632,7 @@ functions:
           final response = await supabase.auth.signInWithIdToken(
             provider: OAuthProvider.google,
             idToken: idToken,
-            accessToken: accessToken,
+            accessToken: authorization.accessToken,
           );
           ```
         response: |
@@ -1567,18 +1569,20 @@ functions:
           const webClientId = '<web client ID>';
           const iosClientId = '<iOS client ID>';
 
-          final GoogleSignIn googleSignIn = GoogleSignIn(
+          final scopes = ['email', 'profile'];
+          final googleSignIn = GoogleSignIn.instance;
+
+          await googleSignIn.initialize(
             clientId: iosClientId,
             serverClientId: webClientId,
           );
-          final googleUser = await googleSignIn.signIn();
-          final googleAuth = await googleUser!.authentication;
-          final accessToken = googleAuth.accessToken;
-          final idToken = googleAuth.idToken;
+          final googleUser = await googleSignIn.authenticate();
 
-          if (accessToken == null) {
-            throw 'No Access Token found.';
-          }
+          final authorization =
+              await googleUser.authorizationClient.authorizationForScopes(scopes) ??
+              await googleUser.authorizationClient.authorizeScopes(scopes);
+          final idToken = googleUser.authentication.idToken;
+
           if (idToken == null) {
             throw 'No ID Token found.';
           }
@@ -1586,7 +1590,7 @@ functions:
           final response = await supabase.auth.linkIdentityWithIdToken(
             provider: OAuthProvider.google,
             idToken: idToken,
-            accessToken: accessToken,
+            accessToken: authorization.accessToken,
           );
           ```
       - id: link-apple-identity


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

`google_sign_in` 7.x removed the `GoogleSignIn(...)` constructor and `signIn()`. The main Google guide (`guides/auth/social-login/auth-google.mdx`) was moved to the v7 API in #36780 (for #36775), but three other Dart samples still use the removed v6 API, so they no longer compile against the current package (7.2.0):

- `apps/docs/content/guides/auth/auth-identity-linking.mdx` (Dart tab)
- `apps/docs/spec/supabase_dart_v2.yml`: `signInWithIdToken` → "Native Google sign in"
- `apps/docs/spec/supabase_dart_v2.yml`: `linkIdentityWithIdToken` → "Link Google identity"

## What is the new behavior?

All three samples follow the v7 flow used by the main guide:

- `GoogleSignIn.instance` + a single `initialize(clientId:, serverClientId:)`
- `authenticate()` to sign the user in
- `authorizationClient.authorizationForScopes(scopes) ?? authorizeScopes(scopes)` for the access token
- `googleUser.authentication.idToken` (now synchronous, and ID token only)

Also fixes a missing closing `>` in the `iosClientId` placeholder of the reference sample.

The `examples/auth/flutter-native-google-auth` app pins `google_sign_in: ^6.1.5`, so it's correct for v6 and is intentionally left unchanged.

## Additional context

API references: [MIGRATION.md](https://github.com/flutter/packages/blob/main/packages/google_sign_in/google_sign_in/MIGRATION.md), [README](https://pub.dev/packages/google_sign_in).

### Self-review

- `pnpm lint:mdx`: no findings in `auth-identity-linking.mdx`. The tree's only error is pre-existing, in `content/_partials/uiLibCta.mdx`, which this PR doesn't touch.
- `prettier --check`: passes on both changed files.
- Rendered pages checked locally (`pnpm dev:docs`): the Dart tab of `/docs/guides/auth/auth-identity-linking` and both Dart reference pages (`auth-signinwithidtoken`, `auth-linkidentitywithidtoken`) show the v7 samples, with no v6 API left.
- Compile check: the updated samples, pasted into a scratch Flutter app with `google_sign_in` 7.2.0 and `supabase_flutter` 2.17.2, give 0 errors from `dart analyze`. The only findings are 3 expected `unused_local_variable` warnings for `response`.
- Negative control: the original v6 samples, analyzed the same way, fail with 6 errors (2 per sample): `The class 'GoogleSignIn' doesn't have an unnamed constructor` and `The method 'signIn' isn't defined for the type 'GoogleSignIn'`.
- `test-the-docs` end-to-end sign-in: deferred. It needs a Google Cloud OAuth client and a device or simulator.
- Dart reference snapshot (`scripts/__snapshots__/build-reference-content.dart.v2.json`): left as-is. The dart/v2 suite has been `describe.skip` since Jun 30, 2026, so it can't be regenerated with `vitest -u`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Dart and Flutter Google sign-in examples to use the current Google Sign-In API.
  * Updated native sign-in and identity-linking examples to retrieve access tokens through the authorization client.
  * Added clearer ID-token validation in the identity-linking example.
  * Corrected the iOS client ID example formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->