### PR TITLE
docs(i18n): fix broken image references in the Croatian and Sinhala READMEs

### DIFF
--- a/i18n/README.hr.md
+++ b/i18n/README.hr.md
@@ -49,7 +49,7 @@ Supabase je kombinacija alata otvorenog koda. Izgrađujemo funkcionalnosti Fireb
 Supabase je [hostana platforma](https://supabase.com/dashboard). Možete se registrirati i odmah počet koristiti Supabase bez ikakvih instalacija.
 Također možete ju [samostalno hostati](https://supabase.com/docs/guides/hosting/overview) i [razvijati lokalno](https://supabase.com/docs/guides/local-development).
 
-![Arhitektura](apps/docs/public/img/supabase-architecture.svg)
+![Arhitektura](https://raw.githubusercontent.com/supabase/supabase/master/apps/docs/public/img/supabase-architecture.svg)
 
 - [Postgres](https://www.postgresql.org/) je objektno-relacijska baza podataka koja je aktivno u razvoju preko 30 godina i na glasu je kao jako pouzdana, robusna i performantna.
 - [Realtime](https://github.com/supabase/realtime) je Elixir server koji vam dopušta da prisluškujete unose, ažuriranja i brisanja u PostgreSQL bazi koristeći websockete. Realtime prati Postgres-ovu funkcionalnost repliciranja i osluškuje promjene u bazi podataka, te iste upakira u JSON, na kraju emitira taj JSON preko websocketa do autoriziranih klijenata.
@@ -204,7 +204,7 @@ Naš pristup za klijentske knjižnice je modularan. Svaka pod-knjižnica je samo
 
 ## Značke
 
-![Made with Supabase](./apps/www/public/badge-made-with-supabase.svg)
+![Made with Supabase](https://supabase.com/badge-made-with-supabase.svg)
 
 ```md
 [![Made with Supabase](https://supabase.com/badge-made-with-supabase.svg)](https://supabase.com)
@@ -221,7 +221,7 @@ Naš pristup za klijentske knjižnice je modularan. Svaka pod-knjižnica je samo
 </a>
 ```
 
-![Made with Supabase (dark)](./apps/www/public/badge-made-with-supabase-dark.svg)
+![Made with Supabase (dark)](https://supabase.com/badge-made-with-supabase-dark.svg)
 
 ```md
 [![Made with Supabase](https://supabase.com/badge-made-with-supabase-dark.svg)](https://supabase.com)

--- a/i18n/README.si.md
+++ b/i18n/README.si.md
@@ -50,7 +50,7 @@ Supabase යනු විවෘත පරිශීලක උපාංග කි�
 Supabase යනු [hosted platform](https://supabase.com/dashboard). ඔබට කිසිවක් ස්ථාපනය නොකර ලියාපදිංචි වී Supabase භාවිතා කිරීම ආරම්භ කළ හැකිය.
 ඔබට [self-host](https://supabase.com/docs/guides/hosting/overview) සහ [develop locally](https://supabase.com/docs/guides/local-development) කළ හැකිය.
 
-![Architecture](apps/docs/public/img/supabase-architecture.svg)
+![Architecture](https://raw.githubusercontent.com/supabase/supabase/master/apps/docs/public/img/supabase-architecture.svg)
 
 - [PostgreSQL](https://www.postgresql.org/) යනු අවුරුදු 30 වඩා කාලයක් ක්‍රියාත්මක වෙමින් පවතින object-relational database system එකක් වන අතර එය විශ්වාසනීයත්වයට,ක්‍රියාකාරීත්වයට හා feature robustness බවට කීර්තියක් අත්පත්කරගෙන සිටියි
 - [Realtime](https://github.com/supabase/realtime) is an Elixir server that allows you to listen to PostgreSQL inserts, updates, and deletes using websockets. Realtime polls Postgres' built-in replication functionality for database changes, converts changes to JSON, then broadcasts the JSON over websockets to authorized clients.
@@ -205,7 +205,7 @@ Client libraries සඳහා අපගේ ප්‍රවේශය modular ව�
 
 ## Badges
 
-![Made with Supabase](./apps/www/public/badge-made-with-supabase.svg)
+![Made with Supabase](https://supabase.com/badge-made-with-supabase.svg)
 
 ```md
 [![Made with Supabase](https://supabase.com/badge-made-with-supabase.svg)](https://supabase.com)
@@ -222,7 +222,7 @@ Client libraries සඳහා අපගේ ප්‍රවේශය modular ව�
 </a>
 ```
 
-![Made with Supabase (dark)](./apps/www/public/badge-made-with-supabase-dark.svg)
+![Made with Supabase (dark)](https://supabase.com/badge-made-with-supabase-dark.svg)
 
 ```md
 [![Made with Supabase](https://supabase.com/badge-made-with-supabase-dark.svg)](https://supabase.com)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs fix.

Fixes #50296, reported by @auroraxo, who offered to send this and was waiting on a maintainer's go-ahead. Opening it since the finding checks out and the change is small — happy to close in favor of theirs if they'd prefer.

## What is the current behavior?

`i18n/README.hr.md` and `i18n/README.si.md` each carry three image references copied from the root README without adjusting for their location:

| reference | resolves from `i18n/` to | exists |
| --- | --- | --- |
| `apps/docs/public/img/supabase-architecture.svg` | `i18n/apps/docs/public/img/supabase-architecture.svg` | no |
| `./apps/www/public/badge-made-with-supabase.svg` | `i18n/apps/www/public/badge-made-with-supabase.svg` | no |
| `./apps/www/public/badge-made-with-supabase-dark.svg` | `i18n/apps/www/public/badge-made-with-supabase-dark.svg` | no |

Those paths are correct in the root `README.md`, which is one directory up. There is no `i18n/apps/` directory, so six images are broken across the two files.

## What is the new behavior?

Each reference now points at a URL that was checked to return an actual image:

- **architecture diagram** → `https://raw.githubusercontent.com/supabase/supabase/master/apps/docs/public/img/supabase-architecture.svg`, the same `raw.githubusercontent.com` form these two files already use for the dashboard screenshot at the top
- **badge previews** → `https://supabase.com/badge-made-with-supabase.svg` and `-dark.svg`, which is exactly what the markdown and HTML samples directly beneath them already tell readers to copy

Only the rendered previews change. The samples inside the fenced code blocks are untouched.

Verified with a request per URL:

```
raw.githubusercontent.com/.../supabase-architecture.svg   200 image/svg+xml
raw.githubusercontent.com/.../supabase-dashboard.png      200 image/png
supabase.com/badge-made-with-supabase.svg                 200 image/svg+xml
supabase.com/badge-made-with-supabase-dark.svg            200 image/svg+xml
```

Every image reference in both files now resolves.

## Additional context

Worth flagging separately, and deliberately **not** changed here: most of the other translations reference the diagram as

```
https://github.com/supabase/supabase/blob/master/apps/docs/public/img/supabase-architecture.svg
```

That URL responds `200 text/html`, not an image — a `/blob/` link is the file-viewer page rather than the file. So the majority convention appears to be broken too, just in a different way, which is why this PR did not adopt it. That affects roughly fifty files and felt like scope creep on a two-file fix; happy to send a follow-up if you'd like it swept.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Croatian and Sinhala README images and badges to use hosted URLs.
  * Improved the reliability of architecture diagrams and light/dark “Made with Supabase” badges across documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->