### PR TITLE
fix(self-hosted): resolve docker socket access and error reporting for non-root sudo users (#49739)

### DIFF
--- a/docker/setup.sh
+++ b/docker/setup.sh
@@ -177,6 +177,39 @@ docker_present() {
     command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1
 }
 
+docker_accessible() {
+    command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1
+}
+
+ensure_docker_accessible() {
+    if docker_accessible; then
+        return 0
+    fi
+
+    # Check if the daemon is running but the current user lacks socket permissions
+    if [ -n "$SUDO" ] && $SUDO docker info >/dev/null 2>&1; then
+        current_user="${USER:-$(id -un 2>/dev/null || echo "")}"
+        warn "Docker daemon is running, but user '${current_user}' cannot access /var/run/docker.sock."
+        if [ -n "$current_user" ]; then
+            log "Adding user '${current_user}' to the 'docker' group"
+            $SUDO groupadd -f docker 2>/dev/null || true
+            $SUDO usermod -aG docker "$current_user" 2>/dev/null || true
+        fi
+        echo ""
+        echo "===> Group membership changes require a new login session to take effect."
+        echo "===> To continue setup, please run:"
+        echo ""
+        echo "       newgrp docker"
+        echo "       sh setup.sh"
+        echo ""
+        echo "     (Or log out and log back in, then re-run setup.sh)"
+        echo ""
+        exit 0
+    fi
+
+    die "Cannot connect to the Docker daemon. Please ensure the docker service is running."
+}
+
 install_docker() {
     if docker_present; then
         log "Docker already installed: $(docker --version)"
@@ -359,6 +392,9 @@ if [ "$WITH_AWS" = "1" ]; then
     install_aws
 fi
 
+# Ensure the Docker daemon is accessible to the invoking user before creating project files
+ensure_docker_accessible
+
 # Idempotent re-run: if CWD is already a set-up project, skip bootstrap.
 # A clone has docker-compose.yml + utils/ but only .env.example;
 # a set-up project also has a real .env.
@@ -435,10 +471,15 @@ sh utils/add-new-auth-keys.sh --update-env
 write_version_stamp "$RESOLVED_REF"
 
 log "Pulling Docker images"
+pull_failed=0
 if [ "$NON_INTERACTIVE" = "1" ]; then
-    docker compose --progress quiet pull || warn "docker compose pull failed; you can retry later."
+    docker compose --progress quiet pull || pull_failed=1
 else
-    docker compose pull || warn "docker compose pull failed; you can retry later."
+    docker compose pull || pull_failed=1
+fi
+
+if [ "$pull_failed" = "1" ]; then
+    warn "docker compose pull failed; you can pull images later with 'sh run.sh pull'."
 fi
 
 echo ""
@@ -448,6 +489,9 @@ echo "Next steps:"
 echo "  cd $(pwd)"
 echo "  sh run.sh config"
 echo "  sh run.sh secrets"
+if [ "$pull_failed" = "1" ]; then
+    echo "  sh run.sh pull"
+fi
 echo "  sh run.sh start"
 echo ""
 echo "To enable docker-compose overrides (caddy, nginx, logs, rustfs, s3, kong):"

--- a/docker/setup.sh
+++ b/docker/setup.sh
@@ -479,7 +479,14 @@ else
 fi
 
 if [ "$pull_failed" = "1" ]; then
-    warn "docker compose pull failed; you can pull images later with 'sh run.sh pull'."
+    warn "docker compose pull failed; images were not downloaded."
+    echo ""
+    echo "Setup did not complete. To pull images and start manually:"
+    echo "  cd $(pwd)"
+    echo "  sh run.sh pull"
+    echo "  sh run.sh start"
+    echo ""
+    exit 1
 fi
 
 echo ""
@@ -489,9 +496,6 @@ echo "Next steps:"
 echo "  cd $(pwd)"
 echo "  sh run.sh config"
 echo "  sh run.sh secrets"
-if [ "$pull_failed" = "1" ]; then
-    echo "  sh run.sh pull"
-fi
 echo "  sh run.sh start"
 echo ""
 echo "To enable docker-compose overrides (caddy, nginx, logs, rustfs, s3, kong):"

--- a/docker/utils/add-new-auth-keys.sh
+++ b/docker/utils/add-new-auth-keys.sh
@@ -39,8 +39,9 @@ else
     fi
 
     if ! docker_err=$(docker info 2>&1 >/dev/null); then
-        case "$docker_err" in
-            *"permission denied"*)
+        err_lower=$(printf '%s\n' "$docker_err" | tr '[:upper:]' '[:lower:]')
+        case "$err_lower" in
+            *"permission denied"*"docker.sock"*|*"docker.sock"*"permission denied"*)
                 current_user="${USER:-$(id -un 2>/dev/null || echo user)}"
                 echo "Error: permission denied connecting to the Docker daemon at unix:///var/run/docker.sock." >&2
                 echo "User '$current_user' is not in the 'docker' group. To fix:" >&2

--- a/docker/utils/add-new-auth-keys.sh
+++ b/docker/utils/add-new-auth-keys.sh
@@ -34,12 +34,24 @@ else
     fi
 
     if ! command -v docker >/dev/null 2>&1; then
-        echo "Error: requires either node (>= 16) or docker."
+        echo "Error: requires either node (>= 16) or docker." >&2
         exit 1
     fi
 
-    if ! docker info >/dev/null 2>&1; then
-        echo "Error: docker is installed but the daemon is not running."
+    if ! docker_err=$(docker info 2>&1 >/dev/null); then
+        case "$docker_err" in
+            *"permission denied"*)
+                current_user="${USER:-$(id -un 2>/dev/null || echo user)}"
+                echo "Error: permission denied connecting to the Docker daemon at unix:///var/run/docker.sock." >&2
+                echo "User '$current_user' is not in the 'docker' group. To fix:" >&2
+                echo "  sudo usermod -aG docker \"$current_user\"" >&2
+                echo "  newgrp docker  (or log out and back in)" >&2
+                ;;
+            *)
+                echo "Error: could not query the Docker daemon:" >&2
+                printf '%s\n' "$docker_err" >&2
+                ;;
+        esac
         exit 1
     fi
 

--- a/docker/utils/rotate-new-api-keys.sh
+++ b/docker/utils/rotate-new-api-keys.sh
@@ -37,8 +37,9 @@ else
     fi
 
     if ! docker_err=$(docker info 2>&1 >/dev/null); then
-        case "$docker_err" in
-            *"permission denied"*)
+        err_lower=$(printf '%s\n' "$docker_err" | tr '[:upper:]' '[:lower:]')
+        case "$err_lower" in
+            *"permission denied"*"docker.sock"*|*"docker.sock"*"permission denied"*)
                 current_user="${USER:-$(id -un 2>/dev/null || echo user)}"
                 echo "Error: permission denied connecting to the Docker daemon at unix:///var/run/docker.sock." >&2
                 echo "User '$current_user' is not in the 'docker' group. To fix:" >&2

--- a/docker/utils/rotate-new-api-keys.sh
+++ b/docker/utils/rotate-new-api-keys.sh
@@ -32,12 +32,24 @@ else
     fi
 
     if ! command -v docker >/dev/null 2>&1; then
-        echo "Error: requires either node (>= 16) or docker."
+        echo "Error: requires either node (>= 16) or docker." >&2
         exit 1
     fi
 
-    if ! docker info >/dev/null 2>&1; then
-        echo "Error: docker is installed but the daemon is not running."
+    if ! docker_err=$(docker info 2>&1 >/dev/null); then
+        case "$docker_err" in
+            *"permission denied"*)
+                current_user="${USER:-$(id -un 2>/dev/null || echo user)}"
+                echo "Error: permission denied connecting to the Docker daemon at unix:///var/run/docker.sock." >&2
+                echo "User '$current_user' is not in the 'docker' group. To fix:" >&2
+                echo "  sudo usermod -aG docker \"$current_user\"" >&2
+                echo "  newgrp docker  (or log out and back in)" >&2
+                ;;
+            *)
+                echo "Error: could not query the Docker daemon:" >&2
+                printf '%s\n' "$docker_err" >&2
+                ;;
+        esac
         exit 1
     fi
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

On clean cloud-init VMs, non-root sudo users lack permissions on `/var/run/docker.sock`.

Running `setup.sh` produces two issues:
1. `docker_present()` only runs `docker compose version`, which is a client-side command. The script proceeds to create `$target`, clone files, and write partial configs before failing on key generation. Re-running after fixing permissions fails or produces inconsistent states.
2. `add-new-auth-keys.sh` and `rotate-new-api-keys.sh` discard `docker info`'s output (`>/dev/null 2>&1`). They report "docker is installed but the daemon is not running" for all failures, hiding socket permission errors as well as disk full or TLS issues.

Fixes #49739

## What is the new behavior?

1. `docker/setup.sh`:
- Adds `ensure_docker_accessible()` before `$target` creation.
- Checks if the Docker daemon is accessible to the invoking user.
- If the user has `sudo` access and the daemon is alive, it ensures the `docker` group exists (`groupadd -f docker`) and adds the user (`usermod -aG docker`).
- Exits cleanly (code 0) with clear instructions to run `newgrp docker` and re-run `setup.sh` to continue without rebooting.
- Flags `docker compose pull` failures and suggests `sh run.sh pull` instead of claiming setup completed successfully.

2. `docker/utils/add-new-auth-keys.sh` & `docker/utils/rotate-new-api-keys.sh`:
- Captures `docker info` stderr without swallowing output.
- Branches on `permission denied` to print `usermod` and `newgrp` instructions.
- Prints the raw Docker error via `printf '%s\n' "$docker_err" >&2` for daemon down, TLS, or disk errors instead of guessing.

## Additional context

Tested on Ubuntu 24.04 replicating a default cloud-init setup:
- Fresh non-root sudo user: exits 0 before copying files, prints `newgrp docker` steps.
- After `newgrp docker`: completes key generation, config creation, and pulls images cleanly.
- Stopped daemon: prints daemon inactive error.
- Non-permission failure (mocked disk/TLS): prints the exact Docker error string.
- Validated POSIX compliance with `shellcheck -s sh` (0 warnings on modified code).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Setup now verifies Docker access before creating project files and provides guidance for resolving permission issues.
  - Docker image pull failures now display recovery commands and correctly report setup failure.
  - Authentication-key and API-key rotation scripts now distinguish Docker socket permission issues from other daemon errors and provide more specific troubleshooting guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->