### PR TITLE
fix(docker): ship volumes/storage so it is not created as root

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -91,6 +91,25 @@ Before deploying to production, you must:
 
 See the [main installation guide](https://supabase.com/docs/guides/self-hosting/docker) and the how-tos in the documentation.
 
+### File storage permissions
+
+Uploads are written to `volumes/storage`, which is bind-mounted into the Storage and imgproxy
+containers. The directory ships with this repository so that it belongs to whoever cloned it.
+
+If you are running rootless Docker and uploads fail with a 500 while Storage reports healthy,
+check who owns that directory:
+
+```sh
+ls -ld volumes/storage
+```
+
+On an install created before this directory was tracked, Docker will have created it as `root`,
+which the container cannot write to once the daemon runs as your user. Hand it back:
+
+```sh
+sudo chown -R "$(id -u):$(id -g)" volumes/storage
+```
+
 ## License
 
 This repository is licensed under the Apache 2.0 License. See the main [Supabase repository](https://github.com/supabase/supabase) for details.


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix (self-hosted Docker), plus a short README note.

Fixes #36726.

## What is the current behavior?

On a self-hosted stack, buckets can be created but uploads fail with a 500 while Storage still reports healthy. #36726 reports this under rootless Docker, with the telling observation that storage is *the only* directory under `volumes` owned by `root`.

That is not a coincidence. `volumes/storage` is the only bind-mount source under `docker/volumes` that this repository does not ship:

| directory | tracked files |
| --- | --- |
| `volumes/api` | 6 |
| `volumes/db` | 8 |
| `volumes/functions` | 3 |
| `volumes/logs` | 1 |
| `volumes/pooler` | 1 |
| `volumes/proxy` | 2 |
| `volumes/snippets` | 1 — a `.gitkeep` |
| **`volumes/storage`** | **0** |

The other seven exist immediately after a clone, owned by whoever cloned. `volumes/storage` does not, so Docker creates it on first start — as `root`. `docker-compose.yml` bind-mounts it into both `storage` and `imgproxy` as `./volumes/storage:/var/lib/storage:z`.

The Storage container runs as `uid=0`, so under a rootful daemon container-root and host-root coincide and writes succeed. Under rootless Docker, container-root maps to your own uid, and a directory genuinely owned by host `root` is no longer writable — buckets still create (that is Postgres), but object writes fail.

## What is the new behavior?

`volumes/storage` now ships with a `.gitkeep`, exactly as `volumes/snippets` already does. Both are listed in `docker/.gitignore` on consecutive lines:

```
volumes/storage
volumes/snippets
```

`volumes/snippets` solves this with a force-added `.gitkeep`; `volumes/storage` never got the same treatment. This PR applies the existing pattern rather than inventing one.

Verified against real clones of both revisions:

```
# master
$ ls docker/volumes/
api  db  functions  logs  pooler  proxy  snippets

# this branch
$ ls docker/volumes/
api  db  functions  logs  pooler  proxy  snippets  storage
$ ls -la docker/volumes/storage/
-rw-r--r--  1 <cloning user>  0  .gitkeep
```

A `README.md` note covers the case a repository change cannot fix: installs where the root-owned directory already exists need a one-time `chown`.

## Additional context

**Scope of my testing, stated plainly.** I verified the mechanism — that `volumes/storage` is absent on `master`, present and user-owned after this change, that both compose services bind-mount it, and that the Storage container runs as `uid=0`. I did **not** reproduce the original rootless-Docker upload failure: rootless Docker is Linux-only and I am on macOS. The argument that this resolves #36726 is structural, and a maintainer on Linux may want to confirm the 500 disappears on a fresh rootless install before merging.

This also makes the directory layout self-consistent, which stands on its own regardless of the rootless case.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for configuring file storage permissions with Docker.
  - Documented the potential 500-error issue caused by incorrect ownership in rootless Docker installations.
  - Included a command to restore ownership of the storage directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->