### PR TITLE
docs: fix grammar in RUM extension guide

### DIFF
--- a/apps/docs/content/guides/database/extensions/rum.mdx
+++ b/apps/docs/content/guides/database/extensions/rum.mdx
@@ -143,7 +143,7 @@ SELECT * FROM test_array WHERE i && '{1}' ORDER BY i `<=>` '{1}' ASC;
 
 `rum_anyarray_addon_ops`
 
-The does the same with `anyarray` index as `rum_tsvector_addon_ops` i.e. allows to order select results using distance
+This does the same with `anyarray` index as `rum_tsvector_addon_ops` i.e. allows ordering select results using distance
 operator by attached column.
 
 ## Limitations


### PR DESCRIPTION
Tiny docs fix in the RUM extension guide:
- `The does` → `This does`
- `allows to order` → `allows ordering`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a grammatical typo in the `rum_anyarray_addon_ops` description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->