### PR TITLE
Clarify branch disk and compute sizing behavior

### DIFF
--- a/apps/docs/content/guides/deployment/branching/dashboard.mdx
+++ b/apps/docs/content/guides/deployment/branching/dashboard.mdx
@@ -53,11 +53,7 @@ A branch created with **Include data** holds a copy of your production data, tre
 
 </Admonition>
 
-<Admonition type="note">
-
-A branch uses a larger disk and matches the compute size of your project, which increases its cost.
-
-</Admonition>
+A branch with data uses a larger disk than production, sized to fit a copy of your production data plus backup overhead (capped at the maximum size for the volume type). Its compute size is estimated from your production disk usage, not copied from your project's actual compute size — a project with disk usage on the smaller end of a compute tier's range may get a branch sized lower or higher than the project's own instance. You can override the branch's compute size explicitly when creating it. Both the disk and compute size increase the branch's cost.
 
 ## Making changes to a branch
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The documentation previously stated that "A branch uses a larger disk and matches the compute size of your project, which increases its cost." This was vague and didn't accurately describe how branch sizing actually works.

## What is the new behavior?

Updated the documentation to clarify:
- Branch disk size is based on production data plus backup overhead (capped at volume type maximum)
- Branch compute size is estimated from production disk usage, not copied from the project's compute size
- Projects with smaller disk usage may get branches sized differently than the project itself
- Compute size can be explicitly overridden when creating a branch
- Both disk and compute increases affect branch cost

This provides users with a more accurate understanding of how Supabase calculates branch resource allocation.

## Additional context

Replaced a brief note with a more detailed explanation that clarifies the distinction between how disk sizing and compute sizing work for branches, and explains the relationship to production metrics.

https://claude.ai/code/session_01SEQj5Hgh9JfgAyno6JmJ6u

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that branches with data use disk space sized for a copy of production data plus backup overhead, subject to the maximum volume size.
  - Explained that branch compute sizing is estimated from production disk usage and may differ from the project’s compute tier.
  - Documented that both branch compute and disk sizes can be specified when creating a branch.
  - Noted that disk and compute sizing both affect branch costs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->