### PR TITLE
fix(pg-meta): don't report aggregates in function_search_path_mutable lint

### DIFF
--- a/packages/pg-meta/src/sql/studio/advisor/lints.ts
+++ b/packages/pg-meta/src/sql/studio/advisor/lints.ts
@@ -689,6 +689,7 @@ where
         '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'pgtle', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
     )
     and dep.objid is null -- exclude functions owned by extensions
+    and p.prokind <> 'a' -- exclude aggregates: CREATE AGGREGATE has no SET clause
     -- Search path not set
     and not exists (
         select 1

--- a/packages/pg-meta/test/sql/studio/lints.test.ts
+++ b/packages/pg-meta/test/sql/studio/lints.test.ts
@@ -1,6 +1,30 @@
-import { describe, expect, it } from 'vitest'
+import { afterAll, describe, expect, it, test } from 'vitest'
 
-import { enrichLintsQuery, safeSql } from '../../../src'
+import { enrichLintsQuery, getLintsSQL, safeSql } from '../../../src'
+import { cleanupRoot, createDatabaseWithAuthSchema, createTestDatabase } from '../../db/utils'
+
+afterAll(async () => {
+  await cleanupRoot()
+})
+
+const withTestDatabase = (
+  name: string,
+  fn: (db: Awaited<ReturnType<typeof createTestDatabase>>) => Promise<void>
+) => {
+  test(name, async () => {
+    const db = await createTestDatabase()
+    try {
+      await fn(db)
+    } finally {
+      await db.cleanup()
+    }
+  })
+}
+
+type LintRow = { name: string; metadata: { name: string } }
+
+const reportedFunctionSearchPathMutable = (rows: LintRow[]) =>
+  rows.filter((row) => row.name === 'function_search_path_mutable').map((row) => row.metadata.name)
 
 describe('enrichLintsQuery', () => {
   const dummyQuery = safeSql`SELECT 1`
@@ -24,4 +48,47 @@ describe('enrichLintsQuery', () => {
     const result = enrichLintsQuery(dummyQuery)
     expect(result).toContain(dummyQuery)
   })
+})
+
+describe('function_search_path_mutable lint', () => {
+  // The lint query reads auth.users and checks privileges for the anon and
+  // authenticated roles, none of which exist in a fresh test database
+  const prepareLintsDatabase = async (db: Awaited<ReturnType<typeof createTestDatabase>>) => {
+    await createDatabaseWithAuthSchema(db)
+    await db.executeQuery(`
+      do $$ begin
+        if not exists (select from pg_roles where rolname = 'anon') then create role anon nologin; end if;
+        if not exists (select from pg_roles where rolname = 'authenticated') then create role authenticated nologin; end if;
+      end $$;
+    `)
+  }
+
+  const runLints = (db: Awaited<ReturnType<typeof createTestDatabase>>) =>
+    db.executeQuery<LintRow[]>(getLintsSQL({ docsUrl: 'https://supabase.com/docs' }))
+
+  withTestDatabase('does not report aggregates', async (db) => {
+    await prepareLintsDatabase(db)
+    // CREATE AGGREGATE has no SET clause, so an aggregate can never pin its search_path
+    await db.executeQuery(`
+      create function public.int_add(a int, b int) returns int
+        language sql set search_path = '' as $$ select a + b $$;
+      create aggregate public.int_sum(int) (sfunc = public.int_add, stype = int, initcond = '0');
+    `)
+
+    expect(reportedFunctionSearchPathMutable(await runLints(db))).not.toContain('int_sum')
+  })
+
+  withTestDatabase(
+    'still reports an aggregate support function without a search_path',
+    async (db) => {
+      await prepareLintsDatabase(db)
+      await db.executeQuery(`
+        create function public.int_add(a int, b int) returns int
+          language sql as $$ select a + b $$;
+        create aggregate public.int_sum(int) (sfunc = public.int_add, stype = int, initcond = '0');
+      `)
+
+      expect(reportedFunctionSearchPathMutable(await runLints(db))).toContain('int_add')
+    }
+  )
 })


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The Security Advisor's **Function Search Path Mutable** lint (`function_search_path_mutable` in `packages/pg-meta/src/sql/studio/advisor/lints.ts`) reports aggregate functions. An aggregate can't pin its `search_path`: `CREATE AGGREGATE` has no `SET` clause, and `ALTER FUNCTION … SET search_path = ''` on an aggregate fails with `"public.my_agg" is an aggregate function`. That leaves a warning users can't resolve.

The hosted linter has the same bug: supabase/splinter#139, with open fixes supabase/splinter#148 and supabase/splinter#178.

## What is the new behavior?

The lint skips aggregates (`p.prokind <> 'a'`). Everything else is unchanged:

- An aggregate's support functions (`sfunc`, `finalfunc`, …) are ordinary functions, so they're still reported if they don't pin a `search_path`.
- Window functions and procedures are still linted, because `CREATE FUNCTION … WINDOW` and `CREATE PROCEDURE` both accept `SET`. This matches the approach in supabase/splinter#178.

`lints.ts` mirrors splinter, so I'm happy to adjust if you'd rather this land in splinter first.

## Additional context

Tests: two DB-backed tests in `packages/pg-meta/test/sql/studio/lints.test.ts`, run against the pg-meta Docker test database with the real `getLintsSQL` query:

- **Aggregates aren't reported.** Before the fix it failed with `expected [ 'add', 'audit_action', …(11) ] to not include 'int_sum'`.
- **An aggregate's support function without a `search_path` is still reported.** I confirmed this test fails (`expected [] to include 'int_add'`) if the filter wrongly excludes normal functions too.

The tests create the `anon` and `authenticated` roles (only if missing) and the `auth` schema, because the lint query reads both and fresh test databases have neither.

### Self-review

- `pnpm test` in `packages/pg-meta`: all 32 test files (483 tests) pass
- `tsc --noEmit`: passes
- `prettier --check`: passes on both changed files
- Checked in self-hosted Studio (`pnpm dev:studio` against the Docker stack): after the fix, `run-lints` no longer lists a test aggregate, but still lists an unpinned control function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved function search-path linting to avoid incorrectly flagging aggregate functions.
  * Aggregate functions are still reported when their support functions do not define a search path.

* **Tests**
  * Added coverage for aggregate function search-path lint behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->