### PR TITLE
fix(functions): prevent JWT verification when legacy keys are disabled

### DIFF
--- a/apps/docs/content/guides/functions/error-codes.mdx
+++ b/apps/docs/content/guides/functions/error-codes.mdx
@@ -180,12 +180,12 @@ For further information, see [Authorization headers](/docs/guides/functions/auth
 
 ### UNAUTHORIZED_NO_AUTH_HEADER
 
-**Cause:** The Edge Function has JWT verification enabled, but the request is missing the `Authorization` or `apikey` header.
+**Cause:** The Edge Function has JWT verification enabled, but the request is missing a JWT in the `Authorization` header. An `apikey` header on its own does not satisfy JWT verification.
 
 **Solution:**
 
 - Ensure you are passing a valid JWT token in the `Authorization` header
-- Check that you are sending an API key in the `apikey` header
+- Check that the credential you are passing is a JWT. Publishable and secret keys (`sb_publishable_...`, `sb_secret_...`) are not JWTs, so they never satisfy JWT verification
 - For webhooks or public endpoints, consider disabling JWT verification
 
 ### UNAUTHORIZED_ASYMMETRIC_JWT

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionDetails.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionDetails.tsx
@@ -25,6 +25,7 @@ import {
   TabsList,
   TabsTrigger,
 } from 'ui'
+import { Admonition } from 'ui-patterns/Admonition'
 import { CodeBlock } from 'ui-patterns/CodeBlock'
 import { Input } from 'ui-patterns/DataInputs/Input'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
@@ -40,6 +41,8 @@ import {
 import z from 'zod'
 
 import CommandRender from '../CommandRender'
+import { getJwtVerificationState } from '../jwtVerification.utils'
+import { useIsJwtVerificationAvailable } from '../useIsJwtVerificationAvailable'
 import { INVOCATION_TABS } from './EdgeFunctionDetails.constants'
 import { generateCLICommands } from './EdgeFunctionDetails.utils'
 import { useAPIKeys } from '@/data/api-keys/api-keys-query'
@@ -83,6 +86,13 @@ export const EdgeFunctionDetails = () => {
   const { anonKey, publishableKey } = apiKeyData ?? {}
 
   const { data: selectedFunction } = useEdgeFunctionQuery({ projectRef, slug: functionSlug })
+
+  const isJwtVerificationAvailable = useIsJwtVerificationAvailable()
+  const { canToggle: canToggleJwtVerification, isUnsatisfiable: isJwtVerificationUnsatisfiable } =
+    getJwtVerificationState({
+      isAvailable: isJwtVerificationAvailable,
+      isEnforced: selectedFunction?.verify_jwt ?? false,
+    })
 
   const { data: endpoint } = useProjectApiUrl({ projectRef })
   const functionUrl = `${endpoint}/functions/v1/${selectedFunction?.slug}`
@@ -181,36 +191,51 @@ export const EdgeFunctionDetails = () => {
                             label="Verify JWT with legacy secret"
                             layout="flex-row-reverse"
                             description={
-                              <>
-                                <p className="mb-2">
-                                  Requires a JWT signed{' '}
-                                  <em className="text-foreground not-italic">
-                                    only by the legacy secret
-                                  </em>{' '}
-                                  in the{' '}
-                                  <code className="text-code-inline break-keep!">
-                                    Authorization
-                                  </code>{' '}
-                                  header. The <code className="text-code-inline">anon</code> key
-                                  satisfies this.
-                                </p>
+                              isJwtVerificationAvailable ? (
+                                <>
+                                  <p className="mb-2">
+                                    Requires a JWT signed{' '}
+                                    <em className="text-foreground not-italic">
+                                      only by the legacy secret
+                                    </em>{' '}
+                                    in the{' '}
+                                    <code className="text-code-inline break-keep!">
+                                      Authorization
+                                    </code>{' '}
+                                    header. The <code className="text-code-inline">anon</code> key
+                                    satisfies this.
+                                  </p>
+                                  <p>
+                                    Recommended: OFF with JWT and custom auth logic in your function
+                                    code.
+                                  </p>
+                                </>
+                              ) : (
                                 <p>
-                                  Recommended: OFF with JWT and custom auth logic in your function
-                                  code.
+                                  Unavailable while legacy JWT keys are disabled on this project.
+                                  Authenticate callers in your function code instead.
                                 </p>
-                              </>
+                              )
                             }
                           >
                             <FormControl>
                               <Switch
                                 checked={field.value}
                                 onCheckedChange={field.onChange}
-                                disabled={!canUpdateEdgeFunction}
+                                disabled={!canUpdateEdgeFunction || !canToggleJwtVerification}
                               />
                             </FormControl>
                           </FormItemLayout>
                         )}
                       />
+                      {isJwtVerificationUnsatisfiable && (
+                        <Admonition
+                          type="warning"
+                          className="mt-4"
+                          title="This function rejects every request"
+                          description="Legacy JWT keys are disabled on this project, so no key can satisfy JWT verification. Turn it off and authenticate callers in your function code."
+                        />
+                      )}
                     </CardContent>
 
                     <CardFooter className="flex justify-end space-x-2">

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionTesterSheet.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionTesterSheet.tsx
@@ -30,6 +30,7 @@ import {
   TabsTrigger,
   Textarea,
 } from 'ui'
+import { Admonition } from 'ui-patterns/Admonition'
 import { CodeBlock } from 'ui-patterns/CodeBlock'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { KeyValueFieldArray } from 'ui-patterns/form/KeyValueFieldArray/KeyValueFieldArray'
@@ -40,9 +41,12 @@ import { ErrorWithStatus, ResponseData } from './EdgeFunctionDetails.types'
 import { getEdgeFunctionErrorDocs } from './EdgeFunctionDetails.utils'
 import { buildEdgeFunctionTestHeaders } from './EdgeFunctionTesterSheet.utils'
 import { buildEdgeFunctionHeaderAddActions } from '@/components/interfaces/Functions/httpHeaderAddActions'
+import { getJwtVerificationState } from '@/components/interfaces/Functions/jwtVerification.utils'
+import { useIsJwtVerificationAvailable } from '@/components/interfaces/Functions/useIsJwtVerificationAvailable'
 import { ShortcutTooltip } from '@/components/ui/ShortcutTooltip'
 import { useAPIKeys } from '@/data/api-keys/api-keys-query'
 import { useProjectSettingsV2Query } from '@/data/config/project-settings-v2-query'
+import { useEdgeFunctionQuery } from '@/data/edge-functions/edge-function-query'
 import { useEdgeFunctionTestMutation } from '@/data/edge-functions/edge-function-test-mutation'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
 import { prettifyJSON } from '@/lib/helpers'
@@ -91,6 +95,15 @@ export const EdgeFunctionTesterSheet = ({ visible, onClose }: EdgeFunctionTester
   )
   const { anonKey, publishableKey, secretKey, serviceKey } = apiKeysData ?? {}
   const { data: settings } = useProjectSettingsV2Query({ projectRef })
+
+  const { data: selectedFunction } = useEdgeFunctionQuery({ projectRef, slug: functionSlug })
+  const isJwtVerificationAvailable = useIsJwtVerificationAvailable()
+  // Nothing the tester can send passes the legacy JWT gate on a deployment without legacy JWT keys,
+  // so say so up front rather than letting the request come back as a bare 401.
+  const { isUnsatisfiable: isJwtVerificationUnsatisfiable } = getJwtVerificationState({
+    isAvailable: isJwtVerificationAvailable,
+    isEnforced: selectedFunction?.verify_jwt ?? false,
+  })
 
   // Sent on the `apikey` header. Defaults to the least privileged key available, matching what the
   // function details page shows in its example snippets.
@@ -212,6 +225,13 @@ export const EdgeFunctionTesterSheet = ({ visible, onClose }: EdgeFunctionTester
             <ResizablePanelGroup orientation="vertical">
               <ResizablePanel>
                 <div className="flex flex-col gap-y-4 p-5 h-full overflow-y-auto">
+                  {isJwtVerificationUnsatisfiable && (
+                    <Admonition
+                      type="warning"
+                      title="This function rejects every request"
+                      description="It verifies JWTs with the legacy secret, but legacy JWT keys are disabled on this project, so no key satisfies that check. Turn off JWT verification in the function's configuration to test it."
+                    />
+                  )}
                   <FormField
                     control={form.control}
                     name="method"

--- a/apps/studio/components/interfaces/Functions/jwtVerification.utils.ts
+++ b/apps/studio/components/interfaces/Functions/jwtVerification.utils.ts
@@ -1,0 +1,32 @@
+interface JwtVerificationStateParams {
+  /** Whether the legacy JWT gate can be satisfied at all — see `useIsJwtVerificationAvailable`. */
+  isAvailable: boolean
+  /**
+   * The function's *saved* `verify_jwt` value. Deliberately not the form value: a function already
+   * deployed with the gate on has to stay toggleable so the user can turn it back off, and reading
+   * the form value would disable the switch the moment they did.
+   */
+  isEnforced: boolean
+}
+
+interface JwtVerificationState {
+  /** Whether `verify_jwt` can be changed on this deployment, permissions aside. */
+  canToggle: boolean
+  /** Whether the function currently rejects every request because the gate can never be passed. */
+  isUnsatisfiable: boolean
+}
+
+/**
+ * Resolves how a function's `verify_jwt` setting should be presented.
+ *
+ * Where legacy JWT keys are turned off the gate can never be satisfied, so it must not be possible
+ * to turn on — but a function already saved with it on stays toggleable, because turning it off is
+ * the only way out of that state.
+ */
+export const getJwtVerificationState = ({
+  isAvailable,
+  isEnforced,
+}: JwtVerificationStateParams): JwtVerificationState => ({
+  canToggle: isAvailable || isEnforced,
+  isUnsatisfiable: isEnforced && !isAvailable,
+})

--- a/apps/studio/components/interfaces/Functions/useIsJwtVerificationAvailable.ts
+++ b/apps/studio/components/interfaces/Functions/useIsJwtVerificationAvailable.ts
@@ -1,0 +1,16 @@
+import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
+
+/**
+ * Whether an edge function's `verify_jwt` gate can be satisfied on this deployment.
+ *
+ * `verify_jwt` is the platform's *legacy* auth check: it only accepts a JWT signed by the project's
+ * legacy JWT secret. Deployments with legacy JWT keys turned off have no such secret, so nothing can
+ * pass the gate — not a publishable key, not a disabled `anon` key — and a function with
+ * `verify_jwt` on rejects every request with `UNAUTHORIZED_NO_AUTH_HEADER` before the handler runs.
+ *
+ * Gate anything that can turn `verify_jwt` on behind this.
+ */
+export const useIsJwtVerificationAvailable = () => {
+  const { projectSettingsLegacyJwtKeys } = useIsFeatureEnabled(['project_settings:legacy_jwt_keys'])
+  return projectSettingsLegacyJwtKeys
+}

--- a/apps/studio/lib/ai/tools/studio-tools.ts
+++ b/apps/studio/lib/ai/tools/studio-tools.ts
@@ -1,5 +1,6 @@
 import { acceptUntrustedSql, untrustedSql } from '@supabase/pg-meta'
 import { tool } from 'ai'
+import { isFeatureEnabled } from 'common/enabled-features'
 import { z } from 'zod'
 
 import { deployEdgeFunction } from '@/data/edge-functions/edge-functions-deploy-mutation'
@@ -104,7 +105,9 @@ export const getStudioTools = (ctx: StudioToolsContext = {}) => {
           metadata: {
             entrypoint_path: 'index.ts',
             name,
-            verify_jwt: true,
+            // The legacy JWT gate can't be satisfied where legacy JWT keys are turned off, so
+            // deploying with it on would produce a function that rejects every request.
+            verify_jwt: isFeatureEnabled('project_settings:legacy_jwt_keys'),
           },
           files: [{ name: 'index.ts', content: code }],
           authorization,

--- a/apps/studio/pages/project/[ref]/functions/new.tsx
+++ b/apps/studio/pages/project/[ref]/functions/new.tsx
@@ -32,6 +32,7 @@ import {
 import * as z from 'zod'
 
 import { EDGE_FUNCTION_TEMPLATES } from '@/components/interfaces/Functions/Functions.templates'
+import { useIsJwtVerificationAvailable } from '@/components/interfaces/Functions/useIsJwtVerificationAvailable'
 import { DefaultLayout } from '@/components/layouts/DefaultLayout'
 import EdgeFunctionsLayout from '@/components/layouts/EdgeFunctionsLayout/EdgeFunctionsLayout'
 import { PageLayout } from '@/components/layouts/PageLayout/PageLayout'
@@ -119,6 +120,9 @@ const NewFunctionPage = () => {
   const snap = useAiAssistantStateSnapshot()
   const track = useTrack()
   const showStripeExample = useIsFeatureEnabled('edge_functions:show_stripe_example')
+  // Where the legacy JWT gate can't be satisfied, deploying with it on produces a function that
+  // rejects every request, so deploy with it off and let the template authenticate its own callers.
+  const isJwtVerificationAvailable = useIsJwtVerificationAvailable()
   const { openSidebar } = useSidebarManagerSnapshot()
 
   const [files, setFiles] = useState<FileData[]>(INITIAL_FILES)
@@ -168,7 +172,7 @@ const NewFunctionPage = () => {
     deployFunction({
       projectRef: ref,
       slug: values.functionName,
-      metadata: { name: values.functionName, verify_jwt: true },
+      metadata: { name: values.functionName, verify_jwt: isJwtVerificationAvailable },
       files: files.map(({ name, content }) => ({ name, content })),
     })
 

--- a/apps/studio/tests/components/Functions/EdgeFunctionDetails.test.tsx
+++ b/apps/studio/tests/components/Functions/EdgeFunctionDetails.test.tsx
@@ -1,0 +1,90 @@
+import { screen, waitFor } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import { describe, expect, test, vi } from 'vitest'
+
+// `EdgeFunctionDetails` only renders the verify_jwt section on platform, and reads the function
+// slug off the route, so both are pinned here rather than relying on the global `common` mock.
+vi.mock('common', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...actual,
+    IS_PLATFORM: true,
+    useParams: () => ({ ref: 'default', functionSlug: 'my-function' }),
+  }
+})
+
+const { EdgeFunctionDetails } =
+  await import('@/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionDetails')
+const { customRender } = await import('@/tests/lib/custom-render')
+const { addAPIMock, mswServer } = await import('@/tests/lib/msw')
+const { createMockProfile, createMockProfileContext } = await import('@/tests/lib/profile-helpers')
+const { API_URL } = await import('@/lib/constants')
+
+const LEGACY_JWT_KEYS = 'project_settings:legacy_jwt_keys'
+
+const renderDetails = ({
+  verifyJwt,
+  isLegacyJwtEnabled,
+}: {
+  verifyJwt: boolean
+  isLegacyJwtEnabled: boolean
+}) => {
+  // Surrounding data the page pulls in but none of these assertions depend on.
+  mswServer.use(
+    http.get(`${API_URL}/enabled-features-overrides`, () =>
+      HttpResponse.json({ disabled_features: [] })
+    ),
+    http.get(`${API_URL}/platform/projects/default`, () => HttpResponse.json({ ref: 'default' })),
+    http.get(`${API_URL}/platform/projects/default/settings`, () => HttpResponse.json({})),
+    http.get(`${API_URL}/v1/projects/default/api-keys`, () => HttpResponse.json([]))
+  )
+
+  addAPIMock({
+    method: 'get',
+    path: '/v1/projects/:ref/functions/:function_slug',
+    response: {
+      id: 'fn-1',
+      slug: 'my-function',
+      name: 'my-function',
+      status: 'ACTIVE',
+      version: 1,
+      created_at: 0,
+      updated_at: 0,
+      verify_jwt: verifyJwt,
+    },
+  })
+
+  return customRender(<EdgeFunctionDetails />, {
+    profileContext: createMockProfileContext({
+      profile: createMockProfile({
+        disabled_features: isLegacyJwtEnabled ? [] : [LEGACY_JWT_KEYS],
+      }),
+    }),
+  })
+}
+
+const getSwitch = () => screen.getByRole('switch')
+
+describe('EdgeFunctionDetails verify_jwt toggle', () => {
+  test('leaves the toggle usable when legacy JWT keys are enabled', async () => {
+    renderDetails({ verifyJwt: false, isLegacyJwtEnabled: true })
+
+    await waitFor(() => expect(getSwitch()).toBeEnabled())
+    expect(screen.queryByText(/rejects every request/i)).not.toBeInTheDocument()
+  })
+
+  test('disables the toggle when legacy JWT keys are disabled and the gate is off', async () => {
+    renderDetails({ verifyJwt: false, isLegacyJwtEnabled: false })
+
+    await waitFor(() => expect(getSwitch()).toBeDisabled())
+    expect(screen.getByText(/Unavailable while legacy JWT keys are disabled/i)).toBeInTheDocument()
+    expect(screen.queryByText(/rejects every request/i)).not.toBeInTheDocument()
+  })
+
+  test('keeps an already enforced gate toggleable and warns that the function is unreachable', async () => {
+    renderDetails({ verifyJwt: true, isLegacyJwtEnabled: false })
+
+    await waitFor(() => expect(getSwitch()).toBeEnabled())
+    expect(screen.getByText(/rejects every request/i)).toBeInTheDocument()
+  })
+})

--- a/apps/studio/tests/components/Functions/jwtVerification.utils.test.ts
+++ b/apps/studio/tests/components/Functions/jwtVerification.utils.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { getJwtVerificationState } from '@/components/interfaces/Functions/jwtVerification.utils'
+
+describe('getJwtVerificationState', () => {
+  it('allows toggling and flags nothing when legacy JWT keys are available and the gate is off', () => {
+    expect(getJwtVerificationState({ isAvailable: true, isEnforced: false })).toStrictEqual({
+      canToggle: true,
+      isUnsatisfiable: false,
+    })
+  })
+
+  it('allows toggling and flags nothing when legacy JWT keys are available and the gate is on', () => {
+    expect(getJwtVerificationState({ isAvailable: true, isEnforced: true })).toStrictEqual({
+      canToggle: true,
+      isUnsatisfiable: false,
+    })
+  })
+
+  it('blocks turning the gate on when legacy JWT keys are unavailable', () => {
+    expect(getJwtVerificationState({ isAvailable: false, isEnforced: false })).toStrictEqual({
+      canToggle: false,
+      isUnsatisfiable: false,
+    })
+  })
+
+  it('keeps an already enforced gate toggleable so it can be turned off, and flags it', () => {
+    expect(getJwtVerificationState({ isAvailable: false, isEnforced: true })).toStrictEqual({
+      canToggle: true,
+      isUnsatisfiable: true,
+    })
+  })
+})


### PR DESCRIPTION
When legacy JWT keys are disabled on a project, `verify_jwt` can never be satisfied — no key (not even `anon`) can pass the check, so the function rejects every request. This adds gating in Studio to stop that state from being created and to surface it clearly when it already exists.

- Add `useIsJwtVerificationAvailable` and `getJwtVerificationState` to determine whether the legacy JWT gate can be satisfied and whether the toggle should be disabled, while still allowing an already-enforced function to be turned back off
- Disable the "Verify JWT with legacy secret" switch on the function details page when unavailable, and show a warning admonition when an existing function is left in an unsatisfiable state
- Warn in the function tester sheet when testing a function whose JWT verification can never succeed
- Default new/AI-deployed functions' `verify_jwt` to the availability of legacy JWT keys instead of always `true`, in both the new function page and the AI assistant's deploy tool
- Clarify the `UNAUTHORIZED_NO_AUTH_HEADER` docs to note that an `apikey` header alone, or publishable/secret keys, never satisfy JWT verification
- Add unit tests for `getJwtVerificationState`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved edge function JWT verification handling based on available authentication settings.
  - Added warnings when verification is enabled but every request would be rejected.
  - Prevented enabling verification when required legacy JWT keys are unavailable.
  - New edge functions avoid unsatisfiable JWT verification configurations.

- **Bug Fixes**
  - Clarified that API keys do not satisfy JWT verification requirements.

- **Tests**
  - Added coverage for JWT verification availability and enforcement states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->