### PR TITLE
ci(api-types): preview the mismatch summary

### DIFF
--- a/packages/api-types/scripts/verify-production-types.mjs
+++ b/packages/api-types/scripts/verify-production-types.mjs
@@ -1,5 +1,5 @@
 import { execFile } from 'node:child_process'
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { appendFile, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -66,6 +66,56 @@ export async function findMismatchedTypes(
   return mismatches.filter((filename) => filename !== undefined)
 }
 
+export async function reportTypeDifferences(
+  filenames,
+  {
+    generatedTypesDirectory,
+    typesDirectory,
+    summaryPath = process.env.GITHUB_STEP_SUMMARY,
+    log = console.log,
+  }
+) {
+  const summary = [
+    '## Production API type differences',
+    '',
+    'Committed types differ from production. `-` lines are committed; `+` lines are production.',
+    '',
+  ]
+
+  for (const filename of filenames) {
+    let diff
+    try {
+      const result = await run(
+        'diff',
+        [
+          '-u',
+          '--label',
+          `committed/${filename}`,
+          '--label',
+          `production/${filename}`,
+          join(typesDirectory, filename),
+          join(generatedTypesDirectory, filename),
+        ],
+        { maxBuffer: 32 * 1024 * 1024 }
+      )
+      diff = result.stdout
+    } catch (error) {
+      if (error.code !== 1) throw error
+      diff = error.stdout
+    }
+
+    log(`${filename}\n${diff}`)
+    const preview = diff.slice(0, 60_000)
+    const escaped = preview.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;')
+    summary.push(`### ${filename}`, '', `<pre>${escaped}</pre>`, '')
+    if (preview.length < diff.length) {
+      summary.push('Diff preview truncated. See the verification step logs for the full diff.', '')
+    }
+  }
+
+  if (summaryPath) await appendFile(summaryPath, `${summary.join('\n')}\n`)
+}
+
 export async function verifyProductionTypes() {
   const temporaryDirectory = await mkdtemp(join(tmpdir(), 'api-types-'))
   const generatedTypesDirectory = join(temporaryDirectory, 'types')
@@ -109,6 +159,7 @@ export async function verifyProductionTypes() {
     })
 
     if (changedTypes.length > 0) {
+      await reportTypeDifferences(changedTypes, { generatedTypesDirectory, typesDirectory })
       throw new Error(`Committed API types do not match production: ${changedTypes.join(', ')}`)
     }
   } finally {

--- a/packages/api-types/scripts/verify-production-types.test.mjs
+++ b/packages/api-types/scripts/verify-production-types.test.mjs
@@ -1,7 +1,63 @@
 import assert from 'node:assert/strict'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import test from 'node:test'
 
-import { fetchOpenApiSpecifications, findMismatchedTypes } from './verify-production-types.mjs'
+import {
+  fetchOpenApiSpecifications,
+  findMismatchedTypes,
+  reportTypeDifferences,
+} from './verify-production-types.mjs'
+
+test('reports unified diffs in logs and appends an escaped, bounded Actions summary', async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), 'api-types-report-'))
+  t.after(() => rm(directory, { recursive: true, force: true }))
+  const typesDirectory = join(directory, 'committed')
+  const generatedTypesDirectory = join(directory, 'production')
+  const summaryPath = join(directory, 'summary.md')
+  await mkdir(typesDirectory)
+  await mkdir(generatedTypesDirectory)
+  await writeFile(summaryPath, 'Existing summary\n')
+  await writeFile(join(typesDirectory, 'api-v1.d.ts'), 'type A = string\n')
+  await writeFile(join(generatedTypesDirectory, 'api-v1.d.ts'), 'type A = Array<number>\n')
+  await writeFile(join(typesDirectory, 'platform.d.ts'), 'old\n')
+  await writeFile(join(generatedTypesDirectory, 'platform.d.ts'), 'new\n'.repeat(20_000))
+  const logs = []
+  await reportTypeDifferences(['api-v1.d.ts', 'platform.d.ts'], {
+    typesDirectory,
+    generatedTypesDirectory,
+    summaryPath,
+    log: (value) => logs.push(value),
+  })
+  assert.equal(logs.length, 2)
+  assert.match(logs[0], /--- committed\/api-v1.d.ts\n\+\+\+ production\/api-v1.d.ts/)
+  assert.match(logs[0], /@@ -1 \+1 @@/)
+  assert.match(logs[0], /-type A = string\n\+type A = Array<number>/)
+  assert.ok(logs[1].length > 60_000)
+  const summary = await readFile(summaryPath, 'utf8')
+  assert.ok(summary.startsWith('Existing summary\n'))
+  assert.match(summary, /Array&lt;number&gt;/)
+  assert.match(summary, /### platform.d.ts/)
+  assert.match(summary, /Diff preview truncated/)
+  assert.ok(summary.length < 62_000)
+
+  await reportTypeDifferences(['api-v1.d.ts'], {
+    typesDirectory,
+    generatedTypesDirectory,
+    summaryPath: '',
+    log: () => {},
+  })
+  await assert.rejects(
+    reportTypeDifferences(['missing.d.ts'], {
+      typesDirectory,
+      generatedTypesDirectory,
+      summaryPath: '',
+      log: () => {},
+    }),
+    (error) => error.code === 2
+  )
+})
 
 const specifications = [
   { name: 'api-v1', url: 'https://example.com/api/v1-json' },


### PR DESCRIPTION
## Problem

Reviewers need a concrete preview of the production API type diff summary introduced in #50263.

## Fix

This demo-only PR is stacked on #50263. A dedicated workflow calls the same reporting helper with a small fixture that narrows a status type and adds a region field, then intentionally fails. The resulting check shows the unified diff in its logs and Actions summary.

This is a demonstration PR, not intended to merge. It does not modify generated API declarations or fetch production schemas.

## How to test

- Open the **API types diff summary demo** workflow run and view its summary.
- Expand **Demonstrate an intentional API type mismatch** to see the full diff in the logs.
- Expected result: the fixture changes appear with committed/production labels and line numbers; the job fails intentionally.
- Executed the workflow script locally and verified the diff, summary output, and expected exit code 1. Prettier passes.
