### PR TITLE
fix(studio): improve SQL folder deletion error handling and modal recovery (#50293)

### DIFF
--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorNav.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorNav.tsx
@@ -343,6 +343,10 @@ export const SQLEditorNav = ({ sort = 'inserted_at' }: SQLEditorNavProps) => {
       snapV2.removeFolder(ids[0])
       setSelectedFolderToDelete(undefined)
     },
+    onError: (error) => {
+      setSelectedFolderToDelete(undefined)
+      toast.error(`Failed to delete folder: ${error.message}`)
+    },
   })
 
   // ===============
@@ -384,12 +388,12 @@ export const SQLEditorNav = ({ sort = 'inserted_at' }: SQLEditorNavProps) => {
           onSuccess: () => {
             ids.forEach((id) => snapV2.removeSnippet(id))
             postDeleteCleanup(ids)
-            deleteFolder({ projectRef, ids: [selectedFolderToDelete?.id] })
+            deleteFolder({ projectRef, ids: [selectedFolderToDelete.id] })
           },
         }
       )
     } else {
-      deleteFolder({ projectRef, ids: [selectedFolderToDelete?.id] })
+      deleteFolder({ projectRef, ids: [selectedFolderToDelete.id] })
     }
   }
 

--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorNav.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorNav.tsx
@@ -385,6 +385,9 @@ export const SQLEditorNav = ({ sort = 'inserted_at' }: SQLEditorNavProps) => {
       deleteContent(
         { projectRef, ids },
         {
+          onError: () => {
+            setSelectedFolderToDelete(undefined)
+          },
           onSuccess: () => {
             ids.forEach((id) => snapV2.removeSnippet(id))
             postDeleteCleanup(ids)

--- a/apps/studio/data/content/sql-folders-delete-mutation.test.ts
+++ b/apps/studio/data/content/sql-folders-delete-mutation.test.ts
@@ -24,4 +24,44 @@ describe('deleteSQLSnippetFolders', () => {
 
     expect(ids).toBe('folder-one,folder-two')
   })
+
+  it('sends a single folder ID correctly as query value', async () => {
+    let ids: string | null = null
+
+    addAPIMock({
+      method: 'delete',
+      path: '/platform/projects/:ref/content/folders',
+      response: ({ request }) => {
+        ids = new URL(request.url).searchParams.get('ids')
+        return HttpResponse.json({})
+      },
+    })
+
+    await deleteSQLSnippetFolders({
+      projectRef: 'default',
+      ids: ['folder-one'],
+    })
+
+    expect(ids).toBe('folder-one')
+  })
+
+  it('throws when the API returns an error', async () => {
+    addAPIMock({
+      method: 'delete',
+      path: '/platform/projects/:ref/content/folders',
+      response: () => {
+        return HttpResponse.json(
+          { message: "Failed to delete project's content folders" },
+          { status: 500 }
+        )
+      },
+    })
+
+    await expect(
+      deleteSQLSnippetFolders({
+        projectRef: 'default',
+        ids: ['folder-one'],
+      })
+    ).rejects.toThrow("Failed to delete project's content folders")
+  })
 })


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix, UI robustness, and unit tests

## What is the current behavior?

Fixes #50293. When attempting to delete a SQL Editor folder on the Dashboard, if the backend encounters a timeout (e.g. 30s statement timeout) or 500 error, the confirmation modal remains stuck in an indefinite loading/pending state. Additionally, redundant optional chaining on `selectedFolderToDelete?.id` is present.

## What is the new behavior?

1. **Clean Modal State Recovery:** When a folder deletion fails or encounters a timeout error, the `onError` callback ensures `setSelectedFolderToDelete(undefined)` is called, gracefully dismissing the confirmation modal and surfacing the toast error notification.
2. **Type Safety:** Removed redundant optional chaining (`selectedFolderToDelete?.id` -> `selectedFolderToDelete.id`), ensuring strictly-typed IDs are sent.
3. **Regression Tests:** Expanded Vitest coverage to verify single-folder deletion parameter serialization and error propagation.

---

## What does this PR do?
This PR addresses issue #50293 regarding SQL Editor folder deletion in the Supabase Dashboard. It hardens client-side error handling for `DELETE /platform/projects/{ref}/content/folders`, ensures clean state recovery for the deletion confirmation modal upon server timeouts/errors, removes redundant optional chaining, and adds regression tests for folder deletion query formatting and error propagation.

- fixing : #50293

## Changes proposed in this pull request:

### User Interface (`apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorNav.tsx`)
- **Modal State Recovery:** Added an `onError` callback to `useSQLSnippetFoldersDeleteMutation` to ensure `setSelectedFolderToDelete(undefined)` is triggered upon failure. This prevents the deletion confirmation modal from being stuck open indefinitely when a server-side timeout or 500 error occurs.
- **Type-safe Folder ID:** Removed redundant optional chaining (`selectedFolderToDelete?.id` -> `selectedFolderToDelete.id`), ensuring only strictly typed strings are passed to `deleteFolder`.

### Tests (`apps/studio/data/content/sql-folders-delete-mutation.test.ts`)
- **Single Folder ID Test:** Added test coverage ensuring single folder deletions correctly format query parameters without unnecessary delimiters.
- **Error Propagation Test:** Added test coverage verifying that 500 / timeout errors returned by the API correctly throw and propagate through the mutation handler.

## How to test this:
1. Open the SQL Editor in Supabase Studio.
2. In the left-hand navigation under **Private**, click **+** -> **Create a new folder**.
3. Right-click the folder and select **Delete folder**.
4. Confirm deletion in the modal dialog:
   - If the API succeeds, the folder is removed from state and tree view.
   - If the API fails or times out with HTTP 500, the confirmation modal cleanly closes, and the error toast is surfaced with the server response message.
5. Run Vitest regression tests:
   ```bash
   pnpm --filter studio exec vitest run data/content/sql-folders-delete-mutation.test.ts
   ```

---

## Proof & Resolution Traces

### 1. Issue Reproduction & Timeout Trace
- **Confirmation Dialog:** https://github.com/user-attachments/assets/06f373fb-a4d0-4930-bdfe-4e8c2721820e
- **30-Second API Timeout:** https://github.com/user-attachments/assets/09e7d142-852e-4de6-b747-ec7bdd821591

### 2. Resolution & Test Verification
- **Passing Suite & Resolved Workflow Proof:**
  - Automated tests pass for single and multi-folder serialization as well as error propagation.
  - Confirmation modal state cleanly recovers on both successful and errored deletions.

## Additional context
Pre-merge checks and repository template adherence verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SQL folder deletion handling when deleting child snippets fails.
  - The selected folder is now cleared and the confirmation modal closes while the existing error message remains available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->