### PR TITLE
docs: forward Set-Cookie headers in server OAuth redirect (fixes #30900)

### DIFF
--- a/apps/docs/content/_partials/oauth_pkce_flow.mdx
+++ b/apps/docs/content/_partials/oauth_pkce_flow.mdx
@@ -32,12 +32,31 @@ await supabase.auth.signInWithOAuth({
 In the server, you need to handle the redirect to the OAuth provider's authentication endpoint. The `signInWithOAuth` method returns the endpoint URL, which you can redirect to.
 
 ```js
-import { createClient, type Provider } from '@supabase/supabase-js'
-const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
+import { createServerClient, parseCookieHeader, serializeCookieHeader } from '@supabase/ssr'
+import type { Provider } from '@supabase/supabase-js'
 const provider = 'provider' as Provider
-const redirect = (url: string) => {}
+const redirect = (url: string, init?: { headers: Headers }) => {}
 
 // ---cut---
+const headers = new Headers()
+
+const supabase = createServerClient(
+  process.env.SUPABASE_URL!,
+  process.env.SUPABASE_PUBLISHABLE_KEY!,
+  {
+    cookies: {
+      getAll() {
+        return parseCookieHeader(request.headers.get('Cookie') ?? '')
+      },
+      setAll(cookiesToSet) {
+        cookiesToSet.forEach(({ name, value, options }) =>
+          headers.append('Set-Cookie', serializeCookieHeader(name, value, options))
+        )
+      },
+    },
+  }
+)
+
 const { data, error } = await supabase.auth.signInWithOAuth({
   provider,
   options: {
@@ -46,9 +65,11 @@ const { data, error } = await supabase.auth.signInWithOAuth({
 })
 
 if (data.url) {
-  redirect(data.url) // use the redirect API for your server framework
+  redirect(data.url, { headers }) // use the redirect API for your server framework
 }
 ```
+
+You must forward the `Set-Cookie` headers on redirect. Otherwise the PKCE verifier cookie never reaches the browser and the OAuth callback fails.
 
 </TabPanel>
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
Docs fix (single shared snippet, no behavior change).

## What is the current behavior?
The server-side OAuth snippet redirects with `data.url` but does not forward `Set-Cookie` headers written by `@supabase/ssr`, dropping the PKCE verifier cookie in Remix/React Router and breaking the OAuth callback. Fixes #30900.

## What is the new behavior?
- Uses `createServerClient` cookie adapters capturing `Set-Cookie` into `headers`.
- Redirects via `redirect(data.url, { headers })` so cookies reach the browser.
- Adds a one-line note explaining why forwarding is required.

## Additional context
- Docs-only, 1 file, +25/−4. Alternative to #43942 (open since Mar 2026, bundles unrelated Studio changes) — happy to close mine in favor of whichever maintainers prefer.

Fixes #30900

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the server-side OAuth PKCE example to use the recommended server client.
  - Added handling for reading and writing cookies through request headers.
  - Redirects now forward response headers, including `Set-Cookie`, so the PKCE verifier reaches the browser.
  - Added guidance explaining that forwarding `Set-Cookie` headers is required for successful OAuth callbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->