### PR TITLE
fix(studio): truncate edge function chart buckets in UTC

### DIFF
--- a/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionOverview.utils.test.ts
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionOverview.utils.test.ts
@@ -196,6 +196,25 @@ describe('EdgeFunctionOverview.utils', () => {
     expect(rollingEnd.toISOString()).toBe('2026-03-20T10:37:00.000Z')
   })
 
+  it('anchors bucketed windows to UTC boundaries for every interval unit', () => {
+    const dayInterval = EDGE_FUNCTION_CHART_INTERVALS.find((item) => item.key === '1day')
+    const minuteInterval = EDGE_FUNCTION_CHART_INTERVALS.find((item) => item.key === '15min')
+    expect(dayInterval).toBeDefined()
+    expect(minuteInterval).toBeDefined()
+
+    // The analytics endpoint returns UTC-truncated buckets, so these boundaries must not follow
+    // the host timezone -- a local truncation would shift them in zones offset by 5:30 or 5:45.
+    const now = new Date('2026-03-20T10:37:42.500Z')
+
+    const [dayStart, dayEnd] = getBucketedTimeRange(dayInterval!, now)
+    expect(dayStart.toISOString()).toBe('2026-03-19T00:00:00.000Z')
+    expect(dayEnd.toISOString()).toBe('2026-03-20T00:00:00.000Z')
+
+    const [minuteStart, minuteEnd] = getBucketedTimeRange(minuteInterval!, now)
+    expect(minuteStart.toISOString()).toBe('2026-03-20T10:22:00.000Z')
+    expect(minuteEnd.toISOString()).toBe('2026-03-20T10:37:00.000Z')
+  })
+
   it('formats metric, rate, and reference deltas consistently', () => {
     expect(formatMetric(12.34, 'MB')).toBe('12.3MB')
     expect(formatMetric(1234, 'ms')).toBe('1,234ms')

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionOverview.utils.test.ts
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionOverview.utils.test.ts
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
   EDGE_FUNCTION_CHART_INTERVALS,
@@ -21,8 +21,28 @@ import {
   toEdgeFunctionChartData,
   type EdgeFunctionChartRawDatum,
 } from './EdgeFunctionOverview.utils'
+import type { ChartIntervals } from '@/types'
+
+/**
+ * Runs `assertions` with the process timezone pinned, so a case can prove that a helper ignores
+ * the host timezone. Node re-reads the `TZ` variable on assignment, so stubbing it changes what
+ * `Date` (and therefore dayjs) treats as local time for the duration of the call.
+ */
+const runInTimeZone = (timeZone: string, assertions: () => void) => {
+  vi.stubEnv('TZ', timeZone)
+
+  try {
+    assertions()
+  } finally {
+    vi.unstubAllEnvs()
+  }
+}
 
 describe('EdgeFunctionOverview.utils', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
   it('uses a full day interval for the 1 day option', () => {
     expect(
       EDGE_FUNCTION_CHART_INTERVALS.find((interval) => interval.key === '1day')?.startUnit
@@ -196,24 +216,39 @@ describe('EdgeFunctionOverview.utils', () => {
     expect(rollingEnd.toISOString()).toBe('2026-03-20T10:37:00.000Z')
   })
 
-  it('anchors bucketed windows to UTC boundaries for every interval unit', () => {
-    const dayInterval = EDGE_FUNCTION_CHART_INTERVALS.find((item) => item.key === '1day')
-    const minuteInterval = EDGE_FUNCTION_CHART_INTERVALS.find((item) => item.key === '15min')
-    expect(dayInterval).toBeDefined()
-    expect(minuteInterval).toBeDefined()
+  // The analytics endpoint returns UTC-truncated buckets, so these boundaries must not follow the
+  // host timezone. The non-UTC zones carry the regression: under UTC alone, local-time truncation
+  // and UTC truncation agree, so a UTC-only case would still pass against the broken helper.
+  it.each(['UTC', 'Asia/Kolkata', 'Asia/Kathmandu', 'Pacific/Chatham', 'America/New_York'])(
+    'anchors bucketed windows to UTC boundaries in %s',
+    (timeZone) => {
+      const dayInterval = EDGE_FUNCTION_CHART_INTERVALS.find((item) => item.key === '1day')
+      const hourInterval = EDGE_FUNCTION_CHART_INTERVALS.find((item) => item.key === '1hr')
+      const minuteInterval = EDGE_FUNCTION_CHART_INTERVALS.find((item) => item.key === '15min')
+      expect(dayInterval).toBeDefined()
+      expect(hourInterval).toBeDefined()
+      expect(minuteInterval).toBeDefined()
 
-    // The analytics endpoint returns UTC-truncated buckets, so these boundaries must not follow
-    // the host timezone -- a local truncation would shift them in zones offset by 5:30 or 5:45.
-    const now = new Date('2026-03-20T10:37:42.500Z')
+      const now = new Date('2026-03-20T10:37:42.500Z')
+      const toRange = (interval: ChartIntervals) =>
+        getBucketedTimeRange(interval, now).map((boundary) => boundary.toISOString())
 
-    const [dayStart, dayEnd] = getBucketedTimeRange(dayInterval!, now)
-    expect(dayStart.toISOString()).toBe('2026-03-19T00:00:00.000Z')
-    expect(dayEnd.toISOString()).toBe('2026-03-20T00:00:00.000Z')
-
-    const [minuteStart, minuteEnd] = getBucketedTimeRange(minuteInterval!, now)
-    expect(minuteStart.toISOString()).toBe('2026-03-20T10:22:00.000Z')
-    expect(minuteEnd.toISOString()).toBe('2026-03-20T10:37:00.000Z')
-  })
+      runInTimeZone(timeZone, () => {
+        expect(toRange(dayInterval!)).toEqual([
+          '2026-03-19T00:00:00.000Z',
+          '2026-03-20T00:00:00.000Z',
+        ])
+        expect(toRange(hourInterval!)).toEqual([
+          '2026-03-20T09:00:00.000Z',
+          '2026-03-20T10:00:00.000Z',
+        ])
+        expect(toRange(minuteInterval!)).toEqual([
+          '2026-03-20T10:22:00.000Z',
+          '2026-03-20T10:37:00.000Z',
+        ])
+      })
+    }
+  )
 
   it('formats metric, rate, and reference deltas consistently', () => {
     expect(formatMetric(12.34, 'MB')).toBe('12.3MB')

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionOverview.utils.ts
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionOverview.utils.ts
@@ -1,10 +1,13 @@
 import dayjs from 'dayjs'
+import utc from 'dayjs/plugin/utc'
 import maxBy from 'lodash/maxBy'
 import meanBy from 'lodash/meanBy'
 import sumBy from 'lodash/sumBy'
 import type { ChartConfig } from 'ui'
 
 import type { ChartIntervals } from '@/types'
+
+dayjs.extend(utc)
 
 export type EdgeFunctionChartRawDatum = {
   timestamp: string | number
@@ -127,7 +130,12 @@ export const getBucketedTimeRange = (
   interval: ChartIntervals,
   now: Date = new Date()
 ): [Date, Date] => {
-  const currentTime = dayjs(now)
+  // Bucket boundaries are truncated in UTC, not in the viewer's local time: the analytics
+  // endpoint returns UTC-truncated buckets, and `fillTimeseries` matches the gap-filled points
+  // it generates from this range against those timestamps in UTC. Truncating locally shifts the
+  // whole grid in zones with a sub-hour offset (UTC+5:30, UTC+5:45, ...), so no filled point
+  // would ever line up with a real bucket.
+  const currentTime = dayjs.utc(now)
   const unit = toManipulateUnit(interval.startUnit)
   const start = currentTime.subtract(interval.startValue, unit).startOf(unit)
   const end = currentTime.startOf(unit)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

`getBucketedTimeRange` in `EdgeFunctionOverview.utils.ts` truncates the Edge Function overview chart's bucket boundaries with `dayjs(now).startOf(unit)`, which resolves in the viewer's local timezone.

That range is passed straight to `useFillTimeseriesSorted` as the `startDate`/`endDate` of the gap-filling grid. `fillTimeseries` reads both with `dayjs.utc()` and matches the points it generates against the analytics response by exact UTC calendar components (`year`/`month`/`date`/`hour`/`minute`/`second`). The `functions.combined-stats` endpoint only receives an interval key and never a time range, so the buckets it returns are always UTC-truncated and the client cannot influence them.

A locally-truncated grid therefore never lines up with the data it is meant to fill:

- The `hour` and `minute` units drift in zones with a sub-hour UTC offset (UTC+5:30, UTC+5:45, UTC+8:45, UTC+12:45), putting every generated point 30–45 minutes off each real bucket.
- The `day` unit — used by the "1 day" interval — drifts in **every** zone that is not UTC, because local midnight is not a UTC day boundary.

For `now = 2026-03-20T10:37:42.500Z`:

| TZ | unit | current start | expected |
| --- | --- | --- | --- |
| Asia/Kolkata (+5:30) | `hour` | `2026-03-20T09:30:00Z` | `2026-03-20T09:00:00Z` |
| Asia/Kolkata (+5:30) | `day` | `2026-03-18T18:30:00Z` | `2026-03-19T00:00:00Z` |
| Europe/Berlin (+1) | `day` | `2026-03-18T23:00:00Z` | `2026-03-19T00:00:00Z` |

This also makes `EdgeFunctionOverview.utils.test.ts` fail outside UTC on `master`. The suite is green in CI because CI runs in UTC and `apps/studio/vitest.config.ts` does not pin `TZ`:

```
AssertionError: expected '2026-03-20T09:30:00.000Z' to be '2026-03-20T09:00:00.000Z'
  at components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionOverview.utils.test.ts:193
```

## What is the new behavior?

`getBucketedTimeRange` truncates in UTC (`dayjs.utc(now)`), so the client grid matches the server buckets in every timezone. `getRollingTimeRange` is unchanged — plain subtraction is offset-independent.

I chose this over pinning `TZ=UTC` in the Vitest config because the timezone dependency is in the helper, not the test: pinning would turn the suite green while leaving the chart misaligned for affected users.

The existing test case only covered the `hour` unit, which whole-hour zones happen to mask. The added case covers the `day`, `hour` and `minute` units, and pins the timezone per run (`vi.stubEnv('TZ', …)`) instead of inheriting the host's.

That pin is what makes the case a regression guard in CI. Under UTC, local-time truncation and UTC truncation return the same instant, so a UTC-only assertion passes against the unfixed helper and protects nothing. With the zones pinned, reverting `getBucketedTimeRange` to local truncation fails four of the five cases under `TZ=UTC`.

## Additional context

- The regression case pins `UTC`, `Asia/Kolkata` (+5:30), `Asia/Kathmandu` (+5:45), `Pacific/Chatham` (+12:45) and `America/New_York`, so it guards the helper whichever timezone CI runs in. Reverting the one-line helper change fails four of those five under `TZ=UTC` — `America/New_York` among them, caught via the `day` unit.
- The file is also green when the *host* timezone varies: `UTC`, `Asia/Kolkata`, `Asia/Kathmandu`, `Australia/Eucla` (+8:45), `Pacific/Chatham`, `Europe/Berlin`, `Pacific/Auckland`, `America/New_York`.
- The full Studio unit suite (616 files / 6582 tests) passes under `TZ=Asia/Kolkata`; this was the only timezone-dependent failure.
- `tsc --noEmit`, `eslint` and Prettier are clean on the changed files. The pin uses `vi.stubEnv` rather than assigning `process.env.TZ`, which `turbo/no-undeclared-env-vars` reports as an error.

Not verified in a running dashboard: the overview chart is `IS_PLATFORM`-gated and needs a hosted project with analytics data, so the behavior above is established from the helper, `fillTimeseries`, and the endpoint's parameters rather than from the rendered chart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Analytics time ranges for Edge Functions now align to UTC boundaries, ensuring consistent daily, hourly, and 15-minute results regardless of the viewer’s timezone.
  - Improved accuracy and consistency when displaying time-based analytics data.

- **Tests**
  - Expanded coverage across multiple timezones to verify UTC-aligned bucket calculations for daily, hourly, and 15-minute intervals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
