### PR TITLE
fix(studio): stop bucket deletion from removing policies that guard other buckets

### DIFF
--- a/apps/studio/components/interfaces/Storage/DeleteBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/DeleteBucketModal.tsx
@@ -2,7 +2,7 @@ import { useParams } from 'common'
 import { useRouter } from 'next/router'
 import { toast } from 'sonner'
 
-import { extractBucketNameFromDefinition } from './Storage.utils'
+import { getPolicyBucketNames } from './Storage.utils'
 import { TextConfirmModal } from '@/components/ui/TextConfirmModalWrapper'
 import { useDatabasePoliciesQuery } from '@/data/database-policies/database-policies-query'
 import { useDatabasePolicyDeleteMutation } from '@/data/database-policies/database-policy-delete-mutation'
@@ -44,8 +44,10 @@ export const DeleteBucketModal = ({ visible, bucket, onClose }: DeleteBucketModa
       const bucketPolicies = (policies ?? []).filter((policy) => {
         if (policy.table !== 'objects') return false
 
-        const policyBucket = extractBucketNameFromDefinition(policy.definition ?? policy.check)
-        return policyBucket === bucket.name
+        // Only clean up policies that exclusively guard this bucket. A policy shared with
+        // other buckets, or one that names no bucket at all, must keep protecting them.
+        const policyBuckets = getPolicyBucketNames(policy)
+        return policyBuckets.length === 1 && policyBuckets[0] === bucket.name
       })
 
       if (bucketPolicies.length === 0) return

--- a/apps/studio/components/interfaces/Storage/DeleteBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/DeleteBucketModal.tsx
@@ -2,7 +2,7 @@ import { useParams } from 'common'
 import { useRouter } from 'next/router'
 import { toast } from 'sonner'
 
-import { getPolicyBucketNames } from './Storage.utils'
+import { isPolicyExclusiveToBucket } from './Storage.utils'
 import { TextConfirmModal } from '@/components/ui/TextConfirmModalWrapper'
 import { useDatabasePoliciesQuery } from '@/data/database-policies/database-policies-query'
 import { useDatabasePolicyDeleteMutation } from '@/data/database-policies/database-policy-delete-mutation'
@@ -44,10 +44,9 @@ export const DeleteBucketModal = ({ visible, bucket, onClose }: DeleteBucketModa
       const bucketPolicies = (policies ?? []).filter((policy) => {
         if (policy.table !== 'objects') return false
 
-        // Only clean up policies that exclusively guard this bucket. A policy shared with
-        // other buckets, or one that names no bucket at all, must keep protecting them.
-        const policyBuckets = getPolicyBucketNames(policy)
-        return policyBuckets.length === 1 && policyBuckets[0] === bucket.name
+        // Only clean up policies that exclusively guard this bucket. Anything shared with
+        // other buckets, or that might still apply beyond them, must be left in place.
+        return isPolicyExclusiveToBucket(policy, bucket.name)
       })
 
       if (bucketPolicies.length === 0) return

--- a/apps/studio/components/interfaces/Storage/Storage.utils.ts
+++ b/apps/studio/components/interfaces/Storage/Storage.utils.ts
@@ -140,22 +140,30 @@ export const getPolicyBucketNames = (policy: {
  * Whether a policy applies to `bucketName` and to nothing else — the only case where it is
  * safe to remove the policy along with the bucket.
  *
- * Naming exactly one bucket is necessary but not sufficient: `(bucket_id = 'avatars') OR
- * (owner = auth.uid())` names only `avatars` yet still grants access to the caller's objects
- * in every other bucket. Rather than parse the expression, anything carrying an `OR`, a
- * `NOT` or a subquery is treated as non-exclusive. The bias is deliberate — leaving a stale
- * policy behind is recoverable, deleting a live one is not.
+ * Every clause the policy actually has must independently confine it to the bucket, because
+ * USING and WITH CHECK govern different operations. `using (owner = auth.uid()) with check
+ * (bucket_id = 'avatars')` mentions one bucket between the two, yet its USING half still
+ * grants the caller access to their objects in every other bucket.
+ *
+ * Naming one bucket is not sufficient either: `(bucket_id = 'avatars') OR (owner =
+ * auth.uid())` names only `avatars` and still reaches beyond it. Rather than parse the
+ * expression, any clause carrying an `OR`, a `NOT` or a subquery is treated as
+ * non-exclusive. The bias is deliberate — leaving a stale policy behind is recoverable,
+ * deleting a live one is not.
  */
 export const isPolicyExclusiveToBucket = (
   policy: { definition: string | null; check: string | null },
   bucketName: string
 ): boolean => {
-  const names = getPolicyBucketNames(policy)
-  if (names.length !== 1 || names[0] !== bucketName) return false
+  const clauses = [policy.definition, policy.check].filter((clause): clause is string => !!clause)
+  if (clauses.length === 0) return false
 
-  return [policy.definition, policy.check].every(
-    (clause) => !clause || !NON_EXCLUSIVE_CLAUSE_REGEX.test(clause)
-  )
+  return clauses.every((clause) => {
+    if (NON_EXCLUSIVE_CLAUSE_REGEX.test(clause)) return false
+
+    const names = getPolicyBucketNames({ definition: clause, check: null })
+    return names.length === 1 && names[0] === bucketName
+  })
 }
 
 const groupPoliciesByBucket = (policies: (Policy & { buckets: (string | Symbol)[] })[]) => {

--- a/apps/studio/components/interfaces/Storage/Storage.utils.ts
+++ b/apps/studio/components/interfaces/Storage/Storage.utils.ts
@@ -75,26 +75,43 @@ const formatStoragePolicies = (buckets: Bucket[], policies: Policy[]) => {
   return formattedPolicies
 }
 
-/** `bucket_id = 'avatars'`, as Postgres renders a single-bucket policy. */
-const BUCKET_ID_EQUALS_REGEX = /bucket_id\s*=\s*'((?:[^']|'')*)'/g
+/**
+ * `bucket_id = 'avatars'`, as Postgres renders a single-bucket policy. The `\b` guards keep
+ * `archive_bucket_id` from reading as `bucket_id`, while still allowing a qualified
+ * `o.bucket_id`. A `NOT (` prefix is captured so negated matches can be discarded.
+ */
+const BUCKET_ID_EQUALS_REGEX = /(NOT\s*\(\s*)?\bbucket_id\b\s*=\s*'((?:[^']|'')*)'/gi
 /** `bucket_id = ANY (ARRAY['avatars'::text, 'logos'::text])`, how Postgres renders `bucket_id in (...)`. */
-const BUCKET_ID_IN_ARRAY_REGEX = /bucket_id\s*=\s*ANY\s*\(\s*ARRAY\s*\[([^\]]*)\]/gi
+const BUCKET_ID_IN_ARRAY_REGEX =
+  /(NOT\s*\(\s*)?\bbucket_id\b\s*=\s*ANY\s*\(\s*ARRAY\s*\[([^\]]*)\]/gi
 const QUOTED_LITERAL_REGEX = /'((?:[^']|'')*)'/g
+
+/**
+ * Constructs that let a policy keep applying outside the buckets it names: an alternative
+ * satisfying branch (`OR`), a negation (`NOT`, beyond the simple `<>` we already drop), or a
+ * subquery whose `bucket_id` belongs to some other table.
+ */
+const NON_EXCLUSIVE_CLAUSE_REGEX = /\b(?:OR|NOT|SELECT)\b/i
 
 const unquote = (literal: string) => literal.replace(/''/g, "'")
 
 /**
- * Collects every bucket a storage policy grants access to, across both its USING
- * (`definition`) and WITH CHECK (`check`) clauses.
+ * Collects every bucket a storage policy *references*, across both its USING (`definition`)
+ * and WITH CHECK (`check`) clauses.
  *
- * Postgres normalizes policy expressions before storing them, so the shapes we read back
- * are predictable: `bucket_id in ('avatars', 'logos')` comes back as
+ * Postgres normalizes policy expressions before storing them, so the shapes we read back are
+ * predictable: `bucket_id in ('avatars', 'logos')` comes back as
  * `bucket_id = ANY (ARRAY['avatars'::text, 'logos'::text])`, and both that form and plain
  * equality are collected.
  *
- * Negated conditions (`bucket_id <> 'avatars'`) deliberately contribute no buckets. Such a
- * policy applies to every bucket *except* the named one, so attributing it to that bucket
- * would be exactly backwards. Callers treat an empty result as "not tied to any one bucket".
+ * Negated conditions contribute no buckets, since such a policy applies to every bucket
+ * *except* the named one and attributing it there would be exactly backwards. That covers
+ * both `bucket_id <> 'avatars'` and the `NOT (bucket_id = 'avatars')` form, which Postgres
+ * stores verbatim rather than folding into `<>`.
+ *
+ * This is a lexical read of a normalized expression, not a Boolean proof: a policy may
+ * reference `avatars` and still apply elsewhere. Use it to decide where a policy is *shown*;
+ * for destructive actions use {@link isPolicyExclusiveToBucket}.
  */
 export const getPolicyBucketNames = (policy: {
   definition: string | null
@@ -103,17 +120,42 @@ export const getPolicyBucketNames = (policy: {
   const names = [policy.definition, policy.check].flatMap((clause) => {
     if (!clause) return []
 
-    const equality = Array.from(clause.matchAll(BUCKET_ID_EQUALS_REGEX), (match) =>
-      unquote(match[1])
-    )
-    const membership = Array.from(clause.matchAll(BUCKET_ID_IN_ARRAY_REGEX)).flatMap((match) =>
-      Array.from(match[1].matchAll(QUOTED_LITERAL_REGEX), (literal) => unquote(literal[1]))
-    )
+    const equality = Array.from(clause.matchAll(BUCKET_ID_EQUALS_REGEX))
+      .filter(([, negation]) => !negation)
+      .map(([, , name]) => unquote(name))
+
+    const membership = Array.from(clause.matchAll(BUCKET_ID_IN_ARRAY_REGEX))
+      .filter(([, negation]) => !negation)
+      .flatMap(([, , array]) =>
+        Array.from(array.matchAll(QUOTED_LITERAL_REGEX), (literal) => unquote(literal[1]))
+      )
 
     return [...equality, ...membership]
   })
 
   return Array.from(new Set(names))
+}
+
+/**
+ * Whether a policy applies to `bucketName` and to nothing else — the only case where it is
+ * safe to remove the policy along with the bucket.
+ *
+ * Naming exactly one bucket is necessary but not sufficient: `(bucket_id = 'avatars') OR
+ * (owner = auth.uid())` names only `avatars` yet still grants access to the caller's objects
+ * in every other bucket. Rather than parse the expression, anything carrying an `OR`, a
+ * `NOT` or a subquery is treated as non-exclusive. The bias is deliberate — leaving a stale
+ * policy behind is recoverable, deleting a live one is not.
+ */
+export const isPolicyExclusiveToBucket = (
+  policy: { definition: string | null; check: string | null },
+  bucketName: string
+): boolean => {
+  const names = getPolicyBucketNames(policy)
+  if (names.length !== 1 || names[0] !== bucketName) return false
+
+  return [policy.definition, policy.check].every(
+    (clause) => !clause || !NON_EXCLUSIVE_CLAUSE_REGEX.test(clause)
+  )
 }
 
 const groupPoliciesByBucket = (policies: (Policy & { buckets: (string | Symbol)[] })[]) => {

--- a/apps/studio/components/interfaces/Storage/Storage.utils.ts
+++ b/apps/studio/components/interfaces/Storage/Storage.utils.ts
@@ -61,45 +61,70 @@ export const UNGROUPED_POLICY_SYMBOL = createWrappedSymbol('ungrouped-policy', '
 const formatStoragePolicies = (buckets: Bucket[], policies: Policy[]) => {
   const availableBuckets = buckets.map((bucket) => bucket.name)
   const formattedPolicies = policies.map((policy) => {
-    const { definition: policyDefinition, check: policyCheck } = policy
+    const bucketNames = getPolicyBucketNames(policy)
 
-    const bucketName =
-      policyDefinition !== null
-        ? extractBucketNameFromDefinition(policyDefinition)
-        : extractBucketNameFromDefinition(policyCheck)
+    if (bucketNames.length === 0) return { ...policy, buckets: [UNGROUPED_POLICY_SYMBOL] }
 
-    if (bucketName) {
-      const isBucketLoaded = availableBuckets.includes(bucketName)
+    const groups = bucketNames.map((name) =>
+      availableBuckets.includes(name) ? name : UNKNOWN_BUCKET_SYMBOL
+    )
 
-      return {
-        ...policy,
-        bucket: isBucketLoaded ? bucketName : UNKNOWN_BUCKET_SYMBOL,
-      }
-    }
-
-    return { ...policy, bucket: UNGROUPED_POLICY_SYMBOL }
+    return { ...policy, buckets: Array.from(new Set(groups)) }
   })
 
   return formattedPolicies
 }
 
-export const extractBucketNameFromDefinition = (definition: string | null) => {
-  if (!definition) return null
+/** `bucket_id = 'avatars'`, as Postgres renders a single-bucket policy. */
+const BUCKET_ID_EQUALS_REGEX = /bucket_id\s*=\s*'((?:[^']|'')*)'/g
+/** `bucket_id = ANY (ARRAY['avatars'::text, 'logos'::text])`, how Postgres renders `bucket_id in (...)`. */
+const BUCKET_ID_IN_ARRAY_REGEX = /bucket_id\s*=\s*ANY\s*\(\s*ARRAY\s*\[([^\]]*)\]/gi
+const QUOTED_LITERAL_REGEX = /'((?:[^']|'')*)'/g
 
-  const definitionSegments = definition?.split(' AND ') ?? []
-  const [bucketDefinition] = definitionSegments.filter((segment: string) =>
-    segment.includes('bucket_id')
-  )
-  return bucketDefinition ? bucketDefinition.split("'")[1] : null
+const unquote = (literal: string) => literal.replace(/''/g, "'")
+
+/**
+ * Collects every bucket a storage policy grants access to, across both its USING
+ * (`definition`) and WITH CHECK (`check`) clauses.
+ *
+ * Postgres normalizes policy expressions before storing them, so the shapes we read back
+ * are predictable: `bucket_id in ('avatars', 'logos')` comes back as
+ * `bucket_id = ANY (ARRAY['avatars'::text, 'logos'::text])`, and both that form and plain
+ * equality are collected.
+ *
+ * Negated conditions (`bucket_id <> 'avatars'`) deliberately contribute no buckets. Such a
+ * policy applies to every bucket *except* the named one, so attributing it to that bucket
+ * would be exactly backwards. Callers treat an empty result as "not tied to any one bucket".
+ */
+export const getPolicyBucketNames = (policy: {
+  definition: string | null
+  check: string | null
+}): string[] => {
+  const names = [policy.definition, policy.check].flatMap((clause) => {
+    if (!clause) return []
+
+    const equality = Array.from(clause.matchAll(BUCKET_ID_EQUALS_REGEX), (match) =>
+      unquote(match[1])
+    )
+    const membership = Array.from(clause.matchAll(BUCKET_ID_IN_ARRAY_REGEX)).flatMap((match) =>
+      Array.from(match[1].matchAll(QUOTED_LITERAL_REGEX), (literal) => unquote(literal[1]))
+    )
+
+    return [...equality, ...membership]
+  })
+
+  return Array.from(new Set(names))
 }
 
-const groupPoliciesByBucket = (policies: (Policy & { bucket: string | Symbol })[]) => {
+const groupPoliciesByBucket = (policies: (Policy & { buckets: (string | Symbol)[] })[]) => {
   const policiesByBucket = new Map<string | Symbol, Policy[]>()
-  policies.forEach((policy) => {
-    if (!policiesByBucket.has(policy.bucket)) {
-      policiesByBucket.set(policy.bucket, [])
-    }
-    policiesByBucket.get(policy.bucket)?.push(policy)
+  policies.forEach(({ buckets, ...policy }) => {
+    buckets.forEach((bucket) => {
+      if (!policiesByBucket.has(bucket)) {
+        policiesByBucket.set(bucket, [])
+      }
+      policiesByBucket.get(bucket)?.push(policy)
+    })
   })
   return Array.from(policiesByBucket).map(([bucketName, policies]) => ({
     name: bucketName,

--- a/apps/studio/components/interfaces/Storage/useBucketPolicyCount.ts
+++ b/apps/studio/components/interfaces/Storage/useBucketPolicyCount.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react'
 
-import { extractBucketNameFromDefinition } from '@/components/interfaces/Storage/Storage.utils'
+import { getPolicyBucketNames } from '@/components/interfaces/Storage/Storage.utils'
 import { useDatabasePoliciesQuery } from '@/data/database-policies/database-policies-query'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 
@@ -16,10 +16,8 @@ export function useBucketPolicyCount() {
     const countMap = new Map<string, number>()
     for (const policy of policiesData) {
       if (policy.table !== 'objects') continue
-      const bucketName =
-        extractBucketNameFromDefinition(policy.definition) ??
-        extractBucketNameFromDefinition(policy.check)
-      if (bucketName) {
+      // A policy can cover several buckets, and counts towards each of them
+      for (const bucketName of getPolicyBucketNames(policy)) {
         countMap.set(bucketName, (countMap.get(bucketName) ?? 0) + 1)
       }
     }

--- a/apps/studio/tests/components/Storage/Storage.utils.test.ts
+++ b/apps/studio/tests/components/Storage/Storage.utils.test.ts
@@ -4,6 +4,7 @@ import type { Policy } from '@/components/interfaces/Database/Policies/PolicyTab
 import {
   formatPoliciesForStorage,
   getPolicyBucketNames,
+  isPolicyExclusiveToBucket,
   UNGROUPED_POLICY_SYMBOL,
   UNKNOWN_BUCKET_SYMBOL,
 } from '@/components/interfaces/Storage/Storage.utils'
@@ -94,6 +95,97 @@ describe('getPolicyBucketNames', () => {
 
   test('does not mistake another column ending in bucket_id for the bucket column', () => {
     expect(getPolicyBucketNames(policy("(owner = 'avatars'::text)"))).toEqual([])
+    // Reachable without touching storage.objects, via a subquery over a user's own table
+    expect(
+      getPolicyBucketNames(
+        policy(
+          "(EXISTS ( SELECT 1 FROM zz_archive a WHERE (a.archive_bucket_id = 'avatars'::text)))"
+        )
+      )
+    ).toEqual([])
+    expect(
+      getPolicyBucketNames(policy("(a.archive_bucket_id = ANY (ARRAY['avatars'::text]))"))
+    ).toEqual([])
+  })
+
+  test('still reads a table-qualified bucket_id reference', () => {
+    expect(getPolicyBucketNames(policy("(objects.bucket_id = 'avatars'::text)"))).toEqual([
+      'avatars',
+    ])
+  })
+
+  test('ignores a NOT-wrapped equality, which Postgres stores verbatim rather than as <>', () => {
+    expect(getPolicyBucketNames(policy("(NOT (bucket_id = 'avatars'::text))"))).toEqual([])
+    expect(
+      getPolicyBucketNames(
+        policy("(NOT (bucket_id = ANY (ARRAY['avatars'::text, 'logos'::text])))")
+      )
+    ).toEqual([])
+  })
+})
+
+describe('isPolicyExclusiveToBucket', () => {
+  test('accepts a policy that only ever applies to the bucket', () => {
+    expect(isPolicyExclusiveToBucket(policy("(bucket_id = 'avatars'::text)"), 'avatars')).toBe(true)
+    expect(
+      isPolicyExclusiveToBucket(
+        policy("((bucket_id = 'avatars'::text) AND (owner = auth.uid()))"),
+        'avatars'
+      )
+    ).toBe(true)
+  })
+
+  test('rejects an OR branch that still grants access in other buckets', () => {
+    expect(
+      isPolicyExclusiveToBucket(
+        policy("((bucket_id = 'avatars'::text) OR (owner = auth.uid()))"),
+        'avatars'
+      )
+    ).toBe(false)
+  })
+
+  test('rejects a negated policy, which guards every other bucket', () => {
+    expect(isPolicyExclusiveToBucket(policy("(bucket_id <> 'avatars'::text)"), 'avatars')).toBe(
+      false
+    )
+    expect(
+      isPolicyExclusiveToBucket(policy("(NOT (bucket_id = 'avatars'::text))"), 'avatars')
+    ).toBe(false)
+  })
+
+  test('rejects a policy whose bucket_id may belong to a subquery', () => {
+    expect(
+      isPolicyExclusiveToBucket(
+        policy("(EXISTS ( SELECT 1 FROM other o WHERE (o.bucket_id = 'avatars'::text)))"),
+        'avatars'
+      )
+    ).toBe(false)
+  })
+
+  test('rejects a policy shared with another bucket', () => {
+    expect(
+      isPolicyExclusiveToBucket(
+        policy("(bucket_id = ANY (ARRAY['avatars'::text, 'logos'::text]))"),
+        'avatars'
+      )
+    ).toBe(false)
+  })
+
+  test('rejects a policy for a different bucket, or for no bucket at all', () => {
+    expect(isPolicyExclusiveToBucket(policy("(bucket_id = 'logos'::text)"), 'avatars')).toBe(false)
+    expect(isPolicyExclusiveToBucket(policy('(owner = auth.uid())'), 'avatars')).toBe(false)
+  })
+
+  test('checks the WITH CHECK clause too', () => {
+    expect(
+      isPolicyExclusiveToBucket(
+        policy(
+          "(bucket_id = 'avatars'::text)",
+          "((bucket_id = 'avatars'::text) OR (owner = auth.uid()))"
+        ),
+        'avatars'
+      )
+    ).toBe(false)
   })
 })
 

--- a/apps/studio/tests/components/Storage/Storage.utils.test.ts
+++ b/apps/studio/tests/components/Storage/Storage.utils.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from 'vitest'
+
+import type { Policy } from '@/components/interfaces/Database/Policies/PolicyTableRow/PolicyTableRow.utils'
+import {
+  formatPoliciesForStorage,
+  getPolicyBucketNames,
+  UNGROUPED_POLICY_SYMBOL,
+  UNKNOWN_BUCKET_SYMBOL,
+} from '@/components/interfaces/Storage/Storage.utils'
+import type { Bucket } from '@/data/storage/buckets-query'
+
+/**
+ * Storage policies are grouped per bucket by parsing the `bucket_id` conditions out of the
+ * policy expression that Postgres hands back. The definitions below are copied from the
+ * shape `pg_policies` actually returns (normalized, `::text` casts and all) rather than the
+ * SQL a user would type.
+ */
+const policy = (definition: string | null, check: string | null = null, name = 'policy') =>
+  ({ id: 1, name, table: 'objects', schema: 'storage', definition, check }) as unknown as Policy
+
+const bucket = (name: string) => ({ id: name, name }) as unknown as Bucket
+
+describe('getPolicyBucketNames', () => {
+  test('reads a single bucket from an equality condition', () => {
+    expect(getPolicyBucketNames(policy("(bucket_id = 'avatars'::text)"))).toEqual(['avatars'])
+  })
+
+  test('reads every bucket from the ANY(ARRAY[...]) form of `in`', () => {
+    expect(
+      getPolicyBucketNames(
+        policy("(bucket_id = ANY (ARRAY['avatars'::text, 'logos'::text, 'docs'::text]))")
+      )
+    ).toEqual(['avatars', 'logos', 'docs'])
+  })
+
+  test('ignores a negated condition, which applies to every other bucket', () => {
+    expect(getPolicyBucketNames(policy("(bucket_id <> 'avatars'::text)"))).toEqual([])
+    expect(getPolicyBucketNames(policy("(bucket_id != 'avatars'::text)"))).toEqual([])
+  })
+
+  test('keeps the positive bucket when a definition both allows and excludes', () => {
+    expect(
+      getPolicyBucketNames(
+        policy("((bucket_id = 'avatars'::text) AND (bucket_id <> 'logos'::text))")
+      )
+    ).toEqual(['avatars'])
+  })
+
+  test('collects buckets across several AND/OR segments', () => {
+    expect(
+      getPolicyBucketNames(policy("((bucket_id = 'avatars'::text) OR (bucket_id = 'logos'::text))"))
+    ).toEqual(['avatars', 'logos'])
+  })
+
+  test('unions the USING and WITH CHECK clauses', () => {
+    expect(
+      getPolicyBucketNames(policy("(bucket_id = 'avatars'::text)", "(bucket_id = 'logos'::text)"))
+    ).toEqual(['avatars', 'logos'])
+  })
+
+  test('reads the bucket from WITH CHECK when USING is null', () => {
+    expect(getPolicyBucketNames(policy(null, "(bucket_id = 'avatars'::text)"))).toEqual(['avatars'])
+  })
+
+  test('deduplicates a bucket named more than once', () => {
+    expect(
+      getPolicyBucketNames(
+        policy(
+          "((bucket_id = 'avatars'::text) AND (owner = auth.uid()))",
+          "(bucket_id = 'avatars'::text)"
+        )
+      )
+    ).toEqual(['avatars'])
+  })
+
+  test('returns nothing when the policy names no bucket', () => {
+    expect(getPolicyBucketNames(policy('(owner = auth.uid())'))).toEqual([])
+    expect(getPolicyBucketNames(policy(null, null))).toEqual([])
+    expect(getPolicyBucketNames(policy(''))).toEqual([])
+  })
+
+  test('tolerates whitespace variations around the operator', () => {
+    expect(getPolicyBucketNames(policy("(bucket_id='avatars'::text)"))).toEqual(['avatars'])
+    expect(getPolicyBucketNames(policy("(bucket_id   =   ANY   (  ARRAY  ['a'::text] ))"))).toEqual(
+      ['a']
+    )
+  })
+
+  test('handles a bucket name containing an escaped single quote', () => {
+    expect(getPolicyBucketNames(policy("(bucket_id = 'bob''s files'::text)"))).toEqual([
+      "bob's files",
+    ])
+  })
+
+  test('does not mistake another column ending in bucket_id for the bucket column', () => {
+    expect(getPolicyBucketNames(policy("(owner = 'avatars'::text)"))).toEqual([])
+  })
+})
+
+describe('formatPoliciesForStorage', () => {
+  test('lists a multi-bucket policy under every bucket it covers', () => {
+    const multiBucket = policy(
+      "(bucket_id = ANY (ARRAY['avatars'::text, 'logos'::text]))",
+      null,
+      'Multi bucket read'
+    )
+
+    const grouped = formatPoliciesForStorage([bucket('avatars'), bucket('logos')], [multiBucket])
+
+    expect(grouped.find((group) => group.name === 'avatars')?.policies).toEqual([multiBucket])
+    expect(grouped.find((group) => group.name === 'logos')?.policies).toEqual([multiBucket])
+  })
+
+  test('puts a negated policy under Ungrouped rather than the bucket it excludes', () => {
+    const negated = policy("(bucket_id <> 'avatars'::text)", null, 'Not avatars')
+
+    const grouped = formatPoliciesForStorage([bucket('avatars')], [negated])
+
+    expect(grouped.find((group) => group.name === 'avatars')).toBeUndefined()
+    expect(grouped.find((group) => group.name === UNGROUPED_POLICY_SYMBOL)?.policies).toEqual([
+      negated,
+    ])
+  })
+
+  test('groups a policy for a bucket that is not loaded under Unknown', () => {
+    const unloaded = policy("(bucket_id = 'not-paginated-yet'::text)", null, 'Unloaded')
+
+    const grouped = formatPoliciesForStorage([bucket('avatars')], [unloaded])
+
+    expect(grouped.find((group) => group.name === UNKNOWN_BUCKET_SYMBOL)?.policies).toEqual([
+      unloaded,
+    ])
+  })
+
+  test('splits a policy across a loaded bucket and the Unknown group', () => {
+    const mixed = policy(
+      "(bucket_id = ANY (ARRAY['avatars'::text, 'not-loaded'::text]))",
+      null,
+      'Mixed'
+    )
+
+    const grouped = formatPoliciesForStorage([bucket('avatars')], [mixed])
+
+    expect(grouped.find((group) => group.name === 'avatars')?.policies).toEqual([mixed])
+    expect(grouped.find((group) => group.name === UNKNOWN_BUCKET_SYMBOL)?.policies).toEqual([mixed])
+  })
+
+  test('returns nothing when there are no policies', () => {
+    expect(formatPoliciesForStorage([bucket('avatars')], [])).toEqual([])
+  })
+})

--- a/apps/studio/tests/components/Storage/Storage.utils.test.ts
+++ b/apps/studio/tests/components/Storage/Storage.utils.test.ts
@@ -176,6 +176,36 @@ describe('isPolicyExclusiveToBucket', () => {
     expect(isPolicyExclusiveToBucket(policy('(owner = auth.uid())'), 'avatars')).toBe(false)
   })
 
+  test('rejects a policy whose other clause is unrestricted', () => {
+    // `using (owner = auth.uid()) with check (bucket_id = 'avatars')` still lets the caller
+    // read their own objects in every other bucket, so the bucket does not own it
+    expect(
+      isPolicyExclusiveToBucket(
+        policy('(owner = auth.uid())', "(bucket_id = 'avatars'::text)"),
+        'avatars'
+      )
+    ).toBe(false)
+    expect(
+      isPolicyExclusiveToBucket(
+        policy("(bucket_id = 'avatars'::text)", '(owner = auth.uid())'),
+        'avatars'
+      )
+    ).toBe(false)
+  })
+
+  test('accepts a policy whose every clause is confined to the bucket', () => {
+    expect(
+      isPolicyExclusiveToBucket(
+        policy("(bucket_id = 'avatars'::text)", "(bucket_id = 'avatars'::text)"),
+        'avatars'
+      )
+    ).toBe(true)
+  })
+
+  test('rejects a policy with no clauses at all', () => {
+    expect(isPolicyExclusiveToBucket(policy(null, null), 'avatars')).toBe(false)
+  })
+
   test('checks the WITH CHECK clause too', () => {
     expect(
       isPolicyExclusiveToBucket(


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix, plus unit tests.

Fixes #48164.

Credit where it's due: #48164 was reported by @jashkarangiya, who also opened #48165 against it. They closed that PR themselves on 10 Sep while it was still awaiting review. This PR is a fresh, smaller take on the same bug that leads with the destructive symptom rather than the grouping one. Happy to close this instead if they'd prefer to reopen theirs.

## What is the current behavior?

`extractBucketNameFromDefinition` splits a policy definition on `' AND '`, takes the first segment mentioning `bucket_id`, and returns the text between the first pair of single quotes. It can only ever name one bucket, and it does not tell `=` apart from `<>`. All three callers inherit that:

**1. Bucket deletion removes policies that still guard other buckets.** `DeleteBucketModal` deletes every policy it believes is "tied to" the bucket being removed. A policy written as `bucket_id <> 'avatars'` guards every bucket *except* avatars, but the parser attributes it to avatars — so deleting the avatars bucket silently deletes it, dropping the protection on every remaining bucket. For a multi-bucket policy, whether it gets deleted depends on which bucket happens to appear first in the definition.

**2. The Storage Policies page hides policies.** A policy written as `bucket_id in ('avatars', 'logos')` is listed under `avatars` only. Under `logos` it does not appear at all, so that bucket reads as unprotected on the page users rely on to audit exactly that.

**3. Per-bucket policy counts undercount**, for the same reason.

## What is the new behavior?

Two functions replace the old helper, split by how much certainty the caller needs.

`getPolicyBucketNames` — which buckets a policy *references*, used to decide where it is displayed:

- reads both the `USING` (`definition`) and `WITH CHECK` (`check`) clauses
- understands the `= ANY (ARRAY[...])` form Postgres normalizes `bucket_id in (...)` into
- attributes **no** bucket to a negated condition, covering both `bucket_id <> 'avatars'` and the `NOT (bucket_id = 'avatars')` form. Those land in the existing "Ungrouped" section
- requires identifier boundaries, so `archive_bucket_id` no longer reads as `bucket_id`
- handles `''`-escaped quotes in bucket names

`isPolicyExclusiveToBucket` — whether a policy applies to one bucket and nothing else, used for the destructive path. Referencing exactly one bucket is necessary but not sufficient, so it additionally rejects any clause carrying an `OR`, a `NOT` or a subquery. This is deliberately conservative: it can only ever delete fewer policies than before, never more. Leaving a stale policy behind is recoverable; deleting a live one is not.

Consequently:

- policies are listed and counted under every bucket they actually cover
- bucket deletion only removes policies that exclusively guard that bucket

Also fixes the internal grouping key leaking into the grouped `Policy` objects, so the returned type is no longer lying about its shape.

The old helper is removed rather than left as a re-export shim, per `apps/studio/AGENTS.md`; there were no other importers.

## Additional context

**The parser is written against real `pg_policies` output, not hand-written SQL.** I created each case on a local Supabase Postgres and read back what is actually stored:

| policy as written | stored in `pg_policies` |
| --- | --- |
| `bucket_id in ('avatars', 'logos')` | `(bucket_id = ANY (ARRAY['avatars'::text, 'logos'::text]))` |
| `bucket_id <> 'avatars'` | `(bucket_id <> 'avatars'::text)` |
| `not (bucket_id = 'avatars')` | `(NOT (bucket_id = 'avatars'::text))` |
| `bucket_id = 'bob''s files'` | `(bucket_id = 'bob''s files'::text)` |
| `(bucket_id = 'avatars') or (owner = auth.uid())` | `((bucket_id = 'avatars'::text) OR (owner = auth.uid()))` |
| `exists (select 1 from archive a where a.archive_bucket_id = 'avatars')` | `(EXISTS ( SELECT 1 FROM archive a WHERE (a.archive_bucket_id = 'avatars'::text)))` |

Worth flagging: Postgres does **not** fold `not (bucket_id = 'x')` into `<>`, and the `archive_bucket_id` case needs no change to `storage.objects` — an ordinary subquery over a user's own table reaches it. Both were missed in my first pass and caught in review. The unit tests use these exact strings as fixtures.

**Verification**

- 26 unit tests in `apps/studio/tests/components/Storage/Storage.utils.test.ts`
- full Studio suite: 616/617 files, 6602/6603 tests pass. The one failure, `EdgeFunctionOverview.utils.test.ts`, is pre-existing and unrelated — I confirmed it fails identically on a clean `master` with this branch stashed. It looks timezone-dependent (fails at UTC+5:30, and the expectations are consistent with a UTC machine)
- `tsc --noEmit` clean
- `pnpm --filter studio run lint:ratchet` passes
- `pnpm knip --workspace apps/studio` clean
- Prettier clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Storage policies covering multiple buckets are now correctly associated with and counted for every applicable bucket.
  - Policy listings more accurately recognize bucket access rules across combined, membership-based, and table-qualified conditions.
  - Policies with negated, unsupported, or unrestricted conditions are no longer incorrectly assigned to buckets.
  - Policies without a matching loaded bucket are grouped more accurately.
  - Deleting a bucket now removes only policies exclusively protecting that bucket, preserving policies shared with other buckets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->